### PR TITLE
Tests: don't leave behind unwanted files

### DIFF
--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,21 +1,9 @@
-import distutils.sysconfig
-import os
 import subprocess
 import sys
 from pathlib import Path
-from typing import Generator
-
-from _pytest.monkeypatch import MonkeyPatch
 
 
-def test_install(
-    monkeypatch: Generator[MonkeyPatch, None, None], tmp_path: Path
-) -> None:
-    site_packages_dir = distutils.sysconfig.get_python_lib(prefix=str(tmp_path))
-    os.makedirs(site_packages_dir)
-    monkeypatch.setenv(  # type: ignore[attr-defined]
-        "PYTHONPATH", site_packages_dir, prepend=os.pathsep
-    )
+def test_install(tmp_path: Path) -> None:
     subprocess.run(
-        [sys.executable, "setup.py", "install", "--prefix", str(tmp_path)], check=True
+        [sys.executable, "setup.py", "build", "--build-base", str(tmp_path)], check=True
     )

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -78,10 +78,12 @@ def test_overwrite_experiment_dir(tmp_path: Path) -> None:
 
 @pytest.mark.parametrize("task", ["test", "foo"])
 def test_invalid_task(task: str, tmp_path: Path) -> None:
+    output_dir = tmp_path / "output"
     args = [
         sys.executable,
         "train.py",
         "program.experiment_name=test",
+        "program.output_dir=" + str(output_dir),
         "task.name=" + task,
     ]
     ps = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -90,11 +92,13 @@ def test_invalid_task(task: str, tmp_path: Path) -> None:
 
 
 def test_missing_config_file(tmp_path: Path) -> None:
+    output_dir = tmp_path / "output"
     config_file = tmp_path / "config.yaml"
     args = [
         sys.executable,
         "train.py",
         "program.experiment_name=test",
+        "program.output_dir=" + str(output_dir),
         "task.name=test",
         "config_file=" + str(config_file),
     ]


### PR DESCRIPTION
Fixes #87 

Also removes an import of distutils, which will be deprecated in Python 3.10 and removed in Python 3.12. Yay, future compatibility!