### PR TITLE
Cleaning up ChesapeakeCVPR

### DIFF
--- a/docs/tutorials/getting_started.ipynb
+++ b/docs/tutorials/getting_started.ipynb
@@ -389,7 +389,7 @@
    "source": [
     "for sample in dataloader:\n",
     "    image = sample[\"image\"]\n",
-    "    target = sample[\"masks\"]"
+    "    target = sample[\"mask\"]"
    ]
   }
  ],

--- a/test_chesapeakecvpr_models.py
+++ b/test_chesapeakecvpr_models.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+"""script for testing saved models on different ChesapeakeCVPR dataset splits."""
+
+import argparse
+import csv
+import os
+
+import pytorch_lightning as pl
+
+from torchgeo.trainers import ChesapeakeCVPRDataModule, ChesapeakeCVPRSegmentationTask
+
+STATES = ["de", "md", "va", "wv", "pa", "ny"]
+
+
+def set_up_parser() -> argparse.ArgumentParser:
+    """Set up the argument parser.
+
+    Returns:
+        the argument parser
+    """
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    parser.add_argument(
+        "--input-dir",
+        required=True,
+        type=str,
+        help="directory containing the experiment run directories",
+        metavar="ROOT",
+    )
+    parser.add_argument(
+        "--chesapeakecvpr-root",
+        required=True,
+        type=str,
+        help="directory containing the ChesapeakeCVPR dataset",
+        metavar="ROOT",
+    )
+    parser.add_argument(
+        "--output-fn",
+        default="chesapeakecvpr-results.csv",
+        type=str,
+        help="path to the CSV file to write results",
+        metavar="FILE",
+    )
+
+    return parser
+
+
+def main(args: argparse.Namespace) -> None:
+    """High-level pipeline.
+
+    Args:
+        args: command-line arguments
+    """
+    if os.path.exists(args.output_fn):
+        print(f"The output file {args.output_fn} already exists, exiting...")
+        return
+
+    # Setup the result file
+    fieldnames = [
+        "train-state",
+        "model",
+        "learning-rate",
+        "initialization",
+        "test-state",
+        "acc",
+        "iou",
+    ]
+    with open(args.output_fn, "w") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+
+    # Test loop
+    trainer = pl.Trainer(
+        gpus=1, logger=False, progress_bar_refresh_rate=0, checkpoint_callback=False
+    )
+
+    for experiment_dir in os.listdir(args.input_dir):
+
+        checkpoint_fn = os.path.join(args.input_dir, experiment_dir, "last.ckpt")
+        try:
+
+            model = ChesapeakeCVPRSegmentationTask.load_from_checkpoint(checkpoint_fn)
+            model.freeze()
+            model.eval()
+        except KeyError:
+            print(
+                f"Skipping {experiment_dir} as we are not able to load a valid"
+                + f" ChesapeakeCVPRSegmentationTask from {checkpoint_fn}"
+            )
+            continue
+
+        try:
+            experiment_dir_parts = experiment_dir.split("_")
+            train_state = experiment_dir_parts[0]
+            model_name = experiment_dir_parts[1]
+            learning_rate = experiment_dir_parts[2]
+            initialization = "random" if len(experiment_dir_parts) == 4 else "imagenet"
+        except IndexError:
+            print(
+                f"Skipping {experiment_dir} as the directory name is not in the"
+                + " expected format"
+            )
+            continue
+
+        # Test the loaded model against the test set from all states
+        for state in STATES:
+
+            dm = ChesapeakeCVPRDataModule(
+                args.chesapeakecvpr_root,
+                train_state=f"{state}",
+                batch_size=32,
+                num_workers=8,
+            )
+            results = trainer.test(model=model, datamodule=dm, verbose=False)
+            print(experiment_dir, state, results[0])
+
+            row = {
+                "train-state": train_state,
+                "model": model_name,
+                "learning-rate": learning_rate,
+                "initialization": initialization,
+                "test-state": state,
+                "acc": results[0]["test_Accuracy"],
+                "iou": results[0]["test_IoU"],
+            }
+            with open(args.output_fn, "a") as f:
+                writer = csv.DictWriter(f, fieldnames=fieldnames)
+                writer.writerow(row)
+
+
+if __name__ == "__main__":
+    parser = set_up_parser()
+    args = parser.parse_args()
+
+    main(args)

