### PR TITLE
Adds Extract and Combine Patches Transforms

### DIFF
--- a/torchgeo/transforms/__init__.py
+++ b/torchgeo/transforms/__init__.py
@@ -5,12 +5,19 @@
 
 from .transforms import (
     CombinePatches,
+    ExtractPatches,
     Identity,
     RandomHorizontalFlip,
     RandomVerticalFlip,
 )
 
-__all__ = ("Identity", "RandomHorizontalFlip", "RandomVerticalFlip", "CombinePatches")
+__all__ = (
+    "Identity",
+    "RandomHorizontalFlip",
+    "RandomVerticalFlip",
+    "ExtractPatches",
+    "CombinePatches",
+)
 
 # https://stackoverflow.com/questions/40018681
 for module in __all__:

--- a/torchgeo/transforms/__init__.py
+++ b/torchgeo/transforms/__init__.py
@@ -3,9 +3,14 @@
 
 """TorchGeo transforms."""
 
-from .transforms import Identity, RandomHorizontalFlip, RandomVerticalFlip
+from .transforms import (
+    CombinePatches,
+    Identity,
+    RandomHorizontalFlip,
+    RandomVerticalFlip,
+)
 
-__all__ = ("Identity", "RandomHorizontalFlip", "RandomVerticalFlip")
+__all__ = ("Identity", "RandomHorizontalFlip", "RandomVerticalFlip", "CombinePatches")
 
 # https://stackoverflow.com/questions/40018681
 for module in __all__:

