### PR TITLE
Add Launch in Hub button to tutorials

### DIFF
--- a/docs/_static/workaround.css
+++ b/docs/_static/workaround.css
@@ -1,3 +1,4 @@
 .colabbadge {
-    width: 200px !important;
+    height: 50px !important;
+    width: auto !important;
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -141,9 +141,9 @@ nbsphinx_prolog = """
     {% set branch = "releases%2Fv" ~ env.config.version %}
 {% endif %}
 
-.. image:: https://img.shields.io/badge/-Launch%20on%20Planetary%20Computer-blue
+.. image:: https://img.shields.io/badge/-Open%20on%20Planetary%20Computer-blue
    :class: colabbadge
-   :alt: Launch on Planetary Computer
+   :alt: Open on Planetary Computer
    :target: {{ host }}?repo={{ repo }}&urlpath={{ urlpath }}&branch={{ branch }}
 """
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -141,9 +141,9 @@ nbsphinx_prolog = """
     {% set branch = "releases%2Fv" ~ env.config.version %}
 {% endif %}
 
-.. image:: https://img.shields.io/badge/-Launch%20in%20Hub-blue
+.. image:: https://img.shields.io/badge/-Launch%20on%20Planetary%20Computer-blue
    :class: colabbadge
-   :alt: Launch in Hub
+   :alt: Launch on Planetary Computer
    :target: {{ host }}?repo={{ repo }}&urlpath={{ urlpath }}&branch={{ branch }}
 """
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -116,18 +116,35 @@ nbsphinx_execute = "never"
 # TODO: width option of image directive is broken, see:
 # https://github.com/pytorch/pytorch_sphinx_theme/issues/140
 nbsphinx_prolog = """
-{% set colab = "https://colab.research.google.com" %}
+{% set host = "https://colab.research.google.com" %}
 {% set repo = "microsoft/torchgeo" %}
+{% set urlpath = "docs/" ~ env.docname ~ ".ipynb" %}
 {% if "dev" in env.config.release %}
     {% set branch = "main" %}
 {% else %}
     {% set branch = "releases/v" ~ env.config.version %}
 {% endif %}
 
-.. image:: {{ colab }}/assets/colab-badge.svg
+.. image:: {{ host }}/assets/colab-badge.svg
    :class: colabbadge
    :alt: Open in Colab
-   :target: {{ colab }}/github/{{ repo }}/blob/{{ branch }}/docs/{{ env.docname }}.ipynb
+   :target: {{ host }}/github/{{ repo }}/blob/{{ branch }}/{{ urlpath }}
+
+{% set host = "https://pccompute.westeurope.cloudapp.azure.com" %}
+{% set host = host ~ "/compute/hub/user-redirect/git-pull" %}
+{% set repo = "https%3A%2F%2Fgithub.com%2Fmicrosoft%2Ftorchgeo" %}
+{% set urlpath = "tree%2Ftorchgeo%2Fdocs%2F" %}
+{% set urlpath = urlpath ~ env.docname | replace("/", "%2F") ~ ".ipynb" %}
+{% if "dev" in env.config.release %}
+    {% set branch = "main" %}
+{% else %}
+    {% set branch = "releases%2Fv" ~ env.config.version %}
+{% endif %}
+
+.. image:: https://img.shields.io/badge/-Launch%20in%20Hub-blue
+   :class: colabbadge
+   :alt: Launch in Hub
+   :target: {{ host }}?repo={{ repo }}&urlpath={{ urlpath }}&branch={{ branch }}
 """
 
 # Disables requirejs in nbsphinx to enable compatibility with the pytorch_sphinx_theme


### PR DESCRIPTION
Adds a "Launch in Hub" button similar to our existing "Open in Colab" button that opens a copy of the tutorial on the Planetary Computer. Note that this requires a Planetary Computer account to use.

@TomAugspurger @RitwikGupta 

Closes #117