### PR TITLE
Proposal: better handling of partial timestamps

### DIFF
--- a/tests/datasets/test_cdl.py
+++ b/tests/datasets/test_cdl.py
@@ -3,6 +3,7 @@
 
 import os
 import shutil
+from datetime import datetime
 from pathlib import Path
 from typing import Generator
 
@@ -54,6 +55,12 @@ class TestCDL:
     def test_add(self, dataset: CDL) -> None:
         ds = dataset + dataset
         assert isinstance(ds, ZipDataset)
+
+    def test_full_year(self, dataset: CDL) -> None:
+        bbox = dataset.bounds
+        time = datetime(2021, 6, 1).timestamp()
+        query = BoundingBox(bbox.minx, bbox.maxx, bbox.miny, bbox.maxy, time, time)
+        next(dataset.index.intersection(query))
 
     def test_already_downloaded(self, dataset: CDL) -> None:
         CDL(root=dataset.root, download=True)

--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -3,10 +3,12 @@
 
 import builtins
 import glob
+import math
 import os
 import pickle
 import shutil
 import sys
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Generator, Tuple
 
@@ -19,6 +21,7 @@ import torchgeo.datasets.utils
 from torchgeo.datasets.utils import (
     BoundingBox,
     collate_dict,
+    disambiguate_timestamp,
     download_and_extract_archive,
     download_radiant_mlhub,
     extract_archive,
@@ -204,6 +207,62 @@ class TestBoundingBox:
             ValueError, match="Bounding box is invalid: 'mint=5' > 'maxt=4'"
         ):
             BoundingBox(0, 1, 2, 3, 5, 4)
+
+
+@pytest.mark.parametrize(
+    "date_string,format,min_datetime,max_datetime",
+    [
+        ("", "", datetime(1970, 1, 1).timestamp(), datetime.max.timestamp()),
+        (
+            "2021",
+            "%Y",
+            datetime(2021, 1, 1, 0, 0, 0, 0).timestamp(),
+            datetime(2021, 12, 31, 23, 59, 59, 999999).timestamp(),
+        ),
+        (
+            "2021-09",
+            "%Y-%m",
+            datetime(2021, 9, 1, 0, 0, 0, 0).timestamp(),
+            datetime(2021, 9, 30, 23, 59, 59, 999999).timestamp(),
+        ),
+        (
+            "2021-09-13",
+            "%Y-%m-%d",
+            datetime(2021, 9, 13, 0, 0, 0, 0).timestamp(),
+            datetime(2021, 9, 13, 23, 59, 59, 999999).timestamp(),
+        ),
+        (
+            "2021-09-13 17",
+            "%Y-%m-%d %H",
+            datetime(2021, 9, 13, 17, 0, 0, 0).timestamp(),
+            datetime(2021, 9, 13, 17, 59, 59, 999999).timestamp(),
+        ),
+        (
+            "2021-09-13 17:21",
+            "%Y-%m-%d %H:%M",
+            datetime(2021, 9, 13, 17, 21, 0, 0).timestamp(),
+            datetime(2021, 9, 13, 17, 21, 59, 999999).timestamp(),
+        ),
+        (
+            "2021-09-13 17:21:53",
+            "%Y-%m-%d %H:%M:%S",
+            datetime(2021, 9, 13, 17, 21, 53, 0).timestamp(),
+            datetime(2021, 9, 13, 17, 21, 53, 999999).timestamp(),
+        ),
+        (
+            "2021-09-13 17:21:53:000123",
+            "%Y-%m-%d %H:%M:%S:%f",
+            datetime(2021, 9, 13, 17, 21, 53, 123).timestamp(),
+            datetime(2021, 9, 13, 17, 21, 53, 123).timestamp(),
+        ),
+    ],
+)
+def test_disambiguate_timestamp(
+    date_string: str, format: str, min_datetime: float, max_datetime: float
+) -> None:
+    mint, maxt = disambiguate_timestamp(date_string, format)
+    assert math.isclose(mint, min_datetime)
+    assert math.isclose(maxt, max_datetime)
 
 
 def test_collate_dict() -> None:

