### PR TITLE
Update Dataset docstrings

### DIFF
--- a/torchgeo/datasets/gid15.py
+++ b/torchgeo/datasets/gid15.py
@@ -23,17 +23,20 @@ class GID15(VisionDataset):
     dataset is a dataset for semantic segmentation.
 
     Dataset features:
+
     * images taken by the Gaofen-2 (GF-2) satellite over 60 cities in China
     * masks representing 15 semantic categories
     * three spectral bands - RGB
     * 150 with 3 m per pixel resolution (6800x7200 px)
 
     Dataset format:
+
     * images are three-channel pngs
     * masks are single-channel pngs
     * colormapped masks are 3 channel tifs
 
     Dataset classes:
+
     1. background
     2. industrial_land
     3. urban_residential
@@ -52,6 +55,7 @@ class GID15(VisionDataset):
     16. pond
 
     If you use this dataset in your research, please cite the following paper:
+
     * https://arxiv.org/abs/1807.05713
     """
 

--- a/torchgeo/datasets/gid15.py
+++ b/torchgeo/datasets/gid15.py
@@ -56,7 +56,7 @@ class GID15(VisionDataset):
 
     If you use this dataset in your research, please cite the following paper:
 
-    * https://arxiv.org/abs/1807.05713
+    * https://doi.org/10.1016/j.rse.2019.111322
     """
 
     url = "https://drive.google.com/file/d/1zbkCEXPEKEV6gq19OKmIbaT8bXXfWW6u"

--- a/torchgeo/datasets/levircd.py
+++ b/torchgeo/datasets/levircd.py
@@ -23,20 +23,24 @@ class LEVIRCDPlus(VisionDataset):
     dataset is a dataset for building change detection.
 
     Dataset features:
+
     * image pairs of 20 different urban regions across Texas between 2002-2020
     * binary change masks representing building change
     * three spectral bands - RGB
     * 985 image pairs with 50 cm per pixel resolution (~1024x1024 px)
 
     Dataset format:
+
     * images are three-channel pngs
     * masks are single-channel pngs where no change = 0, change = 255
 
     Dataset classes:
+
     1. no change
     2. change
 
     If you use this dataset in your research, please cite the following paper:
+
     * https://arxiv.org/abs/2107.09244
     """
 

--- a/torchgeo/datasets/patternnet.py
+++ b/torchgeo/datasets/patternnet.py
@@ -22,14 +22,17 @@ class PatternNet(VisionDataset, ImageFolder):  # type: ignore[misc]
     dataset is a dataset for remote sensing scene classification and image retrieval.
 
     Dataset features:
+
     * 30,400 images with 6-50 cm per pixel resolution (256x256 px)
     * three spectral bands - RGB
     * 38 scene classes, 800 images per class
 
     Dataset format:
+
     * images are three-channel jpgs
 
     Dataset classes:
+
     0. airplane
     1. baseball_field
     2. basketball_court
@@ -70,6 +73,7 @@ class PatternNet(VisionDataset, ImageFolder):  # type: ignore[misc]
     37. wastewater_treatment_plant
 
     If you use this dataset in your research, please cite the following paper:
+
     * https://doi.org/10.1016/j.isprsjprs.2018.01.004
     """
 


### PR DESCRIPTION
After building the docs, I noticed some issues in the docstrings, so this is an update for them. These aren't caught by pydocstyle which is interesting but seems to be more aesthetic.

Datasets changed: GID-15, LEVIR-CD+, and PatternNet.