### PR TITLE
Add type hints for numpy

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -103,6 +103,7 @@ autodoc_typehints_description_target = "documented"
 # sphinx.ext.intersphinx
 intersphinx_mapping = {
     "matplotlib": ("https://matplotlib.org/stable/", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
     "python": ("https://docs.python.org/3", None),
     "pytorch-lightning": ("https://pytorch-lightning.readthedocs.io/en/latest/", None),
     "rasterio": ("https://rasterio.readthedocs.io/en/latest/", None),

--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -562,7 +562,7 @@ def test_nonexisting_directory(tmp_path: Path) -> None:
 
 
 def test_percentile_normalization() -> None:
-    img: "np.typing.NDArray[np.int]" = np.array([[1, 2], [98, 100]])
+    img: "np.typing.NDArray[int]" = np.array([[1, 2], [98, 100]])
 
     img = percentile_normalization(img, 2, 98)
     assert img.min() == 0

--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -562,7 +562,7 @@ def test_nonexisting_directory(tmp_path: Path) -> None:
 
 
 def test_percentile_normalization() -> None:
-    img: "np.typing.NDArray[int]" = np.array([[1, 2], [98, 100]])
+    img: "np.typing.NDArray[np.int_]" = np.array([[1, 2], [98, 100]])
 
     img = percentile_normalization(img, 2, 98)
     assert img.min() == 0

--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -562,7 +562,7 @@ def test_nonexisting_directory(tmp_path: Path) -> None:
 
 
 def test_percentile_normalization() -> None:
-    img = np.array([[1, 2], [98, 100]])
+    img: "np.typing.NDArray[np.int]" = np.array([[1, 2], [98, 100]])
 
     img = percentile_normalization(img, 2, 98)
     assert img.min() == 0

--- a/torchgeo/datamodules/utils.py
+++ b/torchgeo/datamodules/utils.py
@@ -19,6 +19,7 @@ def dataset_split(
         dataset: dataset to be split into train/val or train/val/test subsets
         val_pct: percentage of samples to be in validation set
         test_pct: (Optional) percentage of samples to be in test set
+
     Returns:
         a list of the subset datasets. Either [train, val] or [train, val, test]
     """

--- a/torchgeo/datasets/advance.py
+++ b/torchgeo/datasets/advance.py
@@ -177,7 +177,7 @@ class ADVANCE(VisionDataset):
             the image
         """
         with Image.open(path) as img:
-            array: "np.typing.NDArray[int]" = np.array(img.convert("RGB"))
+            array: "np.typing.NDArray[np.int_]" = np.array(img.convert("RGB"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))

--- a/torchgeo/datasets/advance.py
+++ b/torchgeo/datasets/advance.py
@@ -177,7 +177,7 @@ class ADVANCE(VisionDataset):
             the image
         """
         with Image.open(path) as img:
-            array: "np.typing.NDArray[np.int]" = np.array(img.convert("RGB"))
+            array: "np.typing.NDArray[int]" = np.array(img.convert("RGB"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))

--- a/torchgeo/datasets/advance.py
+++ b/torchgeo/datasets/advance.py
@@ -177,7 +177,7 @@ class ADVANCE(VisionDataset):
             the image
         """
         with Image.open(path) as img:
-            array = np.array(img.convert("RGB"))
+            array: "np.typing.NDArray[np.int]" = np.array(img.convert("RGB"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))

--- a/torchgeo/datasets/bigearthnet.py
+++ b/torchgeo/datasets/bigearthnet.py
@@ -393,7 +393,7 @@ class BigEarthNet(VisionDataset):
                     resampling=Resampling.bilinear,
                 )
                 images.append(array)
-        arrays = np.stack(images, axis=0)
+        arrays: "np.typing.NDArray[np.int]" = np.stack(images, axis=0)
         tensor: Tensor = torch.from_numpy(arrays)  # type: ignore[attr-defined]
         return tensor
 

--- a/torchgeo/datasets/bigearthnet.py
+++ b/torchgeo/datasets/bigearthnet.py
@@ -393,7 +393,7 @@ class BigEarthNet(VisionDataset):
                     resampling=Resampling.bilinear,
                 )
                 images.append(array)
-        arrays: "np.typing.NDArray[int]" = np.stack(images, axis=0)
+        arrays: "np.typing.NDArray[np.int_]" = np.stack(images, axis=0)
         tensor: Tensor = torch.from_numpy(arrays)  # type: ignore[attr-defined]
         return tensor
 

--- a/torchgeo/datasets/bigearthnet.py
+++ b/torchgeo/datasets/bigearthnet.py
@@ -393,7 +393,7 @@ class BigEarthNet(VisionDataset):
                     resampling=Resampling.bilinear,
                 )
                 images.append(array)
-        arrays: "np.typing.NDArray[np.int]" = np.stack(images, axis=0)
+        arrays: "np.typing.NDArray[int]" = np.stack(images, axis=0)
         tensor: Tensor = torch.from_numpy(arrays)  # type: ignore[attr-defined]
         return tensor
 

--- a/torchgeo/datasets/chesapeake.py
+++ b/torchgeo/datasets/chesapeake.py
@@ -511,12 +511,8 @@ class ChesapeakeCVPR(GeoDataset):
         else:
             raise IndexError(f"query: {query} spans multiple tiles which is not valid")
 
-        sample["image"] = np.concatenate(
-            sample["image"], axis=0
-        )
-        sample["mask"] = np.concatenate(
-            sample["mask"], axis=0
-        )
+        sample["image"] = np.concatenate(sample["image"], axis=0)
+        sample["mask"] = np.concatenate(sample["mask"], axis=0)
 
         sample["image"] = torch.from_numpy(  # type: ignore[attr-defined]
             sample["image"]

--- a/torchgeo/datasets/chesapeake.py
+++ b/torchgeo/datasets/chesapeake.py
@@ -511,10 +511,10 @@ class ChesapeakeCVPR(GeoDataset):
         else:
             raise IndexError(f"query: {query} spans multiple tiles which is not valid")
 
-        sample["image"] = np.concatenate(  # type: ignore[no-untyped-call]
+        sample["image"] = np.concatenate(
             sample["image"], axis=0
         )
-        sample["mask"] = np.concatenate(  # type: ignore[no-untyped-call]
+        sample["mask"] = np.concatenate(
             sample["mask"], axis=0
         )
 

--- a/torchgeo/datasets/cowc.py
+++ b/torchgeo/datasets/cowc.py
@@ -146,7 +146,7 @@ class COWC(VisionDataset, abc.ABC):
         """
         filename = os.path.join(self.root, self.images[index])
         with Image.open(filename) as img:
-            array = np.array(img)
+            array: "np.typing.NDArray[np.int]" = np.array(img)
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))

--- a/torchgeo/datasets/cowc.py
+++ b/torchgeo/datasets/cowc.py
@@ -146,7 +146,7 @@ class COWC(VisionDataset, abc.ABC):
         """
         filename = os.path.join(self.root, self.images[index])
         with Image.open(filename) as img:
-            array: "np.typing.NDArray[np.int]" = np.array(img)
+            array: "np.typing.NDArray[int]" = np.array(img)
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))

--- a/torchgeo/datasets/cowc.py
+++ b/torchgeo/datasets/cowc.py
@@ -146,7 +146,7 @@ class COWC(VisionDataset, abc.ABC):
         """
         filename = os.path.join(self.root, self.images[index])
         with Image.open(filename) as img:
-            array: "np.typing.NDArray[int]" = np.array(img)
+            array: "np.typing.NDArray[np.int_]" = np.array(img)
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))

--- a/torchgeo/datasets/cv4a_kenya_crop_type.py
+++ b/torchgeo/datasets/cv4a_kenya_crop_type.py
@@ -356,7 +356,7 @@ class CV4AKenyaCropType(VisionDataset):
 
         return images and targets
 
-    def get_splits(self) -> Tuple[List[np.int_], List[int]]:
+    def get_splits(self) -> Tuple[List[int], List[int]]:
         """Get the field_ids for the train/test splits from the dataset directory.
 
         Returns:

--- a/torchgeo/datasets/cv4a_kenya_crop_type.py
+++ b/torchgeo/datasets/cv4a_kenya_crop_type.py
@@ -233,11 +233,11 @@ class CV4AKenyaCropType(VisionDataset):
         )
 
         with Image.open(os.path.join(directory, "labels.tif")) as img:
