### PR TITLE
Set src properties for vector test data generation

### DIFF
--- a/tests/data/README.md
+++ b/tests/data/README.md
@@ -39,6 +39,7 @@ ROOT = "data/cbf"
 FILENAME = "Ontario.geojson"
 
 src = fiona.open(os.path.join(ROOT, FILENAME))
+src.meta["schema"]["properties"] = OrderedDict()
 dst = fiona.open(FILENAME, "w", **src.meta)
 rec = {"type": "Feature", "id": "0", "properties": OrderedDict(), "geometry": {"type": "Polygon", "coordinates": [[(0, 0), (0, 1), (1, 1), (1, 0), (0, 0)]]}}
 dst.write(rec)


### PR DESCRIPTION
I followed the instructions [here](https://github.com/microsoft/torchgeo/tree/main/tests/data#vector-data) to create a vector test data (for SpaceNet) and ran into this error 

```
ValueError: Record does not match collection schema: odict_keys([]) != ['OBJECTID', 'partialDec', 'Shape_Leng', 'Id', 'OBJECTID_1', 'Shape_Area', 'partialBuilding', 'Shape_Le_1']
```

This is because dst is opened with src's meta. I was able to get around this issue by setting src properties to `OrderedDict()`. 