### PR TITLE
Transform tests: min Kornia version, filter warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ filterwarnings = [
     "ignore:.*Create unlinked descriptors is going to go away.*:DeprecationWarning",
     # https://github.com/tensorflow/tensorboard/pull/5138
     "ignore:.*is a deprecated alias for the builtin.*:DeprecationWarning",
+    "ignore:.*Previous behaviour produces incorrect box coordinates.*:UserWarning",
 ]
 markers = [
     "slow: marks tests as slow",

--- a/tests/transforms/test_transforms.py
+++ b/tests/transforms/test_transforms.py
@@ -11,6 +11,9 @@ from torch import Tensor
 
 from torchgeo.transforms import indices, transforms
 
+# Tests require newer version of Kornia for newer bounding box behavior
+pytest.importorskip("kornia", minversion="0.6.2")
+
 
 @pytest.fixture
 def sample() -> Dict[str, Tensor]:


### PR DESCRIPTION
Follow-up to #268

Our tests currently crash if you use Kornia 0.6.1. Also, even if you use a valid version of Kornia, there are warnings printed by the library.