--- a/tests/datasets/test_cbf.py
+++ b/tests/datasets/test_cbf.py
@@ -66,7 +66,7 @@ class TestCanadianBuildingFootprints:
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
         assert isinstance(x["crs"], CRS)
-        assert isinstance(x["masks"], torch.Tensor)
+        assert isinstance(x["mask"], torch.Tensor)
 
     def test_add(self, dataset: CanadianBuildingFootprints) -> None:
         ds = dataset + dataset
@@ -78,7 +78,7 @@ class TestCanadianBuildingFootprints:
     def test_plot(self, dataset: CanadianBuildingFootprints) -> None:
         query = dataset.bounds
         x = dataset[query]
-        dataset.plot(x["masks"])
+        dataset.plot(x["mask"])
 
     def test_not_downloaded(self, tmp_path: Path) -> None:
         with pytest.raises(RuntimeError, match="Dataset not found or corrupted."):

--- a/tests/datasets/test_cdl.py
+++ b/tests/datasets/test_cdl.py
@@ -49,7 +49,7 @@ class TestCDL:
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
         assert isinstance(x["crs"], CRS)
-        assert isinstance(x["masks"], torch.Tensor)
+        assert isinstance(x["mask"], torch.Tensor)
 
     def test_add(self, dataset: CDL) -> None:
         ds = dataset + dataset
@@ -61,7 +61,7 @@ class TestCDL:
     def test_plot(self, dataset: CDL) -> None:
         query = dataset.bounds
         x = dataset[query]
-        dataset.plot(x["masks"])
+        dataset.plot(x["mask"])
 
     def test_not_downloaded(self, tmp_path: Path) -> None:
         with pytest.raises(RuntimeError, match="Dataset not found or corrupted."):

--- a/tests/datasets/test_chesapeake.py
+++ b/tests/datasets/test_chesapeake.py
@@ -48,7 +48,7 @@ class TestChesapeake13:
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
         assert isinstance(x["crs"], CRS)
-        assert isinstance(x["masks"], torch.Tensor)
+        assert isinstance(x["mask"], torch.Tensor)
 
     def test_add(self, dataset: Chesapeake13) -> None:
         ds = dataset + dataset
@@ -60,7 +60,7 @@ class TestChesapeake13:
     def test_plot(self, dataset: Chesapeake13) -> None:
         query = dataset.bounds
         x = dataset[query]
-        dataset.plot(x["masks"])
+        dataset.plot(x["mask"])
 
     def test_url(self) -> None:
         ds = Chesapeake13(os.path.join("tests", "data", "chesapeake", "BAYWIDE"))

--- a/tests/transforms/test_transforms.py
+++ b/tests/transforms/test_transforms.py
@@ -16,7 +16,7 @@ def sample() -> Dict[str, Tensor]:
         "image": torch.tensor(  # type: ignore[attr-defined]
             [[[1, 2, 3], [4, 5, 6], [7, 8, 9]]]
         ),
