### PR TITLE
Adding VGG models to the classification task and refactoring

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -41,4 +41,5 @@ dependencies:
     - segmentation-models-pytorch>=0.2
     - setuptools>=30.4
     - sphinx>=3
+    - timm>=0.2.1
     - torchmetrics

--- a/setup.cfg
+++ b/setup.cfg
@@ -77,6 +77,8 @@ train =
     scikit-learn>=0.18
     # segmentation-models-pytorch 0.2+ required for smp.losses module
     segmentation-models-pytorch>=0.2
+    # timm 0.2.1+ required for `features_only` option in create_model
+    timm>=0.2.1
     torchmetrics
 # Optional developer requirements
 style =

--- a/tests/trainers/test_tasks.py
+++ b/tests/trainers/test_tasks.py
@@ -99,6 +99,7 @@ class TestClassificationTask:
         return dm
 
     @pytest.fixture(
+        scope="class",
         params=zip(
             ["ce", "jaccard", "focal"],
             ["imagenet", "random", "random"],
@@ -108,14 +109,14 @@ class TestClassificationTask:
     def config(
         self, request: SubRequest, datamodule: DummyDataModule
     ) -> Dict[str, Any]:
-        task_conf = OmegaConf.load(os.path.join("conf", "task_defaults", "so2sat.yaml"))
-        task_args = OmegaConf.to_object(task_conf.experiment.module)
-        task_args = cast(Dict[str, Any], task_args)
-        task_args["in_channels"] = datamodule.num_channels
         loss, weights, model = request.param
+        task_args = {}
+        task_args["classification_model"] = model
+        task_args["learning_rate"] = 3e-4
+        task_args["learning_rate_schedule_patience"] = 6
+        task_args["in_channels"] = datamodule.num_channels
         task_args["loss"] = loss
         task_args["weights"] = weights
-        task_args["classification_model"] = model
         return task_args
 
     @pytest.fixture

--- a/tests/trainers/test_tasks.py
+++ b/tests/trainers/test_tasks.py
@@ -105,7 +105,9 @@ class TestClassificationTask:
             ["resnet18", "hrnet_w18_small_v2", "tf_efficientnet_b0"],
         )
     )
-    def config(self, request: SubRequest, datamodule: DummyDataModule) -> Dict[str, Any]:
+    def config(
+        self, request: SubRequest, datamodule: DummyDataModule
+    ) -> Dict[str, Any]:
         task_conf = OmegaConf.load(os.path.join("conf", "task_defaults", "so2sat.yaml"))
         task_args = OmegaConf.to_object(task_conf.experiment.module)
         task_args = cast(Dict[str, Any], task_args)

--- a/tests/trainers/test_tasks.py
+++ b/tests/trainers/test_tasks.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 import os
-from typing import Any, Dict, Generator, Optional, cast, Tuple
+from typing import Any, Dict, Generator, Optional, cast
 
 import pytest
 import pytorch_lightning as pl
@@ -102,14 +102,14 @@ class TestClassificationTask:
         params=zip(
             ["ce", "jaccard", "focal"],
             ["imagenet", "random", "random"],
-            ["resnet18", "vgg11", "vgg11"],
+            ["resnet18", "hrnet_w18_small_v2", "tf_efficientnet_b0"],
         )
     )
-    def config(self, request: SubRequest, bands: Tuple[str, int]) -> Dict[str, Any]:
+    def config(self, request: SubRequest, datamodule: DummyDataModule) -> Dict[str, Any]:
         task_conf = OmegaConf.load(os.path.join("conf", "task_defaults", "so2sat.yaml"))
         task_args = OmegaConf.to_object(task_conf.experiment.module)
         task_args = cast(Dict[str, Any], task_args)
-        task_args["in_channels"] = bands[1]
+        task_args["in_channels"] = datamodule.num_channels
         loss, weights, model = request.param
         task_args["loss"] = loss
         task_args["weights"] = weights
@@ -158,7 +158,7 @@ class TestClassificationTask:
 
     def test_invalid_model(self, config: Dict[str, Any]) -> None:
         config["classification_model"] = "invalid_model"
-        error_message = "Model type 'invalid_model' is not valid."
+        error_message = "Model type 'invalid_model' is not a valid timm model."
         with pytest.raises(ValueError, match=error_message):
             ClassificationTask(**config)
 

