### PR TITLE
Move imports out of global namespace

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -14,8 +14,8 @@ import pytorch_lightning as pl
 import torch
 from torchmetrics import Accuracy, IoU, Metric, MetricCollection
 
-from torchgeo import _TASK_TO_MODULES_MAPPING as TASK_TO_MODULES_MAPPING
 from torchgeo.trainers import ClassificationTask, SemanticSegmentationTask
+from train import TASK_TO_MODULES_MAPPING
 
 
 def set_up_parser() -> argparse.ArgumentParser:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ exclude_lines = [
 
 [tool.isort]
 profile = "black"
-known_first_party = ["docs", "tests", "torchgeo"]
+known_first_party = ["docs", "tests", "torchgeo", "train"]
 extend_skip = [".spack-env/", "data", "logs", "output"]
 skip_gitignore = true
 color_output = true

--- a/torchgeo/__init__.py
+++ b/torchgeo/__init__.py
@@ -9,55 +9,6 @@ source machine learning framework.
 The :mod:`torchgeo` package consists of popular datasets, model architectures, and
 common image transformations for geospatial data.
 """
-from typing import Dict, Tuple, Type
-
-import pytorch_lightning as pl
-
-from .datamodules import (
-    BigEarthNetDataModule,
-    ChesapeakeCVPRDataModule,
-    COWCCountingDataModule,
-    CycloneDataModule,
-    ETCI2021DataModule,
-    EuroSATDataModule,
-    LandCoverAIDataModule,
-    NAIPChesapeakeDataModule,
-    OSCDDataModule,
-    RESISC45DataModule,
-    SEN12MSDataModule,
-    So2SatDataModule,
-    UCMercedDataModule,
-)
-from .trainers import (
-    BYOLTask,
-    ClassificationTask,
-    MultiLabelClassificationTask,
-    RegressionTask,
-    SemanticSegmentationTask,
-)
-from .trainers.chesapeake import ChesapeakeCVPRSegmentationTask
-from .trainers.landcoverai import LandCoverAISegmentationTask
-from .trainers.naipchesapeake import NAIPChesapeakeSegmentationTask
-from .trainers.resisc45 import RESISC45ClassificationTask
 
 __author__ = "Adam J. Stewart"
 __version__ = "0.2.0.dev0"
-
-_TASK_TO_MODULES_MAPPING: Dict[
-    str, Tuple[Type[pl.LightningModule], Type[pl.LightningDataModule]]
-] = {
-    "bigearthnet": (MultiLabelClassificationTask, BigEarthNetDataModule),
-    "byol": (BYOLTask, ChesapeakeCVPRDataModule),
-    "chesapeake_cvpr": (ChesapeakeCVPRSegmentationTask, ChesapeakeCVPRDataModule),
-    "cowc_counting": (RegressionTask, COWCCountingDataModule),
-    "cyclone": (RegressionTask, CycloneDataModule),
-    "eurosat": (ClassificationTask, EuroSATDataModule),
-    "etci2021": (SemanticSegmentationTask, ETCI2021DataModule),
-    "landcoverai": (LandCoverAISegmentationTask, LandCoverAIDataModule),
-    "naipchesapeake": (NAIPChesapeakeSegmentationTask, NAIPChesapeakeDataModule),
-    "oscd": (SemanticSegmentationTask, OSCDDataModule),
-    "resisc45": (RESISC45ClassificationTask, RESISC45DataModule),
-    "sen12ms": (SemanticSegmentationTask, SEN12MSDataModule),
-    "so2sat": (ClassificationTask, So2SatDataModule),
-    "ucmerced": (ClassificationTask, UCMercedDataModule),
-}

--- a/train.py
+++ b/train.py
@@ -6,14 +6,58 @@
 """torchgeo model training script."""
 
 import os
-from typing import Any, Dict, cast
+from typing import Any, Dict, Tuple, Type, cast
 
 import pytorch_lightning as pl
 from omegaconf import DictConfig, OmegaConf
 from pytorch_lightning import loggers as pl_loggers
 from pytorch_lightning.callbacks import EarlyStopping, ModelCheckpoint
 
-from torchgeo import _TASK_TO_MODULES_MAPPING as TASK_TO_MODULES_MAPPING
+from .datamodules import (
+    BigEarthNetDataModule,
+    ChesapeakeCVPRDataModule,
+    COWCCountingDataModule,
+    CycloneDataModule,
+    ETCI2021DataModule,
+    EuroSATDataModule,
+    LandCoverAIDataModule,
+    NAIPChesapeakeDataModule,
+    OSCDDataModule,
+    RESISC45DataModule,
+    SEN12MSDataModule,
+    So2SatDataModule,
+    UCMercedDataModule,
+)
+from .trainers import (
+    BYOLTask,
+    ClassificationTask,
+    MultiLabelClassificationTask,
+    RegressionTask,
+    SemanticSegmentationTask,
+)
+from .trainers.chesapeake import ChesapeakeCVPRSegmentationTask
+from .trainers.landcoverai import LandCoverAISegmentationTask
+from .trainers.naipchesapeake import NAIPChesapeakeSegmentationTask
+from .trainers.resisc45 import RESISC45ClassificationTask
+
+TASK_TO_MODULES_MAPPING: Dict[
+    str, Tuple[Type[pl.LightningModule], Type[pl.LightningDataModule]]
+] = {
+    "bigearthnet": (MultiLabelClassificationTask, BigEarthNetDataModule),
+    "byol": (BYOLTask, ChesapeakeCVPRDataModule),
+    "chesapeake_cvpr": (ChesapeakeCVPRSegmentationTask, ChesapeakeCVPRDataModule),
+    "cowc_counting": (RegressionTask, COWCCountingDataModule),
+    "cyclone": (RegressionTask, CycloneDataModule),
+    "eurosat": (ClassificationTask, EuroSATDataModule),
+    "etci2021": (SemanticSegmentationTask, ETCI2021DataModule),
+    "landcoverai": (LandCoverAISegmentationTask, LandCoverAIDataModule),
+    "naipchesapeake": (NAIPChesapeakeSegmentationTask, NAIPChesapeakeDataModule),
+    "oscd": (SemanticSegmentationTask, OSCDDataModule),
+    "resisc45": (RESISC45ClassificationTask, RESISC45DataModule),
+    "sen12ms": (SemanticSegmentationTask, SEN12MSDataModule),
+    "so2sat": (ClassificationTask, So2SatDataModule),
+    "ucmerced": (ClassificationTask, UCMercedDataModule),
+}
 
 
 def set_up_omegaconf() -> DictConfig:


### PR DESCRIPTION
This PR moves all imports out of `torchgeo/__init__.py`. Now that #321 has been merged, we no longer need imports in this file to avoid circular import dependencies (#276). The benefits of this are speed. Previously, we were importing all of `torchgeo.datamodules` and `torchgeo.trainers` no matter what component of `torchgeo` we are actually trying to import.

### Before

```console
$ time python -c 'from torchgeo.datasets import GeoDataset'

real	0m9.481s
user	0m5.799s
sys	0m1.887s
$ time python -c 'from torchgeo.samplers import GeoSampler'

real	0m9.311s
user	0m5.699s
sys	0m1.856s
$ time python -c 'from torchgeo.models import resnet50'

real	0m8.822s
user	0m5.731s
sys	0m1.854s
```

### After

```console
$ time python -c 'from torchgeo.datasets import GeoDataset'

real	0m3.826s
user	0m2.808s
sys	0m0.985s
$ time python -c 'from torchgeo.samplers import GeoSampler'

real	0m4.254s
user	0m3.067s
sys	0m1.012s
$ time python -c 'from torchgeo.models import resnet50'

real	0m2.937s
user	0m2.142s
sys	0m0.770s
```