-        "masks": torch.tensor(  # type: ignore[attr-defined]
+        "mask": torch.tensor(  # type: ignore[attr-defined]
             [[0, 0, 1], [0, 1, 1], [1, 1, 1]]
         ),
         "boxes": torch.tensor(  # type: ignore[attr-defined]
@@ -37,7 +37,7 @@ def test_random_horizontal_flip(sample: Dict[str, Tensor]) -> None:
         "image": torch.tensor(  # type: ignore[attr-defined]
             [[[3, 2, 1], [6, 5, 4], [9, 8, 7]]]
         ),
-        "masks": torch.tensor(  # type: ignore[attr-defined]
+        "mask": torch.tensor(  # type: ignore[attr-defined]
             [[1, 0, 0], [1, 1, 0], [1, 1, 1]]
         ),
         "boxes": torch.tensor(  # type: ignore[attr-defined]
@@ -54,7 +54,7 @@ def test_random_vertical_flip(sample: Dict[str, Tensor]) -> None:
         "image": torch.tensor(  # type: ignore[attr-defined]
             [[[7, 8, 9], [4, 5, 6], [1, 2, 3]]]
         ),
-        "masks": torch.tensor(  # type: ignore[attr-defined]
+        "mask": torch.tensor(  # type: ignore[attr-defined]
             [[1, 1, 1], [0, 1, 1], [0, 0, 1]]
         ),
         "boxes": torch.tensor(  # type: ignore[attr-defined]

--- a/torchgeo/datasets/chesapeake.py
+++ b/torchgeo/datasets/chesapeake.py
@@ -312,6 +312,28 @@ class ChesapeakeCVPR(GeoDataset):
         + [f"{state}-test" for state in states]
     )
 
+    files = [
+        "de_1m_2013_extended-debuffered-test_tiles",
+        "de_1m_2013_extended-debuffered-train_tiles",
+        "de_1m_2013_extended-debuffered-val_tiles",
+        "md_1m_2013_extended-debuffered-test_tiles",
+        "md_1m_2013_extended-debuffered-train_tiles",
+        "md_1m_2013_extended-debuffered-val_tiles",
+        "ny_1m_2013_extended-debuffered-test_tiles",
+        "ny_1m_2013_extended-debuffered-train_tiles",
+        "ny_1m_2013_extended-debuffered-val_tiles",
+        "pa_1m_2013_extended-debuffered-test_tiles",
+        "pa_1m_2013_extended-debuffered-train_tiles",
+        "pa_1m_2013_extended-debuffered-val_tiles",
+        "va_1m_2014_extended-debuffered-test_tiles",
+        "va_1m_2014_extended-debuffered-train_tiles",
+        "va_1m_2014_extended-debuffered-val_tiles",
+        "wv_1m_2014_extended-debuffered-test_tiles",
+        "wv_1m_2014_extended-debuffered-train_tiles",
+        "wv_1m_2014_extended-debuffered-val_tiles",
+        "spatial_index.geojson",
+    ]
+
     p_src_crs = pyproj.CRS("epsg:3857")
     p_transformers = {
         "epsg:26917": pyproj.Transformer.from_crs(
@@ -359,7 +381,7 @@ class ChesapeakeCVPR(GeoDataset):
         self.cache = cache
         self.checksum = checksum
 
-        if download:
+        if download and not self._check_structure():
             self._download()
 
         if checksum:
@@ -474,10 +496,10 @@ class ChesapeakeCVPR(GeoDataset):
         return sample
 
     def _check_integrity(self) -> bool:
-        """Check integrity of dataset.
+        """Check integrity of the dataset archive.
 
         Returns:
-            True if dataset files are found and/or MD5s match, else False
+            True if dataset archive is found and/or MD5s match, else False
         """
         integrity: bool = check_integrity(
             os.path.join(self.root, self.filename),
@@ -485,6 +507,18 @@ class ChesapeakeCVPR(GeoDataset):
         )
 
         return integrity
+
+    def _check_structure(self) -> bool:
+        """Checks to see if the dataset files exist in the root directory.
+
+        Returns:
+            True if the dataset files are found, else False
+        """
+        dataset_files = os.listdir(self.root)
+        for file in self.files:
+            if file not in dataset_files:
+                return False
+        return True
 
     def _download(self) -> None:
         """Download the dataset and extract it."""

--- a/torchgeo/datasets/chesapeake.py
+++ b/torchgeo/datasets/chesapeake.py
@@ -291,7 +291,7 @@ class ChesapeakeCVPR(GeoDataset):
 
     url = "https://lilablobssc.blob.core.windows.net/lcmcvpr2019/cvpr_chesapeake_landcover.zip"  # noqa: E501
     filename = "cvpr_chesapeake_landcover.zip"
-    md5 = "54222dde0b911464db19c83b266e473c"
+    md5 = "1225ccbb9590e9396875f221e5031514"
 
     crs = CRS.from_epsg(3857)
     res = 1

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -290,7 +290,7 @@ class RasterDataset(GeoDataset):
         else:
             data = self._merge_files(filepaths, query)
 
-        key = "image" if self.is_image else "masks"
+        key = "image" if self.is_image else "mask"
         sample = {
             key: data,
             "crs": self.crs,
@@ -514,7 +514,7 @@ class VectorDataset(GeoDataset):
         )
 
         sample = {
-            "masks": torch.tensor(masks),  # type: ignore[attr-defined]
+            "mask": torch.tensor(masks),  # type: ignore[attr-defined]
             "crs": self.crs,
             "bbox": query,
         }

--- a/torchgeo/trainers/chesapeake.py
+++ b/torchgeo/trainers/chesapeake.py
@@ -94,10 +94,12 @@ class ChesapeakeCVPRSegmentationTask(LightningModule):
 
         self.config_task()
 
-        self.train_metrics = MetricCollection([
-            Accuracy(num_classes=7, ignore_index=6),
-            IoU(num_classes=7, ignore_index=6)
-        ])
+        self.train_metrics = MetricCollection(
+            [
+                Accuracy(num_classes=7, ignore_index=6),
+                IoU(num_classes=7, ignore_index=6),
+            ]
+        )
         self.val_metrics = self.train_metrics.clone(prefix="val_")
         self.test_metrics = self.train_metrics.clone(prefix="test_")
 

--- a/torchgeo/trainers/chesapeake.py
+++ b/torchgeo/trainers/chesapeake.py
@@ -340,8 +340,6 @@ class ChesapeakeCVPRDataModule(LightningDataModule):
             _, height, width = sample["image"].shape
             assert height >= size and width >= size
 
-            _, height, width = sample["image"].shape
-
             y1 = (height - size) // 2
             x1 = (width - size) // 2
             sample["image"] = sample["image"][:, y1 : y1 + size, x1 : x1 + size]

--- a/torchgeo/trainers/chesapeake.py
+++ b/torchgeo/trainers/chesapeake.py
@@ -3,7 +3,7 @@
 
 """Trainers for the Chesapeake datasets."""
 
-from typing import Any, Dict, Optional, cast
+from typing import Any, Dict, Optional, cast, Callable
 
 import matplotlib
 import matplotlib.pyplot as plt
@@ -11,6 +11,7 @@ import numpy as np
 import segmentation_models_pytorch as smp
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 from pytorch_lightning.core.datamodule import LightningDataModule
 from pytorch_lightning.core.lightning import LightningModule
 from torch import Tensor
@@ -19,9 +20,10 @@ from torch.optim.lr_scheduler import ReduceLROnPlateau
 from torch.utils.data import DataLoader
 from torch.utils.tensorboard import SummaryWriter  # type: ignore[attr-defined]
 from torchmetrics import Accuracy, IoU
+from torchvision.transforms import Compose
 
 from ..datasets import Chesapeake7, ChesapeakeCVPR
-from ..samplers import RandomBatchGeoSampler
+from ..samplers import RandomBatchGeoSampler, GridGeoSampler
 
 # https://github.com/pytorch/pytorch/issues/60979
 # https://github.com/pytorch/pytorch/pull/61045
@@ -275,6 +277,7 @@ class ChesapeakeCVPRDataModule(LightningDataModule):
         root_dir: str,
         train_state: str,
         patches_per_tile: int = 200,
+        patch_size: int = 256,
         batch_size: int = 64,
         num_workers: int = 4,
         **kwargs: Any,
@@ -286,6 +289,8 @@ class ChesapeakeCVPRDataModule(LightningDataModule):
                 classes
             train_state: The state code to use to train the model, e.g. "ny"
             patches_per_tile: The number of patches per tile to sample
+            patch_size: The size of each patch in pixels (test patches will be 1.5 times
+                this size)
             batch_size: The batch size to use in all created DataLoaders
             num_workers: The number of workers to use in all created DataLoaders
         """
@@ -296,46 +301,65 @@ class ChesapeakeCVPRDataModule(LightningDataModule):
         self.train_state = train_state
         self.layers = ["naip-new", "lc"]
         self.patches_per_tile = patches_per_tile
-        self.original_patch_size = 500
+        self.patch_size = patch_size
+        # This is a rough estimate of how large of a patch we will need to sample in
+        # EPSG:3857 in order to garuntee a large enough patch in the local CRS.
+        self.original_patch_size = int(patch_size * 1.5)
         self.batch_size = batch_size
         self.num_workers = num_workers
 
-    def custom_transform(
-        self, sample: Dict[str, Any], patch_size: int = 256
+    def pad_to(
+        self, size: int = 512, image_value: int = 0, mask_value: int = 0
+    ) -> Callable[[Dict[str, Tensor]], Dict[str, Tensor]]:
+        """Returns a function to perform a padding transform on a single sample."""
+
+        def pad_inner(sample: Dict[str, Tensor]) -> Dict[str, Tensor]:
+            _, height, width = sample["image"].shape
+            assert height <= size and width <= size
+
+            height_pad = size - height
+            width_pad = size - width
+
+            # See https://pytorch.org/docs/stable/generated/torch.nn.functional.pad.html
+            # for a description of the format of the padding tuple
+            sample["image"] = F.pad(
+                sample["image"],
+                (0, width_pad, 0, height_pad),
+                mode="constant",
+                value=image_value,
+            )
+            sample["mask"] = F.pad(
+                sample["mask"],
+                (0, width_pad, 0, height_pad),
+                mode="constant",
+                value=mask_value,
+            )
+            return sample
+        return pad_inner
+
+    def center_crop(
+        self, size: int = 512
+    ) -> Callable[[Dict[str, Tensor]], Dict[str, Tensor]]:
+        """Returns a function to perform a center crop transform on a single sample."""
+
+        def center_crop_inner(sample: Dict[str, Tensor]) -> Dict[str, Tensor]:
+            _, height, width = sample["image"].shape
+            assert height >= size and width >= size
+
+            _, height, width = sample["image"].shape
+
+            y1 = (height - size) // 2
+            x1 = (width - size) // 2
+            sample["image"] = sample["image"][:, y1 : y1 + size, x1 : x1 + size]
+            sample["mask"] = sample["mask"][:, y1 : y1 + size, x1 : x1 + size]
+
+            return sample
+        return center_crop_inner
+
+    def preprocess(
+        self, sample: Dict[str, Any]
     ) -> Dict[str, Any]:
-        """Transform a single sample from the Dataset.
-
-        Args:
-            sample: a single sample from the Dataset
-            patch_size: size of center cropped patch to return
-
-        Returns:
-            a transformed sample
-        """
-        # Center crop
-        num_image_channels, height, width = sample["image"].shape
-        num_mask_channels = sample["mask"].shape[0]
-
-        # If we somehow sample a patch that is smaller than the `patch_size` we want to
-        # sample, then we create a nodata patch instead
-        if height < patch_size or width < patch_size:
-            height, width = patch_size, patch_size
-            sample["image"] = torch.zeros(  # type: ignore[attr-defined]
-                (num_image_channels, patch_size, patch_size)
-            )
-            sample["mask"] = (
-                torch.zeros(  # type: ignore[attr-defined]
-                    (num_mask_channels, patch_size, patch_size)
-                )
-                + 7
-            )
-
-        y1 = (height - patch_size) // 2
-        x1 = (width - patch_size) // 2
-        sample["image"] = sample["image"][:, y1 : y1 + patch_size, x1 : x1 + patch_size]
-        sample["mask"] = sample["mask"][:, y1 : y1 + patch_size, x1 : x1 + patch_size]
-        sample["mask"] = sample["mask"].squeeze()
-
+        """Preprocesses a single sample."""
         sample["image"] = sample["image"] / 255.0
         sample["mask"] = sample["mask"] - 1
 
@@ -345,13 +369,18 @@ class ChesapeakeCVPRDataModule(LightningDataModule):
         return sample
 
     def prepare_data(self) -> None:
-        """Initialize the main ``Dataset`` objects for use in :func:`setup`.
+        """Confirms that the dataset is downloaded on the local node.
 
-        This includes optionally downloading the dataset. This is done once per node,
-        while :func:`setup` is done once per GPU.
+        This method is called once per node, while :func:`setup` is called once per GPU.
         """
-        pass  # TODO: do a light check to see if the dataset exists and download it if
-        # it doesn't exist
+        ChesapeakeCVPR(
+            self.root_dir,
+            split=f"{self.train_state}-train",
+            layers=self.layers,
+            transforms=None,
+            download=True,
+            checksum=False,
+        )
 
     def setup(self, stage: Optional[str] = None) -> None:
         """Create the train/val/test splits based on the original Dataset objects.
@@ -359,11 +388,24 @@ class ChesapeakeCVPRDataModule(LightningDataModule):
         The splits should be done here vs. in :func:`__init__` per the docs:
         https://pytorch-lightning.readthedocs.io/en/latest/extensions/datamodules.html#setup.
         """
+        train_transforms = Compose([
+            self.center_crop(self.patch_size),
+            self.preprocess
+        ])
+        val_transforms = Compose([
+            self.center_crop(self.patch_size),
+            self.preprocess
+        ])
+        test_transforms = Compose([
+            self.pad_to(self.original_patch_size, image_value=0, mask_value=7),
+            self.preprocess
+        ])
+
         self.train_dataset = ChesapeakeCVPR(
             self.root_dir,
             split=f"{self.train_state}-train",
             layers=self.layers,
-            transforms=self.custom_transform,
+            transforms=train_transforms,
             download=False,
             checksum=False,
         )
@@ -371,7 +413,7 @@ class ChesapeakeCVPRDataModule(LightningDataModule):
             self.root_dir,
             split=f"{self.train_state}-val",
             layers=self.layers,
-            transforms=self.custom_transform,
+            transforms=val_transforms,
             download=False,
             checksum=False,
         )
@@ -379,7 +421,7 @@ class ChesapeakeCVPRDataModule(LightningDataModule):
             self.root_dir,
             split=f"{self.train_state}-test",
             layers=self.layers,
-            transforms=self.custom_transform,
+            transforms=test_transforms,
             download=False,
             checksum=False,
         )
@@ -390,7 +432,7 @@ class ChesapeakeCVPRDataModule(LightningDataModule):
             self.train_dataset.index,
             size=self.original_patch_size,
             batch_size=self.batch_size,
-            length=self.patches_per_tile * 100,
+            length=self.patches_per_tile * self.train_dataset.index.get_size(),
         )
         return DataLoader(
             self.train_dataset,
@@ -404,7 +446,7 @@ class ChesapeakeCVPRDataModule(LightningDataModule):
             self.val_dataset.index,
             size=self.original_patch_size,
             batch_size=self.batch_size,
-            length=self.patches_per_tile * 5,
+            length=self.patches_per_tile * self.val_dataset.index.get_size(),
         )
         return DataLoader(
             self.val_dataset,
@@ -414,14 +456,14 @@ class ChesapeakeCVPRDataModule(LightningDataModule):
 
     def test_dataloader(self) -> DataLoader[Any]:
         """Return a DataLoader for testing."""
-        sampler = RandomBatchGeoSampler(
+        sampler = GridGeoSampler(
             self.test_dataset.index,
             size=self.original_patch_size,
-            batch_size=self.batch_size,
-            length=self.patches_per_tile * 20,
+            stride=self.original_patch_size,
         )
         return DataLoader(
             self.test_dataset,
-            batch_sampler=sampler,  # type: ignore[arg-type]
-            num_workers=self.num_workers,
+            batch_size=self.batch_size,
+            sampler=sampler,   # type: ignore[arg-type]
+            num_workers=self.num_workers
         )

--- a/torchgeo/transforms/transforms.py
+++ b/torchgeo/transforms/transforms.py
@@ -43,8 +43,8 @@ class RandomHorizontalFlip(Module):  # type: ignore[misc,name-defined]
                     height, width = sample["image"].shape[-2:]
                     sample["boxes"][:, [0, 2]] = width - sample["boxes"][:, [2, 0]]
 
-            if "masks" in sample:
-                sample["masks"] = sample["masks"].flip(-1)
+            if "mask" in sample:
+                sample["mask"] = sample["mask"].flip(-1)
 
         return sample
 
@@ -78,8 +78,8 @@ class RandomVerticalFlip(Module):  # type: ignore[misc,name-defined]
                     height, width = sample["image"].shape[-2:]
                     sample["boxes"][:, [1, 3]] = height - sample["boxes"][:, [3, 1]]
 
-            if "masks" in sample:
-                sample["masks"] = sample["masks"].flip(-2)
+            if "mask" in sample:
+                sample["mask"] = sample["mask"].flip(-2)
 
         return sample
 

--- a/train.py
+++ b/train.py
@@ -26,7 +26,6 @@ from torchgeo.trainers import (
     SEN12MSSegmentationTask,
 )
 
-
 TASK_TO_MODULES_MAPPING: Dict[
     str, Tuple[Type[pl.LightningModule], Type[pl.LightningDataModule]]
 ] = {

--- a/train.py
+++ b/train.py
@@ -26,16 +26,6 @@ from torchgeo.trainers import (
     SEN12MSSegmentationTask,
 )
 
-# Taken from https://github.com/pangeo-data/cog-best-practices
-_rasterio_best_practices = {
-    "GDAL_DISABLE_READDIR_ON_OPEN": "EMPTY_DIR",
-    "AWS_NO_SIGN_REQUEST": "YES",
-    "GDAL_MAX_RAW_BLOCK_CACHE_SIZE": "200000000",
-    "GDAL_SWATH_SIZE": "200000000",
-    "VSI_CURL_CACHE_SIZE": "200000000",
-}
-os.environ.update(_rasterio_best_practices)
-
 
 TASK_TO_MODULES_MAPPING: Dict[
     str, Tuple[Type[pl.LightningModule], Type[pl.LightningDataModule]]
@@ -184,6 +174,16 @@ def main(conf: DictConfig) -> None:
 
 
 if __name__ == "__main__":
+    # Taken from https://github.com/pangeo-data/cog-best-practices
+    _rasterio_best_practices = {
+        "GDAL_DISABLE_READDIR_ON_OPEN": "EMPTY_DIR",
+        "AWS_NO_SIGN_REQUEST": "YES",
+        "GDAL_MAX_RAW_BLOCK_CACHE_SIZE": "200000000",
+        "GDAL_SWATH_SIZE": "200000000",
+        "VSI_CURL_CACHE_SIZE": "200000000",
+    }
+    os.environ.update(_rasterio_best_practices)
+
     conf = set_up_omegaconf()
 
     # Set random seed for reproducibility

--- a/train.py
+++ b/train.py
@@ -26,6 +26,17 @@ from torchgeo.trainers import (
     SEN12MSSegmentationTask,
 )
 
+# Taken from https://github.com/pangeo-data/cog-best-practices
+_rasterio_best_practices = {
+    "GDAL_DISABLE_READDIR_ON_OPEN": "EMPTY_DIR",
+    "AWS_NO_SIGN_REQUEST": "YES",
+    "GDAL_MAX_RAW_BLOCK_CACHE_SIZE": "200000000",
+    "GDAL_SWATH_SIZE": "200000000",
+    "VSI_CURL_CACHE_SIZE": "200000000",
+}
+os.environ.update(_rasterio_best_practices)
+
+
 TASK_TO_MODULES_MAPPING: Dict[
     str, Tuple[Type[pl.LightningModule], Type[pl.LightningDataModule]]
 ] = {


### PR DESCRIPTION
Working on several things explicit to ChesapeakeCVPR for paper benchmarking purposes:
- [x] Changing the test dataset / dataloader to use GridGeoSampler
- [x] Cleaning up transforms to serve as a template for how other transform pipelines can be setup
- [x] Changing the way I log metrics per Isaac's recommendation
- [x] Implementing a test script (similar to benchmark.py) for running a trained model over other states