### PR TITLE
Adding PadTo transform

### DIFF
--- a/tests/transforms/test_transforms.py
+++ b/tests/transforms/test_transforms.py
@@ -71,14 +71,14 @@ def test_identity(sample: Dict[str, Tensor]) -> None:
 
 
 def test_pad(sample: Dict[str, Tensor]) -> None:
-    tr = transforms.PadTo(size=(4, 5), value=1)
+    tr = transforms.PadTo(size=(4, 5), image_value=1, mask_value=2)
     output = tr(sample)
     expected = {
         "image": torch.tensor(  # type: ignore[attr-defined]
             [[[1, 2, 3, 1, 1], [4, 5, 6, 1, 1], [7, 8, 9, 1, 1], [1, 1, 1, 1, 1]]]
         ),
         "masks": torch.tensor(  # type: ignore[attr-defined]
-            [[0, 0, 1, 1, 1], [0, 1, 1, 1, 1], [1, 1, 1, 1, 1], [1, 1, 1, 1, 1]]
+            [[0, 0, 1, 2, 2], [0, 1, 1, 2, 2], [1, 1, 1, 2, 2], [2, 2, 2, 2, 2]]
         ),
         "boxes": torch.tensor(  # type: ignore[attr-defined]
             [[0, 0, 2, 2], [1, 1, 3, 3]]

--- a/tests/transforms/test_transforms.py
+++ b/tests/transforms/test_transforms.py
@@ -68,3 +68,20 @@ def test_identity(sample: Dict[str, Tensor]) -> None:
     tr = transforms.Identity()
     output = tr(sample)
     assert_matching(output, sample)
+
+
+def test_pad(sample: Dict[str, Tensor]) -> None:
+    tr = transforms.PadTo(size=(4, 5), value=1)
+    output = tr(sample)
+    expected = {
+        "image": torch.tensor(  # type: ignore[attr-defined]
+            [[[1, 2, 3, 1, 1], [4, 5, 6, 1, 1], [7, 8, 9, 1, 1], [1, 1, 1, 1, 1]]]
+        ),
+        "masks": torch.tensor(  # type: ignore[attr-defined]
+            [[0, 0, 1, 1, 1], [0, 1, 1, 1, 1], [1, 1, 1, 1, 1], [1, 1, 1, 1, 1]]
+        ),
+        "boxes": torch.tensor(  # type: ignore[attr-defined]
+            [[0, 0, 2, 2], [1, 1, 3, 3]]
+        ),
+    }
+    assert_matching(output, expected)

--- a/torchgeo/transforms/__init__.py
+++ b/torchgeo/transforms/__init__.py
@@ -3,9 +3,9 @@
 
 """TorchGeo transforms."""
 
-from .transforms import Identity, RandomHorizontalFlip, RandomVerticalFlip
+from .transforms import Identity, PadTo, RandomHorizontalFlip, RandomVerticalFlip
 
-__all__ = ("Identity", "RandomHorizontalFlip", "RandomVerticalFlip")
+__all__ = ("Identity", "PadTo", "RandomHorizontalFlip", "RandomVerticalFlip")
 
 # https://stackoverflow.com/questions/40018681
 for module in __all__:

--- a/torchgeo/transforms/transforms.py
+++ b/torchgeo/transforms/transforms.py
@@ -101,22 +101,37 @@ class Identity(Module):  # type: ignore[misc,name-defined]
 
 
 class PadTo(Module):  # type: ignore[misc,name-defined]
-    """Pads the given sample to a specified size with a constant value."""
+    """Pads the given sample to a specified size."""
 
-    def __init__(self, size: Tuple[int, int], value: Union[int, float]) -> None:
+    def __init__(
+        self,
+        size: Tuple[int, int],
+        image_mode: str = "constant",
+        image_value: Union[int, float] = 0,
+        mask_mode: str = "constant",
+        mask_value: Union[int, float] = 0,
+    ) -> None:
         """Initialize a new transform instance.
 
         Args:
             size: a tuple of ints in the format (height, width) that give the spatial
                 dimensions to pad inputs to
-            value : the constant value to fill with
+            image_mode: the type of padding to perform on the image (valid values
+                are those accepted by torch.nn.functional.pad)
+            image_value: fill value for 'constant' padding applied to the image
+            mask_mode: the type of padding to perform on the mask (valid values
+                are those accepted by torch.nn.functional.pad)
+            mask_value: fill value for 'constant' padding applied to the mask
         """
         super().__init__()
         self.size = size
-        self.value = value
+        self.image_mode = image_mode
+        self.image_value = image_value
+        self.mask_mode = mask_mode
+        self.mask_value = mask_value
 
     def forward(self, sample: Dict[str, Tensor]) -> Dict[str, Tensor]:
-        """Pad the inputs to a desired size with a constant value.
+        """Pad the inputs to a specifized size.
 
         The input will be padded along the bottom of the height dimension and along the
         right of the width dimension.
@@ -138,8 +153,8 @@ class PadTo(Module):  # type: ignore[misc,name-defined]
             sample["image"] = pad(
                 sample["image"],
                 (0, width_pad, 0, height_pad),
-                mode="constant",
-                value=self.value,
+                mode=self.image_mode,
+                value=self.image_value,
             )
 
         if "masks" in sample:
@@ -153,8 +168,8 @@ class PadTo(Module):  # type: ignore[misc,name-defined]
             sample["masks"] = pad(
                 sample["masks"],
                 (0, width_pad, 0, height_pad),
-                mode="constant",
-                value=self.value,
+                mode=self.mask_mode,
+                value=self.mask_value,
             )
 
             sample["masks"] = sample["masks"]


### PR DESCRIPTION
In the ChesapeakeCVPR trainer I'd like to use a GridGeoSampler in the test dataset (so that I can test over all pixels). However, the patches that are sampled by the GridGeoSampler are all different sizes, therefore I need to pad everything (vs. center crop in training) to some fixed larger size so that they can work with a dataloader.