### PR TITLE
Remove __module__ hacks from TorchGeo

### DIFF
--- a/torchgeo/datamodules/__init__.py
+++ b/torchgeo/datamodules/__init__.py
@@ -46,7 +46,3 @@ __all__ = (
     "Vaihingen2DDataModule",
     "XView2DataModule",
 )
-
-# https://stackoverflow.com/questions/40018681
-for module in __all__:
-    globals()[module].__module__ = "torchgeo.datamodules"

--- a/torchgeo/datasets/__init__.py
+++ b/torchgeo/datasets/__init__.py
@@ -166,7 +166,3 @@ __all__ = (
     "stack_samples",
     "unbind_samples",
 )
-
-# https://stackoverflow.com/questions/40018681
-for module in __all__:
-    globals()[module].__module__ = "torchgeo.datasets"

--- a/torchgeo/losses/__init__.py
+++ b/torchgeo/losses/__init__.py
@@ -6,7 +6,3 @@
 from .qr import QRLoss, RQLoss
 
 __all__ = ("QRLoss", "RQLoss")
-
-# https://stackoverflow.com/questions/40018681
-for module in __all__:
-    globals()[module].__module__ = "torchgeo.losses"

--- a/torchgeo/models/__init__.py
+++ b/torchgeo/models/__init__.py
@@ -22,7 +22,3 @@ __all__ = (
     "RCF",
     "resnet50",
 )
-
-# https://stackoverflow.com/questions/40018681
-for module in __all__:
-    globals()[module].__module__ = "torchgeo.models"

--- a/torchgeo/samplers/__init__.py
+++ b/torchgeo/samplers/__init__.py
@@ -16,7 +16,3 @@ __all__ = (
     "GeoSampler",
     "BatchGeoSampler",
 )
-
-# https://stackoverflow.com/questions/40018681
-for module in __all__:
-    globals()[module].__module__ = "torchgeo.samplers"

--- a/torchgeo/trainers/__init__.py
+++ b/torchgeo/trainers/__init__.py
@@ -15,7 +15,3 @@ __all__ = (
     "RegressionTask",
     "SemanticSegmentationTask",
 )
-
-# https://stackoverflow.com/questions/40018681
-for module in __all__:
-    globals()[module].__module__ = "torchgeo.trainers"

--- a/torchgeo/transforms/__init__.py
+++ b/torchgeo/transforms/__init__.py
@@ -30,7 +30,3 @@ __all__ = (
     "AppendSWI",
     "AugmentationSequential",
 )
-
-# https://stackoverflow.com/questions/40018681
-for module in __all__:
-    globals()[module].__module__ = "torchgeo.transforms"


### PR DESCRIPTION
According to https://github.com/sphinx-doc/sphinx/issues/9395, these hacks should no longer be needed since we build our docs with Sphinx 4+.

Unfortunately, the torch/torchvision module hacks are still needed until I can convince them to unpin Sphinx: https://github.com/pytorch/pytorch/pull/70309, https://github.com/pytorch/vision/pull/5121

This should help with some of the issues we were seeing in our docs (missing source links).