--- a/torchgeo/transforms/transforms.py
+++ b/torchgeo/transforms/transforms.py
@@ -125,20 +125,23 @@ class ExtractPatches(Module):  # type: ignore[misc,name-defined]
             sample["image"] = rearrange(
                 sample["image"],
                 "b c (h ph) (w pw) -> (b h w) c ph pw",
-                ph=self.ph, pw=self.pw
+                ph=self.ph,
+                pw=self.pw,
             )
         if "mask" in sample:
             if sample["mask"].ndim == 4:
                 sample["mask"] = rearrange(
                     sample["mask"],
                     "b c (h ph) (w pw) -> (b h w) c ph pw",
-                    ph=self.ph, pw=self.pw
+                    ph=self.ph,
+                    pw=self.pw,
                 )
             elif sample["mask"].ndim == 3:
                 sample["mask"] = rearrange(
                     sample["mask"],
                     "b (h ph) (w pw) -> (b h w) ph pw",
-                    ph=self.ph, pw=self.pw
+                    ph=self.ph,
+                    pw=self.pw,
                 )
             else:
                 raise ValueError(

--- a/torchgeo/transforms/transforms.py
+++ b/torchgeo/transforms/transforms.py
@@ -124,20 +124,20 @@ class ExtractPatches(Module):  # type: ignore[misc,name-defined]
         if "image" in sample:
             sample["image"] = rearrange(
                 sample["image"],
-                "b c (h ph) (w pw) -> b (h w) c ph pw",
+                "b c (h ph) (w pw) -> (b h w) c ph pw",
                 ph=self.ph, pw=self.pw
             )
         if "mask" in sample:
             if sample["mask"].ndim == 4:
                 sample["mask"] = rearrange(
                     sample["mask"],
-                    "b c (h ph) (w pw) -> b (h w) c ph pw",
+                    "b c (h ph) (w pw) -> (b h w) c ph pw",
                     ph=self.ph, pw=self.pw
                 )
             elif sample["mask"].ndim == 3:
                 sample["mask"] = rearrange(
                     sample["mask"],
-                    "b (h ph) (w pw) -> b (h w) ph pw",
+                    "b (h ph) (w pw) -> (b h w) ph pw",
                     ph=self.ph, pw=self.pw
                 )
             else:

--- a/torchgeo/transforms/transforms.py
+++ b/torchgeo/transforms/transforms.py
@@ -3,9 +3,10 @@
 
 """TorchGeo transforms."""
 
-from typing import Dict
+from typing import Dict, Tuple
 
 import torch
+from einops import rearrange
 from torch import Tensor
 from torch.nn import Module  # type: ignore[attr-defined]
 
@@ -96,4 +97,107 @@ class Identity(Module):  # type: ignore[misc,name-defined]
         Returns:
             the unchanged input
         """
+        return sample
+
+
+class ExtractPatches(Module):  # type: ignore[misc,name-defined]
+    """Extract patches from single image/mask."""
+
+    def __init__(self, patch_size: Tuple[int, int]) -> None:
+        """Initialize a new transform instance.
+
+        Args:
+            patch_size: a tuple of the (height, width) size of patches
+        """
+        super().__init__()
+        self.ph, self.pw = patch_size
+
+    def forward(self, sample: Dict[str, Tensor]) -> Dict[str, Tensor]:
+        """Transform the image from image->patches or mask if they exist.
+
+        Args:
+            sample: the input
+
+        Returns:
+            the patched input
+        """
+        if "image" in sample:
+            sample["image"] = rearrange(
+                sample["image"],
+                "b c (h ph) (w pw) -> b (h w) c ph pw",
+                ph=self.ph, pw=self.pw
+            )
+        if "mask" in sample:
+            if sample["mask"].ndim == 4:
+                sample["mask"] = rearrange(
+                    sample["mask"],
+                    "b c (h ph) (w pw) -> b (h w) c ph pw",
+                    ph=self.ph, pw=self.pw
+                )
+            elif sample["mask"].ndim == 3:
+                sample["mask"] = rearrange(
+                    sample["mask"],
+                    "b (h ph) (w pw) -> b (h w) ph pw",
+                    ph=self.ph, pw=self.pw
+                )
+            else:
+                raise ValueError(
+                    f"Expected 3/4 dimensional mask but got {sample['mask'].ndim}"
+                )
+
+        return sample
+
+
+class CombinePatches(Module):  # type: ignore[misc,name-defined]
+    """Combine patches to single image/mask."""
+
+    def __init__(self, image_size: Tuple[int, int]) -> None:
+        """Initialize a new transform instance.
+
+        Args:
+            image_size: a tuple of the (height, width) of the original image
+        """
+        super().__init__()
+        self.h, self.w = image_size
+
+    def forward(self, sample: Dict[str, Tensor]) -> Dict[str, Tensor]:
+        """Transform the image from patches->image or mask if they exist.
+
+        Args:
+            sample: the input
+
+        Returns:
+            the combined input
+        """
+        if "image" in sample:
+            ph, pw = sample["image"].shape[-2:]
+
+            sample["image"] = rearrange(
+                sample["image"],
+                "(b h w) c ph pw -> b c (h ph) (w pw)",
+                h=self.h // ph,
+                w=self.w // pw,
+            )
+        if "mask" in sample:
+            ph, pw = sample["mask"].shape[-2:]
+
+            if sample["mask"].ndim == 4:
+                sample["mask"] = rearrange(
+                    sample["mask"],
+                    "(b h w) c ph pw -> b c (h ph) (w pw)",
+                    h=self.h // ph,
+                    w=self.w // pw,
+                )
+            elif sample["mask"].ndim == 3:
+                sample["mask"] = rearrange(
+                    sample["mask"],
+                    "(b h w) ph pw -> b (h ph) (w pw)",
+                    h=self.h // ph,
+                    w=self.w // pw,
+                )
+            else:
+                raise ValueError(
+                    f"Expected 3/4 dimensional mask but got {sample['mask'].ndim}"
+                )
+
         return sample


### PR DESCRIPTION
Added `torchgeo.transforms.ExtractPatches` and `torchgeo.transforms.CombinePatches`

Notes:
- See [example colab notebook](https://colab.research.google.com/drive/1-4fVQBhb2GlNfBDUvCBBNnzTCcc4aWY3?usp=sharing) for a visual example on a LEVIR-CD+ image and mask.
- Operates on dicts of batched tensors
- Flattens the number of patches into the batch dimension (b, c, h, w) -> (b * num_patches, c, ph, pw)
- I originally used [kornia.contrib.ExtractTensorPatches](https://kornia.readthedocs.io/en/latest/contrib.html#kornia.contrib.ExtractTensorPatches) but then realized how memory heavy it was so rolled my own using einops.

Usage:

```python
import torch
from torchgeo.transforms import ExtractPatches, CombinePatches

patch_size = (128, 128)
image_size = (1024, 1024)
image = torch.randn(1, 3, 1024, 1024)
mask = torch.ones(1, 1, 1024, 1024)
sample = dict(image=image, mask=mask)

sample_patched = ExtractPatches(patch_size)(sample)
sample_patched["image"].shape # (64, 3, 128, 128)
sample_patched["mask"].shape # (64, 1, 128, 128)

sample_combined = CombinePatches(image_size)(sample_patched)
sample_combined["image"].shape # (1, 3, 1024, 1024)
sample_combined["mask"].shape # (1, 1, 1024, 1024)

```

TODO:
- more unit tests

Closes #113