### PR TITLE
Feature/chesapeake cvpr training

### DIFF
--- a/conf/chesapeake_cvpr.yaml
+++ b/conf/chesapeake_cvpr.yaml
@@ -15,8 +15,9 @@ experiment:
     encoder_output_stride: 16
     optimizer: "adamw"
     learning_rate: 1e-2
-    learning_rate_schedule_patience: 2
+    learning_rate_schedule_patience: 6
+    class_set: 5
   datamodule:
-    batch_size: 32
-    num_workers: 4
+    batch_size: 64
+    num_workers: 6
     train_state: "de" # train/val/test in Delaware

--- a/conf/task_defaults/chesapeake_cvpr.yaml
+++ b/conf/task_defaults/chesapeake_cvpr.yaml
@@ -8,7 +8,7 @@ experiment:
     encoder_output_stride: 16
     learning_rate: 1e-3
     learning_rate_schedule_patience: 6
-    class_set: 7  # can be 4 or 6
+    class_set: 7
   datamodule:
     train_state: "de"
     patches_per_tile: 200

--- a/conf/task_defaults/chesapeake_cvpr.yaml
+++ b/conf/task_defaults/chesapeake_cvpr.yaml
@@ -7,8 +7,12 @@ experiment:
     encoder_weights: "imagenet"
     encoder_output_stride: 16
     learning_rate: 1e-3
-    learning_rate_schedule_patience: 2
+    learning_rate_schedule_patience: 6
+    class_set: 7  # can be 4 or 6
   datamodule:
-    batch_size: 32
-    num_workers: 4
     train_state: "de"
+    patches_per_tile: 200
+    patch_size: 256
+    batch_size: 64
+    num_workers: 4
+    class_set: ${experiment.module.class_set}

--- a/torchgeo/trainers/chesapeake.py
+++ b/torchgeo/trainers/chesapeake.py
@@ -73,10 +73,12 @@ class ChesapeakeCVPRSegmentationTask(LightningModule):
             )
         elif self.hparams["loss"] == "jaccard":
             self.loss = smp.losses.JaccardLoss(
-                mode="multiclass", classes=[0, 1, 2, 3, 4, 5], normalized=True
+                mode="multiclass", classes=[0, 1, 2, 3, 4, 5]
             )
         elif self.hparams["loss"] == "focal":
-            self.loss = smp.losses.FocalLoss("multiclass", ignore_index=6)
+            self.loss = smp.losses.FocalLoss(
+                "multiclass", ignore_index=6, normalized=True
+            )
         else:
             raise ValueError(f"Loss type '{self.hparams['loss']}' is not valid.")
 

--- a/torchgeo/trainers/chesapeake.py
+++ b/torchgeo/trainers/chesapeake.py
@@ -32,6 +32,7 @@ from ..transforms import RandomHorizontalFlip, RandomVerticalFlip
 DataLoader.__module__ = "torch.utils.data"
 Module.__module__ = "torch.nn"
 
+# TODO: move the color maps to a dataset object
 CMAP_7 = matplotlib.colors.ListedColormap(
     [np.array(Chesapeake7.cmap[i]) / 255.0 for i in range(7)]
 )
@@ -58,14 +59,10 @@ class ChesapeakeCVPRSegmentationTask(LightningModule):
 
     def config_task(self) -> None:
         """Configures the task based on kwargs parameters passed to the constructor."""
-        if self.hparams["class_set"] == 5:
-            num_classes = 5
-            classes = [1, 2, 3, 4]
-        elif self.hparams["class_set"] == 7:
-            num_classes = 7
-            classes = [1, 2, 3, 4, 5, 6]
-        else:
+        if self.hparams["class_set"] not in [5, 7]:
             raise ValueError("'class_set' must be either 5 or 7")
+        num_classes = self.hparams["class_set"]
+        classes = range(1, self.hparams["class_set"])
 
         if self.hparams["segmentation_model"] == "unet":
             self.model = smp.Unet(

--- a/torchgeo/trainers/chesapeake.py
+++ b/torchgeo/trainers/chesapeake.py
@@ -23,6 +23,7 @@ from torchmetrics import Accuracy, IoU, MetricCollection
 from torchvision.transforms import Compose
 
 from ..datasets import Chesapeake7, ChesapeakeCVPR
+from ..models import FCN
 from ..samplers import GridGeoSampler, RandomBatchGeoSampler
 from ..transforms import RandomHorizontalFlip, RandomVerticalFlip
 
@@ -59,6 +60,8 @@ class ChesapeakeCVPRSegmentationTask(LightningModule):
                 in_channels=4,
                 classes=7,
             )
+        elif self.hparams["segmentation_model"] == "fcn":
+            self.model = FCN(in_channels=4, classes=7, num_filters=256)
         else:
             raise ValueError(
                 f"Model type '{self.hparams['segmentation_model']}' is not valid."

--- a/torchgeo/trainers/chesapeake.py
+++ b/torchgeo/trainers/chesapeake.py
@@ -411,8 +411,6 @@ class ChesapeakeCVPRDataModule(LightningDataModule):
         val_transforms = Compose(
             [
                 self.center_crop(self.patch_size),
-                RandomHorizontalFlip(p=0.5),
-                RandomVerticalFlip(p=0.5),
                 self.nodata_check(self.patch_size),
                 self.preprocess,
             ]
@@ -465,15 +463,15 @@ class ChesapeakeCVPRDataModule(LightningDataModule):
 
     def val_dataloader(self) -> DataLoader[Any]:
         """Return a DataLoader for validation."""
-        sampler = RandomBatchGeoSampler(
+        sampler = GridGeoSampler(
             self.val_dataset.index,
             size=self.original_patch_size,
-            batch_size=self.batch_size,
-            length=self.patches_per_tile * self.val_dataset.index.get_size(),
+            stride=self.original_patch_size,
         )
         return DataLoader(
             self.val_dataset,
-            batch_sampler=sampler,  # type: ignore[arg-type]
+            batch_size=self.batch_size,
+            sampler=sampler,  # type: ignore[arg-type]
             num_workers=self.num_workers,
         )
 

--- a/torchgeo/trainers/chesapeake.py
+++ b/torchgeo/trainers/chesapeake.py
@@ -69,7 +69,11 @@ class ChesapeakeCVPRSegmentationTask(LightningModule):
                 ignore_index=6
             )
         elif self.hparams["loss"] == "jaccard":
-            self.loss = smp.losses.JaccardLoss(mode="multiclass", ignore_index=6)
+            self.loss = smp.losses.JaccardLoss(
+                mode="multiclass", classes=[0, 1, 2, 3, 4, 5], normalized=True
+            )
+        elif self.hparams["loss"] == "focal":
+            self.loss = smp.losses.FocalLoss("multiclass", ignore_index=6)
         else:
             raise ValueError(f"Loss type '{self.hparams['loss']}' is not valid.")
 


### PR DESCRIPTION
Small set of changes to improve the Chesapeake CVPR trainer:
- Nodata is always 0
- Patches that are too small are replaced with nodata
- Option to train on two class sets
- Option to use FCN model
- Option to use focal loss
- Val sampler uses GridGeoSampler