-            array: "np.typing.NDArray[np.int]" = np.array(img)
+            array: "np.typing.NDArray[int]" = np.array(img)
             labels: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
 
         with Image.open(os.path.join(directory, "field_ids.tif")) as img:
-            array: "np.typing.NDArray[np.int]" = np.array(img)
+            array: "np.typing.NDArray[int]" = np.array(img)
             field_ids: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
 
         return (labels, field_ids)
@@ -333,7 +333,7 @@ class CV4AKenyaCropType(VisionDataset):
                 f"{band_name}.tif",
             )
             with Image.open(filepath) as band_img:
-                array: "np.typing.NDArray[np.int]" = np.array(band_img)
+                array: "np.typing.NDArray[int]" = np.array(band_img)
                 img[band_index] = torch.from_numpy(array)  # type: ignore[attr-defined]
 
         return img

--- a/torchgeo/datasets/cv4a_kenya_crop_type.py
+++ b/torchgeo/datasets/cv4a_kenya_crop_type.py
@@ -233,11 +233,11 @@ class CV4AKenyaCropType(VisionDataset):
         )
 
         with Image.open(os.path.join(directory, "labels.tif")) as img:
-            array: "np.typing.NDArray[int]" = np.array(img)
+            array: "np.typing.NDArray[np.int_]" = np.array(img)
             labels: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
 
         with Image.open(os.path.join(directory, "field_ids.tif")) as img:
-            array: "np.typing.NDArray[int]" = np.array(img)
+            array = np.array(img)
             field_ids: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
 
         return (labels, field_ids)
@@ -333,7 +333,7 @@ class CV4AKenyaCropType(VisionDataset):
                 f"{band_name}.tif",
             )
             with Image.open(filepath) as band_img:
-                array: "np.typing.NDArray[int]" = np.array(band_img)
+                array: "np.typing.NDArray[np.int_]" = np.array(band_img)
                 img[band_index] = torch.from_numpy(array)  # type: ignore[attr-defined]
 
         return img
@@ -356,7 +356,7 @@ class CV4AKenyaCropType(VisionDataset):
 
         return images and targets
 
-    def get_splits(self) -> Tuple[List[int], List[int]]:
+    def get_splits(self) -> Tuple[List[np.int_], List[int]]:
         """Get the field_ids for the train/test splits from the dataset directory.
 
         Returns:

--- a/torchgeo/datasets/cv4a_kenya_crop_type.py
+++ b/torchgeo/datasets/cv4a_kenya_crop_type.py
@@ -233,11 +233,11 @@ class CV4AKenyaCropType(VisionDataset):
         )
 
         with Image.open(os.path.join(directory, "labels.tif")) as img:
-            array = np.array(img)
+            array: "np.typing.NDArray[np.int]" = np.array(img)
             labels: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
 
         with Image.open(os.path.join(directory, "field_ids.tif")) as img:
-            array = np.array(img)
+            array: "np.typing.NDArray[np.int]" = np.array(img)
             field_ids: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
 
         return (labels, field_ids)
@@ -333,7 +333,7 @@ class CV4AKenyaCropType(VisionDataset):
                 f"{band_name}.tif",
             )
             with Image.open(filepath) as band_img:
-                array = np.array(band_img)
+                array: "np.typing.NDArray[np.int]" = np.array(band_img)
                 img[band_index] = torch.from_numpy(array)  # type: ignore[attr-defined]
 
         return img

--- a/torchgeo/datasets/cyclone.py
+++ b/torchgeo/datasets/cyclone.py
@@ -144,7 +144,7 @@ class TropicalCycloneWindEstimation(VisionDataset):
         with Image.open(filename) as img:
             if img.height != self.size or img.width != self.size:
                 img = img.resize(size=(self.size, self.size), resample=Image.BILINEAR)
-            array = np.array(img)
+            array: "np.typing.NDArray[np.int]" = np.array(img)
             if len(array.shape) == 3:
                 array = array[:, :, 0]
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]

--- a/torchgeo/datasets/cyclone.py
+++ b/torchgeo/datasets/cyclone.py
@@ -144,7 +144,7 @@ class TropicalCycloneWindEstimation(VisionDataset):
         with Image.open(filename) as img:
             if img.height != self.size or img.width != self.size:
                 img = img.resize(size=(self.size, self.size), resample=Image.BILINEAR)
-            array: "np.typing.NDArray[int]" = np.array(img)
+            array: "np.typing.NDArray[np.int_]" = np.array(img)
             if len(array.shape) == 3:
                 array = array[:, :, 0]
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]

--- a/torchgeo/datasets/cyclone.py
+++ b/torchgeo/datasets/cyclone.py
@@ -144,7 +144,7 @@ class TropicalCycloneWindEstimation(VisionDataset):
         with Image.open(filename) as img:
             if img.height != self.size or img.width != self.size:
                 img = img.resize(size=(self.size, self.size), resample=Image.BILINEAR)
-            array: "np.typing.NDArray[np.int]" = np.array(img)
+            array: "np.typing.NDArray[int]" = np.array(img)
             if len(array.shape) == 3:
                 array = array[:, :, 0]
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]

--- a/torchgeo/datasets/etci2021.py
+++ b/torchgeo/datasets/etci2021.py
@@ -204,7 +204,7 @@ class ETCI2021(VisionDataset):
         """
         filename = os.path.join(path)
         with Image.open(filename) as img:
-            array: "np.typing.NDArray[np.int]" = np.array(img.convert("RGB"))
+            array: "np.typing.NDArray[int]" = np.array(img.convert("RGB"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))
@@ -221,7 +221,7 @@ class ETCI2021(VisionDataset):
         """
         filename = os.path.join(path)
         with Image.open(filename) as img:
-            array: "np.typing.NDArray[np.int]" = np.array(img.convert("L"))
+            array: "np.typing.NDArray[int]" = np.array(img.convert("L"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             tensor = torch.clamp(tensor, min=0, max=1)  # type: ignore[attr-defined]
             tensor = tensor.to(torch.long)  # type: ignore[attr-defined]

--- a/torchgeo/datasets/etci2021.py
+++ b/torchgeo/datasets/etci2021.py
@@ -204,7 +204,7 @@ class ETCI2021(VisionDataset):
         """
         filename = os.path.join(path)
         with Image.open(filename) as img:
-            array = np.array(img.convert("RGB"))
+            array: "np.typing.NDArray[np.int]" = np.array(img.convert("RGB"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))
@@ -221,7 +221,7 @@ class ETCI2021(VisionDataset):
         """
         filename = os.path.join(path)
         with Image.open(filename) as img:
-            array = np.array(img.convert("L"))
+            array: "np.typing.NDArray[np.int]" = np.array(img.convert("L"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             tensor = torch.clamp(tensor, min=0, max=1)  # type: ignore[attr-defined]
             tensor = tensor.to(torch.long)  # type: ignore[attr-defined]

--- a/torchgeo/datasets/etci2021.py
+++ b/torchgeo/datasets/etci2021.py
@@ -204,7 +204,7 @@ class ETCI2021(VisionDataset):
         """
         filename = os.path.join(path)
         with Image.open(filename) as img:
-            array: "np.typing.NDArray[int]" = np.array(img.convert("RGB"))
+            array: "np.typing.NDArray[np.int_]" = np.array(img.convert("RGB"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))
@@ -221,7 +221,7 @@ class ETCI2021(VisionDataset):
         """
         filename = os.path.join(path)
         with Image.open(filename) as img:
-            array: "np.typing.NDArray[int]" = np.array(img.convert("L"))
+            array: "np.typing.NDArray[np.int_]" = np.array(img.convert("L"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             tensor = torch.clamp(tensor, min=0, max=1)  # type: ignore[attr-defined]
             tensor = tensor.to(torch.long)  # type: ignore[attr-defined]

--- a/torchgeo/datasets/fair1m.py
+++ b/torchgeo/datasets/fair1m.py
@@ -218,7 +218,7 @@ class FAIR1M(VisionDataset):
         """
         path = os.path.join(self.root, self.image_root, path)
         with Image.open(path) as img:
-            array: "np.typing.NDArray[int]" = np.array(img.convert("RGB"))
+            array: "np.typing.NDArray[np.int_]" = np.array(img.convert("RGB"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))

--- a/torchgeo/datasets/fair1m.py
+++ b/torchgeo/datasets/fair1m.py
@@ -218,7 +218,7 @@ class FAIR1M(VisionDataset):
         """
         path = os.path.join(self.root, self.image_root, path)
         with Image.open(path) as img:
-            array = np.array(img.convert("RGB"))
+            array: "np.typing.NDArray[np.int]" = np.array(img.convert("RGB"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))

--- a/torchgeo/datasets/fair1m.py
+++ b/torchgeo/datasets/fair1m.py
@@ -218,7 +218,7 @@ class FAIR1M(VisionDataset):
         """
         path = os.path.join(self.root, self.image_root, path)
         with Image.open(path) as img:
-            array: "np.typing.NDArray[np.int]" = np.array(img.convert("RGB"))
+            array: "np.typing.NDArray[int]" = np.array(img.convert("RGB"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -515,7 +515,9 @@ class RasterDataset(GeoDataset):
 
             # Only plot RGB bands
             if bands and self.rgb_bands:
-                indices: "np.typing.NDArray[np.int]" = np.array([bands.index(band) for band in self.rgb_bands])
+                indices: "np.typing.NDArray[int]" = np.array(
+                    [bands.index(band) for band in self.rgb_bands]
+                )
                 array = array[indices]
 
             # Convert from CxHxW to HxWxC
@@ -523,7 +525,9 @@ class RasterDataset(GeoDataset):
 
         if self.cmap:
             # Convert from class labels to RGBA values
-            cmap: "np.typing.NDArray[np.int]" = np.array([self.cmap[i] for i in range(len(self.cmap))])
+            cmap: "np.typing.NDArray[int]" = np.array(
+                [self.cmap[i] for i in range(len(self.cmap))]
+            )
             array = cmap[array]
 
         if self.stretch:
@@ -794,7 +798,7 @@ class VisionClassificationDataset(VisionDataset, ImageFolder):  # type: ignore[m
             the image class label
         """
         img, label = ImageFolder.__getitem__(self, index)
-        array: "np.typing.NDArray[np.int]" = np.array(img)
+        array: "np.typing.NDArray[int]" = np.array(img)
         tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
         # Convert from HxWxC to CxHxW
         tensor = tensor.permute((2, 0, 1))

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -515,7 +515,7 @@ class RasterDataset(GeoDataset):
 
             # Only plot RGB bands
             if bands and self.rgb_bands:
-                indices = np.array([bands.index(band) for band in self.rgb_bands])
+                indices: "np.typing.NDArray[np.int]" = np.array([bands.index(band) for band in self.rgb_bands])
                 array = array[indices]
 
             # Convert from CxHxW to HxWxC
@@ -523,13 +523,13 @@ class RasterDataset(GeoDataset):
 
         if self.cmap:
             # Convert from class labels to RGBA values
-            cmap = np.array([self.cmap[i] for i in range(len(self.cmap))])
+            cmap: "np.typing.NDArray[np.int]" = np.array([self.cmap[i] for i in range(len(self.cmap))])
             array = cmap[array]
 
         if self.stretch:
             # Stretch to the range of 2nd to 98th percentile
-            per02 = np.percentile(array, 2)  # type: ignore[no-untyped-call]
-            per98 = np.percentile(array, 98)  # type: ignore[no-untyped-call]
+            per02 = np.percentile(array, 2)
+            per98 = np.percentile(array, 98)
             array = (array - per02) / (per98 - per02)
             array = np.clip(array, 0, 1)
 
@@ -794,7 +794,7 @@ class VisionClassificationDataset(VisionDataset, ImageFolder):  # type: ignore[m
             the image class label
         """
         img, label = ImageFolder.__getitem__(self, index)
-        array = np.array(img)
+        array: "np.typing.NDArray[np.int]" = np.array(img)
         tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
         # Convert from HxWxC to CxHxW
         tensor = tensor.permute((2, 0, 1))

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -515,7 +515,7 @@ class RasterDataset(GeoDataset):
 
             # Only plot RGB bands
             if bands and self.rgb_bands:
-                indices: "np.typing.NDArray[int]" = np.array(
+                indices: "np.typing.NDArray[np.int_]" = np.array(
                     [bands.index(band) for band in self.rgb_bands]
                 )
                 array = array[indices]
@@ -525,7 +525,7 @@ class RasterDataset(GeoDataset):
 
         if self.cmap:
             # Convert from class labels to RGBA values
-            cmap: "np.typing.NDArray[int]" = np.array(
+            cmap: "np.typing.NDArray[np.int_]" = np.array(
                 [self.cmap[i] for i in range(len(self.cmap))]
             )
             array = cmap[array]
@@ -798,7 +798,7 @@ class VisionClassificationDataset(VisionDataset, ImageFolder):  # type: ignore[m
             the image class label
         """
         img, label = ImageFolder.__getitem__(self, index)
-        array: "np.typing.NDArray[int]" = np.array(img)
+        array: "np.typing.NDArray[np.int_]" = np.array(img)
         tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
         # Convert from HxWxC to CxHxW
         tensor = tensor.permute((2, 0, 1))

--- a/torchgeo/datasets/gid15.py
+++ b/torchgeo/datasets/gid15.py
@@ -191,7 +191,7 @@ class GID15(VisionDataset):
         """
         filename = os.path.join(path)
         with Image.open(filename) as img:
-            array: "np.typing.NDArray[int]" = np.array(img.convert("RGB"))
+            array: "np.typing.NDArray[np.int_]" = np.array(img.convert("RGB"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))
@@ -208,7 +208,7 @@ class GID15(VisionDataset):
         """
         filename = os.path.join(path)
         with Image.open(filename) as img:
-            array: "np.typing.NDArray[int]" = np.array(img.convert("L"))
+            array: "np.typing.NDArray[np.int_]" = np.array(img.convert("L"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             tensor = tensor.to(torch.long)  # type: ignore[attr-defined]
             return tensor

--- a/torchgeo/datasets/gid15.py
+++ b/torchgeo/datasets/gid15.py
@@ -191,7 +191,7 @@ class GID15(VisionDataset):
         """
         filename = os.path.join(path)
         with Image.open(filename) as img:
-            array: "np.typing.NDArray[np.int]" = np.array(img.convert("RGB"))
+            array: "np.typing.NDArray[int]" = np.array(img.convert("RGB"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))
@@ -208,7 +208,7 @@ class GID15(VisionDataset):
         """
         filename = os.path.join(path)
         with Image.open(filename) as img:
-            array: "np.typing.NDArray[np.int]" = np.array(img.convert("L"))
+            array: "np.typing.NDArray[int]" = np.array(img.convert("L"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             tensor = tensor.to(torch.long)  # type: ignore[attr-defined]
             return tensor

--- a/torchgeo/datasets/gid15.py
+++ b/torchgeo/datasets/gid15.py
@@ -191,7 +191,7 @@ class GID15(VisionDataset):
         """
         filename = os.path.join(path)
         with Image.open(filename) as img:
-            array = np.array(img.convert("RGB"))
+            array: "np.typing.NDArray[np.int]" = np.array(img.convert("RGB"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))
@@ -208,7 +208,7 @@ class GID15(VisionDataset):
         """
         filename = os.path.join(path)
         with Image.open(filename) as img:
-            array = np.array(img.convert("L"))
+            array: "np.typing.NDArray[np.int]" = np.array(img.convert("L"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             tensor = tensor.to(torch.long)  # type: ignore[attr-defined]
             return tensor

--- a/torchgeo/datasets/idtrees.py
+++ b/torchgeo/datasets/idtrees.py
@@ -254,7 +254,7 @@ class IDTReeS(VisionDataset):
         import laspy
 
         las = laspy.read(path)
-        array: "np.typing.NDArray[int]" = np.stack([las.x, las.y, las.z], axis=0)
+        array: "np.typing.NDArray[np.int_]" = np.stack([las.x, las.y, las.z], axis=0)
         tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
         return tensor
 
@@ -529,7 +529,7 @@ class IDTReeS(VisionDataset):
         path = self.images[index]
         path = path.replace("RGB", "LAS").replace(".tif", ".las")
         las = laspy.read(path)
-        points: "np.typing.NDArray[int]" = np.stack(
+        points: "np.typing.NDArray[np.int_]" = np.stack(
             [las.x, las.y, las.z], axis=0
         ).transpose((1, 0))
 

--- a/torchgeo/datasets/idtrees.py
+++ b/torchgeo/datasets/idtrees.py
@@ -254,7 +254,7 @@ class IDTReeS(VisionDataset):
         import laspy
 
         las = laspy.read(path)
-        array: "np.typing.NDArray[np.int]" = np.stack([las.x, las.y, las.z], axis=0)
+        array: "np.typing.NDArray[int]" = np.stack([las.x, las.y, las.z], axis=0)
         tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
         return tensor
 
@@ -529,7 +529,9 @@ class IDTReeS(VisionDataset):
         path = self.images[index]
         path = path.replace("RGB", "LAS").replace(".tif", ".las")
         las = laspy.read(path)
-        points: "np.typing.NDArray[np.int]" = np.stack([las.x, las.y, las.z], axis=0).transpose((1, 0))
+        points: "np.typing.NDArray[int]" = np.stack(
+            [las.x, las.y, las.z], axis=0
+        ).transpose((1, 0))
 
         if colormap:
             cm = plt.cm.get_cmap(colormap)

--- a/torchgeo/datasets/idtrees.py
+++ b/torchgeo/datasets/idtrees.py
@@ -254,7 +254,7 @@ class IDTReeS(VisionDataset):
         import laspy
 
         las = laspy.read(path)
-        array = np.stack([las.x, las.y, las.z], axis=0)
+        array: "np.typing.NDArray[np.int]" = np.stack([las.x, las.y, las.z], axis=0)
         tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
         return tensor
 
@@ -529,7 +529,7 @@ class IDTReeS(VisionDataset):
         path = self.images[index]
         path = path.replace("RGB", "LAS").replace(".tif", ".las")
         las = laspy.read(path)
-        points = np.stack([las.x, las.y, las.z], axis=0).transpose((1, 0))
+        points: "np.typing.NDArray[np.int]" = np.stack([las.x, las.y, las.z], axis=0).transpose((1, 0))
 
         if colormap:
             cm = plt.cm.get_cmap(colormap)

--- a/torchgeo/datasets/landcoverai.py
+++ b/torchgeo/datasets/landcoverai.py
@@ -153,7 +153,7 @@ class LandCoverAI(VisionDataset):
         """
         filename = os.path.join(self.root, "output", id_ + ".jpg")
         with Image.open(filename) as img:
-            array: "np.typing.NDArray[np.int]" = np.array(img)
+            array: "np.typing.NDArray[int]" = np.array(img)
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))
@@ -171,7 +171,7 @@ class LandCoverAI(VisionDataset):
         """
         filename = os.path.join(self.root, "output", id_ + "_m.png")
         with Image.open(filename) as img:
-            array: "np.typing.NDArray[np.int]" = np.array(img.convert("L"))
+            array: "np.typing.NDArray[int]" = np.array(img.convert("L"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             return tensor
 

--- a/torchgeo/datasets/landcoverai.py
+++ b/torchgeo/datasets/landcoverai.py
@@ -153,7 +153,7 @@ class LandCoverAI(VisionDataset):
         """
         filename = os.path.join(self.root, "output", id_ + ".jpg")
         with Image.open(filename) as img:
-            array: "np.typing.NDArray[int]" = np.array(img)
+            array: "np.typing.NDArray[np.int_]" = np.array(img)
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))
@@ -171,7 +171,7 @@ class LandCoverAI(VisionDataset):
         """
         filename = os.path.join(self.root, "output", id_ + "_m.png")
         with Image.open(filename) as img:
-            array: "np.typing.NDArray[int]" = np.array(img.convert("L"))
+            array: "np.typing.NDArray[np.int_]" = np.array(img.convert("L"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             return tensor
 

--- a/torchgeo/datasets/landcoverai.py
+++ b/torchgeo/datasets/landcoverai.py
@@ -153,7 +153,7 @@ class LandCoverAI(VisionDataset):
         """
         filename = os.path.join(self.root, "output", id_ + ".jpg")
         with Image.open(filename) as img:
