### PR TITLE
Fix bug with latest version of mypy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -102,8 +102,9 @@ style =
     # pydocstyle 6.1+ required for pyproject.toml support
     pydocstyle[toml]>=6.1
 tests =
-    # mypy 0.900+ required for pyproject.toml support
-    mypy>=0.900
+    # mypy 0.900+ required for pyproject.toml support, 0.920 has a decorator bug:
+    # https://github.com/python/mypy/issues/11763
+    mypy>=0.900,!=0.920
     # nbmake 0.1+ required to fix path_source bug
     nbmake>=0.1
     # pytest 6+ required for pyproject.toml support


### PR DESCRIPTION
From what I can tell in https://github.com/python/mypy/issues/11763, there seems to be a bug in the latest mypy release. Until we can confirm, let's avoid using it for now. If this later turns out to be an issue with our code or with pytest's type hints, this can be reverted later.