### PR TITLE
Replace pytorch-gpu with pytorch in environment.yml

### DIFF
--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -67,6 +67,7 @@ Conda does not directly support installing development versions, but you can use
    $ conda activate torchgeo
    $ pip install .
 
+.. note:: The above method will not work on Windows. Windows users are recommended to create a conda environment and install dependencies via pip.
 
 Conda does not directly support optional dependencies. If you install from conda-forge, only required dependencies will be installed by default. Optional dependencies can be installed afterwards using pip. If you install using the ``environment.yml`` file, all optional dependencies are installed by default.
 

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -68,8 +68,6 @@ Conda does not directly support installing development versions, but you can use
    $ pip install .
 
 
-.. note:: If you do not have access to a GPU or are running on macOS, replace ``pytorch-gpu`` with ``pytorch-cpu`` in the ``environment.yml`` file.
-
 Conda does not directly support optional dependencies. If you install from conda-forge, only required dependencies will be installed by default. Optional dependencies can be installed afterwards using pip. If you install using the ``environment.yml`` file, all optional dependencies are installed by default.
 
 See the `conda-forge documentation <https://conda-forge.org/>`_ for more details.

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - pycocotools
   - pyproj>=2.2
   - python>=3.6
-  - pytorch-gpu>=1.7
+  - pytorch>=1.7
   - rarfile>=3
   - rasterio>=1.0.16
   - shapely>=1.3


### PR DESCRIPTION
Fixes #293 

Tried this on my Linux machine and it installs pytorch 1.10.0 with gpu support. 