### PR TITLE
Adding a length property to GridGeoSampler

### DIFF
--- a/torchgeo/samplers/batch.py
+++ b/torchgeo/samplers/batch.py
@@ -12,7 +12,7 @@ from torch.utils.data import Sampler
 
 from torchgeo.datasets import BoundingBox
 
-from .utils import _to_tuple
+from .utils import _to_tuple, get_random_bounding_box
 
 # https://github.com/pytorch/pytorch/issues/60979
 # https://github.com/pytorch/pytorch/pull/61045
@@ -95,16 +95,9 @@ class RandomBatchGeoSampler(BatchGeoSampler):
             # Choose random indices within that tile
             batch = []
             for _ in range(self.batch_size):
-                minx = random.uniform(bounds.minx, bounds.maxx - self.size[1])
-                maxx = minx + self.size[1]
 
-                miny = random.uniform(bounds.miny, bounds.maxy - self.size[0])
-                maxy = miny + self.size[0]
-
-                mint = bounds.mint
-                maxt = bounds.maxt
-
-                batch.append(BoundingBox(minx, maxx, miny, maxy, mint, maxt))
+                bounding_box = get_random_bounding_box(bounds, self.size)
+                batch.append(bounding_box)
 
             yield batch
 

--- a/torchgeo/samplers/batch.py
+++ b/torchgeo/samplers/batch.py
@@ -12,7 +12,7 @@ from torch.utils.data import Sampler
 
 from torchgeo.datasets import BoundingBox
 
-from .utils import get_random_bounding_box
+from .utils import _to_tuple, get_random_bounding_box
 
 # https://github.com/pytorch/pytorch/issues/60979
 # https://github.com/pytorch/pytorch/pull/61045
@@ -73,7 +73,7 @@ class RandomBatchGeoSampler(BatchGeoSampler):
                 (defaults to the bounds of ``index``)
         """
         self.index = index
-        self.size = size
+        self.size = _to_tuple(size)
         self.batch_size = batch_size
         self.length = length
         if roi is None:

--- a/torchgeo/samplers/batch.py
+++ b/torchgeo/samplers/batch.py
@@ -12,7 +12,7 @@ from torch.utils.data import Sampler
 
 from torchgeo.datasets import BoundingBox
 
-from .utils import _to_tuple, get_random_bounding_box
+from .utils import get_random_bounding_box
 
 # https://github.com/pytorch/pytorch/issues/60979
 # https://github.com/pytorch/pytorch/pull/61045
@@ -73,7 +73,7 @@ class RandomBatchGeoSampler(BatchGeoSampler):
                 (defaults to the bounds of ``index``)
         """
         self.index = index
-        self.size = _to_tuple(size)
+        self.size = size
         self.batch_size = batch_size
         self.length = length
         if roi is None:

--- a/torchgeo/samplers/single.py
+++ b/torchgeo/samplers/single.py
@@ -71,7 +71,7 @@ class RandomGeoSampler(GeoSampler):
                 (defaults to the bounds of ``index``)
         """
         self.index = index
-        self.size = size
+        self.size = _to_tuple(size)
         self.length = length
         if roi is None:
             roi = BoundingBox(*index.bounds)

--- a/torchgeo/samplers/single.py
+++ b/torchgeo/samplers/single.py
@@ -71,7 +71,7 @@ class RandomGeoSampler(GeoSampler):
                 (defaults to the bounds of ``index``)
         """
         self.index = index
-        self.size = _to_tuple(size)
+        self.size = size
         self.length = length
         if roi is None:
             roi = BoundingBox(*index.bounds)

--- a/torchgeo/samplers/single.py
+++ b/torchgeo/samplers/single.py
@@ -156,7 +156,15 @@ class GridGeoSampler(GeoSampler):
         if roi is None:
             roi = BoundingBox(*index.bounds)
         self.roi = roi
