### PR TITLE
Fix various bugs in data loader benchmarking script

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -83,7 +83,7 @@ def set_up_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "-s",
         "--stride",
-        default=2 ** 7,
+        default=112,
         type=int,
         help="sampling stride for GridGeoSampler",
     )
@@ -145,26 +145,15 @@ def main(args: argparse.Namespace) -> None:
         length = args.num_batches * args.batch_size
         num_batches = args.num_batches
 
-    # Workaround for https://github.com/microsoft/torchgeo/issues/149
-    roi = BoundingBox(
-        -2000000, 2200000, 280000, 3170000, dataset.bounds.mint, dataset.bounds.maxt
-    )
+    # Convert from pixel coords to CRS coords
+    size = args.patch_size * cdl.res
+    stride = args.stride * cdl.res
+
     samplers = [
-        RandomGeoSampler(
-            landsat.index,
-            size=args.patch_size,
-            length=length,
-            roi=roi,
-        ),
-        GridGeoSampler(
-            landsat.index, size=args.patch_size, stride=args.stride, roi=roi
-        ),
+        RandomGeoSampler(landsat.index, size=size, length=length),
+        GridGeoSampler(landsat.index, size=size, stride=stride),
         RandomBatchGeoSampler(
-            landsat.index,
-            size=args.patch_size,
-            batch_size=args.batch_size,
-            length=length,
-            roi=roi,
+            landsat.index, size=size, batch_size=args.batch_size, length=length
         ),
     ]
 

--- a/benchmark.py
+++ b/benchmark.py
@@ -14,7 +14,7 @@ import torch.optim as optim
 from torch.utils.data import DataLoader
 from torchvision.models import resnet18
 
-from torchgeo.datasets import CDL, BoundingBox, Landsat8
+from torchgeo.datasets import CDL, Landsat8
 from torchgeo.samplers import GridGeoSampler, RandomBatchGeoSampler, RandomGeoSampler
 
 

--- a/experiments/run_benchmarks_experiments.py
+++ b/experiments/run_benchmarks_experiments.py
@@ -8,7 +8,7 @@ import subprocess
 import time
 from typing import List
 
-NUM_BATCHES = 100
+EPOCH_SIZE = 2048
 
 SEED_OPTIONS = [0, 1, 2]
 CACHE_OPTIONS = [True, False]
@@ -27,7 +27,7 @@ if __name__ == "__main__":
     for i, (cache, batch_size, seed) in enumerate(
         itertools.product(CACHE_OPTIONS, BATCH_SIZE_OPTIONS, SEED_OPTIONS)
     ):
-        print(f"{i}/{total_num_experiments} -- {time.time() - tic}")
+        print(f"\n{i}/{total_num_experiments} -- {time.time() - tic}")
         tic = time.time()
         command: List[str] = [
             "python",
@@ -40,8 +40,8 @@ if __name__ == "__main__":
             "8",
             "--batch-size",
             str(batch_size),
-            "--num-batches",
-            str(NUM_BATCHES),
+            "--epoch-size",
+            str(EPOCH_SIZE),
             "--seed",
             str(seed),
             "--verbose",

--- a/experiments/run_benchmarks_experiments.py
+++ b/experiments/run_benchmarks_experiments.py
@@ -37,7 +37,7 @@ if __name__ == "__main__":
             "--cdl-root",
             CDL_DATA_ROOT,
             "--num-workers",
-            "6",
+            "8",
             "--batch-size",
             str(batch_size),
             "--num-batches",

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -286,7 +286,7 @@ class RasterDataset(GeoDataset):
                     filepath = glob.glob(os.path.join(directory, filename))[0]
                     band_filepaths.append(filepath)
                 data_list.append(self._merge_files(band_filepaths, query))
-            data = torch.cat(data_list)
+            data = torch.cat(data_list)  # type: ignore[attr-defined]
         else:
             data = self._merge_files(filepaths, query)
 

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -286,7 +286,7 @@ class RasterDataset(GeoDataset):
                     filepath = glob.glob(os.path.join(directory, filename))[0]
                     band_filepaths.append(filepath)
                 data_list.append(self._merge_files(band_filepaths, query))
-            data = torch.stack(data_list)
+            data = torch.cat(data_list)
         else:
             data = self._merge_files(filepaths, query)
 


### PR DESCRIPTION
This PR makes the following changes:

- [x] default stride is now half of default patch size
- [x] remove ROI hacks now that test dataset only contains tiles within CONUS
- [x] `size` and `stride` args of samplers should be in CRS coords, not pixel coords
- [x] default `num_workers` is now 8, provides better performance
- [x] use the same number of data points per epoch in every experiment
- [x] need to concatenate instead of stack image channels