### PR TITLE
Update min kornia version to support PadTo

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,7 @@ dependencies:
     - ipywidgets>=7
     - isort[colors]>=5.8
     - jupyterlab
-    - kornia>=0.5.4
+    - kornia>=0.5.11
     - laspy>=2.0.0
     - mypy>=0.900
     - nbmake>=0.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,8 +33,8 @@ install_requires =
     einops
     # fiona 1.5+ required for fiona.transform module
     fiona>=1.5
-    # kornia 0.5.4+ required for kornia.augmentation.AugmentationSequential
-    kornia>=0.5.4
+    # kornia 0.5.11+ required for kornia.augmentation.PadTo
+    kornia>=0.5.11
     matplotlib
     numpy
     # omegaconf 2.1+ required for to_object method


### PR DESCRIPTION
`PadTo` was added in kornia 0.5.11 (kornia/kornia#1286). This PR updates the min version accordingly. Currently `K.PadTo` is only used in the OSCDDatamodule ([here](https://github.com/microsoft/torchgeo/blob/8ab254a24c2778ddaa64c163c99bfac49987bbf4/torchgeo/datamodules/oscd.py#L110)). 