### PR TITLE
Add pre-trained models for ResNet

### DIFF
--- a/tests/models/test_resnet.py
+++ b/tests/models/test_resnet.py
@@ -18,4 +18,4 @@ def test_resnet(
     x = torch.zeros(1, in_channels, 256, 256)  # type: ignore[attr-defined]
     y = model(x)
     assert isinstance(y, torch.Tensor)
-    assert y.size() == torch.Size([1, 17])
+    assert y.size() == torch.Size([1, 17])  # type: ignore[attr-defined]

--- a/tests/models/test_resnet.py
+++ b/tests/models/test_resnet.py
@@ -1,0 +1,21 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import pytest
+import torch
+from torch.nn.modules import Module
+
+from torchgeo.models import resnet50
+
+
+@pytest.mark.parametrize(
+    "model_class,sensor,in_channels,num_classes", [(resnet50, "sentinel2", 10, 17)]
+)
+def test_resnet(
+    model_class: Module, sensor: str, in_channels: int, num_classes: int
+) -> None:
+    model = model_class(sensor, pretrained=True)
+    x = torch.zeros(1, in_channels, 256, 256)  # type: ignore[attr-defined]
+    y = model(x)
+    assert isinstance(y, torch.Tensor)
+    assert y.size() == torch.Size([1, 17])

--- a/tests/models/test_resnet.py
+++ b/tests/models/test_resnet.py
@@ -9,12 +9,13 @@ from torchgeo.models import resnet50
 
 
 @pytest.mark.parametrize(
-    "model_class,sensor,in_channels,num_classes", [(resnet50, "sentinel2", 10, 17)]
+    "model_class,sensor,bands,in_channels,num_classes",
+    [(resnet50, "sentinel2", "all", 10, 17)],
 )
 def test_resnet(
-    model_class: Module, sensor: str, in_channels: int, num_classes: int
+    model_class: Module, sensor: str, bands: str, in_channels: int, num_classes: int
 ) -> None:
-    model = model_class(sensor, pretrained=True)
+    model = model_class(sensor, bands, pretrained=True)
     x = torch.zeros(1, in_channels, 256, 256)  # type: ignore[attr-defined]
     y = model(x)
     assert isinstance(y, torch.Tensor)

--- a/torchgeo/models/__init__.py
+++ b/torchgeo/models/__init__.py
@@ -8,6 +8,7 @@ from .farseg import FarSeg
 from .fccd import FCEF, FCSiamConc, FCSiamDiff
 from .fcn import FCN
 from .rcf import RCF
+from .resnet import resnet50
 
 __all__ = (
     "ChangeMixin",
@@ -19,6 +20,7 @@ __all__ = (
     "FCSiamConc",
     "FCSiamDiff",
     "RCF",
+    "resnet50",
 )
 
 # https://stackoverflow.com/questions/40018681

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -1,0 +1,76 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+"""Pre-trained ResNet models."""
+
+from typing import Type, Union, List
+
+from torch.hub import load_state_dict_from_url
+from torchvision.models import ResNet, Bottleneck, BasicBlock
+
+
+MODEL_URLS = {
+    "sentinel2": {
+        "resnet50": "https://zenodo.org/record/5610000/files/resnet50-sentinel2.pt"
+    }
+}
+
+
+IN_CHANNELS = {
+    "sentinel2": 10
+}
+
+NUM_CLASSES = {
+    "sentinel2": 17
+}
+
+
+def _resnet(sensor: str, arch: str, block: Type[Union[BasicBlock, BottleNeck]], layers: List[int], pretrained: bool, progress: bool, **kwargs: Any) -> ResNet:
+    """ResNet model.
+
+    If you use this model in your research, please cite the following paper:
+
+    * https://arxiv.org/pdf/1512.03385.pdf
+
+    Args:
+        sensor: imagery source which determines number of input channels
+        arch: ResNet version specifying number of layers
+        block: type of network block
+        layers: number of layers per block
+        pretrained: if True, returns a model pre-trained on ``sensor`` imagery
+        progress: if True, displays a progress bar of the download to stderr
+
+    Returns:
+        A ResNet-50 model
+    """
+    # Initialize a new model
+    model = ResNet(block, layers, NUM_CLASSES[sensor], **kwargs)
+
+    # Replace the first layer with the correct number of input channels
+    model.conv1 = nn.Conv2d(  # type: ignore[attr-defined]
+        IN_CHANNELS[sensor], out_channels=64, kernel_size=7, stride=1, padding=2, bias=False
+    )
+
+    # Load pretrained weights
+    if pretrained:
+        state_dict = load_state_dict_from_url(MODEL_URLS[sensor][arch], progress=progress)
+        model.load_state_dict(state_dict)
+
+    return model
+
+def resnet50(sensor: str, pretrained: bool = False, progress: bool = True, **kwargs: Any) -> ResNet:
+    """ResNet-50 model.
+
+    If you use this model in your research, please cite the following paper:
+
+    * https://arxiv.org/pdf/1512.03385.pdf
+
+    Args:
+        sensor: imagery source which determines number of input channels
+        pretrained: if True, returns a model pre-trained on ``sensor`` imagery
+        progress: if True, displays a progress bar of the download to stderr
+
+    Returns:
+        A ResNet-50 model
+    """
+    return _resnet(sensor, "resnet50", Bottleneck, [3, 4, 6, 3], pretrained, progress, **kwargs)

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -3,11 +3,11 @@
 
 """Pre-trained ResNet models."""
 
-from typing import Type, Union, List
+from typing import Any, List, Type, Union
 
+import torch.nn as nn
 from torch.hub import load_state_dict_from_url
-from torchvision.models import ResNet, Bottleneck, BasicBlock
-
+from torchvision.models.resnet import BasicBlock, Bottleneck, ResNet
 
 MODEL_URLS = {
     "sentinel2": {
@@ -16,17 +16,21 @@ MODEL_URLS = {
 }
 
 
-IN_CHANNELS = {
-    "sentinel2": 10
-}
+IN_CHANNELS = {"sentinel2": 10}
 
-NUM_CLASSES = {
-    "sentinel2": 17
-}
+NUM_CLASSES = {"sentinel2": 17}
 
 
-def _resnet(sensor: str, arch: str, block: Type[Union[BasicBlock, BottleNeck]], layers: List[int], pretrained: bool, progress: bool, **kwargs: Any) -> ResNet:
-    """ResNet model.
+def _resnet(
+    sensor: str,
+    arch: str,
+    block: Type[Union[BasicBlock, Bottleneck]],
+    layers: List[int],
+    pretrained: bool,
+    progress: bool,
+    **kwargs: Any,
+) -> ResNet:
+    """Resnet model.
 
     If you use this model in your research, please cite the following paper:
 
@@ -48,17 +52,27 @@ def _resnet(sensor: str, arch: str, block: Type[Union[BasicBlock, BottleNeck]], 
 
     # Replace the first layer with the correct number of input channels
     model.conv1 = nn.Conv2d(  # type: ignore[attr-defined]
-        IN_CHANNELS[sensor], out_channels=64, kernel_size=7, stride=1, padding=2, bias=False
+        IN_CHANNELS[sensor],
+        out_channels=64,
+        kernel_size=7,
+        stride=1,
+        padding=2,
+        bias=False,
     )
 
     # Load pretrained weights
     if pretrained:
-        state_dict = load_state_dict_from_url(MODEL_URLS[sensor][arch], progress=progress)
+        state_dict = load_state_dict_from_url(  # type: ignore[no-untyped-call]
+            MODEL_URLS[sensor][arch], progress=progress
+        )
         model.load_state_dict(state_dict)
 
     return model
 
-def resnet50(sensor: str, pretrained: bool = False, progress: bool = True, **kwargs: Any) -> ResNet:
+
+def resnet50(
+    sensor: str, pretrained: bool = False, progress: bool = True, **kwargs: Any
+) -> ResNet:
     """ResNet-50 model.
 
     If you use this model in your research, please cite the following paper:
@@ -73,4 +87,6 @@ def resnet50(sensor: str, pretrained: bool = False, progress: bool = True, **kwa
     Returns:
         A ResNet-50 model
     """
-    return _resnet(sensor, "resnet50", Bottleneck, [3, 4, 6, 3], pretrained, progress, **kwargs)
+    return _resnet(
+        sensor, "resnet50", Bottleneck, [3, 4, 6, 3], pretrained, progress, **kwargs
+    )


### PR DESCRIPTION
Still need to add tests, but this is basically what I'm thinking for pre-trained models. It's almost a carbon-copy of how torchvision does things, but with an added "sensor" field that lets you specify which satellite you want your model trained on.

Some things to consider:

* Do we want to support model + sensor + task combinations? I'm thinking not since torchvision only supports model and not model + task
* Do we want to support arbitrary band subsets? We could support Sentinel 2 "all bands" and "rgb" but I don't think we want to support any more than we have to
* Do we want error checking or some way to let users know which models have been trained for which sensors?