### PR TITLE
Docs: get rid of "Return type: None" for procedures with no return value

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,8 +50,8 @@ extensions = [
 exclude_patterns = ["_build"]
 
 # Sphinx 3.0+ required for:
-# autodoc_typehints = "description"
-needs_sphinx = "3.0"
+# autodoc_typehints_description_target = "documented"
+needs_sphinx = "4.0"
 
 nitpicky = True
 nitpick_ignore = [
@@ -91,6 +91,7 @@ html_css_files = ["workaround.css"]
 # -- Extension configuration -------------------------------------------------
 
 # sphinx.ext.autodoc
+autoclass_content = "class"
 autodoc_default_options = {
     "members": True,
     "special-members": True,
@@ -98,6 +99,7 @@ autodoc_default_options = {
 }
 autodoc_member_order = "bysource"
 autodoc_typehints = "description"
+autodoc_typehints_description_target = "documented"
 
 # sphinx.ext.intersphinx
 intersphinx_mapping = {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -91,7 +91,6 @@ html_css_files = ["workaround.css"]
 # -- Extension configuration -------------------------------------------------
 
 # sphinx.ext.autodoc
-autoclass_content = "class"
 autodoc_default_options = {
     "members": True,
     "special-members": True,

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,5 +4,5 @@ ipywidgets>=7
 nbsphinx>=0.8.5
 # release versions missing files, must install from master
 -e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
-# sphinx 3+ required for autodoc_typehints = description
-sphinx>=3
+# sphinx 4+ required for autodoc_typehints_description_target = documented
+sphinx>=4

--- a/environment.yml
+++ b/environment.yml
@@ -43,6 +43,6 @@ dependencies:
     - scipy>=0.9
     - segmentation-models-pytorch>=0.2
     - setuptools>=42
-    - sphinx>=3
+    - sphinx>=4
     - timm>=0.2.1
     - torchmetrics


### PR DESCRIPTION
Because we use mypy in strict mode, all methods must declare a return type. For procedures with no return value, this is None. Sphinx tries to document this by adding "Return type: None" to all procedures, but we don't really need this clutter. This PR removes that.