### PR TITLE
LandCover.ai: support already-downloaded dataset

### DIFF
--- a/tests/datasets/test_landcoverai.py
+++ b/tests/datasets/test_landcoverai.py
@@ -18,7 +18,7 @@ import torchgeo.datasets.utils
 from torchgeo.datasets import LandCoverAI
 
 
-def download_url(url: str, root: str, *args: str) -> None:
+def download_url(url: str, root: str, *args: str, **kwarsgs: str) -> None:
     shutil.copy(url, root)
 
 
@@ -31,7 +31,7 @@ class TestLandCoverAI:
         request: SubRequest,
     ) -> LandCoverAI:
         monkeypatch.setattr(  # type: ignore[attr-defined]
-            torchgeo.datasets.utils, "download_url", download_url
+            torchgeo.datasets.landcoverai, "download_url", download_url
         )
         md5 = "46108372402292213789342d58929708"
         monkeypatch.setattr(LandCoverAI, "md5", md5)  # type: ignore[attr-defined]
@@ -58,16 +58,26 @@ class TestLandCoverAI:
         assert isinstance(ds, ConcatDataset)
         assert len(ds) == 4
 
-    def test_already_downloaded(self, dataset: LandCoverAI) -> None:
+    def test_already_extracted(self, dataset: LandCoverAI) -> None:
         LandCoverAI(root=dataset.root, download=True)
+
+    def test_already_downloaded(
+        self, monkeypatch: Generator[MonkeyPatch, None, None], tmp_path: Path
+    ) -> None:
+        sha256 = "ce84fa0e8d89b461c66fba4e78aa5a860e2871722c4a9ca8c2384eae1521c7c8"
+        monkeypatch.setattr(LandCoverAI, "sha256", sha256)  # type: ignore[attr-defined]
+        url = os.path.join("tests", "data", "landcoverai", "landcover.ai.v1.zip")
+        root = str(tmp_path)
+        shutil.copy(url, root)
+        LandCoverAI(root)
+
+    def test_not_downloaded(self, tmp_path: Path) -> None:
+        with pytest.raises(RuntimeError, match="Dataset not found"):
+            LandCoverAI(str(tmp_path))
 
     def test_invalid_split(self) -> None:
         with pytest.raises(AssertionError):
             LandCoverAI(split="foo")
-
-    def test_not_downloaded(self, tmp_path: Path) -> None:
-        with pytest.raises(RuntimeError, match="Dataset not found or corrupted."):
-            LandCoverAI(str(tmp_path))
 
     def test_plot(self, dataset: LandCoverAI) -> None:
         x = dataset[0].copy()

--- a/tests/datasets/test_landcoverai.py
+++ b/tests/datasets/test_landcoverai.py
@@ -18,7 +18,7 @@ import torchgeo.datasets.utils
 from torchgeo.datasets import LandCoverAI
 
 
-def download_url(url: str, root: str, *args: str, **kwarsgs: str) -> None:
+def download_url(url: str, root: str, *args: str, **kwargs: str) -> None:
     shutil.copy(url, root)
 
 


### PR DESCRIPTION
See #99 for rationale/design.

This dataset actually has 3 phases: download, extract, and generate patches from larger images. We could actually have a third `_generate` phase of `_verify` in case we want to allow people to delete the original image tiles after the patches are generated. Not sure if that's necessary though.