### PR TITLE
VisionClassificationDataset: fix Sphinx base class mapping

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -104,6 +104,7 @@ intersphinx_mapping = {
     "rasterio": ("https://rasterio.readthedocs.io/en/latest/", None),
     "rtree": ("https://rtree.readthedocs.io/en/latest/", None),
     "torch": ("https://pytorch.org/docs/stable", None),
+    "torchvision": ("https://pytorch.org/vision/stable", None),
 }
 
 # nbsphinx

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -34,6 +34,7 @@ from .utils import BoundingBox, disambiguate_timestamp
 # https://github.com/pytorch/pytorch/issues/60979
 # https://github.com/pytorch/pytorch/pull/61045
 Dataset.__module__ = "torch.utils.data"
+ImageFolder.__module__ = "torchvision.datasets"
 
 
 class GeoDataset(Dataset[Dict[str, Any]], abc.ABC):

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -26,7 +26,7 @@ from rasterio.windows import from_bounds
 from rtree.index import Index, Property
 from torch import Tensor
 from torch.utils.data import Dataset
-from torchvision.datasets.folder import ImageFolder
+from torchvision.datasets import ImageFolder
 from torchvision.datasets.folder import default_loader as pil_loader
 
 from .utils import BoundingBox, disambiguate_timestamp


### PR DESCRIPTION
This should fix the failing unit tests.

For context, Sphinx displays the base class of each class in our documentation. When that base class comes from another library (not TorchGeo), Sphinx attempts to find where it is documented and add a link. It does this by looking at the `intersphinx_mapping` setting.

The reason that this previously worked and all of a sudden broke is that Sphinx just released version 4.3.0 yesterday, which includes a fix for https://github.com/sphinx-doc/sphinx/issues/9607. Previously, the base class wasn't being detected correctly. Now that it is being correctly detected, Sphinx is complaining that it can't find the documentation for it.