-            array = np.array(img)
+            array: "np.typing.NDArray[np.int]" = np.array(img)
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))
@@ -171,7 +171,7 @@ class LandCoverAI(VisionDataset):
         """
         filename = os.path.join(self.root, "output", id_ + "_m.png")
         with Image.open(filename) as img:
-            array = np.array(img.convert("L"))
+            array: "np.typing.NDArray[np.int]" = np.array(img.convert("L"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             return tensor
 

--- a/torchgeo/datasets/levircd.py
+++ b/torchgeo/datasets/levircd.py
@@ -156,7 +156,7 @@ class LEVIRCDPlus(VisionDataset):
         """
         filename = os.path.join(path)
         with Image.open(filename) as img:
-            array = np.array(img.convert("RGB"))
+            array: "np.typing.NDArray[np.int]" = np.array(img.convert("RGB"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))
@@ -173,7 +173,7 @@ class LEVIRCDPlus(VisionDataset):
         """
         filename = os.path.join(path)
         with Image.open(filename) as img:
-            array = np.array(img.convert("L"))
+            array: "np.typing.NDArray[np.int]" = np.array(img.convert("L"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             tensor = torch.clamp(tensor, min=0, max=1)  # type: ignore[attr-defined]
             tensor = tensor.to(torch.long)  # type: ignore[attr-defined]

--- a/torchgeo/datasets/levircd.py
+++ b/torchgeo/datasets/levircd.py
@@ -156,7 +156,7 @@ class LEVIRCDPlus(VisionDataset):
         """
         filename = os.path.join(path)
         with Image.open(filename) as img:
-            array: "np.typing.NDArray[int]" = np.array(img.convert("RGB"))
+            array: "np.typing.NDArray[np.int_]" = np.array(img.convert("RGB"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))
@@ -173,7 +173,7 @@ class LEVIRCDPlus(VisionDataset):
         """
         filename = os.path.join(path)
         with Image.open(filename) as img:
-            array: "np.typing.NDArray[int]" = np.array(img.convert("L"))
+            array: "np.typing.NDArray[np.int_]" = np.array(img.convert("L"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             tensor = torch.clamp(tensor, min=0, max=1)  # type: ignore[attr-defined]
             tensor = tensor.to(torch.long)  # type: ignore[attr-defined]

--- a/torchgeo/datasets/levircd.py
+++ b/torchgeo/datasets/levircd.py
@@ -156,7 +156,7 @@ class LEVIRCDPlus(VisionDataset):
         """
         filename = os.path.join(path)
         with Image.open(filename) as img:
-            array: "np.typing.NDArray[np.int]" = np.array(img.convert("RGB"))
+            array: "np.typing.NDArray[int]" = np.array(img.convert("RGB"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))
@@ -173,7 +173,7 @@ class LEVIRCDPlus(VisionDataset):
         """
         filename = os.path.join(path)
         with Image.open(filename) as img:
-            array: "np.typing.NDArray[np.int]" = np.array(img.convert("L"))
+            array: "np.typing.NDArray[int]" = np.array(img.convert("L"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             tensor = torch.clamp(tensor, min=0, max=1)  # type: ignore[attr-defined]
             tensor = tensor.to(torch.long)  # type: ignore[attr-defined]

--- a/torchgeo/datasets/loveda.py
+++ b/torchgeo/datasets/loveda.py
@@ -214,7 +214,7 @@ class LoveDA(VisionDataset):
         """
         filename = os.path.join(path)
         with Image.open(filename) as img:
