### PR TITLE
Required checks must always be run

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -3,19 +3,9 @@ on:
   push:
     branches:
     - main
-    paths:
-    - 'docs/**'
-    - '**.py'
-    - 'requirements.txt'
-    - '.github/workflows/docs.yaml'
   pull_request:
     branches:
     - main
-    paths:
-    - 'docs/**'
-    - '**.py'
-    - 'requirements.txt'
-    - '.github/workflows/docs.yaml'
 jobs:
   pydocstyle:
     name: pydocstyle

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,19 +3,9 @@ on:
   push:
     branches:
     - release**
-    paths:
-    - '**.py'
-    - 'pyproject.toml'
-    - 'requirements.txt'
-    - '.github/workflows/release.yaml'
   pull_request:
     branches:
     - release**
-    paths:
-    - '**.py'
-    - 'pyproject.toml'
-    - 'requirements.txt'
-    - '.github/workflows/release.yaml'
 jobs:
   notebooks:
     name: notebooks

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -3,19 +3,9 @@ on:
   push:
     branches:
     - main
-    paths:
-    - '**.py'
-    - '.flake8'
-    - 'pyproject.toml'
-    - '.github/workflows/style.yaml'
   pull_request:
     branches:
     - main
-    paths:
-    - '**.py'
-    - '.flake8'
-    - 'pyproject.toml'
-    - '.github/workflows/style.yaml'
 jobs:
   black:
     name: black

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,19 +3,9 @@ on:
   push:
     branches:
     - main
-    paths:
-    - '**.py'
-    - 'pyproject.toml'
-    - 'requirements.txt'
-    - '.github/workflows/tests.yaml'
   pull_request:
     branches:
     - main
-    paths:
-    - '**.py'
-    - 'pyproject.toml'
-    - 'requirements.txt'
-    - '.github/workflows/tests.yaml'
 jobs:
   mypy:
     name: mypy


### PR DESCRIPTION
All of our GitHub Actions tests are required to pass in order for a PR to be merged. Previously, these tests were set up such that they would only be run depending on which files were modified. Unfortunately, GitHub doesn't seem to support [conditional required checks](https://github.community/t/feature-request-conditional-required-checks/16761). This PR changes the tests to run on every commit regardless of whether or not Python files were modified.