### PR TITLE
Add plot method to base chesapeake

### DIFF
--- a/tests/datasets/test_chesapeake.py
+++ b/tests/datasets/test_chesapeake.py
@@ -82,7 +82,13 @@ class TestChesapeake13:
     def test_plot(self, dataset: Chesapeake13) -> None:
         query = dataset.bounds
         x = dataset[query]
-        dataset.plot(x["mask"])
+        dataset.plot(x, suptitle="Test")
+
+    def test_plot_prediction(self, dataset: Chesapeake13) -> None:
+        query = dataset.bounds
+        x = dataset[query]
+        x["prediction"] = x["mask"].clone()
+        dataset.plot(x, suptitle="Prediction")
 
     def test_url(self) -> None:
         ds = Chesapeake13(os.path.join("tests", "data", "chesapeake", "BAYWIDE"))

--- a/torchgeo/datasets/chesapeake.py
+++ b/torchgeo/datasets/chesapeake.py
@@ -9,7 +9,6 @@ import sys
 from typing import Any, Callable, Dict, Optional, Sequence
 
 import fiona
-from matplotlib.colors import ListedColormap
 import matplotlib.pyplot as plt
 import numpy as np
 import pyproj
@@ -18,6 +17,7 @@ import rasterio.mask
 import shapely.geometry
 import shapely.ops
 import torch
+from matplotlib.colors import ListedColormap
 from rasterio.crs import CRS
 from torch import Tensor
 

--- a/torchgeo/datasets/chesapeake.py
+++ b/torchgeo/datasets/chesapeake.py
@@ -174,7 +174,7 @@ class Chesapeake(RasterDataset, abc.ABC):
             pred = sample["prediction"].squeeze(0)
             ncols = 2
 
-        fig, axs = plt.subplots(nrows=1, ncols=ncols, figisze=(4 * ncols, 4))
+        fig, axs = plt.subplots(nrows=1, ncols=ncols, figsize=(4 * ncols, 4))
 
         if showing_predictions:
             axs[0].imshow(mask)

--- a/torchgeo/datasets/chesapeake.py
+++ b/torchgeo/datasets/chesapeake.py
@@ -47,6 +47,8 @@ class Chesapeake(RasterDataset, abc.ABC):
       <https://chesapeakeconservancy.org/wp-content/uploads/2017/01/Chesapeake_Conservancy_Accuracy_Assessment_Methodology.pdf>`_
     """
 
+    # TODO: this shouldn't be needed, but .tif.ovr file is getting picked up
+    filename_glob = "*.tif"
     is_image = False
 
     # subclasses use the 13 class cmap by default
@@ -260,7 +262,6 @@ class Chesapeake7(Chesapeake):
 
     base_folder = "BAYWIDE"
     filename = "Baywide_7class_20132014.tif"
-    filename_glob = "Baywide_7class_20132014.tif"
     zipfile = "Baywide_7Class_20132014.zip"
     md5 = "61a4e948fb2551840b6557ef195c2084"
 
@@ -299,7 +300,6 @@ class Chesapeake13(Chesapeake):
 
     base_folder = "BAYWIDE"
     filename = "Baywide_13Class_20132014.tif"
-    filename_glob = "Baywide_13Class_20132014.tif"
     zipfile = "Baywide_13Class_20132014.zip"
     md5 = "7e51118923c91e80e6e268156d25a4b9"
 
@@ -309,7 +309,6 @@ class ChesapeakeDC(Chesapeake):
 
     base_folder = "DC"
     filename = os.path.join("DC_11001", "DC_11001.img")
-    filename_glob = os.path.join("DC_11001", "DC_11001.img")
     zipfile = "DC_11001.zip"
     md5 = "ed06ba7570d2955e8857d7d846c53b06"
 
@@ -319,7 +318,6 @@ class ChesapeakeDE(Chesapeake):
 
     base_folder = "DE"
     filename = "DE_STATEWIDE.tif"
-    filename_glob = "DE_STATEWIDE.tif"
     zipfile = "_DE_STATEWIDE.zip"
     md5 = "5e12eff3b6950c01092c7e480b38e544"
 
@@ -337,7 +335,6 @@ class ChesapeakeMD(Chesapeake):
 
     base_folder = "MD"
     filename = "MD_STATEWIDE.tif"
-    filename_glob = "MD_STATEWIDE.tif"
     zipfile = "_MD_STATEWIDE.zip"
     md5 = "40c7cd697a887f2ffdb601b5c114e567"
 
@@ -355,7 +352,6 @@ class ChesapeakeNY(Chesapeake):
 
     base_folder = "NY"
     filename = "NY_STATEWIDE.tif"
-    filename_glob = "NY_STATEWIDE.tif"
     zipfile = "_NY_STATEWIDE.zip"
     md5 = "1100078c526616454ef2e508affda915"
 
@@ -365,7 +361,6 @@ class ChesapeakePA(Chesapeake):
 
     base_folder = "PA"
     filename = "PA_STATEWIDE.tif"
-    filename_glob = "PA_STATEWIDE.tif"
     zipfile = "_PA_STATEWIDE.zip"
     md5 = "20a2a857c527a4dbadd6beed8b47e5ab"
 
@@ -383,7 +378,6 @@ class ChesapeakeVA(Chesapeake):
 
     base_folder = "VA"
     filename = "CIC2014_VA_STATEWIDE.tif"
-    filename_glob = "CIC2014_VA_STATEWIDE.tif"
     zipfile = "_VA_STATEWIDE.zip"
     md5 = "6f2c97deaf73bb3e1ea9b21bd7a3fc8e"
 
@@ -393,7 +387,6 @@ class ChesapeakeWV(Chesapeake):
 
     base_folder = "WV"
     filename = "WV_STATEWIDE.tif"
-    filename_glob = "WV_STATEWIDE.tif"
     zipfile = "_WV_STATEWIDE.zip"
     md5 = "350621ea293651fbc557a1c3e3c64cc3"
 

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -349,8 +349,7 @@ class RasterDataset(GeoDataset):
                     with rasterio.open(filepath) as src:
                         # See if file has a color map
                         try:
-                            if len(self.cmap) == 0:
-                                self.cmap = src.colormap(1)
+                            self.cmap = src.colormap(1)
                         except ValueError:
                             pass
 

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -349,7 +349,8 @@ class RasterDataset(GeoDataset):
                     with rasterio.open(filepath) as src:
                         # See if file has a color map
                         try:
-                            self.cmap = src.colormap(1)
+                            if len(self.cmap) == 0:
+                                self.cmap = src.colormap(1)
                         except ValueError:
                             pass
 


### PR DESCRIPTION
This PR adds a plot method to the Chesapeake dataset baseclass to address #253. I was unable to run pytest, because the currently generated fake data cannot be unzipped:
`NotImplementedError: That compression method is not supported`

should I change the archive method in the base data.py class to the `shutil.make_archive()` used in other data.py files?