### PR TITLE
Test on Python 3.10

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: "3.10"
     - name: Install pip dependencies
       run: pip install .[style]
     - name: Run pydocstyle checks
@@ -32,7 +32,7 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: "3.10"
     - name: Install apt dependencies
       run: sudo apt-get install pandoc
     - name: Install pip dependencies

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: "3.10"
     - name: Install apt dependencies
       run: |
         sudo apt-add-repository ppa:ubuntugis/ubuntugis-unstable
@@ -40,7 +40,7 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: "3.10"
     - name: Install pip dependencies
       run: pip install .[datasets,tests,train]
     - name: Run integration checks

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: "3.10"
     - name: Install pip dependencies
       run: pip install .[style]
     - name: Run black checks
@@ -30,7 +30,7 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: "3.10"
     - name: Install pip dependencies
       run: pip install .[style]
     - name: Run flake8 checks
@@ -44,7 +44,7 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: "3.10"
     - name: Install pip dependencies
       run: pip install .[style]
     - name: Run isort checks

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: "3.10"
     - name: Install pip dependencies
       run: |
         pip install cython numpy  # needed for pycocotools
@@ -29,10 +29,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         exclude:
         - os: windows-latest
-          python-version: 3.6
+          python-version: "3.6"
     steps:
     - name: Clone repo
       uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Topic :: Scientific/Engineering :: Artificial Intelligence


### PR DESCRIPTION
Python 3.10 is out now, so we should start testing with it. We'll see if all of our dependencies support Python 3.10 yet.

Fun fact: YAML parses 3.10 as 3.1 since it's a float, you have to wrap it in quotes to force it to parse as a string "3.10".