### PR TITLE
Add formulas to indices docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,6 +38,7 @@ release = torchgeo.__version__
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
+    "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",

--- a/torchgeo/transforms/indices.py
+++ b/torchgeo/transforms/indices.py
@@ -29,7 +29,7 @@ class AppendNormalizedDifferenceIndex(Module):
 
     .. math::
 
-       NDI = \frac{A - B}{A + B}
+       \text{NDI} = \frac{A - B}{A + B}
 
     .. versionadded:: 0.2
     """
@@ -88,7 +88,7 @@ class AppendNBR(AppendNormalizedDifferenceIndex):
 
     .. math::
 
-       NBR = \frac{NIR - SWIR}{NIR + SWIR}
+       \text{NBR} = \frac{\text{NIR} - \text{SWIR}}{\text{NIR} + \text{SWIR}}
 
     If you use this index in your research, please cite the following paper:
 
@@ -114,7 +114,7 @@ class AppendNDBI(AppendNormalizedDifferenceIndex):
 
     .. math::
 
-       NDBI = \frac{SWIR - NIR}{SWIR + NIR}
+       \text{NDBI} = \frac{\text{SWIR} - \text{NIR}}{\text{SWIR} + \text{NIR}}
 
     If you use this index in your research, please cite the following paper:
 
@@ -138,7 +138,7 @@ class AppendNDSI(AppendNormalizedDifferenceIndex):
 
     .. math::
 
-       NDSI = \frac{G - SWIR}{G + SWIR}
+       \text{NDSI} = \frac{\text{G} - \text{SWIR}}{\text{G} + \text{SWIR}}
 
     If you use this index in your research, please cite the following paper:
 
@@ -162,7 +162,7 @@ class AppendNDVI(AppendNormalizedDifferenceIndex):
 
     .. math::
 
-       NDVI = \frac{R - NIR}{R + NIR}
+       \text{NDVI} = \frac{\text{R} - \text{NIR}}{\text{R} + \text{NIR}}
 
     If you use this index in your research, please cite the following paper:
 
@@ -186,7 +186,7 @@ class AppendNDWI(AppendNormalizedDifferenceIndex):
 
     .. math::
 
-       NDWI = \frac{G - NIR}{G + NIR}
+       \text{NDWI} = \frac{\text{G} - \text{NIR}}{\text{G} + \text{NIR}}
 
     If you use this index in your research, please cite the following paper:
 
@@ -210,7 +210,7 @@ class AppendSWI(AppendNormalizedDifferenceIndex):
 
     .. math::
 
-       SWI = \frac{R - SWIR}{R + SWIR}
+       \text{SWI} = \frac{\text{R} - \text{SWIR}}{\text{R} + \text{SWIR}}
 
     If you use this index in your research, please cite the following paper:
 
@@ -234,7 +234,7 @@ class AppendGNDVI(AppendNormalizedDifferenceIndex):
 
     .. math::
 
-       GNDVI = \frac{NIR - G}{NIR + G}
+       \text{GNDVI} = \frac{\text{NIR} - \text{G}}{\text{NIR} + \text{G}}
 
     If you use this index in your research, please cite the following paper:
 
@@ -258,7 +258,7 @@ class AppendBNDVI(AppendNormalizedDifferenceIndex):
 
     .. math::
 
-       BNDVI = \frac{NIR - B}{NIR + B}
+       \text{BNDVI} = \frac{\text{NIR} - \text{B}}{\text{NIR} + \text{B}}
 
     If you use this index in your research, please cite the following paper:
 
@@ -284,7 +284,7 @@ class AppendNDRE(AppendNormalizedDifferenceIndex):
 
     .. math::
 
-       NDRE = \frac{NIR - VRE1}{NIR + VRE1}
+       \text{NDRE} = \frac{\text{NIR} - \text{VRE1}}{\text{NIR} + \text{VRE1}}
 
     If you use this index in your research, please cite the following paper:
 

--- a/torchgeo/transforms/indices.py
+++ b/torchgeo/transforms/indices.py
@@ -23,7 +23,13 @@ _EPSILON = 1e-10
 
 
 class AppendNormalizedDifferenceIndex(Module):
-    """Append normalized difference index as channel to image tensor.
+    r"""Append normalized difference index as channel to image tensor.
+
+    Computes the following index:
+
+    .. math::
+
+       NDI = \frac{A - B}{A + B}
 
     .. versionadded:: 0.2
     """
@@ -76,7 +82,13 @@ class AppendNormalizedDifferenceIndex(Module):
 
 
 class AppendNBR(AppendNormalizedDifferenceIndex):
