### PR TITLE
Remove Python 3.6 support

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,10 +49,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
-        exclude:
-        - os: windows-latest
-          python-version: 3.6
+        python-version: [3.7, 3.8, 3.9]
     steps:
     - name: Clone repo
       uses: actions/checkout@v2

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - pip
   - pycocotools
   - pyproj>=2.2
-  - python>=3.6
+  - python>=3.7
   - pytorch>=1.7
   - rarfile>=3
   - rasterio>=1.0.16

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.black]
-target-version = ["py36", "py37", "py38", "py39"]
+target-version = ["py37", "py38", "py39"]
 color = true
 skip_magic_trailing_comma = true
 exclude = '''

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ classifiers =
     Development Status :: 3 - Alpha
     Intended Audience :: Science/Research
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -28,8 +27,6 @@ setup_requires =
     # setuptools 42+ required for metadata.license_files support in setup.cfg
     setuptools>=42
 install_requires =
-    # dataclasses was added in Python 3.7
-    dataclasses;python_version<'3.7'
     einops
     # fiona 1.5+ required for fiona.transform module
     fiona>=1.5
@@ -62,7 +59,7 @@ install_requires =
     torchmetrics
     # torchvision 0.10+ required for torchvision.utils.draw_segmentation_masks
     torchvision>=0.10
-python_requires = >= 3.6
+python_requires = >= 3.7
 packages = find:
 
 [options.packages.find]
@@ -72,13 +69,13 @@ include = torchgeo*
 # Optional dataset requirements
 datasets =
     h5py
-    # laspy 2+ required for Python 3.6+ support
+    # laspy 2+ required for Python 3.7+ support
     laspy>=2
     # open3d 0.11.2+ required to avoid GLFW error:
     # https://github.com/isl-org/Open3D/issues/1550
     open3d>=0.11.2
     opencv-python
-    # pandas 0.19.1+ required for python 3.6 support
+    # pandas 0.19.1+ required for python 3.7 support
     pandas>=0.19.1
     pycocotools
     # radiant-mlhub 0.2.1+ required for api_key bugfix:


### PR DESCRIPTION
As of [today](https://endoflife.date/python), Python 3.6 is no longer supported. Other than dataclasses (which has a backport), we don't currently use any features that require Python 3.7+, but I see no reason to continue testing it, and if it isn't tested it will break eventually. So I think the best course of action is to remove support for it entirely.