### PR TITLE
Updated dependencies for Open3d v0.14.1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,6 @@
 name: torchgeo
 channels:
   - conda-forge
-  - open3d-admin
 dependencies:
   - cudatoolkit
   - einops

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,9 +67,9 @@ datasets =
     h5py
     # loading .las point clouds (idtrees) laspy 2+ required for Python 3.6+ support
     laspy>=2.0.0
-    # open3d will add add support for python 3.9 in pypi in v0.14. v0.11.2 last version for tests to pass
+    # open3d v0.11.2 last version for tests to pass
     # https://github.com/isl-org/Open3D/issues/1550
-    open3d>=0.11.2;python_version<'3.9'
+    open3d>=0.11.2
     opencv-python
     # pandas 0.19.1+ required for python 3.6 support
     pandas>=0.19.1


### PR DESCRIPTION
Open3d just made a new release 0.14.1 and added support for Python 3.9. This PR updates `setup.cfg` and `environment.yaml`.

- Remove unused `open3d-admin` conda channel
- Removes Python < 3.9 open3d dependency