### PR TITLE
Fix len for empty GeoDataset

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,8 +47,8 @@ install_requires =
     pytorch-lightning>=1.3
     # rasterio 1.0.16+ required for CRS support
     rasterio>=1.0.16
-    # rtree 0.5+ required for 3D index support
-    rtree>=0.5
+    # rtree 0.9.4+ required for Index.get_size
+    rtree>=0.9.4
     # scikit-learn 0.18+ required for sklearn.model_selection module
     scikit-learn>=0.18
     # segmentation-models-pytorch 0.2+ required for smp.losses module

--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -333,17 +333,20 @@ class TestIntersectionDataset:
     def test_different_crs(self) -> None:
         ds1 = CustomGeoDataset(crs=CRS.from_epsg(3005))
         ds2 = CustomGeoDataset(crs=CRS.from_epsg(32616))
-        IntersectionDataset(ds1, ds2)
+        ds = IntersectionDataset(ds1, ds2)
+        assert len(ds) == 0
 
     def test_different_res(self) -> None:
         ds1 = CustomGeoDataset(res=1)
         ds2 = CustomGeoDataset(res=2)
-        IntersectionDataset(ds1, ds2)
+        ds = IntersectionDataset(ds1, ds2)
+        assert len(ds) == 1
 
     def test_no_overlap(self) -> None:
         ds1 = CustomGeoDataset(BoundingBox(0, 1, 2, 3, 4, 5))
         ds2 = CustomGeoDataset(BoundingBox(6, 7, 8, 9, 10, 11))
-        IntersectionDataset(ds1, ds2)
+        ds = IntersectionDataset(ds1, ds2)
+        assert len(ds) == 0
 
     def test_invalid_query(self, dataset: IntersectionDataset) -> None:
         query = BoundingBox(0, 0, 0, 0, 0, 0)
@@ -382,17 +385,20 @@ class TestUnionDataset:
     def test_different_crs(self) -> None:
         ds1 = CustomGeoDataset(crs=CRS.from_epsg(3005))
         ds2 = CustomGeoDataset(crs=CRS.from_epsg(32616))
-        UnionDataset(ds1, ds2)
+        ds = UnionDataset(ds1, ds2)
+        assert len(ds) == 2
 
     def test_different_res(self) -> None:
         ds1 = CustomGeoDataset(res=1)
         ds2 = CustomGeoDataset(res=2)
-        UnionDataset(ds1, ds2)
+        ds = UnionDataset(ds1, ds2)
+        assert len(ds) == 2
 
     def test_no_overlap(self) -> None:
         ds1 = CustomGeoDataset(BoundingBox(0, 1, 2, 3, 4, 5))
         ds2 = CustomGeoDataset(BoundingBox(6, 7, 8, 9, 10, 11))
-        UnionDataset(ds1, ds2)
+        ds = UnionDataset(ds1, ds2)
+        assert len(ds) == 2
 
     def test_invalid_query(self, dataset: UnionDataset) -> None:
         query = BoundingBox(0, 0, 0, 0, 0, 0)

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -161,7 +161,7 @@ class GeoDataset(Dataset[Dict[str, Any]], abc.ABC):
         Returns:
             length of the dataset
         """
-        count: int = self.index.count(self.index.bounds)
+        count: int = self.index.get_size()
         return count
 
     def __str__(self) -> str:


### PR DESCRIPTION
When trying to compute the length of an empty GeoDataset, instead of returning 0, rtree crashes. See https://github.com/Toblerity/rtree/issues/204 for a description of the issue. We can instead use `Index.get_size()` which has a try-except that happens to catch this issue and return 0.

`Index.get_size()` is undocumented and was added in rtree 0.9.4, which is relatively new. We could instead add our own try-except with the same implementation as `Index.get_size()` if we want to support older versions of rtree. Thoughts on this?