### PR TITLE
Refactor UCM & EuroSAT to VisionClassificationDatasets

### DIFF
--- a/torchgeo/datasets/eurosat.py
+++ b/torchgeo/datasets/eurosat.py
@@ -6,29 +6,10 @@
 import os
 from typing import Callable, Dict, Optional
 
-import numpy as np
-import rasterio
-from numpy.typing import NDArray
 from torch import Tensor
 
 from .geo import VisionClassificationDataset
-from .utils import check_integrity, download_url, extract_archive
-
-
-def rasterio_loader(path: str) -> NDArray[np.int32]:
-    """Load an image file using rasterio.
-
-    Args:
-        path: path to the image to be loaded
-
-    Returns:
-        the image
-    """
-    with rasterio.open(path) as f:
-        array: NDArray[np.int32] = f.read().astype(np.int32)
-        # VisionClassificationDataset expects images returned with channels last (HWC)
-        array = array.transpose(1, 2, 0)
-    return array
+from .utils import check_integrity, download_url, extract_archive, rasterio_loader
 
 
 class EuroSAT(VisionClassificationDataset):

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -25,7 +25,8 @@ from rasterio.vrt import WarpedVRT
 from rtree.index import Index, Property
 from torch import Tensor
 from torch.utils.data import Dataset
-from torchvision.datasets.folder import ImageFolder, default_loader
+from torchvision.datasets.folder import ImageFolder
+from torchvision.datasets.folder import default_loader as pil_loader
 
 from .utils import BoundingBox, disambiguate_timestamp
 
@@ -590,7 +591,7 @@ class VisionClassificationDataset(VisionDataset, ImageFolder):  # type: ignore[m
         self,
         root: str,
         transforms: Optional[Callable[[Dict[str, Tensor]], Dict[str, Tensor]]] = None,
-        loader: Optional[Callable[[str], Any]] = default_loader,
+        loader: Optional[Callable[[str], Any]] = pil_loader,
     ) -> None:
         """Initialize a new VisionClassificationDataset instance.
 

--- a/torchgeo/datasets/ucmerced.py
+++ b/torchgeo/datasets/ucmerced.py
@@ -100,6 +100,10 @@ class UCMerced(VisionClassificationDataset):
                 entry and returns a transformed version
             download: if True, download dataset and store it in the root directory
             checksum: if True, check the MD5 of the downloaded files (may be slow)
+
+        Raises:
+            RuntimeError: if ``download=False`` and data is not found, or checksums
+                don't match
         """
         self.root = root
         self.transforms = transforms

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -14,6 +14,8 @@ import zipfile
 from datetime import datetime, timedelta
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
+import numpy as np
+import rasterio
 import torch
 from torch import Tensor
 from torchvision.datasets.utils import check_integrity, download_url
@@ -27,6 +29,7 @@ __all__ = (
     "disambiguate_timestamp",
     "working_dir",
     "collate_dict",
+    "rasterio_loader",
 )
 
 
@@ -375,3 +378,19 @@ def collate_dict(samples: List[Dict[str, Any]]) -> Dict[str, Any]:
                 sample[key] for sample in samples
             ]  # type: ignore[assignment]
     return collated
+
+
+def rasterio_loader(path: str) -> np.ndarray[Any, np.dtype[np.int32]]:
+    """Load an image file using rasterio.
+
+    Args:
+        path: path to the image to be loaded
+
+    Returns:
+        the image
+    """
+    with rasterio.open(path) as f:
+        array: np.ndarray[Any, np.dtype[np.int32]] = f.read().astype(np.int32)
+        # VisionClassificationDataset expects images returned with channels last (HWC)
+        array = array.transpose(1, 2, 0)
+    return array

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -380,7 +380,7 @@ def collate_dict(samples: List[Dict[str, Any]]) -> Dict[str, Any]:
     return collated
 
 
-def rasterio_loader(path: str) -> np.ndarray[Any, np.dtype[np.int32]]:
+def rasterio_loader(path: str) -> np.ndarray:  # type: ignore[type-arg]
     """Load an image file using rasterio.
 
     Args:
@@ -390,7 +390,7 @@ def rasterio_loader(path: str) -> np.ndarray[Any, np.dtype[np.int32]]:
         the image
     """
     with rasterio.open(path) as f:
-        array: np.ndarray[Any, np.dtype[np.int32]] = f.read().astype(np.int32)
+        array: np.ndarray = f.read().astype(np.int32)  # type: ignore[type-arg]
         # VisionClassificationDataset expects images returned with channels last (HWC)
         array = array.transpose(1, 2, 0)
     return array


### PR DESCRIPTION
- Refactored the `UCMerced` and `EuroSAT` datasets to inherit from `VisionClassificationDataset` and removed boilerplate code
- Update tests to increase code cov

Note that I removed some attributes other than the `class_counts`, however they are still available since they are computed under the hood by `torchvision.datasets.ImageFolder`. Stealing from the docs:

```
 Attributes:
    classes (list): List of the class names sorted alphabetically.
    class_to_idx (dict): Dict with items (class_name, class_index).
    imgs (list): List of (image path, class_index) tuples
```