### PR TITLE
Various improvements to API docs

### DIFF
--- a/torchgeo/datasets/spacenet.py
+++ b/torchgeo/datasets/spacenet.py
@@ -148,9 +148,9 @@ class SpaceNet(VisionDataset, abc.ABC):
         """Rasterizes the dataset's labels (in geojson format).
 
         Args:
-            path (str): path to the label
-            tfm (Affine): transform of corresponding image
-            shape (List[int, int]): shape of corresponding image
+            path: path to the label
+            tfm: transform of corresponding image
+            shape: shape of corresponding image
 
         Returns:
             Tensor: label tensor
@@ -289,9 +289,12 @@ class SpaceNet1(SpaceNet):
     Dataset format:
 
     * Imagery - Worldview-2 GeoTIFFs
+
         * 8Band.tif (Multispectral)
         * RGB.tif (Pansharpened RGB)
+
     * Labels - GeoJSON
+
         * labels.geojson
 
     If you use this dataset in your research, please cite the following paper:
@@ -350,8 +353,7 @@ class SpaceNet2(SpaceNet):
     is a dataset of building footprints over the cities of Las Vegas,
     Paris, Shanghai and Khartoum.
 
-    Collection features
-
+    Collection features:
 
     +------------+---------------------+------------+------------+
     |    AOI     | Area (km\ :sup:`2`\)| # Images   | # Buildings|
@@ -365,7 +367,7 @@ class SpaceNet2(SpaceNet):
     | Khartoum   |    765              |   1012     |  35,503    |
     +------------+---------------------+------------+------------+
 
-    Imagery features
+    Imagery features:
 
     .. list-table::
         :widths: 10 10 10 10 10
@@ -388,15 +390,17 @@ class SpaceNet2(SpaceNet):
             - 650 x 650
             - 650 x 650
 
-
-    Dataset format
+    Dataset format:
 
     * Imagery - Worldview-3 GeoTIFFs
+
         * PAN.tif (Panchromatic)
         * MS.tif (Multispectral)
         * PS-MS (Pansharpened Multispectral)
         * PS-RGB (Pansharpened RGB)
+
     * Labels - GeoJSON
+
         * label.geojson
 
     If you use this dataset in your research, please cite the following paper:
@@ -504,8 +508,7 @@ class SpaceNet4(SpaceNet):
     associated building footprints over the city of Atlanta. The off-nadir angle
     ranges from 7 degrees to 54 degrees.
 
-
-    Dataset features
+    Dataset features:
 
     * No. of chipped images: 28,728 (PAN/MS/PS-RGBNIR)
     * No. of label files: 1064
@@ -513,13 +516,16 @@ class SpaceNet4(SpaceNet):
     * Area Coverage: 665 sq km
     * Chip size: 225 x 225 (MS), 900 x 900 (PAN/PS-RGBNIR)
 
-    Dataset format
+    Dataset format:
 
     * Imagery - Worldview-2 GeoTIFFs
+
         * PAN.tif (Panchromatic)
         * MS.tif (Multispectral)
         * PS-RGBNIR (Pansharpened RGBNIR)
+
     * Labels - GeoJSON
+
         * labels.geojson
 
     If you use this dataset in your research, please cite the following paper:
@@ -594,7 +600,7 @@ class SpaceNet4(SpaceNet):
             root: root directory where dataset can be found
             image: image selection which must be in ["MS", "PAN", "PS-RGBNIR"]
             angles: angle selection which must be in ["nadir", "off-nadir",
-            "very-off-nadir"]
+                "very-off-nadir"]
             transforms: a function/transform that takes input sample and its target as
                 entry and returns a transformed version
             download: if True, download dataset and store it in the root directory.

--- a/torchgeo/models/changestar.py
+++ b/torchgeo/models/changestar.py
@@ -72,7 +72,7 @@ class ChangeMixin(Module):
         """Forward pass of the model.
 
         Args:
