### PR TITLE
Add own plot method to CMSMangroveCanopy 

### DIFF
--- a/tests/datasets/test_cms_mangrove_canopy.py
+++ b/tests/datasets/test_cms_mangrove_canopy.py
@@ -90,4 +90,10 @@ class TestCMSGlobalMangroveCanopy:
     def test_plot(self, dataset: CMSGlobalMangroveCanopy) -> None:
         query = dataset.bounds
         x = dataset[query]
-        dataset.plot(x["mask"])
+        dataset.plot(x, suptitle="Test")
+
+    def test_plot_prediction(self, dataset: CMSGlobalMangroveCanopy) -> None:
+        query = dataset.bounds
+        x = dataset[query]
+        x["prediction"] = x["mask"].clone()
+        dataset.plot(x, suptitle="Prediction")

--- a/torchgeo/datasets/cms_mangrove_canopy.py
+++ b/torchgeo/datasets/cms_mangrove_canopy.py
@@ -267,10 +267,6 @@ class CMSGlobalMangroveCanopy(RasterDataset):
 
         Returns:
             a matplotlib Figure with the rendered sample
-
-        .. versionchanged:: 0.3
-            Method now takes a sample dict, not a Tensor. Additionally, it is possible
-            to show subplot titles and/or use a custom suptitle.
         """
         mask = sample["mask"].squeeze()
         ncols = 1

--- a/torchgeo/datasets/cms_mangrove_canopy.py
+++ b/torchgeo/datasets/cms_mangrove_canopy.py
@@ -267,7 +267,7 @@ class CMSGlobalMangroveCanopy(RasterDataset):
 
         Returns:
             a matplotlib Figure with the rendered sample
-        
+
         .. versionchanged:: 0.3
             Method now takes a sample dict, not a Tensor. Additionally, it is possible
             to show subplot titles and/or use a custom suptitle.

--- a/torchgeo/datasets/cms_mangrove_canopy.py
+++ b/torchgeo/datasets/cms_mangrove_canopy.py
@@ -9,7 +9,6 @@ from typing import Any, Callable, Dict, Optional
 
 import matplotlib.pyplot as plt
 from rasterio.crs import CRS
-from torch import Tensor
 
 from .geo import RasterDataset
 from .utils import check_integrity, extract_archive
@@ -254,7 +253,7 @@ class CMSGlobalMangroveCanopy(RasterDataset):
 
     def plot(  # type: ignore[override]
         self,
-        sample: Dict[str, Tensor],
+        sample: Dict[str, Any],
         show_titles: bool = True,
         suptitle: Optional[str] = None,
     ) -> plt.Figure:

--- a/torchgeo/datasets/cms_mangrove_canopy.py
+++ b/torchgeo/datasets/cms_mangrove_canopy.py
@@ -269,8 +269,8 @@ class CMSGlobalMangroveCanopy(RasterDataset):
             a matplotlib Figure with the rendered sample
         
         .. versionchanged:: 0.3
-            Method now takes a sample dict, not a Tensor. Additionally, it is possible to
-            show subplot titles and/or use a custom suptitle.
+            Method now takes a sample dict, not a Tensor. Additionally, it is possible
+            to show subplot titles and/or use a custom suptitle.
         """
         mask = sample["mask"].squeeze()
         ncols = 1

--- a/torchgeo/datasets/cms_mangrove_canopy.py
+++ b/torchgeo/datasets/cms_mangrove_canopy.py
@@ -267,6 +267,10 @@ class CMSGlobalMangroveCanopy(RasterDataset):
 
         Returns:
             a matplotlib Figure with the rendered sample
+        
+        .. versionchanged:: 0.3
+            Method now takes a sample dict, not a Tensor. Additionally, it is possible to
+            show subplot titles and/or use a custom suptitle.
         """
         mask = sample["mask"].squeeze()
         ncols = 1


### PR DESCRIPTION
When adding the CMSMangroveCanopy dataset in #391, I did not add its own plot method. This PR does so.

Example:
![cms1](https://user-images.githubusercontent.com/35272119/155180884-5651654d-843f-4f89-919b-433f8696c0bc.png)

