### PR TITLE
CDL: don't pick up .tif.ovr files

### DIFF
--- a/torchgeo/datasets/cdl.py
+++ b/torchgeo/datasets/cdl.py
@@ -31,7 +31,7 @@ class CDL(RasterDataset):
     * https://www.nass.usda.gov/Research_and_Science/Cropland/sarsfaqs2.php#Section1_14.0
     """  # noqa: E501
 
-    filename_glob = "*_30m_cdls.*"
+    filename_glob = "*_30m_cdls.tif"
     filename_regex = r"""
         ^(?P<date>\d+)
         _30m_cdls\..*$


### PR DESCRIPTION
Fixes #423 

Maybe someone with a wired internet connection can double check that every year of data has a `.tif` file? From what I call, this dataset was not consistent across all years. I feel like some years might have used `.img`...

Unfortunately this prevents users from changing the file format of the data they download. But those users can always override `filename_glob` if they need to.