--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -212,7 +212,7 @@ class TestBoundingBox:
 @pytest.mark.parametrize(
     "date_string,format,min_datetime,max_datetime",
     [
-        ("", "", datetime(1970, 1, 1).timestamp(), datetime.max.timestamp()),
+        ("", "", 0, datetime.max.timestamp()),
         (
             "2021",
             "%Y",

--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -212,7 +212,7 @@ class TestBoundingBox:
 @pytest.mark.parametrize(
     "date_string,format,min_datetime,max_datetime",
     [
-        ("", "", 0, datetime.max.timestamp()),
+        ("", "", 0, sys.maxsize),
         (
             "2021",
             "%Y",

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -231,7 +231,15 @@ class RasterDataset(GeoDataset):
                     if "date" in match.groupdict():
                         date = match.group("date")
                         time = datetime.strptime(date, self.date_format)
-                        mint = maxt = time.timestamp()
+                        mint = time.timestamp()
+
+                        # If filename only contains the year (e.g. CDL),
+                        # assume that this data point spans the entire year
+                        if self.date_format in ["%Y", "%y"]:
+                            time = datetime(time.year, 12, 31, 23, 59, 59)
+                            maxt = time.timestamp()
+                        else:
+                            maxt = mint
 
                     coords = (minx, maxx, miny, maxy, mint, maxt)
                     self.index.insert(i, coords, filepath)

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -9,7 +9,7 @@ import glob
 import math
 import os
 import re
-from datetime import datetime
+import sys
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, cast
 
 import fiona
@@ -226,7 +226,7 @@ class RasterDataset(GeoDataset):
                     continue
                 else:
                     mint = 0.0
-                    maxt = datetime.max.timestamp()
+                    maxt = sys.maxsize
                     if "date" in match.groupdict():
                         date = match.group("date")
                         mint, maxt = disambiguate_timestamp(date, self.date_format)
@@ -450,7 +450,7 @@ class VectorDataset(GeoDataset):
                 continue
             else:
                 mint = 0
-                maxt = datetime.max.timestamp()
+                maxt = sys.maxsize
                 coords = (minx, maxx, miny, maxy, mint, maxt)
                 self.index.insert(i, coords, filepath)
                 i += 1

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -225,8 +225,8 @@ class RasterDataset(GeoDataset):
                     # Skip files that rasterio is unable to read
                     continue
                 else:
-                    mint = 0.0
-                    maxt = sys.maxsize
+                    mint: float = 0
+                    maxt: float = sys.maxsize
                     if "date" in match.groupdict():
                         date = match.group("date")
                         mint, maxt = disambiguate_timestamp(date, self.date_format)

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -225,7 +225,7 @@ class RasterDataset(GeoDataset):
                     # Skip files that rasterio is unable to read
                     continue
                 else:
-                    mint = datetime(1970, 1, 1).timestamp()
+                    mint = 0.0
                     maxt = datetime.max.timestamp()
                     if "date" in match.groupdict():
                         date = match.group("date")
@@ -449,7 +449,7 @@ class VectorDataset(GeoDataset):
                 # Skip files that fiona is unable to read
                 continue
             else:
-                mint = datetime(1970, 1, 1).timestamp()
+                mint = 0
                 maxt = datetime.max.timestamp()
                 coords = (minx, maxx, miny, maxy, mint, maxt)
                 self.index.insert(i, coords, filepath)

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -225,8 +225,8 @@ class RasterDataset(GeoDataset):
                     # Skip files that rasterio is unable to read
                     continue
                 else:
-                    mint: float = datetime.min.timestamp()
-                    maxt: float = datetime.max.timestamp()
+                    mint = datetime(1970, 1, 1).timestamp()
+                    maxt = datetime.max.timestamp()
                     if "date" in match.groupdict():
                         date = match.group("date")
                         mint, maxt = disambiguate_timestamp(date, self.date_format)
@@ -449,7 +449,7 @@ class VectorDataset(GeoDataset):
                 # Skip files that fiona is unable to read
                 continue
             else:
-                mint = datetime.min.timestamp()
+                mint = datetime(1970, 1, 1).timestamp()
                 maxt = datetime.max.timestamp()
                 coords = (minx, maxx, miny, maxy, mint, maxt)
                 self.index.insert(i, coords, filepath)

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -279,8 +279,7 @@ def disambiguate_timestamp(date_str: str, format: str) -> Tuple[float, float]:
 
     if not any([f"%{c}" in format for c in "yYcxG"]):
         # No temporal info
-        mint = datetime(1970, 1, 1)
-        maxt = datetime.max
+        return 0, datetime.max.timestamp()
     elif not any([f"%{c}" in format for c in "bBmjUWcxV"]):
         # Year resolution
         maxt = datetime(mint.year, 12, 31, 23, 59, 59, 999999)

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -10,6 +10,7 @@ import lzma
 import os
 import tarfile
 import zipfile
+from calendar import monthrange
 from datetime import datetime
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
@@ -276,28 +277,29 @@ def disambiguate_timestamp(date_str: str, format: str) -> Tuple[float, float]:
 
     # TODO: This is really tedious, is there a better way to do this?
 
-    if not any([f"{c}%" in format for c in "yYcxG"]):
+    if not any([f"%{c}" in format for c in "yYcxG"]):
         # No temporal info
-        mint = datetime.min
+        mint = datetime(1970, 1, 1)
         maxt = datetime.max
-    elif not any([f"{c}%" in format for c in "bBmjUWcxV"]):
+    elif not any([f"%{c}" in format for c in "bBmjUWcxV"]):
         # Year resolution
         maxt = datetime(mint.year, 12, 31, 23, 59, 59, 999999)
-    elif not any([f"{c}%" in format for c in "djcx"]):
+    elif not any([f"%{c}" in format for c in "djcx"]):
         # Month resolution
-        maxt = datetime(mint.year, mint.month, 31, 23, 59, 59, 999999)
-    elif not any([f"{c}%" in format for c in "HIcX"]):
+        maxday = monthrange(mint.year, mint.month)[1]
+        maxt = datetime(mint.year, mint.month, maxday, 23, 59, 59, 999999)
+    elif not any([f"%{c}" in format for c in "HIcX"]):
         # Day resolution
         maxt = datetime(mint.year, mint.month, mint.day, 23, 59, 59, 999999)
-    elif not any([f"{c}%" in format for c in "McX"]):
+    elif not any([f"%{c}" in format for c in "McX"]):
         # Hour resolution
         maxt = datetime(mint.year, mint.month, mint.day, mint.hour, 59, 59, 999999)
-    elif not any([f"{c}%" in format for c in "ScX"]):
+    elif not any([f"%{c}" in format for c in "ScX"]):
         # Minute resolution
         maxt = datetime(
             mint.year, mint.month, mint.day, mint.hour, mint.minute, 59, 999999
         )
-    elif not any([f"{c}%" in format for c in "f"]):
+    elif not any([f"%{c}" in format for c in "f"]):
         # Second resolution
         maxt = datetime(
             mint.year, mint.month, mint.day, mint.hour, mint.minute, mint.second, 999999

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -8,6 +8,7 @@ import contextlib
 import gzip
 import lzma
 import os
+import sys
 import tarfile
 import zipfile
 from calendar import monthrange
@@ -279,7 +280,7 @@ def disambiguate_timestamp(date_str: str, format: str) -> Tuple[float, float]:
 
     if not any([f"%{c}" in format for c in "yYcxG"]):
         # No temporal info
-        return 0, datetime.max.timestamp()
+        return 0, sys.maxsize
     elif not any([f"%{c}" in format for c in "bBmjUWcxV"]):
         # Year resolution
         maxt = datetime(mint.year, 12, 31, 23, 59, 59, 999999)


### PR DESCRIPTION
In #115, @calebrob6 noted that there is rarely intersection between the CDL dataset and any other dataset due to the way that indexing works for partial timestamps. This PR is an attempt to fix this issue.

## Proposal

The proposed behavior is as follows. For files with partial timestamps, the [mint, maxt] range should span all possible times within that range. For example:

* year only (e.g. CDL): first and last second of the year
* year, month only: first and last second of the month
* year, week only: first and last second of the week
* year, month, day only: first and last second of the day
* year, month, day, hour only: first and last second of the hour
* year, month, day, hour, min only: first and last second of the min

This should cover all possible [timestamp formats](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes).

## Solution

Add some `disambiguate_timestamp` helper function that returns a `mint` and `maxt` based on a timestamp and a `strptime` format string. I'll have to look at `datetime` more closely, but I don't see an easy way to do this without checking for specific format codes.

## Discussion

There are many temporal resolutions we could care about. Right now, indices in the R-tree are seconds since 1970 (POSIX timestamp). We could use a different index, although `datetime.timestamp()` seems to be the only easy way to get a single float from a `datetime`, and R-trees can only take ints/floats. Regardless of the number we store, we should think about the level of accuracy we care about. For example, we could pretend that time isn't a thing and only look at date. For most (all?) of the datasets we have so far, the level of granularity provided by the timestamp is date, not datetime. However, I could envision some datasets (from drones or planes) that take multiple samples within the same day. On the other hand, we could go down to the resolution of milliseconds if we think there might be datasets that sample at such a high rate.

Possible remaining gotchas:

* time zone: if times are not all in UTC, images taken from different time zones could have issues
* daylight savings time: a dataset could have multiple samples from the same local time due to overlap, solution is to always store times in UTC if possible
* UTC vs local time: if a filename contains a time, we don't necessarily know if that is local time or UTC time