### PR TITLE
Fix PyTorch + setuptools bug

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -59,7 +59,9 @@ jobs:
       if: ${{ runner.os == 'Windows' }}
     - name: Install conda dependencies (Windows)
       run: |
-        conda install 'fiona>=1.5' h5py 'rasterio>=1.0.16'
+        # PyTorch isn't compatible with setuptools 59.6+, pin for now until new PyTorch release
+        # https://github.com/pytorch/pytorch/pull/69904
+        conda install 'fiona>=1.5' h5py 'rasterio>=1.0.16' 'setuptools<59.6'
         conda list
         conda info
       if: ${{ runner.os == 'Windows' }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,9 +26,7 @@ keywords = pytorch, deep learning, machine learning, remote sensing, satellite i
 [options]
 setup_requires =
     # setuptools 42+ required for metadata.license_files support in setup.cfg
-    # PyTorch isn't compatible with setuptools 59.6+, pin for now until new PyTorch release
-    # https://github.com/pytorch/pytorch/pull/69904
-    setuptools>=42,<59.6
+    setuptools>=42
 install_requires =
     # dataclasses was added in Python 3.7
     dataclasses;python_version<'3.7'

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,9 @@ keywords = pytorch, deep learning, machine learning, remote sensing, satellite i
 [options]
 setup_requires =
     # setuptools 42+ required for metadata.license_files support in setup.cfg
-    setuptools>=42
+    # PyTorch isn't compatible with setuptools 59.6+, pin for now until new PyTorch release
+    # https://github.com/pytorch/pytorch/pull/69904
+    setuptools>=42,<59.6
 install_requires =
     # dataclasses was added in Python 3.7
     dataclasses;python_version<'3.7'


### PR DESCRIPTION
If this doesn't work I'll try moving the constraint to `.github/workflows/tests.yaml`.