### PR TITLE
Add train/val/test splits to UCMerced

### DIFF
--- a/tests/data/ucmerced/uc_merced-test.txt
+++ b/tests/data/ucmerced/uc_merced-test.txt
@@ -1,0 +1,4 @@
+agricultural00.tif
+agricultural01.tif
+agricultural02.tif
+airplane00.tif

--- a/tests/data/ucmerced/uc_merced-train.txt
+++ b/tests/data/ucmerced/uc_merced-train.txt
@@ -1,0 +1,4 @@
+agricultural00.tif
+agricultural01.tif
+agricultural02.tif
+airplane00.tif

--- a/tests/data/ucmerced/uc_merced-val.txt
+++ b/tests/data/ucmerced/uc_merced-val.txt
@@ -1,0 +1,4 @@
+agricultural00.tif
+agricultural01.tif
+agricultural02.tif
+airplane00.tif

--- a/tests/datasets/test_ucmerced.py
+++ b/tests/datasets/test_ucmerced.py
@@ -9,8 +9,8 @@ from typing import Generator
 import pytest
 import torch
 import torch.nn as nn
-from _pytest.monkeypatch import MonkeyPatch
 from _pytest.fixtures import SubRequest
+from _pytest.monkeypatch import MonkeyPatch
 from torch.utils.data import ConcatDataset
 
 import torchgeo.datasets.utils