-    """Normalized Burn Ratio (NBR).
+    r"""Normalized Burn Ratio (NBR).
+
+    Computes the following index:
+
+    .. math::
+
+       NBR = \frac{NIR - SWIR}{NIR + SWIR}
 
     If you use this index in your research, please cite the following paper:
 
@@ -96,7 +108,13 @@ class AppendNBR(AppendNormalizedDifferenceIndex):
 
 
 class AppendNDBI(AppendNormalizedDifferenceIndex):
-    """Normalized Difference Built-up Index (NDBI).
+    r"""Normalized Difference Built-up Index (NDBI).
+
+    Computes the following index:
+
+    .. math::
+
+       NDBI = \frac{SWIR - NIR}{SWIR + NIR}
 
     If you use this index in your research, please cite the following paper:
 
@@ -114,7 +132,13 @@ class AppendNDBI(AppendNormalizedDifferenceIndex):
 
 
 class AppendNDSI(AppendNormalizedDifferenceIndex):
-    """Normalized Difference Snow Index (NDSI).
+    r"""Normalized Difference Snow Index (NDSI).
+
+    Computes the following index:
+
+    .. math::
+
+       NDSI = \frac{G - SWIR}{G + SWIR}
 
     If you use this index in your research, please cite the following paper:
 
@@ -132,7 +156,13 @@ class AppendNDSI(AppendNormalizedDifferenceIndex):
 
 
 class AppendNDVI(AppendNormalizedDifferenceIndex):
-    """Normalized Difference Vegetation Index (NDVI).
+    r"""Normalized Difference Vegetation Index (NDVI).
+
+    Computes the following index:
+
+    .. math::
+
+       NDVI = \frac{R - NIR}{R + NIR}
 
     If you use this index in your research, please cite the following paper:
 
@@ -150,7 +180,13 @@ class AppendNDVI(AppendNormalizedDifferenceIndex):
 
 
 class AppendNDWI(AppendNormalizedDifferenceIndex):
-    """Normalized Difference Water Index (NDWI).
+    r"""Normalized Difference Water Index (NDWI).
+
+    Computes the following index:
+
+    .. math::
+
+       NDWI = \frac{G - NIR}{G + NIR}
 
     If you use this index in your research, please cite the following paper:
 
@@ -168,7 +204,13 @@ class AppendNDWI(AppendNormalizedDifferenceIndex):
 
 
 class AppendSWI(AppendNormalizedDifferenceIndex):
-    """Standardized Water-Level Index (SWI).
+    r"""Standardized Water-Level Index (SWI).
+
+    Computes the following index:
+
+    .. math::
+
+       SWI = \frac{R - SWIR}{R + SWIR}
 
     If you use this index in your research, please cite the following paper:
 
@@ -186,7 +228,13 @@ class AppendSWI(AppendNormalizedDifferenceIndex):
 
 
 class AppendGNDVI(AppendNormalizedDifferenceIndex):
-    """Green Normalized Difference Vegetation Index (GNDVI).
+    r"""Green Normalized Difference Vegetation Index (GNDVI).
+
+    Computes the following index:
+
+    .. math::
+
+       GNDVI = \frac{NIR - G}{NIR + G}
 
     If you use this index in your research, please cite the following paper:
 
@@ -204,7 +252,13 @@ class AppendGNDVI(AppendNormalizedDifferenceIndex):
 
 
 class AppendBNDVI(AppendNormalizedDifferenceIndex):
-    """Blue Normalized Difference Vegetation Index (BNDVI).
+    r"""Blue Normalized Difference Vegetation Index (BNDVI).
+
+    Computes the following index:
+
+    .. math::
+
+       BNDVI = \frac{NIR - B}{NIR + B}
 
     If you use this index in your research, please cite the following paper:
 
@@ -224,7 +278,13 @@ class AppendBNDVI(AppendNormalizedDifferenceIndex):
 
 
 class AppendNDRE(AppendNormalizedDifferenceIndex):
-    """Normalized Difference Red Edge Vegetation Index (NDRE).
+    r"""Normalized Difference Red Edge Vegetation Index (NDRE).
+
+    Computes the following index:
+
+    .. math::
+
+       NDRE = \frac{NIR - VRE1}{NIR + VRE1}
 
     If you use this index in your research, please cite the following paper:
 


### PR DESCRIPTION
See #387 

We may need to develop a consistent naming scheme for bands. For example, some indices take in the index of the red-edge band, but many satellites don't have a red-edge band, so we use red instead. The parameter names should be somehow consistent in this scenario.

I haven't yet added common use cases and interpretation to the docs. That can probably be done in a separate PR.