### PR TITLE
Missing plt.close() on dataset tests

### DIFF
--- a/tests/datasets/test_astergdem.py
+++ b/tests/datasets/test_astergdem.py
@@ -5,6 +5,7 @@ import os
 import shutil
 from pathlib import Path
 
+import matplotlib.pyplot as plt
 import pytest
 import torch
 import torch.nn as nn
@@ -46,12 +47,14 @@ class TestAsterGDEM:
         query = dataset.bounds
         x = dataset[query]
         dataset.plot(x, suptitle="Test")
+        plt.close()
 
     def test_plot_prediction(self, dataset: AsterGDEM) -> None:
         query = dataset.bounds
         x = dataset[query]
         x["prediction"] = x["mask"].clone()
         dataset.plot(x, suptitle="Prediction")
+        plt.close()
 
     def test_invalid_query(self, dataset: AsterGDEM) -> None:
         query = BoundingBox(100, 100, 100, 100, 0, 0)

--- a/tests/datasets/test_cdl.py
+++ b/tests/datasets/test_cdl.py
@@ -91,6 +91,7 @@ class TestCDL:
         query = dataset.bounds
         x = dataset[query]
         dataset.plot(x["mask"])
+        plt.close()
 
     def test_not_downloaded(self, tmp_path: Path) -> None:
         with pytest.raises(RuntimeError, match="Dataset not found"):

--- a/tests/datasets/test_chesapeake.py
+++ b/tests/datasets/test_chesapeake.py
@@ -83,12 +83,14 @@ class TestChesapeake13:
         query = dataset.bounds
         x = dataset[query]
         dataset.plot(x, suptitle="Test")
+        plt.close()
 
     def test_plot_prediction(self, dataset: Chesapeake13) -> None:
         query = dataset.bounds
         x = dataset[query]
         x["prediction"] = x["mask"].clone()
         dataset.plot(x, suptitle="Prediction")
+        plt.close()
 
     def test_url(self) -> None:
         ds = Chesapeake13(os.path.join("tests", "data", "chesapeake", "BAYWIDE"))

--- a/tests/datasets/test_cms_mangrove_canopy.py
+++ b/tests/datasets/test_cms_mangrove_canopy.py
@@ -6,6 +6,7 @@ import shutil
 from pathlib import Path
 from typing import Generator
 
+import matplotlib.pyplot as plt
 import pytest
 import torch
 import torch.nn as nn
@@ -91,9 +92,11 @@ class TestCMSGlobalMangroveCanopy:
         query = dataset.bounds
         x = dataset[query]
         dataset.plot(x, suptitle="Test")
+        plt.close()
 
     def test_plot_prediction(self, dataset: CMSGlobalMangroveCanopy) -> None:
         query = dataset.bounds
         x = dataset[query]
         x["prediction"] = x["mask"].clone()
         dataset.plot(x, suptitle="Prediction")
+        plt.close()

--- a/tests/datasets/test_esri2020.py
+++ b/tests/datasets/test_esri2020.py
@@ -6,6 +6,7 @@ import shutil
 from pathlib import Path
 from typing import Generator
 
+import matplotlib.pyplot as plt
 import pytest
 import torch
 import torch.nn as nn
@@ -80,6 +81,7 @@ class TestEsri2020:
         query = dataset.bounds
         x = dataset[query]
         dataset.plot(x["mask"])
+        plt.close()
 
     def test_url(self) -> None:
         ds = Esri2020(os.path.join("tests", "data", "esri2020"))

--- a/tests/datasets/test_eudem.py
+++ b/tests/datasets/test_eudem.py
@@ -6,6 +6,7 @@ import shutil
 from pathlib import Path
 from typing import Generator
 
+import matplotlib.pyplot as plt
 import pytest
 import torch
 import torch.nn as nn
@@ -64,12 +65,14 @@ class TestEUDEM:
         query = dataset.bounds
         x = dataset[query]
         dataset.plot(x, suptitle="Test")
+        plt.close()
 
     def test_plot_prediction(self, dataset: EUDEM) -> None:
         query = dataset.bounds
         x = dataset[query]
         x["prediction"] = x["mask"].clone()
         dataset.plot(x, suptitle="Prediction")
+        plt.close()
 
     def test_invalid_query(self, dataset: EUDEM) -> None:
         query = BoundingBox(100, 100, 100, 100, 0, 0)

--- a/tests/datasets/test_gid15.py
+++ b/tests/datasets/test_gid15.py
@@ -81,3 +81,4 @@ class TestGID15:
             sample = dataset[0]
             sample["prediction"] = torch.ones((1, 1))  # type: ignore[attr-defined]
             dataset.plot(sample)
+        plt.close()

--- a/tests/datasets/test_globbiomass.py
+++ b/tests/datasets/test_globbiomass.py
@@ -6,6 +6,7 @@ import shutil
 from pathlib import Path
 from typing import Generator
 
+import matplotlib.pyplot as plt
 import pytest
 import torch
 import torch.nn as nn
@@ -73,12 +74,14 @@ class TestGlobBiomass:
         query = dataset.bounds
         x = dataset[query]
         dataset.plot(x, suptitle="Test")
+        plt.close()
 
     def test_plot_prediction(self, dataset: GlobBiomass) -> None:
         query = dataset.bounds
         x = dataset[query]
         x["prediction"] = x["mask"].clone()
         dataset.plot(x, suptitle="Prediction")
+        plt.close()
 
     def test_invalid_query(self, dataset: GlobBiomass) -> None:
         query = BoundingBox(100, 100, 100, 100, 0, 0)

--- a/tests/datasets/test_sentinel.py
+++ b/tests/datasets/test_sentinel.py
@@ -4,6 +4,7 @@
 import os
 from pathlib import Path
 
+import matplotlib.pyplot as plt
 import pytest
 import torch
 import torch.nn as nn
@@ -56,6 +57,7 @@ class TestSentinel2:
     def test_plot(self, dataset: Sentinel2) -> None:
         x = dataset[dataset.bounds]
         dataset.plot(x, suptitle="Test")
+        plt.close()
 
     def test_plot_wrong_bands(self, dataset: Sentinel2) -> None:
         bands = ("B01",)


### PR DESCRIPTION
This PR closes #436 by adding `plt.close()` to test files in order to prevent file handle leaks.