### PR TITLE
BoundingBox: add area/volume attributes

### DIFF
--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -334,6 +334,28 @@ class TestBoundingBox:
     @pytest.mark.parametrize(
         "test_input,expected",
         [
+            # Rectangular prism
+            ((0, 1, 0, 1, 0, 1), 1),
+            ((0, 2, 0, 3, 0, 4), 24),
+            # Plane
+            ((0, 0, 0, 1, 0, 1), 0),
+            # Line
+            ((0, 0, 0, 0, 0, 1), 0),
+            # Point
+            ((0, 0, 0, 0, 0, 0), 0),
+        ],
+    )
+    def test_volume(
+        self,
+        test_input: Tuple[float, float, float, float, float, float],
+        expected: int,
+    ) -> None:
+        bbox = BoundingBox(*test_input)
+        assert bbox.volume == expected
+
+    @pytest.mark.parametrize(
+        "test_input,expected",
+        [
             # Same box
             ((0, 1, 0, 1, 0, 1), True),
             ((0.0, 1.0, 0.0, 1.0, 0.0, 1.0), True),

--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -346,9 +346,7 @@ class TestBoundingBox:
         ],
     )
     def test_volume(
-        self,
-        test_input: Tuple[float, float, float, float, float, float],
-        expected: int,
+        self, test_input: Tuple[float, float, float, float, float, float], expected: int
     ) -> None:
         bbox = BoundingBox(*test_input)
         assert bbox.volume == expected

--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -336,6 +336,26 @@ class TestBoundingBox:
         [
             # Rectangular prism
             ((0, 1, 0, 1, 0, 1), 1),
+            ((0, 2, 0, 3, 0, 4), 6),
+            # Plane
+            ((0, 0, 0, 1, 0, 1), 0),
+            # Line
+            ((0, 0, 0, 0, 0, 1), 0),
+            # Point
+            ((0, 0, 0, 0, 0, 0), 0),
+        ],
+    )
+    def test_area(
+        self, test_input: Tuple[float, float, float, float, float, float], expected: int
+    ) -> None:
+        bbox = BoundingBox(*test_input)
+        assert bbox.area == expected
+
+    @pytest.mark.parametrize(
+        "test_input,expected",
+        [
+            # Rectangular prism
+            ((0, 1, 0, 1, 0, 1), 1),
             ((0, 2, 0, 3, 0, 4), 24),
             # Plane
             ((0, 0, 0, 1, 0, 1), 0),

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -352,6 +352,19 @@ class BoundingBox:
         except ValueError:
             raise ValueError(f"Bounding boxes {self} and {other} do not overlap")
 
+    @property
+    def volume(self) -> float:
+        """Volume of bounding box.
+
+        Returns:
+            volume
+
+        .. versionadded:: 0.3
+        """
+        return (
+            (self.maxx - self.minx) * (self.maxy - self.miny) * (self.maxt - self.mint)
+        )
+
     def intersects(self, other: "BoundingBox") -> bool:
         """Whether or not two bounding boxes intersect.
 

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -353,17 +353,30 @@ class BoundingBox:
             raise ValueError(f"Bounding boxes {self} and {other} do not overlap")
 
     @property
+    def area(self) -> float:
+        """Area of bounding box.
+
+        Area is defined as spatial area.
+
+        Returns:
+            area
+
+        .. versionadded:: 0.3
+        """
+        return (self.maxx - self.minx) * (self.maxy - self.miny)
+
+    @property
     def volume(self) -> float:
         """Volume of bounding box.
+
+        Volume is defined as spatial area times temporal range.
 
         Returns:
             volume
 
         .. versionadded:: 0.3
         """
-        return (
-            (self.maxx - self.minx) * (self.maxy - self.miny) * (self.maxt - self.mint)
-        )
+        return self.area * (self.maxt - self.mint)
 
     def intersects(self, other: "BoundingBox") -> bool:
         """Whether or not two bounding boxes intersect.


### PR DESCRIPTION
This PR adds area/volume attributes to the `BoundingBox` class. 

This is needed for a check I would like to add for #319, but I figured I would submit it as a separate PR to keep things easier to review.