-        self.hits = index.intersection(roi, objects=True)
+        self.hits = list(index.intersection(roi, objects=True))
+
+        self.length: int = 0
+        for hit in self.hits:
+            bounds = BoundingBox(*hit.bounds)
+
+            rows = int((bounds.maxy - bounds.miny - self.size[0]) // self.stride[0]) + 1
+            cols = int((bounds.maxx - bounds.minx - self.size[1]) // self.stride[1]) + 1
+            self.length += rows * cols
 
     def __iter__(self) -> Iterator[BoundingBox]:
         """Return the index of a dataset.
@@ -185,3 +193,11 @@ class GridGeoSampler(GeoSampler):
                     maxx = minx + self.size[1]
 
                     yield BoundingBox(minx, maxx, miny, maxy, mint, maxt)
+
+    def __len__(self) -> int:
+        """Return the number of samples over the ROI.
+
+        Returns:
+            number of patches that will be sampled
+        """
+        return self.length

--- a/torchgeo/samplers/single.py
+++ b/torchgeo/samplers/single.py
@@ -12,7 +12,7 @@ from torch.utils.data import Sampler
 
 from torchgeo.datasets import BoundingBox
 
-from .utils import _to_tuple
+from .utils import _to_tuple, get_random_bounding_box
 
 # https://github.com/pytorch/pytorch/issues/60979
 # https://github.com/pytorch/pytorch/pull/61045
@@ -90,16 +90,9 @@ class RandomGeoSampler(GeoSampler):
             bounds = BoundingBox(*hit.bounds)
 
             # Choose a random index within that tile
-            minx = random.uniform(bounds.minx, bounds.maxx - self.size[1])
-            maxx = minx + self.size[1]
+            bounding_box = get_random_bounding_box(bounds, self.size)
 
-            miny = random.uniform(bounds.miny, bounds.maxy - self.size[0])
-            maxy = miny + self.size[0]
-
-            mint = bounds.mint
-            maxt = bounds.maxt
-
-            yield BoundingBox(minx, maxx, miny, maxy, mint, maxt)
+            yield bounding_box
 
     def __len__(self) -> int:
         """Return the number of samples in a single epoch.

--- a/torchgeo/samplers/utils.py
+++ b/torchgeo/samplers/utils.py
@@ -29,6 +29,13 @@ def get_random_bounding_box(
 ) -> BoundingBox:
     """Returns a random bounding box within a given bounding box.
 
+    The ``size`` argument can either be:
+
+        * a single ``float`` - in which case the same value is used for the height and
+          width dimension
+        * a ``tuple`` of two floats - in which case, the first *float* is used for the
+          height dimension, and the second *float* for the width dimension
+
     Args:
         bounds: the larger bounding box to sample from
         size: the size of the bounding box to sample

--- a/torchgeo/samplers/utils.py
+++ b/torchgeo/samplers/utils.py
@@ -3,7 +3,10 @@
 
 """Common sampler utilities."""
 
+import random
 from typing import Tuple, Union
+
+from torchgeo.datasets.utils import BoundingBox
 
 
 def _to_tuple(value: Union[Tuple[float, float], float]) -> Tuple[float, float]:
@@ -19,3 +22,29 @@ def _to_tuple(value: Union[Tuple[float, float], float]) -> Tuple[float, float]:
         return (value, value)
     else:
         return value
+
+
+def get_random_bounding_box(
+    bounds: BoundingBox, size: Union[Tuple[float, float], float]
+) -> BoundingBox:
+    """Returns a random bounding box within a given bounding box.
+
+    Args:
+        bounds: the larger bounding box to sample from
+        size: the size of the bounding box to sample
+
+    Returns:
+        randomly sampled bounding box from the extent of the input
+    """
+    t_size: Tuple[float, float] = _to_tuple(size)
+
+    minx = random.uniform(bounds.minx, bounds.maxx - t_size[1])
+    maxx = minx + t_size[1]
+
+    miny = random.uniform(bounds.miny, bounds.maxy - t_size[0])
+    maxy = miny + t_size[0]
+
+    mint = bounds.mint
+    maxt = bounds.maxt
+
+    return BoundingBox(minx, maxx, miny, maxy, mint, maxt)


### PR DESCRIPTION
Two changes in sampler land: 
- Adds a `__len__` to GridGeoSampler
- Factors out the logic for sampling a random bounding box from the extent of another bounding box