--- a/tests/trainers/test_tasks.py
+++ b/tests/trainers/test_tasks.py
@@ -104,7 +104,7 @@ class TestClassificationTask:
             ["ce", "jaccard", "focal"],
             ["imagenet", "random", "random"],
             ["resnet18", "hrnet_w18_small_v2", "tf_efficientnet_b0"],
-        )
+        ),
     )
     def config(
         self, request: SubRequest, datamodule: DummyDataModule

--- a/tests/trainers/test_utils.py
+++ b/tests/trainers/test_utils.py
@@ -10,7 +10,11 @@ import torch
 import torch.nn as nn
 from torch.nn.modules import Module
 
-from torchgeo.trainers.utils import extract_encoder, load_state_dict
+from torchgeo.trainers.utils import (
+    extract_encoder,
+    load_state_dict,
+    reinit_initial_conv_layer,
+)
 
 
 class FakeExperiment(object):
@@ -87,3 +91,17 @@ def test_load_state_dict_unequal_classes(checkpoint: str, model: Module) -> None
     )
     with pytest.warns(UserWarning, match=warning):
         model = load_state_dict(model, state_dict)
+
+
+def test_reinit_initial_conv_layer() -> None:
+    conv_layer = nn.Conv2d(3, 5, kernel_size=3, stride=2, padding=1, bias=True)
+    initial_weights = conv_layer.weight.data.clone()
+
+    new_conv_layer = reinit_initial_conv_layer(conv_layer, 4, keep_rgb_weights=True)
+
+    out_channels, in_channels, k1, k2 = new_conv_layer.weight.shape
+    assert torch.allclose(initial_weights, new_conv_layer.weight.data[:, :3, :, :])
+    assert out_channels == 5
+    assert in_channels == 4
+    assert k1 == 3 and k2 == 3
+    assert new_conv_layer.stride[0] == 2

--- a/tests/trainers/test_utils.py
+++ b/tests/trainers/test_utils.py
@@ -94,13 +94,17 @@ def test_load_state_dict_unequal_classes(checkpoint: str, model: Module) -> None
 
 
 def test_reinit_initial_conv_layer() -> None:
-    conv_layer = nn.Conv2d(3, 5, kernel_size=3, stride=2, padding=1, bias=True)
+    conv_layer = nn.Conv2d(  # type: ignore[attr-defined]
+        3, 5, kernel_size=3, stride=2, padding=1, bias=True
+    )
     initial_weights = conv_layer.weight.data.clone()
 
     new_conv_layer = reinit_initial_conv_layer(conv_layer, 4, keep_rgb_weights=True)
 
     out_channels, in_channels, k1, k2 = new_conv_layer.weight.shape
-    assert torch.allclose(initial_weights, new_conv_layer.weight.data[:, :3, :, :])
+    assert torch.allclose(  # type: ignore[attr-defined]
+        initial_weights, new_conv_layer.weight.data[:, :3, :, :]
+    )
     assert out_channels == 5
     assert in_channels == 4
     assert k1 == 3 and k2 == 3

