### PR TITLE
TropicalCyclone dataset: use target for sample key

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ import torchgeo.datasets
 
 dataset = torchgeo.datasets.TropicalCycloneWindEstimation(split="train", download=True)
 print(dataset[0]["image"].shape)
-print(dataset[0]["wind_speed"])
+print(dataset[0]["target"])
 ```
 
 ## Contributing

--- a/tests/datasets/test_cyclone.py
+++ b/tests/datasets/test_cyclone.py
@@ -70,7 +70,7 @@ class TestTropicalCycloneWindEstimation:
         assert isinstance(x["storm_id"], str)
         assert isinstance(x["relative_time"], int)
         assert isinstance(x["ocean"], int)
-        assert isinstance(x["wind_speed"], int)
+        assert isinstance(x["target"], int)
         assert x["image"].shape == (dataset.size, dataset.size)
 
     def test_len(self, dataset: TropicalCycloneWindEstimation) -> None:

--- a/torchgeo/datasets/cyclone.py
+++ b/torchgeo/datasets/cyclone.py
@@ -168,7 +168,7 @@ class TropicalCycloneWindEstimation(VisionDataset):
 
         features["relative_time"] = int(features["relative_time"])
         features["ocean"] = int(features["ocean"])
-        features["wind_speed"] = int(features["wind_speed"])
+        features["target"] = int(features["wind_speed"])
 
         return features
 

--- a/torchgeo/trainers/cyclone.py
+++ b/torchgeo/trainers/cyclone.py
@@ -66,7 +66,7 @@ class CycloneSimpleRegressionTask(pl.LightningModule):
             training loss
         """
         x = batch["image"]
-        y = batch["wind_speed"].view(-1, 1)
+        y = batch["target"].view(-1, 1)
         y_hat = self.forward(x)
 
         loss = F.mse_loss(y_hat, y)
@@ -88,7 +88,7 @@ class CycloneSimpleRegressionTask(pl.LightningModule):
             batch_idx: Index of current batch
         """
         x = batch["image"]
-        y = batch["wind_speed"].view(-1, 1)
+        y = batch["target"].view(-1, 1)
         y_hat = self.forward(x)
 
         loss = F.mse_loss(y_hat, y)
@@ -107,7 +107,7 @@ class CycloneSimpleRegressionTask(pl.LightningModule):
             batch_idx: Index of current batch
         """
         x = batch["image"]
-        y = batch["wind_speed"].view(-1, 1)
+        y = batch["target"].view(-1, 1)
         y_hat = self.forward(x)
 
         loss = F.mse_loss(y_hat, y)
@@ -177,8 +177,8 @@ class CycloneDataModule(pl.LightningDataModule):
         sample["image"] = (
             sample["image"].unsqueeze(0).repeat(3, 1, 1)
         )  # convert to 3 channel
-        sample["wind_speed"] = torch.as_tensor(  # type: ignore[attr-defined]
-            sample["wind_speed"]
+        sample["target"] = torch.as_tensor(  # type: ignore[attr-defined]
+            sample["target"]
         ).float()
 
         return sample


### PR DESCRIPTION
This dataset uses a random key name "wind_speed" instead of a more typical name like "target". This makes it harder to combine with other regression datasets using a single trainer.

Once this is merged I'm planning to refactor things to make a single `RegressionTask` trainer that I can use for Cyclone, COWCCounting, and other regression datasets.