### PR TITLE
Kornia v0.6.2 test updates

### DIFF
--- a/tests/transforms/test_transforms.py
+++ b/tests/transforms/test_transforms.py
@@ -22,7 +22,7 @@ def sample() -> Dict[str, Tensor]:
             [[0, 0, 1], [0, 1, 1], [1, 1, 1]]
         ),
         "boxes": torch.tensor(  # type: ignore[attr-defined]
-            [[0, 0, 2, 2], [1, 1, 3, 3]]
+            [[[0, 0, 2, 2], [1, 1, 3, 3]]]
         ),
     }
 
@@ -39,7 +39,7 @@ def batch_gray() -> Dict[str, Tensor]:
             dtype=torch.long,  # type: ignore[attr-defined]
         ),
         "boxes": torch.tensor(  # type: ignore[attr-defined]
-            [[0, 0, 0, 0], [1, 1, 2, 2]],
+            [[[0, 0, 0, 0], [1, 1, 2, 2]]],
             dtype=torch.float,  # type: ignore[attr-defined]
         ),
         "labels": torch.tensor([[0, 1]]),  # type: ignore[attr-defined]
@@ -64,7 +64,7 @@ def batch_rgb() -> Dict[str, Tensor]:
             dtype=torch.long,  # type: ignore[attr-defined]
         ),
         "boxes": torch.tensor(  # type: ignore[attr-defined]
-            [[0, 0, 0, 0], [1, 1, 2, 2]],
+            [[[0, 0, 0, 0], [1, 1, 2, 2]]],
             dtype=torch.float,  # type: ignore[attr-defined]
         ),
         "labels": torch.tensor([[0, 1]]),  # type: ignore[attr-defined]
@@ -91,7 +91,7 @@ def batch_multispectral() -> Dict[str, Tensor]:
             dtype=torch.long,  # type: ignore[attr-defined]
         ),
         "boxes": torch.tensor(  # type: ignore[attr-defined]
-            [[0, 0, 0, 0], [1, 1, 2, 2]],
+            [[[0, 0, 0, 0], [1, 1, 2, 2]]],
             dtype=torch.float,  # type: ignore[attr-defined]
         ),
         "labels": torch.tensor([[0, 1]]),  # type: ignore[attr-defined]
@@ -116,7 +116,7 @@ def test_augmentation_sequential_gray(batch_gray: Dict[str, Tensor]) -> None:
             dtype=torch.long,  # type: ignore[attr-defined]
         ),
         "boxes": torch.tensor(  # type: ignore[attr-defined]
-            [[2, 0, 2, 0], [1, 1, 0, 2]],
+            [[[2, 0, 2, 0], [0, 1, 1, 2]]],
             dtype=torch.float,  # type: ignore[attr-defined]
         ),
         "labels": torch.tensor([[0, 1]]),  # type: ignore[attr-defined]
@@ -145,7 +145,7 @@ def test_augmentation_sequential_rgb(batch_rgb: Dict[str, Tensor]) -> None:
             dtype=torch.long,  # type: ignore[attr-defined]
         ),
         "boxes": torch.tensor(  # type: ignore[attr-defined]
-            [[2, 0, 2, 0], [1, 1, 0, 2]],
+            [[[2, 0, 2, 0], [0, 1, 1, 2]]],
             dtype=torch.float,  # type: ignore[attr-defined]
         ),
         "labels": torch.tensor([[0, 1]]),  # type: ignore[attr-defined]
@@ -178,7 +178,7 @@ def test_augmentation_sequential_multispectral(
             dtype=torch.long,  # type: ignore[attr-defined]
         ),
         "boxes": torch.tensor(  # type: ignore[attr-defined]
-            [[2, 0, 2, 0], [1, 1, 0, 2]],
+            [[[2, 0, 2, 0], [0, 1, 1, 2]]],
             dtype=torch.float,  # type: ignore[attr-defined]
         ),
         "labels": torch.tensor([[0, 1]]),  # type: ignore[attr-defined]
@@ -211,7 +211,7 @@ def test_augmentation_sequential_image_only(
             dtype=torch.long,  # type: ignore[attr-defined]
         ),
         "boxes": torch.tensor(  # type: ignore[attr-defined]
-            [[0, 0, 0, 0], [1, 1, 2, 2]],
+            [[[0, 0, 0, 0], [1, 1, 2, 2]]],
             dtype=torch.float,  # type: ignore[attr-defined]
         ),
         "labels": torch.tensor([[0, 1]]),  # type: ignore[attr-defined]
@@ -248,7 +248,7 @@ def test_sequential_transforms_augmentations(
             dtype=torch.long,  # type: ignore[attr-defined]
         ),
         "boxes": torch.tensor(  # type: ignore[attr-defined]
-            [[2, 0, 2, 0], [1, 1, 0, 2]],
+            [[[2, 0, 2, 0], [0, 1, 1, 2]]],
             dtype=torch.float,  # type: ignore[attr-defined]
         ),
         "labels": torch.tensor([[0, 1]]),  # type: ignore[attr-defined]


### PR DESCRIPTION
In Kornia v0.6.2 release, a fix was made to correctly augment boxes when a random flip augmentation was performed in `kornia.augmentation.AugmentationSequential`. A check was also added to ensure batch dimensions agree.

To accommodate our tests with these updates:
- add batch dim to dummy box data
- correct the expected output of the augmented boxes 

Relevant kornia PR https://github.com/kornia/kornia/pull/1304