### PR TITLE
Fix GeoDataset pickling

### DIFF
--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 import os
+import pickle
 from pathlib import Path
 from typing import Dict
 
@@ -120,6 +121,14 @@ class TestGeoDataset:
         assert "type: GeoDataset" in out
         assert "bbox: BoundingBox" in out
         assert "size: 1" in out
+
+    def test_picklable(self, dataset: GeoDataset) -> None:
+        x = pickle.dumps(dataset)
+        y = pickle.loads(x)
+        assert dataset.crs == y.crs
+        assert dataset.res == y.res
+        assert len(dataset) == len(y)
+        assert dataset.bounds == y.bounds
 
     def test_abstract(self) -> None:
         with pytest.raises(TypeError, match="Can't instantiate abstract class"):

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -175,25 +175,36 @@ class GeoDataset(Dataset[Dict[str, Any]], abc.ABC):
     # NOTE: This hack should be removed once the following issue is fixed:
     # https://github.com/Toblerity/rtree/issues/87
 
-    def __getstate__(self):
+    def __getstate__(
+        self,
+    ) -> Tuple[
+        Dict[Any, Any],
+        List[Tuple[int, Tuple[float, float, float, float, float, float], str]],
+    ]:
         """Define how instances are pickled.
 
         Returns:
             the state necessary to unpickle the instance
         """
-        index = self.index.intersection(self.index.bounds, objects=True)
-        index = [(item.id, item.bounds, item.object) for item in index]
-        return self.__dict__, index
+        objects = self.index.intersection(self.index.bounds, objects=True)
+        tuples = [(item.id, item.bounds, item.object) for item in objects]
+        return self.__dict__, tuples
 
-    def __setstate__(self, state):
+    def __setstate__(
+        self,
+        state: Tuple[
+            Dict[Any, Any],
+            List[Tuple[int, Tuple[float, float, float, float, float, float], str]],
+        ],
+    ) -> None:
         """Define how to unpickle an instance.
 
         Args:
             state: the state of the instance when it was pickled
         """
-        attrs, index = state
+        attrs, tuples = state
         self.__dict__.update(attrs)
-        for item in index:
+        for item in tuples:
             self.index.insert(*item)
 
     @property


### PR DESCRIPTION
This is an ugly hack, but it does allow users to use parallel data loading on macOS/Windows. The `benchmark.py` script now works on macOS with `--num-workers` > 0.

Fixes #184