### PR TITLE
Update SpaceNet plot fns

### DIFF
--- a/tests/datasets/test_spacenet.py
+++ b/tests/datasets/test_spacenet.py
@@ -80,6 +80,7 @@ class TestSpaceNet1:
 
     def test_plot(self, dataset: SpaceNet1) -> None:
         x = dataset[0].copy()
+        x["prediction"] = x["mask"]
         dataset.plot(x, suptitle="Test")
         plt.close()
         dataset.plot(x, show_titles=False)
@@ -149,6 +150,7 @@ class TestSpaceNet2:
 
     def test_plot(self, dataset: SpaceNet2) -> None:
         x = dataset[0].copy()
+        x["prediction"] = x["mask"]
         dataset.plot(x, suptitle="Test")
         plt.close()
         dataset.plot(x, show_titles=False)
@@ -218,6 +220,7 @@ class TestSpaceNet4:
 
     def test_plot(self, dataset: SpaceNet4) -> None:
         x = dataset[0].copy()
+        x["prediction"] = x["mask"]
         dataset.plot(x, suptitle="Test")
         plt.close()
         dataset.plot(x, show_titles=False)
@@ -289,9 +292,12 @@ class TestSpaceNet5:
 
     def test_plot(self, dataset: SpaceNet5) -> None:
         x = dataset[0].copy()
+        x["prediction"] = x["mask"]
         dataset.plot(x, suptitle="Test")
         plt.close()
         dataset.plot(x, show_titles=False)
+        plt.close()
+        dataset.plot({"image": x["image"]})
         plt.close()
 
 
@@ -349,6 +355,8 @@ class TestSpaceNet7:
 
     def test_plot(self, dataset: SpaceNet7) -> None:
         x = dataset[0].copy()
+        if dataset.split == "train":
+            x["prediction"] = x["mask"]
         dataset.plot(x, suptitle="Test")
         plt.close()
         dataset.plot(x, show_titles=False)

--- a/torchgeo/datasets/spacenet.py
+++ b/torchgeo/datasets/spacenet.py
@@ -319,11 +319,17 @@ class SpaceNet(VisionDataset, abc.ABC):
         image = percentile_normalization(image, axis=(0, 1))
 
         ncols = 1
-        show_mask = False
-        if "mask" in sample:
+        show_mask = "mask" in sample
+        show_predictions = "prediction" in sample
+
+        if show_mask:
             mask = sample["mask"].numpy()
             ncols += 1
-            show_mask = True
+
+        if show_predictions:
+            prediction = sample["prediction"].numpy()
+            ncols += 1
+
         fig, axs = plt.subplots(ncols=ncols, figsize=(ncols * 8, 8))
         if not isinstance(axs, np.ndarray):
             axs = [axs]
@@ -336,7 +342,13 @@ class SpaceNet(VisionDataset, abc.ABC):
             axs[1].imshow(mask, interpolation="none")
             axs[1].axis("off")
             if show_titles:
-                axs[1].set_title("Labels")
+                axs[1].set_title("Label")
+
+        if show_predictions:
+            axs[2].imshow(prediction, interpolation="none")
+            axs[2].axis("off")
+            if show_titles:
+                axs[2].set_title("Prediction")
 
         if suptitle is not None:
             plt.suptitle(suptitle)
@@ -953,24 +965,49 @@ class SpaceNet5(SpaceNet):
             image = np.rollaxis(sample["image"][:3].numpy(), 0, 3)
         image = percentile_normalization(image, axis=(0, 1))
 
-        ncols = 2
-        mask = sample["mask"].numpy()
-        fig, axs = plt.subplots(ncols=ncols, figsize=(ncols * 8, 8))
+        ncols = 1
+        show_mask = "mask" in sample
+        show_predictions = "prediction" in sample
 
+        if show_mask:
+            mask = sample["mask"].numpy()
+            ncols += 1
+
+        if show_predictions:
+            prediction = sample["prediction"].numpy()
+            ncols += 1
+
+        fig, axs = plt.subplots(ncols=ncols, figsize=(ncols * 8, 8))
+        if not isinstance(axs, np.ndarray):
+            axs = [axs]
         axs[0].imshow(image)
         axs[0].axis("off")
         if show_titles:
             axs[0].set_title("Image")
 
-        if self.speed_mask:
-            cmap = copy.copy(plt.get_cmap("autumn_r"))
-            cmap.set_under(color="black")
-            axs[1].imshow(mask, vmin=0.1, vmax=7, cmap=cmap, interpolation="none")
-        else:
-            axs[1].imshow(mask, cmap="Greys_r", interpolation="none")
-        axs[1].axis("off")
-        if show_titles:
-            axs[1].set_title("Labels")
+        if show_mask:
+            if self.speed_mask:
+                cmap = copy.copy(plt.get_cmap("autumn_r"))
+                cmap.set_under(color="black")
+                axs[1].imshow(mask, vmin=0.1, vmax=7, cmap=cmap, interpolation="none")
+            else:
+                axs[1].imshow(mask, cmap="Greys_r", interpolation="none")
+            axs[1].axis("off")
+            if show_titles:
+                axs[1].set_title("Label")
+
+        if show_predictions:
+            if self.speed_mask:
+                cmap = copy.copy(plt.get_cmap("autumn_r"))
+                cmap.set_under(color="black")
+                axs[2].imshow(
+                    prediction, vmin=0.1, vmax=7, cmap=cmap, interpolation="none"
+                )
+            else:
+                axs[2].imshow(prediction, cmap="Greys_r", interpolation="none")
+            axs[2].axis("off")
+            if show_titles:
+                axs[2].set_title("Prediction")
 
         if suptitle is not None:
             plt.suptitle(suptitle)


### PR DESCRIPTION
Add option to plot prediction if present in sample dict

Plot works for the following cases:
- Plot only image
- Plot image and mask(label)
- Plot image, mask and prediction


Following cases won't work:
- Plot only prediction
- Plot only mask
- Plot mask and prediction 
- Plot image and prediction

First two might not be that important. Not sure if we want to support the last two. If required this could be done in a follow up PR.
