### PR TITLE
Skip slow sampler tests

### DIFF
--- a/tests/samplers/test_batch.py
+++ b/tests/samplers/test_batch.py
@@ -54,6 +54,7 @@ class TestBatchGeoSampler:
     def test_len(self, sampler: CustomBatchGeoSampler) -> None:
         assert len(sampler) == 2
 
+    @pytest.mark.slow
     @pytest.mark.parametrize("num_workers", [0, 1, 2])
     def test_dataloader(self, sampler: CustomBatchGeoSampler, num_workers: int) -> None:
         ds = CustomGeoDataset()
@@ -93,6 +94,7 @@ class TestRandomBatchGeoSampler:
     def test_len(self, sampler: RandomBatchGeoSampler) -> None:
         assert len(sampler) == sampler.length // sampler.batch_size
 
+    @pytest.mark.slow
     @pytest.mark.parametrize("num_workers", [0, 1, 2])
     def test_dataloader(self, sampler: RandomBatchGeoSampler, num_workers: int) -> None:
         ds = CustomGeoDataset()

--- a/tests/samplers/test_single.py
+++ b/tests/samplers/test_single.py
@@ -53,6 +53,7 @@ class TestGeoSampler:
     def test_len(self, sampler: CustomGeoSampler) -> None:
         assert len(sampler) == 2
 
+    @pytest.mark.slow
     @pytest.mark.parametrize("num_workers", [0, 1, 2])
     def test_dataloader(self, sampler: CustomGeoSampler, num_workers: int) -> None:
         ds = CustomGeoDataset()
@@ -91,6 +92,7 @@ class TestRandomGeoSampler:
     def test_len(self, sampler: RandomGeoSampler) -> None:
         assert len(sampler) == sampler.length
 
+    @pytest.mark.slow
     @pytest.mark.parametrize("num_workers", [0, 1, 2])
     def test_dataloader(self, sampler: RandomGeoSampler, num_workers: int) -> None:
         ds = CustomGeoDataset()
@@ -132,6 +134,7 @@ class TestGridGeoSampler:
                 query.maxt - query.mint, sampler.roi.maxt - sampler.roi.mint
             )
 
+    @pytest.mark.slow
     @pytest.mark.parametrize("num_workers", [0, 1, 2])
     def test_dataloader(self, sampler: GridGeoSampler, num_workers: int) -> None:
         ds = CustomGeoDataset()


### PR DESCRIPTION
The parallel data loader sampler tests are extremely slow on macOS/Windows. See #102 for details. This PR skips them for normal test usage, but keeps them for longer integration testing. Even without these tests we still have 100% test coverage for the samplers.

### Before

```console
$ time pytest tests/samplers
...
real	7m30.759s
user	2m18.260s
sys	0m52.247s
```

### After

```console
$ time pytest tests/samplers
...
real	0m4.402s
user	0m3.223s
sys	0m1.057s
```