--- a/torchgeo/trainers/tasks.py
+++ b/torchgeo/trainers/tasks.py
@@ -58,9 +58,7 @@ class ClassificationTask(pl.LightningModule):
             # Update first layer
             if in_channels != 3:
                 self.model.conv1 = utils.reinit_initial_conv_layer(
-                    self.model.conv1,
-                    in_channels,
-                    keep_rgb_weights=pretrained
+                    self.model.conv1, in_channels, keep_rgb_weights=pretrained
                 )
         elif "vgg" in self.hparams["classification_model"]:
             self.model = getattr(
@@ -71,9 +69,7 @@ class ClassificationTask(pl.LightningModule):
             # Update first layer
             if in_channels != 3:
                 self.model.features[0] = utils.reinit_initial_conv_layer(
-                    self.model.features[0],
-                    in_channels,
-                    keep_rgb_weights=pretrained
+                    self.model.features[0], in_channels, keep_rgb_weights=pretrained
                 )
         else:
             raise ValueError(

--- a/torchgeo/trainers/tasks.py
+++ b/torchgeo/trainers/tasks.py
@@ -7,6 +7,7 @@ import os
 from typing import Any, Dict, cast
 
 import pytorch_lightning as pl
+import timm
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -16,7 +17,6 @@ from torch.nn.modules import Conv2d, Linear
 from torch.optim.lr_scheduler import ReduceLROnPlateau
 from torchmetrics import Accuracy, FBeta, IoU, MeanSquaredError, MetricCollection
 from torchvision import models
-import timm
 
 from . import utils
 
@@ -59,7 +59,7 @@ class ClassificationTask(pl.LightningModule):
                 classification_model,
                 num_classes=self.num_classes,
                 in_chans=in_channels,
-                pretrained=imagenet_pretrained
+                pretrained=imagenet_pretrained,
             )
         else:
             raise ValueError(

--- a/torchgeo/trainers/utils.py
+++ b/torchgeo/trainers/utils.py
@@ -129,8 +129,8 @@ def reinit_initial_conv_layer(
             # mypy doesn't realize that bias isn't None here...
             b_old = layer.bias.data.clone()  # type: ignore[union-attr]
 
-    updated_stride = layer.stride if new_stride is not None else new_stride
-    updated_padding = layer.padding if new_padding is not None else new_padding
+    updated_stride = layer.stride if new_stride is None else new_stride
+    updated_padding = layer.padding if new_padding is None else new_padding
 
     new_layer = Conv2d(
         new_in_channels,

--- a/torchgeo/trainers/utils.py
+++ b/torchgeo/trainers/utils.py
@@ -116,10 +116,12 @@ def reinit_initial_conv_layer(
     Returns:
         a Conv2d layer with new kernel weights
     """
+    use_bias = layer.bias is not None
     if keep_rgb_weights:
         w_old = layer.weight.data[:, :3, :, :].clone()
-        if layer.bias:
-            b_old = layer.bias.data.clone()
+        if use_bias:
+            # mypy doesn't realize that bias isn't None here...
+            b_old = layer.bias.data.clone()  # type: ignore[union-attr]
 
     new_layer = Conv2d(
         new_in_channels,
@@ -129,7 +131,7 @@ def reinit_initial_conv_layer(
         padding=layer.padding,  # type: ignore[arg-type]
         dilation=layer.dilation,  # type: ignore[arg-type]
         groups=layer.groups,
-        bias=layer.bias,  # type: ignore[arg-type]
+        bias=use_bias,
         padding_mode=layer.padding_mode,
     )
     nn.init.kaiming_normal_(  # type: ignore[no-untyped-call]
@@ -138,7 +140,7 @@ def reinit_initial_conv_layer(
 
     if keep_rgb_weights:
         new_layer.weight.data[:, :3, :, :] = w_old
-        if new_layer.bias:
-            new_layer.bias.data = b_old
+        if use_bias:
+            new_layer.bias.data = b_old  # type: ignore[union-attr]
 
     return new_layer

--- a/torchgeo/trainers/utils.py
+++ b/torchgeo/trainers/utils.py
@@ -10,7 +10,7 @@ from typing import Dict, Tuple
 import torch
 import torch.nn as nn
 from torch import Tensor
-from torch.nn.modules import Module, Conv2d
+from torch.nn.modules import Conv2d, Module
 
 # https://github.com/pytorch/pytorch/issues/60979
 # https://github.com/pytorch/pytorch/pull/61045
@@ -99,9 +99,7 @@ def load_state_dict(model: Module, state_dict: Dict[str, Tensor]) -> Module:
 
 
 def reinit_initial_conv_layer(
-    layer: Conv2d,
-    new_in_channels: int,
-    keep_rgb_weights: bool
+    layer: Conv2d, new_in_channels: int, keep_rgb_weights: bool
 ) -> Conv2d:
     """Clones a Conv2d layer while optionally retaining some of the original weights.
 

--- a/torchgeo/trainers/utils.py
+++ b/torchgeo/trainers/utils.py
@@ -106,7 +106,7 @@ def reinit_initial_conv_layer(
     When replacing the first convolutional layer in a model with one that operates over
     different number of input channels, we sometimes want to keep a subset of the kernel
     weights the same (e.g. the RGB weights of an ImageNet pretrained model). This is a
-    convinience function that performs that function.
+    convenience function that performs that function.
 
     Args:
         layer: the Conv2d layer to initialize

--- a/torchgeo/trainers/utils.py
+++ b/torchgeo/trainers/utils.py
@@ -110,7 +110,7 @@ def reinit_initial_conv_layer(
 
     Args:
         layer: the Conv2d layer to initialize
-        new_in_channels: the new number of input
+        new_in_channels: the new number of input channels
         keep_rgb_weights: flag indicating whether to re-initialize the first 3 channels
 
     Returns:


### PR DESCRIPTION
Pretty much any new class of models we add to the classification task (or soon-to-be segmentation task) will need to have its first conv layer replaced. This PR refactors that logic and adds VGG as a template for "how to add new types of models to the trainers".