### PR TITLE
Make BoundingBox picklable

### DIFF
--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Dict
+from typing import Dict
 
 import pytest
 from rasterio.crs import CRS
@@ -27,12 +27,12 @@ class CustomGeoDataset(GeoDataset):
         self.crs = crs
         self.res = res
 
-    def __getitem__(self, query: BoundingBox) -> Dict[str, Any]:
+    def __getitem__(self, query: BoundingBox) -> Dict[str, BoundingBox]:
         return {"index": query}
 
 
 class CustomVisionDataset(VisionDataset):
-    def __getitem__(self, index: int) -> Dict[str, Any]:
+    def __getitem__(self, index: int) -> Dict[str, int]:
         return {"index": index}
 
     def __len__(self) -> int:

--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -1,6 +1,7 @@
 import builtins
 import glob
 import os
+import pickle
 import shutil
 import sys
 from pathlib import Path
@@ -176,6 +177,12 @@ class TestBoundingBox:
         bbox1 = BoundingBox(0, 1, 0, 1, 0, 1)
         bbox2 = BoundingBox(*test_input)
         assert bbox1.intersects(bbox2) == bbox2.intersects(bbox1) == expected
+
+    def test_picklable(self) -> None:
+        bbox = BoundingBox(0, 1, 2, 3, 4, 5)
+        x = pickle.dumps(bbox)
+        y = pickle.loads(x)
+        assert bbox == y
 
     def test_invalid_x(self) -> None:
         with pytest.raises(

--- a/tests/samplers/test_single.py
+++ b/tests/samplers/test_single.py
@@ -1,11 +1,13 @@
 import math
-from typing import Iterator
+from typing import Dict, Iterator
 
 import pytest
 from _pytest.fixtures import SubRequest
+from rasterio.crs import CRS
 from rtree.index import Index, Property
+from torch.utils.data import DataLoader
 
-from torchgeo.datasets import BoundingBox
+from torchgeo.datasets import BoundingBox, GeoDataset
 from torchgeo.samplers import GeoSampler, GridGeoSampler, RandomGeoSampler
 
 
@@ -21,6 +23,22 @@ class CustomGeoSampler(GeoSampler):
         return 2
 
 
+class CustomGeoDataset(GeoDataset):
+    def __init__(
+        self,
+        bounds: BoundingBox = BoundingBox(0, 1, 2, 3, 4, 5),
+        crs: CRS = CRS.from_epsg(3005),
+        res: float = 1,
+    ) -> None:
+        super().__init__()
+        self.index.insert(0, bounds)
+        self.crs = crs
+        self.res = res
+
+    def __getitem__(self, query: BoundingBox) -> Dict[str, BoundingBox]:
+        return {"index": query}
+
+
 class TestGeoSampler:
     @pytest.fixture(scope="function")
     def sampler(self) -> CustomGeoSampler:
@@ -31,6 +49,15 @@ class TestGeoSampler:
 
     def test_len(self, sampler: CustomGeoSampler) -> None:
         assert len(sampler) == 2
+
+    @pytest.mark.parametrize("num_workers", [0, 1, 2])
+    def test_dataloader(self, sampler: CustomGeoSampler, num_workers: int) -> None:
+        ds = CustomGeoDataset()
+        dl = DataLoader(
+            ds, sampler=sampler, num_workers=num_workers  # type: ignore[arg-type]
+        )
+        for _ in dl:
+            continue
 
     def test_abstract(self) -> None:
         with pytest.raises(TypeError, match="Can't instantiate abstract class"):
@@ -60,6 +87,15 @@ class TestRandomGeoSampler:
 
     def test_len(self, sampler: RandomGeoSampler) -> None:
         assert len(sampler) == sampler.length
+
+    @pytest.mark.parametrize("num_workers", [0, 1, 2])
+    def test_dataloader(self, sampler: RandomGeoSampler, num_workers: int) -> None:
+        ds = CustomGeoDataset()
+        dl = DataLoader(
+            ds, sampler=sampler, num_workers=num_workers  # type: ignore[arg-type]
+        )
+        for _ in dl:
+            continue
 
 
 class TestGridGeoSampler:
@@ -92,3 +128,12 @@ class TestGridGeoSampler:
             assert math.isclose(
                 query.maxt - query.mint, sampler.roi.maxt - sampler.roi.mint
             )
+
+    @pytest.mark.parametrize("num_workers", [0, 1, 2])
+    def test_dataloader(self, sampler: GridGeoSampler, num_workers: int) -> None:
+        ds = CustomGeoDataset()
+        dl = DataLoader(
+            ds, sampler=sampler, num_workers=num_workers  # type: ignore[arg-type]
+        )
+        for _ in dl:
+            continue

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -214,6 +214,14 @@ class BoundingBox(Tuple[float, float, float, float, float, float]):
         self.mint = mint
         self.maxt = maxt
 
+    def __getnewargs__(self) -> Tuple[float, float, float, float, float, float]:
+        """Values passed to the ``__new__()`` method upon unpickling.
+
+        Returns:
+            tuple of bounds
+        """
+        return self.minx, self.maxx, self.miny, self.maxy, self.mint, self.maxt
+
     def __repr__(self) -> str:
         """Return the formal string representation of the object.
 


### PR DESCRIPTION
To use a DataLoader with multiple parallel workers, the index of the dataset must be picklable.

Fixes #89 by implementing `__getnewargs__()` in the `BoundingBox` class.