-            x: input bitemporal feature maps of shape [b, t, c, h, w]
+            bi_feature: input bitemporal feature maps of shape [b, t, c, h, w]
 
         Returns:
             a list of bidirected output predictions
@@ -146,13 +146,8 @@ class ChangeStar(Module):
             x: a bitemporal input tensor of shape [B, T, C, H, W]
 
         Returns:
-            a dictionary containing
-                if training stage, returning
-                    bi_seg_logit: bitemporal semantic segmentation logit
-                    bi_change_logit: bidirected binary change detection logit
-                if inference stage, returning
-                    bi_seg_logit: bitemporal semantic segmentation logit
-                    change_prob:  binary change detection probability
+            a dictionary containing bitemporal semantic segmentation logit and binary
+            change detection logit/probability
         """
         b, t, c, h, w = x.shape
         x = rearrange(x, "b t c h w -> (b t) c h w")

--- a/torchgeo/models/fccd.py
+++ b/torchgeo/models/fccd.py
@@ -231,7 +231,14 @@ class FCEF(Module):
         self.upsample = Upsample()
 
     def forward(self, x: Tensor) -> Tensor:
-        """Forward pass of the model."""
+        """Forward pass of the model.
+
+        Args:
+            x: input image
+
+        Returns:
+            prediction
+        """
         b, t, c, h, w = x.shape
         x = rearrange(x, "b t c h w -> b (t c) h w")
 
@@ -274,7 +281,14 @@ class FCSiamConc(Module):
         self.pool = nn.modules.MaxPool2d(kernel_size=2)
 
     def forward(self, x: Tensor) -> Tensor:
-        """Forward pass of the model."""
+        """Forward pass of the model.
+
+        Args:
+            x: input image
+
+        Returns:
+            prediction
+        """
         b, t, c, h, w = x.shape
         x = rearrange(x, "b t c h w -> (b t) c h w")
 
@@ -325,7 +339,14 @@ class FCSiamDiff(nn.modules.Module):
         self.pool = nn.modules.MaxPool2d(kernel_size=2)
 
     def forward(self, x: Tensor) -> Tensor:
-        """Forward pass of the model."""
+        """Forward pass of the model.
+
+        Args:
+            x: input image
+
+        Returns:
+            prediction
+        """
         b, t, c, h, w = x.shape
         x = rearrange(x, "b t c h w -> (b t) c h w")
 

--- a/torchgeo/trainers/chesapeake.py
+++ b/torchgeo/trainers/chesapeake.py
@@ -415,7 +415,7 @@ class ChesapeakeCVPRDataModule(LightningDataModule):
         """Preprocesses a single sample.
 
         Args:
-            sample dictionary containing image and mask
+            sample: sample dictionary containing image and mask
 
         Returns:
             preprocessed sample

--- a/torchgeo/trainers/chesapeake.py
+++ b/torchgeo/trainers/chesapeake.py
@@ -351,7 +351,16 @@ class ChesapeakeCVPRDataModule(LightningDataModule):
     def pad_to(
         self, size: int = 512, image_value: int = 0, mask_value: int = 0
     ) -> Callable[[Dict[str, Tensor]], Dict[str, Tensor]]:
-        """Returns a function to perform a padding transform on a single sample."""
+        """Returns a function to perform a padding transform on a single sample.
+
+        Args:
+            size: output image size
+            image_value: value to pad image with
+            mask_value: value to pad mask with
+
+        Returns:
+            function to perform padding
+        """
 
         def pad_inner(sample: Dict[str, Tensor]) -> Dict[str, Tensor]:
             _, height, width = sample["image"].shape
@@ -381,7 +390,14 @@ class ChesapeakeCVPRDataModule(LightningDataModule):
     def center_crop(
         self, size: int = 512
     ) -> Callable[[Dict[str, Tensor]], Dict[str, Tensor]]:
