### PR TITLE
Benin: don't hardcode tile transform

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,6 @@ dependencies:
   - rasterio>=1.0
   - torchvision>=0.3
   - pip:
-    - affine
     - black[colorama]>=21b
     - flake8
     - isort[colors]>=4.3.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-affine
 black[colorama]>=21b
 fiona
 flake8

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,6 @@ keywords = pytorch, deep learning, machine learning
 setup_requires =
     setuptools>=42
 install_requires =
-    affine
     fiona
     matplotlib
     numpy

--- a/spack.yaml
+++ b/spack.yaml
@@ -3,7 +3,6 @@ spack:
   - opencv+python3+imgcodecs+tiff+jpeg+png
   - pil
   - "python@3.7:+bz2"
-  - py-affine
   - "py-black@21:+colorama"
   - py-fiona
   - py-flake8


### PR DESCRIPTION
The main reason I did this was so that I could remove the `affine` dependency. `affine` is still required by `rasterio`, but now it is no longer a direct dependency, so there's one less version requirement we have to keep track of.

Aside from dependencies, hardcoding is bad and someone might want to change the CRS/projection of the files. With this change, everything should still work.