-            array: "np.typing.NDArray[int]" = np.array(img.convert("RGB"))
+            array: "np.typing.NDArray[np.int_]" = np.array(img.convert("RGB"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))
@@ -231,7 +231,7 @@ class LoveDA(VisionDataset):
         """
         filename = os.path.join(path)
         with Image.open(filename) as img:
-            array: "np.typing.NDArray[int]" = np.array(img.convert("L"))
+            array: "np.typing.NDArray[np.int_]" = np.array(img.convert("L"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             tensor = tensor.to(torch.long)  # type: ignore[attr-defined]
             return tensor

--- a/torchgeo/datasets/loveda.py
+++ b/torchgeo/datasets/loveda.py
@@ -214,7 +214,7 @@ class LoveDA(VisionDataset):
         """
         filename = os.path.join(path)
         with Image.open(filename) as img:
-            array: "np.typing.NDArray[np.int]" = np.array(img.convert("RGB"))
+            array: "np.typing.NDArray[int]" = np.array(img.convert("RGB"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))
@@ -231,7 +231,7 @@ class LoveDA(VisionDataset):
         """
         filename = os.path.join(path)
         with Image.open(filename) as img:
-            array: "np.typing.NDArray[np.int]" = np.array(img.convert("L"))
+            array: "np.typing.NDArray[int]" = np.array(img.convert("L"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             tensor = tensor.to(torch.long)  # type: ignore[attr-defined]
             return tensor

--- a/torchgeo/datasets/loveda.py
+++ b/torchgeo/datasets/loveda.py
@@ -214,7 +214,7 @@ class LoveDA(VisionDataset):
         """
         filename = os.path.join(path)
         with Image.open(filename) as img:
-            array = np.array(img.convert("RGB"))
+            array: "np.typing.NDArray[np.int]" = np.array(img.convert("RGB"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))
@@ -231,7 +231,7 @@ class LoveDA(VisionDataset):
         """
         filename = os.path.join(path)
         with Image.open(filename) as img:
-            array = np.array(img.convert("L"))
+            array: "np.typing.NDArray[np.int]" = np.array(img.convert("L"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             tensor = tensor.to(torch.long)  # type: ignore[attr-defined]
             return tensor

--- a/torchgeo/datasets/nasa_marine_debris.py
+++ b/torchgeo/datasets/nasa_marine_debris.py
@@ -135,7 +135,7 @@ class NASAMarineDebris(VisionDataset):
         Returns:
             the target boxes
         """
-        array = np.load(path)  # type: ignore[no-untyped-call]
+        array = np.load(path)
         # boxes contain unecessary value of 1 after xyxy coords
         array = array[:, :4]
         tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]

--- a/torchgeo/datasets/nwpu.py
+++ b/torchgeo/datasets/nwpu.py
@@ -174,7 +174,7 @@ class VHR10(VisionDataset):
             f"{id_:03d}.jpg",
         )
         with Image.open(filename) as img:
-            array: "np.typing.NDArray[int]" = np.array(img)
+            array: "np.typing.NDArray[np.int_]" = np.array(img)
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))

--- a/torchgeo/datasets/nwpu.py
+++ b/torchgeo/datasets/nwpu.py
@@ -174,7 +174,7 @@ class VHR10(VisionDataset):
             f"{id_:03d}.jpg",
         )
         with Image.open(filename) as img:
-            array = np.array(img)
+            array: "np.typing.NDArray[np.int]" = np.array(img)
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))

--- a/torchgeo/datasets/nwpu.py
+++ b/torchgeo/datasets/nwpu.py
@@ -174,7 +174,7 @@ class VHR10(VisionDataset):
             f"{id_:03d}.jpg",
         )
         with Image.open(filename) as img:
-            array: "np.typing.NDArray[np.int]" = np.array(img)
+            array: "np.typing.NDArray[int]" = np.array(img)
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))

--- a/torchgeo/datasets/oscd.py
+++ b/torchgeo/datasets/oscd.py
@@ -198,13 +198,11 @@ class OSCD(VisionDataset):
         Returns:
             the image
         """
-        images: List["np.typing.NDArray[np.int]"] = []
+        images: List["np.typing.NDArray[int]"] = []
         for path in paths:
             with Image.open(path) as img:
                 images.append(np.array(img))
-        array = np.stack(images, axis=0).astype(
-            np.int_
-        )
+        array = np.stack(images, axis=0).astype(int_)
         tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
         return tensor
 
@@ -219,7 +217,7 @@ class OSCD(VisionDataset):
         """
         filename = os.path.join(path)
         with Image.open(filename) as img:
-            array: "np.typing.NDArray[np.int]" = np.array(img.convert("L"))
+            array: "np.typing.NDArray[int]" = np.array(img.convert("L"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             tensor = torch.clamp(tensor, min=0, max=1)  # type: ignore[attr-defined]
             tensor = tensor.to(torch.long)  # type: ignore[attr-defined]

--- a/torchgeo/datasets/oscd.py
+++ b/torchgeo/datasets/oscd.py
@@ -202,7 +202,7 @@ class OSCD(VisionDataset):
         for path in paths:
             with Image.open(path) as img:
                 images.append(np.array(img))
-        array = np.stack(images, axis=0).astype(int_)
+        array = np.stack(images, axis=0).astype(np.int_)
         tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
         return tensor
 

--- a/torchgeo/datasets/oscd.py
+++ b/torchgeo/datasets/oscd.py
@@ -198,11 +198,11 @@ class OSCD(VisionDataset):
         Returns:
             the image
         """
-        images: List["np.typing.NDArray[int]"] = []
+        images = []
         for path in paths:
             with Image.open(path) as img:
                 images.append(np.array(img))
-        array = np.stack(images, axis=0).astype(np.int_)
+        array: "np.typing.NDArray[np.int_]" = np.stack(images, axis=0).astype(np.int_)
         tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
         return tensor
 
@@ -217,7 +217,7 @@ class OSCD(VisionDataset):
         """
         filename = os.path.join(path)
         with Image.open(filename) as img:
-            array: "np.typing.NDArray[int]" = np.array(img.convert("L"))
+            array: "np.typing.NDArray[np.int_]" = np.array(img.convert("L"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             tensor = torch.clamp(tensor, min=0, max=1)  # type: ignore[attr-defined]
             tensor = tensor.to(torch.long)  # type: ignore[attr-defined]

--- a/torchgeo/datasets/oscd.py
+++ b/torchgeo/datasets/oscd.py
@@ -11,7 +11,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import torch
 from matplotlib.figure import Figure
-from numpy import ndarray as Array
 from PIL import Image
 from torch import Tensor
 
@@ -199,11 +198,11 @@ class OSCD(VisionDataset):
         Returns:
             the image
         """
-        images = []
+        images: List["np.typing.NDArray[np.int]"] = []
         for path in paths:
             with Image.open(path) as img:
                 images.append(np.array(img))
-        array: Array = np.stack(images, axis=0).astype(  # type: ignore[type-arg]
+        array = np.stack(images, axis=0).astype(
             np.int_
         )
         tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
@@ -220,7 +219,7 @@ class OSCD(VisionDataset):
         """
         filename = os.path.join(path)
         with Image.open(filename) as img:
-            array = np.array(img.convert("L"))
+            array: "np.typing.NDArray[np.int]" = np.array(img.convert("L"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             tensor = torch.clamp(tensor, min=0, max=1)  # type: ignore[attr-defined]
             tensor = tensor.to(torch.long)  # type: ignore[attr-defined]
@@ -294,18 +293,18 @@ class OSCD(VisionDataset):
 
         rgb_inds = [3, 2, 1] if self.bands == "all" else [0, 1, 2]
 
-        def get_masked(img: Tensor) -> Array:  # type: ignore[type-arg]
+        def get_masked(img: Tensor) -> "np.typing.NDArray[np.uint8]":
             rgb_img = img[rgb_inds].float().numpy()
-            per02 = np.percentile(rgb_img, 2)  # type: ignore[no-untyped-call]
-            per98 = np.percentile(rgb_img, 98)  # type: ignore[no-untyped-call]
+            per02 = np.percentile(rgb_img, 2)
+            per98 = np.percentile(rgb_img, 98)
             rgb_img = (np.clip((rgb_img - per02) / (per98 - per02), 0, 1) * 255).astype(
                 np.uint8
             )
-            array: Array = draw_semantic_segmentation_masks(  # type: ignore[type-arg]
+            array: "np.typing.NDArray[np.uint8]" = draw_semantic_segmentation_masks(
                 torch.from_numpy(rgb_img),  # type: ignore[attr-defined]
                 sample["mask"],
                 alpha=alpha,
-                colors=self.colormap,  # type: ignore[arg-type]
+                colors=self.colormap,
             )
             return array
 

--- a/torchgeo/datasets/oscd.py
+++ b/torchgeo/datasets/oscd.py
@@ -198,7 +198,7 @@ class OSCD(VisionDataset):
         Returns:
             the image
         """
-        images = []
+        images: List["np.typing.NDArray[np.int_]"] = []
         for path in paths:
             with Image.open(path) as img:
                 images.append(np.array(img))

--- a/torchgeo/datasets/potsdam.py
+++ b/torchgeo/datasets/potsdam.py
@@ -201,7 +201,7 @@ class Potsdam2D(VisionDataset):
         """
         path = self.files[index]["mask"]
         with Image.open(path) as img:
-            array: "np.typing.NDArray[np.int]" = np.array(img.convert("RGB"))
+            array: "np.typing.NDArray[int]" = np.array(img.convert("RGB"))
             array = rgb_to_mask(array, self.colormap)
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             # Convert from HxWxC to CxHxW

--- a/torchgeo/datasets/potsdam.py
+++ b/torchgeo/datasets/potsdam.py
@@ -259,10 +259,7 @@ class Potsdam2D(VisionDataset):
         """
         ncols = 1
         image1 = draw_semantic_segmentation_masks(
-            sample["image"][:3],
-            sample["mask"],
-            alpha=alpha,
-            colors=self.colormap,
+            sample["image"][:3], sample["mask"], alpha=alpha, colors=self.colormap
         )
         if "prediction" in sample:
             ncols += 1

--- a/torchgeo/datasets/potsdam.py
+++ b/torchgeo/datasets/potsdam.py
@@ -201,7 +201,7 @@ class Potsdam2D(VisionDataset):
         """
         path = self.files[index]["mask"]
         with Image.open(path) as img:
-            array = np.array(img.convert("RGB"))
+            array: "np.typing.NDArray[np.int]" = np.array(img.convert("RGB"))
             array = rgb_to_mask(array, self.colormap)
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             # Convert from HxWxC to CxHxW

--- a/torchgeo/datasets/potsdam.py
+++ b/torchgeo/datasets/potsdam.py
@@ -201,7 +201,7 @@ class Potsdam2D(VisionDataset):
         """
         path = self.files[index]["mask"]
         with Image.open(path) as img:
-            array: "np.typing.NDArray[np.int_]" = np.array(img.convert("RGB"))
+            array: "np.typing.NDArray[np.uint8]" = np.array(img.convert("RGB"))
             array = rgb_to_mask(array, self.colormap)
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             # Convert from HxWxC to CxHxW

--- a/torchgeo/datasets/potsdam.py
+++ b/torchgeo/datasets/potsdam.py
@@ -201,7 +201,7 @@ class Potsdam2D(VisionDataset):
         """
         path = self.files[index]["mask"]
         with Image.open(path) as img:
-            array: "np.typing.NDArray[int]" = np.array(img.convert("RGB"))
+            array: "np.typing.NDArray[np.int_]" = np.array(img.convert("RGB"))
             array = rgb_to_mask(array, self.colormap)
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             # Convert from HxWxC to CxHxW

--- a/torchgeo/datasets/potsdam.py
+++ b/torchgeo/datasets/potsdam.py
@@ -262,7 +262,7 @@ class Potsdam2D(VisionDataset):
             sample["image"][:3],
             sample["mask"],
             alpha=alpha,
-            colors=self.colormap,  # type: ignore[arg-type]
+            colors=self.colormap,
         )
         if "prediction" in sample:
             ncols += 1
@@ -270,7 +270,7 @@ class Potsdam2D(VisionDataset):
                 sample["image"][:3],
                 sample["prediction"],
                 alpha=alpha,
-                colors=self.colormap,  # type: ignore[arg-type]
+                colors=self.colormap,
             )
 
         fig, axs = plt.subplots(ncols=ncols, figsize=(ncols * 10, 10))

--- a/torchgeo/datasets/spacenet.py
+++ b/torchgeo/datasets/spacenet.py
@@ -894,7 +894,7 @@ class SpaceNet5(SpaceNet):
         max_speed_bin = 65
         speed_arr_bin = np.arange(min_speed_bin, max_speed_bin + 1)
         bin_size_mph = 10.0
-        speed_cls_arr: "np.typing.NDArray[int]" = np.array(
+        speed_cls_arr: "np.typing.NDArray[np.int_]" = np.array(
             [int(math.ceil(s / bin_size_mph)) for s in speed_arr_bin]
         )
 

--- a/torchgeo/datasets/spacenet.py
+++ b/torchgeo/datasets/spacenet.py
@@ -894,7 +894,7 @@ class SpaceNet5(SpaceNet):
         max_speed_bin = 65
         speed_arr_bin = np.arange(min_speed_bin, max_speed_bin + 1)
         bin_size_mph = 10.0
-        speed_cls_arr = np.array(
+        speed_cls_arr: "np.typing.NDArray[np.int]" = np.array(
             [int(math.ceil(s / bin_size_mph)) for s in speed_arr_bin]
         )
 

--- a/torchgeo/datasets/spacenet.py
+++ b/torchgeo/datasets/spacenet.py
@@ -894,7 +894,7 @@ class SpaceNet5(SpaceNet):
         max_speed_bin = 65
         speed_arr_bin = np.arange(min_speed_bin, max_speed_bin + 1)
         bin_size_mph = 10.0
-        speed_cls_arr: "np.typing.NDArray[np.int]" = np.array(
+        speed_cls_arr: "np.typing.NDArray[int]" = np.array(
             [int(math.ceil(s / bin_size_mph)) for s in speed_arr_bin]
         )
 

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -564,7 +564,9 @@ def draw_semantic_segmentation_masks(
     return img  # type: ignore[no-any-return]
 
 
-def rgb_to_mask(rgb: np.ndarray, colors: List[Tuple[int, int, int]]) -> "np.typing.NDArray[np.int_]":
+def rgb_to_mask(
+    rgb: "np.typing.NDArray[np.int_]", colors: List[Tuple[int, int, int]]
+) -> "np.typing.NDArray[np.int_]":
     """Converts an RGB colormap mask to a integer mask.
 
     Args:
@@ -588,7 +590,7 @@ def percentile_normalization(
     img: "np.typing.NDArray[np.int_]",
     lower: float = 2,
     upper: float = 98,
-    axis: Optional[Union[int, Sequence[np.int_]]] = None,
+    axis: Optional[Union[int, Sequence[int]]] = None,
 ) -> "np.typing.NDArray[np.int_]":
     """Applies percentile normalization to an input image.
 
@@ -611,7 +613,7 @@ def percentile_normalization(
     assert lower < upper
     lower_percentile = np.percentile(img, lower, axis=axis)
     upper_percentile = np.percentile(img, upper, axis=axis)
-    img_normalized = np.clip(
+    img_normalized: "np.typing.NDArray[np.int_]" = np.clip(
         (img - lower_percentile) / (upper_percentile - lower_percentile), 0, 1
     )
     return img_normalized

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -569,7 +569,7 @@ def draw_semantic_segmentation_masks(
 
 
 def rgb_to_mask(
-    rgb: "np.typing.NDArray[np.int_]", colors: List[Tuple[int, int, int]]
+    rgb: "np.typing.NDArray[np.uint8]", colors: List[Tuple[int, int, int]]
 ) -> "np.typing.NDArray[np.uint8]":
     """Converts an RGB colormap mask to a integer mask.
 

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -526,7 +526,7 @@ def rasterio_loader(path: str) -> np.ndarray:
         the image
     """
     with rasterio.open(path) as f:
-        array: np.ndarray = f.read().astype(np.int32)
+        array: "np.typing.NDArray[int]" = f.read().astype(np.int32)
         # VisionClassificationDataset expects images returned with channels last (HWC)
         array = array.transpose(1, 2, 0)
     return array
@@ -564,9 +564,7 @@ def draw_semantic_segmentation_masks(
     return img  # type: ignore[no-any-return]
 
 
-def rgb_to_mask(
-    rgb: np.ndarray, colors: List[Tuple[int, int, int]]
-) -> np.ndarray:
+def rgb_to_mask(rgb: np.ndarray, colors: List[Tuple[int, int, int]]) -> np.ndarray:
     """Converts an RGB colormap mask to a integer mask.
 
     Args:
@@ -611,12 +609,8 @@ def percentile_normalization(
     .. versionadded:: 0.2
     """
     assert lower < upper
-    lower_percentile = np.percentile(
-        img, lower, axis=axis
-    )
-    upper_percentile = np.percentile(
-        img, upper, axis=axis
-    )
+    lower_percentile = np.percentile(img, lower, axis=axis)
+    upper_percentile = np.percentile(img, upper, axis=axis)
     img_normalized = np.clip(
         (img - lower_percentile) / (upper_percentile - lower_percentile), 0, 1
     )

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -566,7 +566,7 @@ def draw_semantic_segmentation_masks(
 
 def rgb_to_mask(
     rgb: "np.typing.NDArray[np.int_]", colors: List[Tuple[int, int, int]]
-) -> "np.typing.NDArray[np.int_]":
+) -> "np.typing.NDArray[np.uint8]":
     """Converts an RGB colormap mask to a integer mask.
 
     Args:
@@ -576,6 +576,9 @@ def rgb_to_mask(
     Returns:
         integer array mask
     """
+    assert len(colors) <= 256  # we currently return a uint8 array, so the largest value
+    # we can map is 255
+
     h, w = rgb.shape[:2]
     mask: "np.typing.NDArray[np.uint8]" = np.zeros(shape=(h, w), dtype=np.uint8)
     for i, c in enumerate(colors):

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -24,7 +24,6 @@ from typing import (
     Sequence,
     Tuple,
     Union,
-    cast,
     overload,
 )
 
@@ -517,7 +516,7 @@ def merge_samples(samples: Iterable[Dict[Any, Any]]) -> Dict[Any, Any]:
     return collated
 
 
-def rasterio_loader(path: str) -> np.ndarray:  # type: ignore[type-arg]
+def rasterio_loader(path: str) -> np.ndarray:
     """Load an image file using rasterio.
 
     Args:
@@ -527,7 +526,7 @@ def rasterio_loader(path: str) -> np.ndarray:  # type: ignore[type-arg]
         the image
     """
     with rasterio.open(path) as f:
-        array: np.ndarray = f.read().astype(np.int32)  # type: ignore[type-arg]
+        array: np.ndarray = f.read().astype(np.int32)
         # VisionClassificationDataset expects images returned with channels last (HWC)
         array = array.transpose(1, 2, 0)
     return array
@@ -544,7 +543,7 @@ def sort_sentinel2_bands(x: str) -> str:
 
 def draw_semantic_segmentation_masks(
     image: Tensor, mask: Tensor, alpha: float = 0.5, colors: Optional[ColorMap] = None
-) -> np.ndarray:  # type: ignore[type-arg]
+) -> np.ndarray:
     """Overlay a semantic segmentation mask onto an image.
 
     Args:
@@ -566,8 +565,8 @@ def draw_semantic_segmentation_masks(
 
 
 def rgb_to_mask(
-    rgb: np.ndarray, colors: List[Tuple[int, int, int]]  # type: ignore[type-arg]
-) -> np.ndarray:  # type: ignore[type-arg]
+    rgb: np.ndarray, colors: List[Tuple[int, int, int]]
+) -> np.ndarray:
     """Converts an RGB colormap mask to a integer mask.
 
     Args:
@@ -578,7 +577,7 @@ def rgb_to_mask(
         integer array mask
     """
     h, w = rgb.shape[:2]
-    mask = np.zeros(shape=(h, w), dtype=np.uint8)
+    mask: "np.typing.NDArray[np.uint8]" = np.zeros(shape=(h, w), dtype=np.uint8)
     for i, c in enumerate(colors):
         cmask = rgb == c
         # Only update mask if class is present in mask
@@ -588,11 +587,11 @@ def rgb_to_mask(
 
 
 def percentile_normalization(
-    img: np.ndarray,  # type: ignore[type-arg]
+    img: np.ndarray,
     lower: float = 2,
     upper: float = 98,
     axis: Optional[Union[int, Sequence[int]]] = None,
-) -> np.ndarray:  # type: ignore[type-arg]
+) -> np.ndarray:
     """Applies percentile normalization to an input image.
 
     Specifically, this will rescale the values in the input such that values <= the
@@ -612,13 +611,13 @@ def percentile_normalization(
     .. versionadded:: 0.2
     """
     assert lower < upper
-    lower_percentile = np.percentile(  # type: ignore[no-untyped-call]
+    lower_percentile = np.percentile(
         img, lower, axis=axis
     )
-    upper_percentile = np.percentile(  # type: ignore[no-untyped-call]
+    upper_percentile = np.percentile(
         img, upper, axis=axis
     )
     img_normalized = np.clip(
         (img - lower_percentile) / (upper_percentile - lower_percentile), 0, 1
     )
-    return cast(np.ndarray, img_normalized)  # type: ignore[type-arg]
+    return img_normalized

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -516,7 +516,7 @@ def merge_samples(samples: Iterable[Dict[Any, Any]]) -> Dict[Any, Any]:
     return collated
 
 
-def rasterio_loader(path: str) -> np.ndarray:
+def rasterio_loader(path: str) -> "np.typing.NDArray[np.int_]":
     """Load an image file using rasterio.
 
     Args:
@@ -526,7 +526,7 @@ def rasterio_loader(path: str) -> np.ndarray:
         the image
     """
     with rasterio.open(path) as f:
-        array: "np.typing.NDArray[int]" = f.read().astype(np.int32)
+        array: "np.typing.NDArray[np.int_]" = f.read().astype(np.int32)
         # VisionClassificationDataset expects images returned with channels last (HWC)
         array = array.transpose(1, 2, 0)
     return array
@@ -543,7 +543,7 @@ def sort_sentinel2_bands(x: str) -> str:
 
 def draw_semantic_segmentation_masks(
     image: Tensor, mask: Tensor, alpha: float = 0.5, colors: Optional[ColorMap] = None
-) -> np.ndarray:
+) -> "np.typing.NDArray[np.int_]":
     """Overlay a semantic segmentation mask onto an image.
 
     Args:
@@ -564,7 +564,7 @@ def draw_semantic_segmentation_masks(
     return img  # type: ignore[no-any-return]
 
 
-def rgb_to_mask(rgb: np.ndarray, colors: List[Tuple[int, int, int]]) -> np.ndarray:
+def rgb_to_mask(rgb: np.ndarray, colors: List[Tuple[int, int, int]]) -> "np.typing.NDArray[np.int_]":
     """Converts an RGB colormap mask to a integer mask.
 
     Args:
@@ -585,11 +585,11 @@ def rgb_to_mask(rgb: np.ndarray, colors: List[Tuple[int, int, int]]) -> np.ndarr
 
 
 def percentile_normalization(
-    img: np.ndarray,
+    img: "np.typing.NDArray[np.int_]",
     lower: float = 2,
     upper: float = 98,
-    axis: Optional[Union[int, Sequence[int]]] = None,
-) -> np.ndarray:
+    axis: Optional[Union[int, Sequence[np.int_]]] = None,
+) -> "np.typing.NDArray[np.int_]":
     """Applies percentile normalization to an input image.
 
     Specifically, this will rescale the values in the input such that values <= the

--- a/torchgeo/datasets/vaihingen.py
+++ b/torchgeo/datasets/vaihingen.py
@@ -201,7 +201,7 @@ class Vaihingen2D(VisionDataset):
         """
         path = self.files[index]["mask"]
         with Image.open(path) as img:
-            array: "np.typing.NDArray[np.int_]" = np.array(img.convert("RGB"))
+            array: "np.typing.NDArray[np.uint8]" = np.array(img.convert("RGB"))
             array = rgb_to_mask(array, self.colormap)
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             # Convert from HxWxC to CxHxW

--- a/torchgeo/datasets/vaihingen.py
+++ b/torchgeo/datasets/vaihingen.py
@@ -259,10 +259,7 @@ class Vaihingen2D(VisionDataset):
         """
         ncols = 1
         image1 = draw_semantic_segmentation_masks(
-            sample["image"][:3],
-            sample["mask"],
-            alpha=alpha,
-            colors=self.colormap,
+            sample["image"][:3], sample["mask"], alpha=alpha, colors=self.colormap
         )
         if "prediction" in sample:
             ncols += 1

--- a/torchgeo/datasets/vaihingen.py
+++ b/torchgeo/datasets/vaihingen.py
@@ -262,7 +262,7 @@ class Vaihingen2D(VisionDataset):
             sample["image"][:3],
             sample["mask"],
             alpha=alpha,
-            colors=self.colormap,  # type: ignore[arg-type]
+            colors=self.colormap,
         )
         if "prediction" in sample:
             ncols += 1
@@ -270,7 +270,7 @@ class Vaihingen2D(VisionDataset):
                 sample["image"][:3],
                 sample["prediction"],
                 alpha=alpha,
-                colors=self.colormap,  # type: ignore[arg-type]
+                colors=self.colormap,
             )
 
         fig, axs = plt.subplots(ncols=ncols, figsize=(ncols * 10, 10))

--- a/torchgeo/datasets/vaihingen.py
+++ b/torchgeo/datasets/vaihingen.py
@@ -184,7 +184,7 @@ class Vaihingen2D(VisionDataset):
         """
         path = self.files[index]["image"]
         with Image.open(path) as img:
-            array: "np.typing.NDArray[np.int]" = np.array(img.convert("RGB"))
+            array: "np.typing.NDArray[int]" = np.array(img.convert("RGB"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))
@@ -201,7 +201,7 @@ class Vaihingen2D(VisionDataset):
         """
         path = self.files[index]["mask"]
         with Image.open(path) as img:
-            array: "np.typing.NDArray[np.int]" = np.array(img.convert("RGB"))
+            array: "np.typing.NDArray[int]" = np.array(img.convert("RGB"))
             array = rgb_to_mask(array, self.colormap)
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             # Convert from HxWxC to CxHxW

--- a/torchgeo/datasets/vaihingen.py
+++ b/torchgeo/datasets/vaihingen.py
@@ -184,7 +184,7 @@ class Vaihingen2D(VisionDataset):
         """
         path = self.files[index]["image"]
         with Image.open(path) as img:
-            array = np.array(img.convert("RGB"))
+            array: "np.typing.NDArray[np.int]" = np.array(img.convert("RGB"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))
@@ -201,7 +201,7 @@ class Vaihingen2D(VisionDataset):
         """
         path = self.files[index]["mask"]
         with Image.open(path) as img:
-            array = np.array(img.convert("RGB"))
+            array: "np.typing.NDArray[np.int]" = np.array(img.convert("RGB"))
             array = rgb_to_mask(array, self.colormap)
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             # Convert from HxWxC to CxHxW

--- a/torchgeo/datasets/vaihingen.py
+++ b/torchgeo/datasets/vaihingen.py
@@ -184,7 +184,7 @@ class Vaihingen2D(VisionDataset):
         """
         path = self.files[index]["image"]
         with Image.open(path) as img:
-            array: "np.typing.NDArray[int]" = np.array(img.convert("RGB"))
+            array: "np.typing.NDArray[np.int_]" = np.array(img.convert("RGB"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))
@@ -201,7 +201,7 @@ class Vaihingen2D(VisionDataset):
         """
         path = self.files[index]["mask"]
         with Image.open(path) as img:
-            array: "np.typing.NDArray[int]" = np.array(img.convert("RGB"))
+            array: "np.typing.NDArray[np.int_]" = np.array(img.convert("RGB"))
             array = rgb_to_mask(array, self.colormap)
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             # Convert from HxWxC to CxHxW

--- a/torchgeo/datasets/xview.py
+++ b/torchgeo/datasets/xview.py
@@ -157,7 +157,7 @@ class XView2(VisionDataset):
         """
         filename = os.path.join(path)
         with Image.open(filename) as img:
-            array: "np.typing.NDArray[int]" = np.array(img.convert("RGB"))
+            array: "np.typing.NDArray[np.int_]" = np.array(img.convert("RGB"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))
@@ -174,7 +174,7 @@ class XView2(VisionDataset):
         """
         filename = os.path.join(path)
         with Image.open(filename) as img:
-            array: "np.typing.NDArray[int]" = np.array(img.convert("L"))
+            array: "np.typing.NDArray[np.int_]" = np.array(img.convert("L"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             tensor = tensor.to(torch.long)  # type: ignore[attr-defined]
             return tensor

--- a/torchgeo/datasets/xview.py
+++ b/torchgeo/datasets/xview.py
@@ -157,7 +157,7 @@ class XView2(VisionDataset):
         """
         filename = os.path.join(path)
         with Image.open(filename) as img:
-            array: "np.typing.NDArray[np.int]" = np.array(img.convert("RGB"))
+            array: "np.typing.NDArray[int]" = np.array(img.convert("RGB"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))
@@ -174,7 +174,7 @@ class XView2(VisionDataset):
         """
         filename = os.path.join(path)
         with Image.open(filename) as img:
-            array: "np.typing.NDArray[np.int]" = np.array(img.convert("L"))
+            array: "np.typing.NDArray[int]" = np.array(img.convert("L"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             tensor = tensor.to(torch.long)  # type: ignore[attr-defined]
             return tensor

--- a/torchgeo/datasets/xview.py
+++ b/torchgeo/datasets/xview.py
@@ -242,13 +242,13 @@ class XView2(VisionDataset):
             sample["image"][0],
             sample["mask"][0],
             alpha=alpha,
-            colors=self.colormap,  # type: ignore[arg-type]
+            colors=self.colormap,
         )
         image2 = draw_semantic_segmentation_masks(
             sample["image"][1],
             sample["mask"][1],
             alpha=alpha,
-            colors=self.colormap,  # type: ignore[arg-type]
+            colors=self.colormap,
         )
         if "prediction" in sample:  # NOTE: this assumes predictions are made for post
             ncols += 1
@@ -256,7 +256,7 @@ class XView2(VisionDataset):
                 sample["image"][1],
                 sample["prediction"],
                 alpha=alpha,
-                colors=self.colormap,  # type: ignore[arg-type]
+                colors=self.colormap,
             )
 
         fig, axs = plt.subplots(ncols=ncols, figsize=(ncols * 10, 10))

--- a/torchgeo/datasets/xview.py
+++ b/torchgeo/datasets/xview.py
@@ -239,16 +239,10 @@ class XView2(VisionDataset):
         """
         ncols = 2
         image1 = draw_semantic_segmentation_masks(
-            sample["image"][0],
-            sample["mask"][0],
-            alpha=alpha,
-            colors=self.colormap,
+            sample["image"][0], sample["mask"][0], alpha=alpha, colors=self.colormap
         )
         image2 = draw_semantic_segmentation_masks(
-            sample["image"][1],
-            sample["mask"][1],
-            alpha=alpha,
-            colors=self.colormap,
+            sample["image"][1], sample["mask"][1], alpha=alpha, colors=self.colormap
         )
         if "prediction" in sample:  # NOTE: this assumes predictions are made for post
             ncols += 1

--- a/torchgeo/datasets/xview.py
+++ b/torchgeo/datasets/xview.py
@@ -157,7 +157,7 @@ class XView2(VisionDataset):
         """
         filename = os.path.join(path)
         with Image.open(filename) as img:
-            array = np.array(img.convert("RGB"))
+            array: "np.typing.NDArray[np.int]" = np.array(img.convert("RGB"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))
@@ -174,7 +174,7 @@ class XView2(VisionDataset):
         """
         filename = os.path.join(path)
         with Image.open(filename) as img:
-            array = np.array(img.convert("L"))
+            array: "np.typing.NDArray[np.int]" = np.array(img.convert("L"))
             tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
             tensor = tensor.to(torch.long)  # type: ignore[attr-defined]
             return tensor


### PR DESCRIPTION
I don't have most of these data files lying around so I can't actually test the type of these arrays, so I guessed int for most of them. I wonder if there's a way to do dynamic type analysis where you compare the actual types with what mypy expects them to be.

Note that type hints are in quotes until we either 1) drop Python 3.6 support, or 2) drop numpy 1.20 support, or both.