-        """Returns a function to perform a center crop transform on a single sample."""
+        """Returns a function to perform a center crop transform on a single sample.
+
+        Args:
+            size: output image size
+
+        Returns:
+            function to perform center crop
+        """
 
         def center_crop_inner(sample: Dict[str, Tensor]) -> Dict[str, Tensor]:
             _, height, width = sample["image"].shape
@@ -396,7 +412,14 @@ class ChesapeakeCVPRDataModule(LightningDataModule):
         return center_crop_inner
 
     def preprocess(self, sample: Dict[str, Any]) -> Dict[str, Any]:
-        """Preprocesses a single sample."""
+        """Preprocesses a single sample.
+
+        Args:
+            sample dictionary containing image and mask
+
+        Returns:
+            preprocessed sample
+        """
         sample["image"] = sample["image"] / 255.0
         sample["mask"] = sample["mask"]
         sample["mask"] = sample["mask"].squeeze()
@@ -413,7 +436,14 @@ class ChesapeakeCVPRDataModule(LightningDataModule):
     def nodata_check(
         self, size: int = 512
     ) -> Callable[[Dict[str, Tensor]], Dict[str, Tensor]]:
-        """Returns a function to check for nodata or missized input."""
+        """Returns a function to check for nodata or mis-sized input.
+
+        Args:
+            size: output image size
+
+        Returns:
+            function to check for nodata values
+        """
 
         def nodata_check_inner(sample: Dict[str, Tensor]) -> Dict[str, Tensor]:
             num_channels, height, width = sample["image"].shape
@@ -447,6 +477,9 @@ class ChesapeakeCVPRDataModule(LightningDataModule):
 
         The splits should be done here vs. in :func:`__init__` per the docs:
         https://pytorch-lightning.readthedocs.io/en/latest/extensions/datamodules.html#setup.
+
+        Args:
+            stage: stage to set up
         """
         train_transforms = Compose(
             [
@@ -495,7 +528,11 @@ class ChesapeakeCVPRDataModule(LightningDataModule):
         )
 
     def train_dataloader(self) -> DataLoader[Any]:
-        """Return a DataLoader for training."""
+        """Return a DataLoader for training.
+
+        Returns:
+            training data loader
+        """
         sampler = RandomBatchGeoSampler(
             self.train_dataset,
             size=self.original_patch_size,
@@ -507,7 +544,11 @@ class ChesapeakeCVPRDataModule(LightningDataModule):
         )
 
     def val_dataloader(self) -> DataLoader[Any]:
-        """Return a DataLoader for validation."""
+        """Return a DataLoader for validation.
+
+        Returns:
+            validation data loader
+        """
         sampler = GridGeoSampler(
             self.val_dataset,
             size=self.original_patch_size,
@@ -521,7 +562,11 @@ class ChesapeakeCVPRDataModule(LightningDataModule):
         )
 
     def test_dataloader(self) -> DataLoader[Any]:
-        """Return a DataLoader for testing."""
+        """Return a DataLoader for testing.
+
+        Returns:
+            testing data loader
+        """
         sampler = GridGeoSampler(
             self.test_dataset,
             size=self.original_patch_size,

--- a/torchgeo/trainers/cyclone.py
+++ b/torchgeo/trainers/cyclone.py
@@ -172,7 +172,14 @@ class CycloneDataModule(pl.LightningDataModule):
         self.api_key = api_key
 
     def custom_transform(self, sample: Dict[str, Any]) -> Dict[str, Any]:
-        """Transform a single sample from the Dataset."""
+        """Transform a single sample from the Dataset.
+
+        Args:
+            sample: dictionary containing image and target
+
+        Returns:
+            preprocessed sample
+        """
         sample["image"] = sample["image"] / 255.0  # scale to [0,1]
         sample["image"] = (
             sample["image"].unsqueeze(0).repeat(3, 1, 1)
@@ -209,6 +216,9 @@ class CycloneDataModule(pl.LightningDataModule):
         storm, can we predict its windspeed. The test set, however, contains *some*
         storms from the training set (specifically, the latter parts of the storms) as
         well as some novel storms.
+
+        Args:
+            stage: stage to set up
         """
         self.all_train_dataset = TropicalCycloneWindEstimation(
             self.root_dir,
@@ -242,7 +252,11 @@ class CycloneDataModule(pl.LightningDataModule):
         )
 
     def train_dataloader(self) -> DataLoader[Any]:
