### PR TITLE
Open specific version of tutorial in Colab

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -115,10 +115,10 @@ nbsphinx_execute = "never"
 # TODO: branch/tag should change depending on which version of docs you look at
 # TODO: width option of image directive is broken, see:
 # https://github.com/pytorch/pytorch_sphinx_theme/issues/140
-nbsphinx_prolog = """
+nbsphinx_prolog = f"""
 {% set colab = "https://colab.research.google.com" %}
 {% set repo = "microsoft/torchgeo" %}
-{% set branch = "main" %}
+{% set branch = "releases/v{version}" %}
 
 .. image:: {{ colab }}/assets/colab-badge.svg
    :class: colabbadge

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -118,7 +118,7 @@ nbsphinx_execute = "never"
 nbsphinx_prolog = """
 {% set colab = "https://colab.research.google.com" %}
 {% set repo = "microsoft/torchgeo" %}
-{% set branch = "releases/v{{ env.config.version }}" %}
+{% set branch = "releases/v" ~ {{ env.config.version }} %}
 
 .. image:: {{ colab }}/assets/colab-badge.svg
    :class: colabbadge

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -115,10 +115,10 @@ nbsphinx_execute = "never"
 # TODO: branch/tag should change depending on which version of docs you look at
 # TODO: width option of image directive is broken, see:
 # https://github.com/pytorch/pytorch_sphinx_theme/issues/140
-nbsphinx_prolog = f"""
+nbsphinx_prolog = """
 {% set colab = "https://colab.research.google.com" %}
 {% set repo = "microsoft/torchgeo" %}
-{% set branch = "releases/v{version}" %}
+{% set branch = "releases/v{{ env.config.version }}" %}
 
 .. image:: {{ colab }}/assets/colab-badge.svg
    :class: colabbadge

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -118,7 +118,11 @@ nbsphinx_execute = "never"
 nbsphinx_prolog = """
 {% set colab = "https://colab.research.google.com" %}
 {% set repo = "microsoft/torchgeo" %}
-{% set branch = "releases/v" ~ {{ env.config.version }} %}
+{% if "dev" in env.config.release %}
+    {% set branch = "main" %}
+{% else %}
+    {% set branch = "releases/v" ~ env.config.version %}
+{% endif %}
 
 .. image:: {{ colab }}/assets/colab-badge.svg
    :class: colabbadge


### PR DESCRIPTION
If you view the tutorials on RtD, we now default to the latest stable release. However, the "Open in Colab" button still opens up the `main` version. This PR fixes that.

The only remaining "gotcha" is that all versions of the tutorial will `pip install torchgeo`, so they'll all use the latest stable release, even if something has changed since then in main. We can avoid this issue by defaulting to the docs for the latest stable release, but as soon as someone tries a different versions of the docs it may not work.

Fixes #274
Fixes #310