@@ -24,9 +24,10 @@ def download_url(url: str, root: str, *args: str, **kwargs: str) -> None:
 class TestUCMerced:
     @pytest.fixture(params=["train", "val", "test"])
     def dataset(
-        self, monkeypatch: Generator[MonkeyPatch, None, None],
+        self,
+        monkeypatch: Generator[MonkeyPatch, None, None],
         tmp_path: Path,
-        request: SubRequest
+        request: SubRequest,
     ) -> UCMerced:
         monkeypatch.setattr(  # type: ignore[attr-defined]
             torchgeo.datasets.ucmerced, "download_url", download_url
@@ -35,16 +36,26 @@ class TestUCMerced:
         monkeypatch.setattr(UCMerced, "md5", md5)  # type: ignore[attr-defined]
         url = os.path.join("tests", "data", "ucmerced", "UCMerced_LandUse.zip")
         monkeypatch.setattr(UCMerced, "url", url)  # type: ignore[attr-defined]
-        monkeypatch.setattr(UCMerced, "split_urls", {  # type: ignore[attr-defined]
-            "train": os.path.join("tests", "data", "ucmerced", "uc_merced-train.txt"),
-            "val": os.path.join("tests", "data", "ucmerced", "uc_merced-val.txt"),
-            "test": os.path.join("tests", "data", "ucmerced", "uc_merced-test.txt"),
-        })
-        monkeypatch.setattr(UCMerced, "split_md5s", {  # type: ignore[attr-defined]
-            "train": "a01fa9f13333bb176fc1bfe26ff4c711",
-            "val": "a01fa9f13333bb176fc1bfe26ff4c711",
-            "test": "a01fa9f13333bb176fc1bfe26ff4c711",
-        })
+        monkeypatch.setattr(
+            UCMerced,
+            "split_urls",
+            {  # type: ignore[attr-defined]
+                "train": os.path.join(
+                    "tests", "data", "ucmerced", "uc_merced-train.txt"
+                ),
+                "val": os.path.join("tests", "data", "ucmerced", "uc_merced-val.txt"),
+                "test": os.path.join("tests", "data", "ucmerced", "uc_merced-test.txt"),
+            },
+        )
+        monkeypatch.setattr(
+            UCMerced,
+            "split_md5s",
+            {  # type: ignore[attr-defined]
+                "train": "a01fa9f13333bb176fc1bfe26ff4c711",
+                "val": "a01fa9f13333bb176fc1bfe26ff4c711",
+                "test": "a01fa9f13333bb176fc1bfe26ff4c711",
+            },
+        )
         root = str(tmp_path)
         split = request.param
         transforms = nn.Identity()  # type: ignore[attr-defined]

--- a/tests/datasets/test_ucmerced.py
+++ b/tests/datasets/test_ucmerced.py
@@ -36,10 +36,10 @@ class TestUCMerced:
         monkeypatch.setattr(UCMerced, "md5", md5)  # type: ignore[attr-defined]
         url = os.path.join("tests", "data", "ucmerced", "UCMerced_LandUse.zip")
         monkeypatch.setattr(UCMerced, "url", url)  # type: ignore[attr-defined]
-        monkeypatch.setattr(
+        monkeypatch.setattr(  # type: ignore[attr-defined]
             UCMerced,
             "split_urls",
-            {  # type: ignore[attr-defined]
+            {
                 "train": os.path.join(
                     "tests", "data", "ucmerced", "uc_merced-train.txt"
                 ),
@@ -47,10 +47,10 @@ class TestUCMerced:
                 "test": os.path.join("tests", "data", "ucmerced", "uc_merced-test.txt"),
             },
         )
-        monkeypatch.setattr(
+        monkeypatch.setattr(  # type: ignore[attr-defined]
             UCMerced,
             "split_md5s",
-            {  # type: ignore[attr-defined]
+            {
                 "train": "a01fa9f13333bb176fc1bfe26ff4c711",
                 "val": "a01fa9f13333bb176fc1bfe26ff4c711",
                 "test": "a01fa9f13333bb176fc1bfe26ff4c711",

--- a/tests/trainers/test_ucmerced.py
+++ b/tests/trainers/test_ucmerced.py
@@ -4,25 +4,16 @@
 import os
 
 import pytest
-from _pytest.fixtures import SubRequest
 
 from torchgeo.trainers import UCMercedDataModule
 
 
-@pytest.fixture(scope="module", params=[True, False])
-def datamodule(request: SubRequest) -> UCMercedDataModule:
+@pytest.fixture(scope="module")
+def datamodule() -> UCMercedDataModule:
     root = os.path.join("tests", "data", "ucmerced")
     batch_size = 2
     num_workers = 0
-    unsupervised_mode = request.param
-    dm = UCMercedDataModule(
-        root,
-        batch_size,
-        num_workers,
-        val_split_pct=0.33,
-        test_split_pct=0.33,
-        unsupervised_mode=unsupervised_mode,
-    )
+    dm = UCMercedDataModule(root, batch_size, num_workers)
     dm.prepare_data()
     dm.setup()
     return dm

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -617,8 +617,8 @@ class VisionClassificationDataset(VisionDataset, ImageFolder):  # type: ignore[m
                 entry and returns a transformed version
             loader: a callable function which takes as input a path to an image and
                 returns a PIL Image or numpy array
-            is_valid_file (callable, optional): A function that takes path of an Image
-                file and check if the file is a valid file
+            is_valid_file: A function that takes the path of an Image file and checks if
+                the file is a valid file
         """
         # When transform & target_transform are None, ImageFolder.__getitem__(index)
         # returns a PIL.Image and int for image and label, respectively

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -607,6 +607,7 @@ class VisionClassificationDataset(VisionDataset, ImageFolder):  # type: ignore[m
         root: str,
         transforms: Optional[Callable[[Dict[str, Tensor]], Dict[str, Tensor]]] = None,
         loader: Optional[Callable[[str], Any]] = pil_loader,
+        is_valid_file: Optional[Callable[[str], bool]] = None,
     ) -> None:
         """Initialize a new VisionClassificationDataset instance.
 
@@ -616,11 +617,17 @@ class VisionClassificationDataset(VisionDataset, ImageFolder):  # type: ignore[m
                 entry and returns a transformed version
             loader: a callable function which takes as input a path to an image and
                 returns a PIL Image or numpy array
+            is_valid_file (callable, optional): A function that takes path of an Image
+                file and check if the file is a valid file
         """
         # When transform & target_transform are None, ImageFolder.__getitem__(index)
         # returns a PIL.Image and int for image and label, respectively
         super().__init__(
-            root=root, transform=None, target_transform=None, loader=loader
+            root=root,
+            transform=None,
+            target_transform=None,
+            loader=loader,
+            is_valid_file=is_valid_file,
         )
 
         # Must be set after calling super().__init__()

--- a/torchgeo/datasets/ucmerced.py
+++ b/torchgeo/datasets/ucmerced.py
@@ -140,7 +140,7 @@ class UCMerced(VisionClassificationDataset):
         super().__init__(
             root=os.path.join(root, self.base_dir),
             transforms=transforms,
-            is_valid_file=is_in_split
+            is_valid_file=is_in_split,
         )
 
     def _check_integrity(self) -> bool:
@@ -194,8 +194,8 @@ class UCMerced(VisionClassificationDataset):
             download_url(
                 self.split_urls[split],
                 self.root,
-                filename=f'uc_merced-{split}.txt',
-                md5=self.split_md5s[split] if self.checksum else None
+                filename=f"uc_merced-{split}.txt",
+                md5=self.split_md5s[split] if self.checksum else None,
             )
 
     def _extract(self) -> None:

--- a/torchgeo/trainers/ucmerced.py
+++ b/torchgeo/trainers/ucmerced.py
@@ -13,7 +13,6 @@ from torch.utils.data import DataLoader
 from torchvision.transforms import Compose, Normalize
 
 from ..datasets import UCMerced
-from ..datasets.utils import dataset_split
 from .tasks import ClassificationTask
 
 # https://github.com/pytorch/pytorch/issues/60979


### PR DESCRIPTION
The "In-Domain Representation Learning for Remote Sensing" paper contains train/val/test splits for the datasets that they test with -- https://github.com/google-research/google-research/blob/master/remote_sensing_representations/README.md. In the cases of UC Merced, RESISC45, and EuroSAT (which don't have official train test splits) I think it makes more sense to use these splits instead of just returning the whole dataset. These splits are being "used in the wild" already (e.g. the SeCo paper uses the BigEarthNet split from the In Domain ... paper although the BigEarthNet dataset defines its own (different) splits).