### PR TITLE
Docs: pin Sphinx to v2

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,7 +84,7 @@ autodoc_default_options = {
     "show-inheritance": True,
 }
 autodoc_member_order = "bysource"
-autodoc_typehints = "description"
+autodoc_typehints = "none"
 
 # sphinx.ext.intersphinx
 intersphinx_mapping = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ rtree>=0.5.0
 scikit-learn
 segmentation-models-pytorch
 setuptools>=42
-sphinx
+sphinx<3
 torch>=1.7
 torchmetrics
 torchvision>=0.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ datasets =
 
 # Optional developer requirements
 docs =
-    sphinx
+    sphinx<3
     pydocstyle[toml]>=6.1
     pytorch-sphinx-theme
 style =

--- a/spack.yaml
+++ b/spack.yaml
@@ -26,7 +26,7 @@ spack:
   - py-scikit-learn
   - py-segmentation-models-pytorch
   - "py-setuptools@42:"
-  - py-sphinx
+  - "py-sphinx@:2.999"
   - "py-torch@1.7:"
   - py-torchmetrics
   - "py-torchvision@0.3:"


### PR DESCRIPTION
`pytorch-sphinx-theme` does not support Sphinx 3+: https://github.com/pytorch/pytorch_sphinx_theme/issues/115

Practically, this means that although things build, they look very ugly. torchvision, torchaudio, etc. pin their Sphinx to 2.4.4. If we want our docs to match, we should also use Sphinx 2.

The biggest downside I've noticed so far is that `autodoc_typehints = "description"` doesn't work. This means that instead of automatically pulling in the type of each parameter/return value from the type hints, we'll need to add it to the docstring too. Will do this in a follow-up commit.