-        """Return a DataLoader for training."""
+        """Return a DataLoader for training.
+
+        Returns:
+            training data loader
+        """
         return DataLoader(
             self.train_dataset,
             batch_size=self.batch_size,
@@ -251,7 +265,11 @@ class CycloneDataModule(pl.LightningDataModule):
         )
 
     def val_dataloader(self) -> DataLoader[Any]:
-        """Return a DataLoader for validation."""
+        """Return a DataLoader for validation.
+
+        Returns:
+            validation data loader
+        """
         return DataLoader(
             self.val_dataset,
             batch_size=self.batch_size,
@@ -260,7 +278,11 @@ class CycloneDataModule(pl.LightningDataModule):
         )
 
     def test_dataloader(self) -> DataLoader[Any]:
-        """Return a DataLoader for testing."""
+        """Return a DataLoader for testing.
+
+        Returns:
+            testing data loader
+        """
         return DataLoader(
             self.test_dataset,
             batch_size=self.batch_size,

--- a/torchgeo/trainers/landcoverai.py
+++ b/torchgeo/trainers/landcoverai.py
@@ -107,7 +107,14 @@ class LandcoverAISegmentationTask(pl.LightningModule):
         self.test_metrics = self.train_metrics.clone(prefix="test_")
 
     def forward(self, x: Tensor) -> Any:  # type: ignore[override]
-        """Forward pass of the model."""
+        """Forward pass of the model.
+
+        Args:
+            x: input image
+
+        Returns:
+            prediction
+        """
         return self.model(x)
 
     def training_step(  # type: ignore[override]
@@ -277,7 +284,14 @@ class LandcoverAIDataModule(pl.LightningDataModule):
         self.num_workers = num_workers
 
     def preprocess(self, sample: Dict[str, Any]) -> Dict[str, Any]:
-        """Transform a single sample from the Dataset."""
+        """Transform a single sample from the Dataset.
+
+        Args:
+            sample: dictionary containing image and mask
+
+        Returns:
+            preprocessed sample
+        """
         sample["image"] = sample["image"] / 255.0
 
         sample["image"] = sample["image"].float()
@@ -296,6 +310,9 @@ class LandcoverAIDataModule(pl.LightningDataModule):
         """Initialize the main ``Dataset`` objects.
 
         This method is called once per GPU per run.
+
+        Args:
+            stage: stage to set up
         """
         train_transforms = self.preprocess
         val_test_transforms = self.preprocess
@@ -313,7 +330,11 @@ class LandcoverAIDataModule(pl.LightningDataModule):
         )
 
     def train_dataloader(self) -> DataLoader[Any]:
-        """Return a DataLoader for training."""
+        """Return a DataLoader for training.
+
+        Returns:
+            training data loader
+        """
         return DataLoader(
             self.train_dataset,
             batch_size=self.batch_size,
@@ -322,7 +343,11 @@ class LandcoverAIDataModule(pl.LightningDataModule):
         )
 
     def val_dataloader(self) -> DataLoader[Any]:
-        """Return a DataLoader for validation."""
+        """Return a DataLoader for validation.
+
+        Returns:
+            validation data loader
+        """
         return DataLoader(
             self.val_dataset,
             batch_size=self.batch_size,
@@ -331,7 +356,11 @@ class LandcoverAIDataModule(pl.LightningDataModule):
         )
 
     def test_dataloader(self) -> DataLoader[Any]:
-        """Return a DataLoader for testing."""
+        """Return a DataLoader for testing.
+
+        Returns:
+            testing data loader
+        """
         return DataLoader(
             self.test_dataset,
             batch_size=self.batch_size,

--- a/torchgeo/trainers/resisc45.py
+++ b/torchgeo/trainers/resisc45.py
@@ -76,7 +76,14 @@ class RESISC45DataModule(pl.LightningDataModule):
         self.norm = Normalize(self.band_means, self.band_stds)
 
     def preprocess(self, sample: Dict[str, Any]) -> Dict[str, Any]:
-        """Transform a single sample from the Dataset."""
+        """Transform a single sample from the Dataset.
+
+        Args:
+            sample: input image dictionary
+
+        Returns:
+            preprocessed sample
+        """
         sample["image"] = sample["image"].float()
         sample["image"] /= 255.0
         sample["image"] = self.norm(sample["image"])
@@ -93,6 +100,9 @@ class RESISC45DataModule(pl.LightningDataModule):
         """Initialize the main ``Dataset`` objects.
 
         This method is called once per GPU per run.
+
+        Args:
+            stage: stage to set up
         """
         transforms = Compose([self.preprocess])
 
@@ -108,7 +118,11 @@ class RESISC45DataModule(pl.LightningDataModule):
             self.val_dataset, self.test_dataset = None, None  # type: ignore[assignment]
 
     def train_dataloader(self) -> DataLoader[Any]:
-        """Return a DataLoader for training."""
+        """Return a DataLoader for training.
+
+        Returns:
+            training data loader
+        """
         return DataLoader(
             self.train_dataset,
             batch_size=self.batch_size,
@@ -117,7 +131,11 @@ class RESISC45DataModule(pl.LightningDataModule):
         )
 
     def val_dataloader(self) -> DataLoader[Any]:
-        """Return a DataLoader for validation."""
+        """Return a DataLoader for validation.
+
+        Returns:
+            validation data loader
+        """
         if self.unsupervised_mode or self.val_split_pct == 0:
             return self.train_dataloader()
         else:
@@ -129,7 +147,11 @@ class RESISC45DataModule(pl.LightningDataModule):
             )
 
     def test_dataloader(self) -> DataLoader[Any]:
-        """Return a DataLoader for testing."""
+        """Return a DataLoader for testing.
+
+        Returns:
+            testing data loader
+        """
         if self.unsupervised_mode or self.test_split_pct == 0:
             return self.train_dataloader()
         else:

--- a/torchgeo/trainers/sen12ms.py
+++ b/torchgeo/trainers/sen12ms.py
@@ -72,7 +72,14 @@ class SEN12MSSegmentationTask(pl.LightningModule):
         self.test_metrics = self.train_metrics.clone(prefix="test_")
 
     def forward(self, x: Tensor) -> Any:  # type: ignore[override]
-        """Forward pass of the model."""
+        """Forward pass of the model.
+
+        Args:
+            x: input image
+
+        Returns:
+            prediction
+        """
         return self.model(x)
 
     def training_step(  # type: ignore[override]
@@ -196,8 +203,8 @@ class SEN12MSDataModule(pl.LightningDataModule):
     https://arxiv.org/abs/2002.08254.
     """
 
-    # Mapping from the IGBP class definitions to the DFC2020, taken from the dataloader
-    # here https://github.com/lukasliebel/dfc2020_baseline.
+    #: Mapping from the IGBP class definitions to the DFC2020, taken from the dataloader
+    #: here https://github.com/lukasliebel/dfc2020_baseline.
     DFC2020_CLASS_MAPPING = torch.tensor(  # type: ignore[attr-defined]
         [
             0,  # maps 0s to 0
@@ -252,7 +259,14 @@ class SEN12MSDataModule(pl.LightningDataModule):
         self.num_workers = num_workers
 
     def custom_transform(self, sample: Dict[str, Any]) -> Dict[str, Any]:
-        """Transform a single sample from the Dataset."""
+        """Transform a single sample from the Dataset.
+
+        Args:
+            sample: dictionary containing image and mask
+
+        Returns:
+            preprocessed sample
+        """
         sample["image"] = sample["image"].float()
 
         if self.band_set == "all":
@@ -278,6 +292,9 @@ class SEN12MSDataModule(pl.LightningDataModule):
 
         We split samples between train and val geographically with proportions of 80/20.
         This mimics the geographic test set split.
+
+        Args:
+            stage: stage to set up
         """
         season_to_int = {"winter": 0, "spring": 1000, "summer": 2000, "fall": 3000}
 
@@ -322,7 +339,11 @@ class SEN12MSDataModule(pl.LightningDataModule):
         )
 
     def train_dataloader(self) -> DataLoader[Any]:
-        """Return a DataLoader for training."""
+        """Return a DataLoader for training.
+
+        Returns:
+            training data loader
+        """
         return DataLoader(
             self.train_dataset,
             batch_size=self.batch_size,
@@ -331,7 +352,11 @@ class SEN12MSDataModule(pl.LightningDataModule):
         )
 
     def val_dataloader(self) -> DataLoader[Any]:
-        """Return a DataLoader for validation."""
+        """Return a DataLoader for validation.
+
+        Returns:
+            validation data loader
+        """
         return DataLoader(
             self.val_dataset,
             batch_size=self.batch_size,
@@ -340,7 +365,11 @@ class SEN12MSDataModule(pl.LightningDataModule):
         )
 
     def test_dataloader(self) -> DataLoader[Any]:
-        """Return a DataLoader for testing."""
+        """Return a DataLoader for testing.
+
+        Returns:
+            testing data loader
+        """
         return DataLoader(
             self.test_dataset,
             batch_size=self.batch_size,

--- a/torchgeo/trainers/so2sat.py
+++ b/torchgeo/trainers/so2sat.py
@@ -197,7 +197,14 @@ class So2SatDataModule(pl.LightningDataModule):
         self.unsupervised_mode = unsupervised_mode
 
     def preprocess(self, sample: Dict[str, Any]) -> Dict[str, Any]:
-        """Transform a single sample from the Dataset."""
+        """Transform a single sample from the Dataset.
+
+        Args:
+            sample: dictionary containing image
+
+        Returns:
+            preprocessed sample
+        """
         # sample["image"] = (sample["image"] - self.band_means) / self.band_stds
         sample["image"] = sample["image"].float()
         sample["image"] = sample["image"][self.reindex_to_rgb_first, :, :]
@@ -218,6 +225,9 @@ class So2SatDataModule(pl.LightningDataModule):
         """Initialize the main ``Dataset`` objects.
 
         This method is called once per GPU per run.
+
+        Args:
+            stage: stage to set up
         """
         train_transforms = Compose([self.preprocess])
         val_test_transforms = self.preprocess
@@ -255,7 +265,11 @@ class So2SatDataModule(pl.LightningDataModule):
             )
 
     def train_dataloader(self) -> DataLoader[Any]:
-        """Return a DataLoader for training."""
+        """Return a DataLoader for training.
+
+        Returns:
+            training data loader
+        """
         return DataLoader(
             self.train_dataset,
             batch_size=self.batch_size,
@@ -264,7 +278,11 @@ class So2SatDataModule(pl.LightningDataModule):
         )
 
     def val_dataloader(self) -> DataLoader[Any]:
-        """Return a DataLoader for validation."""
+        """Return a DataLoader for validation.
+
+        Returns:
+            validation data loader
+        """
         return DataLoader(
             self.val_dataset,
             batch_size=self.batch_size,
@@ -273,7 +291,11 @@ class So2SatDataModule(pl.LightningDataModule):
         )
 
     def test_dataloader(self) -> DataLoader[Any]:
-        """Return a DataLoader for testing."""
+        """Return a DataLoader for testing.
+
+        Returns:
+            testing data loader
+        """
         return DataLoader(
             self.test_dataset,
             batch_size=self.batch_size,

--- a/torchgeo/trainers/tasks.py
+++ b/torchgeo/trainers/tasks.py
@@ -143,7 +143,14 @@ class ClassificationTask(pl.LightningModule):
         self.test_metrics = self.train_metrics.clone(prefix="test_")
 
     def forward(self, x: Tensor) -> Any:  # type: ignore[override]
-        """Forward pass of the model."""
+        """Forward pass of the model.
+
+        Args:
+            x: input image
+
+        Returns:
+            prediction
+        """
         return self.model(x)
 
     def training_step(  # type: ignore[override]

--- a/torchgeo/trainers/ucmerced.py
+++ b/torchgeo/trainers/ucmerced.py
@@ -72,7 +72,14 @@ class UCMercedDataModule(pl.LightningDataModule):
         self.norm = Normalize(self.band_means, self.band_stds)
 
     def preprocess(self, sample: Dict[str, Any]) -> Dict[str, Any]:
-        """Transform a single sample from the Dataset."""
+        """Transform a single sample from the Dataset.
+
+        Args:
+            sample: dictionary containing image
+
+        Returns:
+            preprocessed sample
+        """
         sample["image"] = sample["image"].float()
         sample["image"] /= 255.0
         c, h, w = sample["image"].shape
@@ -94,6 +101,9 @@ class UCMercedDataModule(pl.LightningDataModule):
         """Initialize the main ``Dataset`` objects.
 
         This method is called once per GPU per run.
+
+        Args:
+            stage: stage to set up
         """
         transforms = Compose([self.preprocess])
 
@@ -109,7 +119,11 @@ class UCMercedDataModule(pl.LightningDataModule):
             self.val_dataset, self.test_dataset = None, None  # type: ignore[assignment]
 
     def train_dataloader(self) -> DataLoader[Any]:
-        """Return a DataLoader for training."""
+        """Return a DataLoader for training.
+
+        Returns:
+            training data loader
+        """
         return DataLoader(
             self.train_dataset,
             batch_size=self.batch_size,
@@ -118,7 +132,11 @@ class UCMercedDataModule(pl.LightningDataModule):
         )
 
     def val_dataloader(self) -> DataLoader[Any]:
-        """Return a DataLoader for validation."""
+        """Return a DataLoader for validation.
+
+        Returns:
+            validation data loader
+        """
         if self.unsupervised_mode or self.val_split_pct == 0:
             return self.train_dataloader()
         else:
@@ -130,7 +148,11 @@ class UCMercedDataModule(pl.LightningDataModule):
             )
 
     def test_dataloader(self) -> DataLoader[Any]:
-        """Return a DataLoader for testing."""
+        """Return a DataLoader for testing.
+
+        Returns:
+            testing data loader
+        """
         if self.unsupervised_mode or self.test_split_pct == 0:
             return self.train_dataloader()
         else:

--- a/torchgeo/trainers/utils.py
+++ b/torchgeo/trainers/utils.py
@@ -23,8 +23,7 @@ def extract_encoder(path: str) -> Tuple[str, Dict[str, Tensor]]:
         path: path to checkpoint file (.ckpt)
 
     Returns:
-        name: str representing model name (generally a torchvision resnet model)
-        state_dict: dict of layer names and weight tensors
+        tuple containing model name and state dict
 
     Raises:
         ValueError: if 'classification_model' or 'encoder' not in


### PR DESCRIPTION
I'm sure there are more things I missed, but these were the most obvious things I noticed while looking through our API docs.

- [x] Dataset: improved formatting for SpaceNet docs
- [x] Models: document all args and return values
- [x] Trainers: document all args and return values

Overall I'm pretty disappointed that `pydocstyle` didn't catch any of these automatically. In the long run I think we'll need to contribute a few improvements to `pydocstyle` so that we don't have to manually search for these kinds of things.