### PR TITLE
Add numpy dependency to pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,5 +28,5 @@ repos:
         hooks:
         -   id: mypy
             args: [--strict, --ignore-missing-imports, --show-error-codes]
-            additional_dependencies: [torch>=1.7, pytorch-lightning>=1.3, pytest>=6, omegaconf>=2.1, kornia>=0.6]
+            additional_dependencies: [torch>=1.7, pytorch-lightning>=1.3, pytest>=6, omegaconf>=2.1, kornia>=0.6, numpy>=1.22.0]
             exclude: (build|data|dist|logo|logs|output)/


### PR DESCRIPTION
numpy 1.22.0 added type annotations for `np.percentile`, `np.load` and `np.concatenate` (among others) so it needs to be added as an additional dependency.