### PR TITLE
Remove type ignores for PyTorch

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,12 @@
 # Required
 version: 2
 
+# Set the version of Python
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+
 # Configuration of the Python environment to be used
 python:
    install:

--- a/benchmark.py
+++ b/benchmark.py
@@ -208,17 +208,15 @@ def main(args: argparse.Namespace) -> None:
     # Benchmark model
     model = resnet34()
     # Change number of input channels to match Landsat
-    model.conv1 = nn.Conv2d(  # type: ignore[attr-defined]
+    model.conv1 = nn.Conv2d(
         len(bands), 64, kernel_size=7, stride=2, padding=3, bias=False
     )
 
-    criterion = nn.CrossEntropyLoss()  # type: ignore[attr-defined]
+    criterion = nn.CrossEntropyLoss()
     params = model.parameters()
     optimizer = optim.SGD(params, lr=0.0001)
 
-    device = torch.device(  # type: ignore[attr-defined]
-        "cuda" if torch.cuda.is_available() else "cpu", args.device
-    )
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu", args.device)
     model = model.to(device)
 
     tic = time.time()
@@ -227,7 +225,7 @@ def main(args: argparse.Namespace) -> None:
         num_total_patches += args.batch_size
         x = torch.rand(args.batch_size, len(bands), args.patch_size, args.patch_size)
         # y = torch.randint(0, 256, (args.batch_size, args.patch_size, args.patch_size))
-        y = torch.randint(0, 256, (args.batch_size,))  # type: ignore[attr-defined]
+        y = torch.randint(0, 256, (args.batch_size,))
         x = x.to(device)
         y = y.to(device)
 

--- a/evaluate.py
+++ b/evaluate.py
@@ -179,7 +179,7 @@ def main(args: argparse.Namespace) -> None:
         raise ValueError(f"{TASK} is not supported")
 
     # Compute metrics
-    device = torch.device("cuda:%d" % (args.gpu))  # type: ignore[attr-defined]
+    device = torch.device("cuda:%d" % (args.gpu))
     model = model.to(device)
 
     if args.task == "etci2021":  # Custom metric setup for testing ETCI2021

--- a/evaluate.py
+++ b/evaluate.py
@@ -158,7 +158,7 @@ def main(args: argparse.Namespace) -> None:
             "loss": model.hparams["loss"],
         }
     elif issubclass(TASK, SemanticSegmentationTask):
-        val_row: Dict[str, Union[str, float]] = {  # type: ignore[no-redef]
+        val_row = {
             "split": "val",
             "segmentation_model": model.hparams["segmentation_model"],
             "encoder_name": model.hparams["encoder_name"],
@@ -167,7 +167,7 @@ def main(args: argparse.Namespace) -> None:
             "loss": model.hparams["loss"],
         }
 
-        test_row: Dict[str, Union[str, float]] = {  # type: ignore[no-redef]
+        test_row = {
             "split": "test",
             "segmentation_model": model.hparams["segmentation_model"],
             "encoder_name": model.hparams["encoder_name"],

--- a/evaluate.py
+++ b/evaluate.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, Union
 
 import pytorch_lightning as pl
 import torch
-from torchmetrics import Accuracy, JaccardIndex, Metric, MetricCollection
+from torchmetrics import Accuracy, JaccardIndex, MetricCollection
 
 from torchgeo.trainers import ClassificationTask, SemanticSegmentationTask
 from train import TASK_TO_MODULES_MAPPING
@@ -85,8 +85,8 @@ def set_up_parser() -> argparse.ArgumentParser:
 def run_eval_loop(
     model: pl.LightningModule,
     dataloader: Any,
-    device: torch.device,  # type: ignore[name-defined]
-    metrics: Metric,
+    device: torch.device,
+    metrics: MetricCollection,
 ) -> Any:
     """Runs a standard test loop over a dataloader and records metrics.
 
@@ -94,10 +94,11 @@ def run_eval_loop(
         model: the model used for inference
         dataloader: the dataloader to get samples from
         device: the device to put data on
-        metrics: a torchmetrics compatible Metric to score the output from the model
+        metrics: a torchmetrics compatible metric collection to score the output
+            from the model
 
     Returns:
-        the result of ``metric.compute()``
+        the result of ``metrics.compute()``
     """
     for batch in dataloader:
         x = batch["image"].to(device)

--- a/tests/datamodules/test_chesapeake.py
+++ b/tests/datamodules/test_chesapeake.py
@@ -25,17 +25,10 @@ class TestChesapeakeCVPRDataModule:
 
     def test_nodata_check(self, datamodule: ChesapeakeCVPRDataModule) -> None:
         nodata_check = datamodule.nodata_check(4)
-        sample = {
-            "image": torch.ones(1, 2, 2),  # type: ignore[attr-defined]
-            "mask": torch.ones(2, 2),  # type: ignore[attr-defined]
-        }
+        sample = {"image": torch.ones(1, 2, 2), "mask": torch.ones(2, 2)}
         out = nodata_check(sample)
-        assert torch.equal(  # type: ignore[attr-defined]
-            out["image"], torch.zeros(1, 4, 4)  # type: ignore[attr-defined]
-        )
-        assert torch.equal(  # type: ignore[attr-defined]
-            out["mask"], torch.zeros(4, 4)  # type: ignore[attr-defined]
-        )
+        assert torch.equal(out["image"], torch.zeros(1, 4, 4))
+        assert torch.equal(out["mask"], torch.zeros(4, 4))
 
     def test_invalid_param_config(self) -> None:
         with pytest.raises(ValueError, match="The pre-generated prior labels"):

--- a/tests/datamodules/test_utils.py
+++ b/tests/datamodules/test_utils.py
@@ -9,8 +9,8 @@ from torchgeo.datamodules.utils import dataset_split
 
 def test_dataset_split() -> None:
     num_samples = 24
-    x = torch.ones(num_samples, 5)  # type: ignore[attr-defined]
-    y = torch.randint(low=0, high=2, size=(num_samples,))  # type: ignore[attr-defined]
+    x = torch.ones(num_samples, 5)
+    y = torch.randint(low=0, high=2, size=(num_samples,))
     ds = TensorDataset(x, y)
 
     # Test only train/val set split

--- a/tests/datasets/test_advance.py
+++ b/tests/datasets/test_advance.py
@@ -34,7 +34,7 @@ class TestADVANCE:
         monkeypatch.setattr(ADVANCE, "urls", urls)
         monkeypatch.setattr(ADVANCE, "md5s", md5s)
         root = str(tmp_path)
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return ADVANCE(root, transforms, download=True, checksum=True)
 
     @pytest.fixture

--- a/tests/datasets/test_advance.py
+++ b/tests/datasets/test_advance.py
@@ -23,9 +23,7 @@ def download_url(url: str, root: str, *args: str) -> None:
 
 class TestADVANCE:
     @pytest.fixture
-    def dataset(
-        self, monkeypatch: MonkeyPatch, tmp_path: Path
-    ) -> ADVANCE:
+    def dataset(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> ADVANCE:
         monkeypatch.setattr(torchgeo.datasets.utils, "download_url", download_url)
         data_dir = os.path.join("tests", "data", "advance")
         urls = [
@@ -40,9 +38,7 @@ class TestADVANCE:
         return ADVANCE(root, transforms, download=True, checksum=True)
 
     @pytest.fixture
-    def mock_missing_module(
-        self, monkeypatch: MonkeyPatch
-    ) -> None:
+    def mock_missing_module(self, monkeypatch: MonkeyPatch) -> None:
         import_orig = builtins.__import__
 
         def mocked_import(name: str, *args: Any, **kwargs: Any) -> Any:

--- a/tests/datasets/test_advance.py
+++ b/tests/datasets/test_advance.py
@@ -24,7 +24,7 @@ def download_url(url: str, root: str, *args: str) -> None:
 class TestADVANCE:
     @pytest.fixture
     def dataset(
-        self, monkeypatch: Generator[MonkeyPatch, None, None], tmp_path: Path
+        self, monkeypatch: MonkeyPatch, tmp_path: Path
     ) -> ADVANCE:
         monkeypatch.setattr(torchgeo.datasets.utils, "download_url", download_url)
         data_dir = os.path.join("tests", "data", "advance")
@@ -41,7 +41,7 @@ class TestADVANCE:
 
     @pytest.fixture
     def mock_missing_module(
-        self, monkeypatch: Generator[MonkeyPatch, None, None]
+        self, monkeypatch: MonkeyPatch
     ) -> None:
         import_orig = builtins.__import__
 

--- a/tests/datasets/test_advance.py
+++ b/tests/datasets/test_advance.py
@@ -26,19 +26,17 @@ class TestADVANCE:
     def dataset(
         self, monkeypatch: Generator[MonkeyPatch, None, None], tmp_path: Path
     ) -> ADVANCE:
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            torchgeo.datasets.utils, "download_url", download_url
-        )
+        monkeypatch.setattr(torchgeo.datasets.utils, "download_url", download_url)
         data_dir = os.path.join("tests", "data", "advance")
         urls = [
             os.path.join(data_dir, "ADVANCE_vision.zip"),
             os.path.join(data_dir, "ADVANCE_sound.zip"),
         ]
         md5s = ["43acacecebecd17a82bc2c1e719fd7e4", "039b7baa47879a8a4e32b9dd8287f6ad"]
-        monkeypatch.setattr(ADVANCE, "urls", urls)  # type: ignore[attr-defined]
-        monkeypatch.setattr(ADVANCE, "md5s", md5s)  # type: ignore[attr-defined]
+        monkeypatch.setattr(ADVANCE, "urls", urls)
+        monkeypatch.setattr(ADVANCE, "md5s", md5s)
         root = str(tmp_path)
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return ADVANCE(root, transforms, download=True, checksum=True)
 
     @pytest.fixture
@@ -52,9 +50,7 @@ class TestADVANCE:
                 raise ImportError()
             return import_orig(name, *args, **kwargs)
 
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            builtins, "__import__", mocked_import
-        )
+        monkeypatch.setattr(builtins, "__import__", mocked_import)
 
     def test_getitem(self, dataset: ADVANCE) -> None:
         pytest.importorskip("scipy", minversion="0.9.0")

--- a/tests/datasets/test_advance.py
+++ b/tests/datasets/test_advance.py
@@ -5,7 +5,7 @@ import builtins
 import os
 import shutil
 from pathlib import Path
-from typing import Any, Generator
+from typing import Any
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/datasets/test_agb_live_woody_density.py
+++ b/tests/datasets/test_agb_live_woody_density.py
@@ -5,7 +5,6 @@ import os
 import shutil
 from pathlib import Path
 
-
 import matplotlib.pyplot as plt
 import pytest
 import torch

--- a/tests/datasets/test_agb_live_woody_density.py
+++ b/tests/datasets/test_agb_live_woody_density.py
@@ -31,8 +31,8 @@ class TestAbovegroundLiveWoodyBiomassDensity:
         self, monkeypatch: Generator[MonkeyPatch, None, None], tmp_path: Path
     ) -> AbovegroundLiveWoodyBiomassDensity:
 
-        transforms = nn.Identity()  # type: ignore[attr-defined]
-        monkeypatch.setattr(  # type: ignore[attr-defined]
+        transforms = nn.Identity()
+        monkeypatch.setattr(
             torchgeo.datasets.agb_live_woody_density, "download_url", download_url
         )
         url = os.path.join(
@@ -41,9 +41,7 @@ class TestAbovegroundLiveWoodyBiomassDensity:
             "agb_live_woody_density",
             "Aboveground_Live_Woody_Biomass_Density.geojson",
         )
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            AbovegroundLiveWoodyBiomassDensity, "url", url
-        )
+        monkeypatch.setattr(AbovegroundLiveWoodyBiomassDensity, "url", url)
 
         root = str(tmp_path)
         return AbovegroundLiveWoodyBiomassDensity(

--- a/tests/datasets/test_agb_live_woody_density.py
+++ b/tests/datasets/test_agb_live_woody_density.py
@@ -31,7 +31,7 @@ class TestAbovegroundLiveWoodyBiomassDensity:
         self, monkeypatch: MonkeyPatch, tmp_path: Path
     ) -> AbovegroundLiveWoodyBiomassDensity:
 
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         monkeypatch.setattr(
             torchgeo.datasets.agb_live_woody_density, "download_url", download_url
         )

--- a/tests/datasets/test_agb_live_woody_density.py
+++ b/tests/datasets/test_agb_live_woody_density.py
@@ -4,7 +4,7 @@
 import os
 import shutil
 from pathlib import Path
-from typing import Generator
+
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/datasets/test_agb_live_woody_density.py
+++ b/tests/datasets/test_agb_live_woody_density.py
@@ -28,7 +28,7 @@ def download_url(url: str, root: str, *args: str, **kwargs: str) -> None:
 class TestAbovegroundLiveWoodyBiomassDensity:
     @pytest.fixture
     def dataset(
-        self, monkeypatch: Generator[MonkeyPatch, None, None], tmp_path: Path
+        self, monkeypatch: MonkeyPatch, tmp_path: Path
     ) -> AbovegroundLiveWoodyBiomassDensity:
 
         transforms = nn.Identity()

--- a/tests/datasets/test_astergdem.py
+++ b/tests/datasets/test_astergdem.py
@@ -20,7 +20,7 @@ class TestAsterGDEM:
         zipfile = os.path.join("tests", "data", "astergdem", "astergdem.zip")
         shutil.unpack_archive(zipfile, tmp_path, "zip")
         root = str(tmp_path)
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return AsterGDEM(root, transforms=transforms)
 
     def test_datasetmissing(self, tmp_path: Path) -> None:

--- a/tests/datasets/test_astergdem.py
+++ b/tests/datasets/test_astergdem.py
@@ -20,7 +20,7 @@ class TestAsterGDEM:
         zipfile = os.path.join("tests", "data", "astergdem", "astergdem.zip")
         shutil.unpack_archive(zipfile, tmp_path, "zip")
         root = str(tmp_path)
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return AsterGDEM(root, transforms=transforms)
 
     def test_datasetmissing(self, tmp_path: Path) -> None:

--- a/tests/datasets/test_benin_cashews.py
+++ b/tests/datasets/test_benin_cashews.py
@@ -41,7 +41,7 @@ class TestBeninSmallHolderCashews:
         monkeypatch.setitem(BeninSmallHolderCashews.target_meta, "md5", labels_md5)
         monkeypatch.setattr(BeninSmallHolderCashews, "dates", ("2019_11_05",))
         root = str(tmp_path)
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         bands = BeninSmallHolderCashews.ALL_BANDS
 
         return BeninSmallHolderCashews(

--- a/tests/datasets/test_benin_cashews.py
+++ b/tests/datasets/test_benin_cashews.py
@@ -34,22 +34,14 @@ class TestBeninSmallHolderCashews:
         self, monkeypatch: Generator[MonkeyPatch, None, None], tmp_path: Path
     ) -> BeninSmallHolderCashews:
         radiant_mlhub = pytest.importorskip("radiant_mlhub", minversion="0.2.1")
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            radiant_mlhub.Dataset, "fetch", fetch
-        )
+        monkeypatch.setattr(radiant_mlhub.Dataset, "fetch", fetch)
         source_md5 = "255efff0f03bc6322470949a09bc76db"
         labels_md5 = "ed2195d93ca6822d48eb02bc3e81c127"
-        monkeypatch.setitem(  # type: ignore[attr-defined]
-            BeninSmallHolderCashews.image_meta, "md5", source_md5
-        )
-        monkeypatch.setitem(  # type: ignore[attr-defined]
-            BeninSmallHolderCashews.target_meta, "md5", labels_md5
-        )
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            BeninSmallHolderCashews, "dates", ("2019_11_05",)
-        )
+        monkeypatch.setitem(BeninSmallHolderCashews.image_meta, "md5", source_md5)
+        monkeypatch.setitem(BeninSmallHolderCashews.target_meta, "md5", labels_md5)
+        monkeypatch.setattr(BeninSmallHolderCashews, "dates", ("2019_11_05",))
         root = str(tmp_path)
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         bands = BeninSmallHolderCashews.ALL_BANDS
 
         return BeninSmallHolderCashews(

--- a/tests/datasets/test_benin_cashews.py
+++ b/tests/datasets/test_benin_cashews.py
@@ -5,7 +5,7 @@ import glob
 import os
 import shutil
 from pathlib import Path
-from typing import Generator
+
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/datasets/test_benin_cashews.py
+++ b/tests/datasets/test_benin_cashews.py
@@ -31,7 +31,7 @@ def fetch(dataset_id: str, **kwargs: str) -> Dataset:
 class TestBeninSmallHolderCashews:
     @pytest.fixture
     def dataset(
-        self, monkeypatch: Generator[MonkeyPatch, None, None], tmp_path: Path
+        self, monkeypatch: MonkeyPatch, tmp_path: Path
     ) -> BeninSmallHolderCashews:
         radiant_mlhub = pytest.importorskip("radiant_mlhub", minversion="0.2.1")
         monkeypatch.setattr(radiant_mlhub.Dataset, "fetch", fetch)

--- a/tests/datasets/test_benin_cashews.py
+++ b/tests/datasets/test_benin_cashews.py
@@ -6,7 +6,6 @@ import os
 import shutil
 from pathlib import Path
 
-
 import matplotlib.pyplot as plt
 import pytest
 import torch

--- a/tests/datasets/test_bigearthnet.py
+++ b/tests/datasets/test_bigearthnet.py
@@ -5,7 +5,6 @@ import os
 import shutil
 from pathlib import Path
 
-
 import matplotlib.pyplot as plt
 import pytest
 import torch

--- a/tests/datasets/test_bigearthnet.py
+++ b/tests/datasets/test_bigearthnet.py
@@ -4,7 +4,7 @@
 import os
 import shutil
 from pathlib import Path
-from typing import Generator
+
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/datasets/test_bigearthnet.py
+++ b/tests/datasets/test_bigearthnet.py
@@ -27,7 +27,7 @@ class TestBigEarthNet:
     )
     def dataset(
         self,
-        monkeypatch: Generator[MonkeyPatch, None, None],
+        monkeypatch: MonkeyPatch,
         tmp_path: Path,
         request: SubRequest,
     ) -> BigEarthNet:

--- a/tests/datasets/test_bigearthnet.py
+++ b/tests/datasets/test_bigearthnet.py
@@ -65,7 +65,7 @@ class TestBigEarthNet:
         monkeypatch.setattr(BigEarthNet, "splits_metadata", splits_metadata)
         bands, num_classes, split = request.param
         root = str(tmp_path)
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return BigEarthNet(
             root, split, bands, num_classes, transforms, download=True, checksum=True
         )

--- a/tests/datasets/test_bigearthnet.py
+++ b/tests/datasets/test_bigearthnet.py
@@ -26,10 +26,7 @@ class TestBigEarthNet:
         params=zip(["all", "s1", "s2"], [43, 19, 19], ["train", "val", "test"])
     )
     def dataset(
-        self,
-        monkeypatch: MonkeyPatch,
-        tmp_path: Path,
-        request: SubRequest,
+        self, monkeypatch: MonkeyPatch, tmp_path: Path, request: SubRequest
     ) -> BigEarthNet:
         monkeypatch.setattr(torchgeo.datasets.bigearthnet, "download_url", download_url)
         data_dir = os.path.join("tests", "data", "bigearthnet")

--- a/tests/datasets/test_bigearthnet.py
+++ b/tests/datasets/test_bigearthnet.py
@@ -31,9 +31,7 @@ class TestBigEarthNet:
         tmp_path: Path,
         request: SubRequest,
     ) -> BigEarthNet:
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            torchgeo.datasets.bigearthnet, "download_url", download_url
-        )
+        monkeypatch.setattr(torchgeo.datasets.bigearthnet, "download_url", download_url)
         data_dir = os.path.join("tests", "data", "bigearthnet")
         metadata = {
             "s1": {
@@ -66,15 +64,11 @@ class TestBigEarthNet:
                 "md5": "851a6bdda484d47f60e121352dcb1bf5",
             },
         }
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            BigEarthNet, "metadata", metadata
-        )
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            BigEarthNet, "splits_metadata", splits_metadata
-        )
+        monkeypatch.setattr(BigEarthNet, "metadata", metadata)
+        monkeypatch.setattr(BigEarthNet, "splits_metadata", splits_metadata)
         bands, num_classes, split = request.param
         root = str(tmp_path)
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return BigEarthNet(
             root, split, bands, num_classes, transforms, download=True, checksum=True
         )
@@ -85,8 +79,8 @@ class TestBigEarthNet:
         assert isinstance(x["image"], torch.Tensor)
         assert isinstance(x["label"], torch.Tensor)
         assert x["label"].shape == (dataset.num_classes,)
-        assert x["image"].dtype == torch.int32  # type: ignore[attr-defined]
-        assert x["label"].dtype == torch.int64  # type: ignore[attr-defined]
+        assert x["image"].dtype == torch.int32
+        assert x["label"].dtype == torch.int64
 
         if dataset.bands == "all":
             assert x["image"].shape == (14, 120, 120)

--- a/tests/datasets/test_cbf.py
+++ b/tests/datasets/test_cbf.py
@@ -5,7 +5,6 @@ import os
 import shutil
 from pathlib import Path
 
-
 import matplotlib.pyplot as plt
 import pytest
 import torch

--- a/tests/datasets/test_cbf.py
+++ b/tests/datasets/test_cbf.py
@@ -4,7 +4,7 @@
 import os
 import shutil
 from pathlib import Path
-from typing import Generator
+
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/datasets/test_cbf.py
+++ b/tests/datasets/test_cbf.py
@@ -52,7 +52,7 @@ class TestCanadianBuildingFootprints:
         monkeypatch.setattr(CanadianBuildingFootprints, "url", url)
         monkeypatch.setattr(plt, "show", lambda *args: None)
         root = str(tmp_path)
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return CanadianBuildingFootprints(
             root, res=0.1, transforms=transforms, download=True, checksum=True
         )

--- a/tests/datasets/test_cbf.py
+++ b/tests/datasets/test_cbf.py
@@ -29,7 +29,7 @@ def download_url(url: str, root: str, *args: str) -> None:
 class TestCanadianBuildingFootprints:
     @pytest.fixture
     def dataset(
-        self, monkeypatch: Generator[MonkeyPatch, None, None], tmp_path: Path
+        self, monkeypatch: MonkeyPatch, tmp_path: Path
     ) -> CanadianBuildingFootprints:
         monkeypatch.setattr(torchgeo.datasets.utils, "download_url", download_url)
         md5s = [

--- a/tests/datasets/test_cbf.py
+++ b/tests/datasets/test_cbf.py
@@ -31,9 +31,7 @@ class TestCanadianBuildingFootprints:
     def dataset(
         self, monkeypatch: Generator[MonkeyPatch, None, None], tmp_path: Path
     ) -> CanadianBuildingFootprints:
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            torchgeo.datasets.utils, "download_url", download_url
-        )
+        monkeypatch.setattr(torchgeo.datasets.utils, "download_url", download_url)
         md5s = [
             "8a4a0a57367f67c69608d1452e30df13",
             "1829f4054a9a81bb23871ca797a3895c",
@@ -49,18 +47,12 @@ class TestCanadianBuildingFootprints:
             "067664d066c4152fb96a5c129cbabadf",
             "474bc084bc41b124aa4919e7a37a9648",
         ]
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            CanadianBuildingFootprints, "md5s", md5s
-        )
+        monkeypatch.setattr(CanadianBuildingFootprints, "md5s", md5s)
         url = os.path.join("tests", "data", "cbf") + os.sep
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            CanadianBuildingFootprints, "url", url
-        )
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            plt, "show", lambda *args: None
-        )
+        monkeypatch.setattr(CanadianBuildingFootprints, "url", url)
+        monkeypatch.setattr(plt, "show", lambda *args: None)
         root = str(tmp_path)
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return CanadianBuildingFootprints(
             root, res=0.1, transforms=transforms, download=True, checksum=True
         )

--- a/tests/datasets/test_cdl.py
+++ b/tests/datasets/test_cdl.py
@@ -26,7 +26,7 @@ def download_url(url: str, root: str, *args: str, **kwargs: str) -> None:
 class TestCDL:
     @pytest.fixture
     def dataset(
-        self, monkeypatch: Generator[MonkeyPatch, None, None], tmp_path: Path
+        self, monkeypatch: MonkeyPatch, tmp_path: Path
     ) -> CDL:
         monkeypatch.setattr(torchgeo.datasets.cdl, "download_url", download_url)
 

--- a/tests/datasets/test_cdl.py
+++ b/tests/datasets/test_cdl.py
@@ -7,7 +7,6 @@ import shutil
 from datetime import datetime
 from pathlib import Path
 
-
 import matplotlib.pyplot as plt
 import pytest
 import torch

--- a/tests/datasets/test_cdl.py
+++ b/tests/datasets/test_cdl.py
@@ -28,22 +28,18 @@ class TestCDL:
     def dataset(
         self, monkeypatch: Generator[MonkeyPatch, None, None], tmp_path: Path
     ) -> CDL:
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            torchgeo.datasets.cdl, "download_url", download_url
-        )
+        monkeypatch.setattr(torchgeo.datasets.cdl, "download_url", download_url)
 
         md5s = [
             (2021, "e929beb9c8e59fa1d7b7f82e64edaae1"),
             (2020, "e95c2d40ce0c261ed6ee0bd00b49e4b6"),
         ]
-        monkeypatch.setattr(CDL, "md5s", md5s)  # type: ignore[attr-defined]
+        monkeypatch.setattr(CDL, "md5s", md5s)
         url = os.path.join("tests", "data", "cdl", "{}_30m_cdls.zip")
-        monkeypatch.setattr(CDL, "url", url)  # type: ignore[attr-defined]
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            plt, "show", lambda *args: None
-        )
+        monkeypatch.setattr(CDL, "url", url)
+        monkeypatch.setattr(plt, "show", lambda *args: None)
         root = str(tmp_path)
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return CDL(root, transforms=transforms, download=True, checksum=True)
 
     def test_getitem(self, dataset: CDL) -> None:

--- a/tests/datasets/test_cdl.py
+++ b/tests/datasets/test_cdl.py
@@ -25,9 +25,7 @@ def download_url(url: str, root: str, *args: str, **kwargs: str) -> None:
 
 class TestCDL:
     @pytest.fixture
-    def dataset(
-        self, monkeypatch: MonkeyPatch, tmp_path: Path
-    ) -> CDL:
+    def dataset(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> CDL:
         monkeypatch.setattr(torchgeo.datasets.cdl, "download_url", download_url)
 
         md5s = [

--- a/tests/datasets/test_cdl.py
+++ b/tests/datasets/test_cdl.py
@@ -37,7 +37,7 @@ class TestCDL:
         monkeypatch.setattr(CDL, "url", url)
         monkeypatch.setattr(plt, "show", lambda *args: None)
         root = str(tmp_path)
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return CDL(root, transforms=transforms, download=True, checksum=True)
 
     def test_getitem(self, dataset: CDL) -> None:

--- a/tests/datasets/test_cdl.py
+++ b/tests/datasets/test_cdl.py
@@ -6,7 +6,7 @@ import os
 import shutil
 from datetime import datetime
 from pathlib import Path
-from typing import Generator
+
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/datasets/test_chesapeake.py
+++ b/tests/datasets/test_chesapeake.py
@@ -31,7 +31,7 @@ def download_url(url: str, root: str, *args: str, **kwargs: str) -> None:
 class TestChesapeake13:
     @pytest.fixture
     def dataset(
-        self, monkeypatch: Generator[MonkeyPatch, None, None], tmp_path: Path
+        self, monkeypatch: MonkeyPatch, tmp_path: Path
     ) -> Chesapeake13:
         pytest.importorskip("zipfile_deflate64")
         monkeypatch.setattr(torchgeo.datasets.chesapeake, "download_url", download_url)
@@ -112,7 +112,7 @@ class TestChesapeakeCVPR:
     def dataset(
         self,
         request: SubRequest,
-        monkeypatch: Generator[MonkeyPatch, None, None],
+        monkeypatch: MonkeyPatch,
         tmp_path: Path,
     ) -> ChesapeakeCVPR:
         monkeypatch.setattr(torchgeo.datasets.chesapeake, "download_url", download_url)

--- a/tests/datasets/test_chesapeake.py
+++ b/tests/datasets/test_chesapeake.py
@@ -5,7 +5,6 @@ import os
 import shutil
 from pathlib import Path
 
-
 import matplotlib.pyplot as plt
 import pytest
 import torch

--- a/tests/datasets/test_chesapeake.py
+++ b/tests/datasets/test_chesapeake.py
@@ -4,7 +4,7 @@
 import os
 import shutil
 from pathlib import Path
-from typing import Generator
+
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/datasets/test_chesapeake.py
+++ b/tests/datasets/test_chesapeake.py
@@ -30,9 +30,7 @@ def download_url(url: str, root: str, *args: str, **kwargs: str) -> None:
 
 class TestChesapeake13:
     @pytest.fixture
-    def dataset(
-        self, monkeypatch: MonkeyPatch, tmp_path: Path
-    ) -> Chesapeake13:
+    def dataset(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> Chesapeake13:
         pytest.importorskip("zipfile_deflate64")
         monkeypatch.setattr(torchgeo.datasets.chesapeake, "download_url", download_url)
         md5 = "fe35a615b8e749b21270472aa98bb42c"
@@ -110,10 +108,7 @@ class TestChesapeakeCVPR:
         ]
     )
     def dataset(
-        self,
-        request: SubRequest,
-        monkeypatch: MonkeyPatch,
-        tmp_path: Path,
+        self, request: SubRequest, monkeypatch: MonkeyPatch, tmp_path: Path
     ) -> ChesapeakeCVPR:
         monkeypatch.setattr(torchgeo.datasets.chesapeake, "download_url", download_url)
         monkeypatch.setattr(

--- a/tests/datasets/test_chesapeake.py
+++ b/tests/datasets/test_chesapeake.py
@@ -34,20 +34,16 @@ class TestChesapeake13:
         self, monkeypatch: Generator[MonkeyPatch, None, None], tmp_path: Path
     ) -> Chesapeake13:
         pytest.importorskip("zipfile_deflate64")
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            torchgeo.datasets.chesapeake, "download_url", download_url
-        )
+        monkeypatch.setattr(torchgeo.datasets.chesapeake, "download_url", download_url)
         md5 = "fe35a615b8e749b21270472aa98bb42c"
-        monkeypatch.setattr(Chesapeake13, "md5", md5)  # type: ignore[attr-defined]
+        monkeypatch.setattr(Chesapeake13, "md5", md5)
         url = os.path.join(
             "tests", "data", "chesapeake", "BAYWIDE", "Baywide_13Class_20132014.zip"
         )
-        monkeypatch.setattr(Chesapeake13, "url", url)  # type: ignore[attr-defined]
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            plt, "show", lambda *args: None
-        )
+        monkeypatch.setattr(Chesapeake13, "url", url)
+        monkeypatch.setattr(plt, "show", lambda *args: None)
         root = str(tmp_path)
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return Chesapeake13(root, transforms=transforms, download=True, checksum=True)
 
     def test_getitem(self, dataset: Chesapeake13) -> None:
@@ -119,10 +115,8 @@ class TestChesapeakeCVPR:
         monkeypatch: Generator[MonkeyPatch, None, None],
         tmp_path: Path,
     ) -> ChesapeakeCVPR:
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            torchgeo.datasets.chesapeake, "download_url", download_url
-        )
-        monkeypatch.setattr(  # type: ignore[attr-defined]
+        monkeypatch.setattr(torchgeo.datasets.chesapeake, "download_url", download_url)
+        monkeypatch.setattr(
             ChesapeakeCVPR,
             "md5s",
             {
@@ -130,7 +124,7 @@ class TestChesapeakeCVPR:
                 "prior_extension": "677446c486f3145787938b14ee3da13f",
             },
         )
-        monkeypatch.setattr(  # type: ignore[attr-defined]
+        monkeypatch.setattr(
             ChesapeakeCVPR,
             "urls",
             {
@@ -150,13 +144,13 @@ class TestChesapeakeCVPR:
                 ),
             },
         )
-        monkeypatch.setattr(  # type: ignore[attr-defined]
+        monkeypatch.setattr(
             ChesapeakeCVPR,
             "files",
             ["de_1m_2013_extended-debuffered-test_tiles", "spatial_index.geojson"],
         )
         root = str(tmp_path)
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return ChesapeakeCVPR(
             root,
             splits=["de-test"],

--- a/tests/datasets/test_chesapeake.py
+++ b/tests/datasets/test_chesapeake.py
@@ -41,7 +41,7 @@ class TestChesapeake13:
         monkeypatch.setattr(Chesapeake13, "url", url)
         monkeypatch.setattr(plt, "show", lambda *args: None)
         root = str(tmp_path)
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return Chesapeake13(root, transforms=transforms, download=True, checksum=True)
 
     def test_getitem(self, dataset: Chesapeake13) -> None:
@@ -145,7 +145,7 @@ class TestChesapeakeCVPR:
             ["de_1m_2013_extended-debuffered-test_tiles", "spatial_index.geojson"],
         )
         root = str(tmp_path)
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return ChesapeakeCVPR(
             root,
             splits=["de-test"],

--- a/tests/datasets/test_cms_mangrove_canopy.py
+++ b/tests/datasets/test_cms_mangrove_canopy.py
@@ -5,7 +5,6 @@ import os
 import shutil
 from pathlib import Path
 
-
 import matplotlib.pyplot as plt
 import pytest
 import torch

--- a/tests/datasets/test_cms_mangrove_canopy.py
+++ b/tests/datasets/test_cms_mangrove_canopy.py
@@ -4,7 +4,7 @@
 import os
 import shutil
 from pathlib import Path
-from typing import Generator
+
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/datasets/test_cms_mangrove_canopy.py
+++ b/tests/datasets/test_cms_mangrove_canopy.py
@@ -26,17 +26,13 @@ class TestCMSGlobalMangroveCanopy:
         self, monkeypatch: Generator[MonkeyPatch, None, None], tmp_path: Path
     ) -> CMSGlobalMangroveCanopy:
         zipfile = "CMS_Global_Map_Mangrove_Canopy_1665.zip"
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            CMSGlobalMangroveCanopy, "zipfile", zipfile
-        )
+        monkeypatch.setattr(CMSGlobalMangroveCanopy, "zipfile", zipfile)
 
         md5 = "d6894fa6293cc9c0f3f95a810e842de5"
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            CMSGlobalMangroveCanopy, "md5", md5
-        )
+        monkeypatch.setattr(CMSGlobalMangroveCanopy, "md5", md5)
 
         root = os.path.join("tests", "data", "cms_mangrove_canopy")
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         country = "Angola"
 
         return CMSGlobalMangroveCanopy(

--- a/tests/datasets/test_cms_mangrove_canopy.py
+++ b/tests/datasets/test_cms_mangrove_canopy.py
@@ -32,7 +32,7 @@ class TestCMSGlobalMangroveCanopy:
         monkeypatch.setattr(CMSGlobalMangroveCanopy, "md5", md5)
 
         root = os.path.join("tests", "data", "cms_mangrove_canopy")
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         country = "Angola"
 
         return CMSGlobalMangroveCanopy(

--- a/tests/datasets/test_cms_mangrove_canopy.py
+++ b/tests/datasets/test_cms_mangrove_canopy.py
@@ -23,7 +23,7 @@ def download_url(url: str, root: str, *args: str, **kwargs: str) -> None:
 class TestCMSGlobalMangroveCanopy:
     @pytest.fixture
     def dataset(
-        self, monkeypatch: Generator[MonkeyPatch, None, None], tmp_path: Path
+        self, monkeypatch: MonkeyPatch, tmp_path: Path
     ) -> CMSGlobalMangroveCanopy:
         zipfile = "CMS_Global_Map_Mangrove_Canopy_1665.zip"
         monkeypatch.setattr(CMSGlobalMangroveCanopy, "zipfile", zipfile)

--- a/tests/datasets/test_cowc.py
+++ b/tests/datasets/test_cowc.py
@@ -5,7 +5,6 @@ import os
 import shutil
 from pathlib import Path
 
-
 import matplotlib.pyplot as plt
 import pytest
 import torch

--- a/tests/datasets/test_cowc.py
+++ b/tests/datasets/test_cowc.py
@@ -4,7 +4,7 @@
 import os
 import shutil
 from pathlib import Path
-from typing import Generator
+
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/datasets/test_cowc.py
+++ b/tests/datasets/test_cowc.py
@@ -50,7 +50,7 @@ class TestCOWCCounting:
         monkeypatch.setattr(COWCCounting, "md5s", md5s)
         root = str(tmp_path)
         split = request.param
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return COWCCounting(root, split, transforms, download=True, checksum=True)
 
     def test_getitem(self, dataset: COWC) -> None:
@@ -114,7 +114,7 @@ class TestCOWCDetection:
         monkeypatch.setattr(COWCDetection, "md5s", md5s)
         root = str(tmp_path)
         split = request.param
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return COWCDetection(root, split, transforms, download=True, checksum=True)
 
     def test_getitem(self, dataset: COWC) -> None:

--- a/tests/datasets/test_cowc.py
+++ b/tests/datasets/test_cowc.py
@@ -32,10 +32,7 @@ class TestCOWC:
 class TestCOWCCounting:
     @pytest.fixture(params=["train", "test"])
     def dataset(
-        self,
-        monkeypatch: MonkeyPatch,
-        tmp_path: Path,
-        request: SubRequest,
+        self, monkeypatch: MonkeyPatch, tmp_path: Path, request: SubRequest
     ) -> COWC:
         monkeypatch.setattr(torchgeo.datasets.utils, "download_url", download_url)
         base_url = os.path.join("tests", "data", "cowc_counting") + os.sep
@@ -99,10 +96,7 @@ class TestCOWCCounting:
 class TestCOWCDetection:
     @pytest.fixture(params=["train", "test"])
     def dataset(
-        self,
-        monkeypatch: MonkeyPatch,
-        tmp_path: Path,
-        request: SubRequest,
+        self, monkeypatch: MonkeyPatch, tmp_path: Path, request: SubRequest
     ) -> COWC:
         monkeypatch.setattr(torchgeo.datasets.utils, "download_url", download_url)
         base_url = os.path.join("tests", "data", "cowc_detection") + os.sep

--- a/tests/datasets/test_cowc.py
+++ b/tests/datasets/test_cowc.py
@@ -33,7 +33,7 @@ class TestCOWCCounting:
     @pytest.fixture(params=["train", "test"])
     def dataset(
         self,
-        monkeypatch: Generator[MonkeyPatch, None, None],
+        monkeypatch: MonkeyPatch,
         tmp_path: Path,
         request: SubRequest,
     ) -> COWC:
@@ -100,7 +100,7 @@ class TestCOWCDetection:
     @pytest.fixture(params=["train", "test"])
     def dataset(
         self,
-        monkeypatch: Generator[MonkeyPatch, None, None],
+        monkeypatch: MonkeyPatch,
         tmp_path: Path,
         request: SubRequest,
     ) -> COWC:

--- a/tests/datasets/test_cowc.py
+++ b/tests/datasets/test_cowc.py
@@ -37,13 +37,9 @@ class TestCOWCCounting:
         tmp_path: Path,
         request: SubRequest,
     ) -> COWC:
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            torchgeo.datasets.utils, "download_url", download_url
-        )
+        monkeypatch.setattr(torchgeo.datasets.utils, "download_url", download_url)
         base_url = os.path.join("tests", "data", "cowc_counting") + os.sep
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            COWCCounting, "base_url", base_url
-        )
+        monkeypatch.setattr(COWCCounting, "base_url", base_url)
         md5s = [
             "7d0c6d1fb548d3ea3a182a56ce231f97",
             "2e9a806b19b21f9d796c7393ad8f51ee",
@@ -54,10 +50,10 @@ class TestCOWCCounting:
             "f159e23d52bd0b5656fe296f427b98e1",
             "0a4daed8c5f6c4e20faa6e38636e4346",
         ]
-        monkeypatch.setattr(COWCCounting, "md5s", md5s)  # type: ignore[attr-defined]
+        monkeypatch.setattr(COWCCounting, "md5s", md5s)
         root = str(tmp_path)
         split = request.param
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return COWCCounting(root, split, transforms, download=True, checksum=True)
 
     def test_getitem(self, dataset: COWC) -> None:
@@ -108,13 +104,9 @@ class TestCOWCDetection:
         tmp_path: Path,
         request: SubRequest,
     ) -> COWC:
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            torchgeo.datasets.utils, "download_url", download_url
-        )
+        monkeypatch.setattr(torchgeo.datasets.utils, "download_url", download_url)
         base_url = os.path.join("tests", "data", "cowc_detection") + os.sep
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            COWCDetection, "base_url", base_url
-        )
+        monkeypatch.setattr(COWCDetection, "base_url", base_url)
         md5s = [
             "6bbbdb36ee4922e879f66ed9234cb8ab",
             "09e4af08c6e6553afe5098b328ce9749",
@@ -125,10 +117,10 @@ class TestCOWCDetection:
             "dd315cfb48dfa7ddb8230c942682bc37",
             "dccc2257e9c4a9dde2b4f84769804046",
         ]
-        monkeypatch.setattr(COWCDetection, "md5s", md5s)  # type: ignore[attr-defined]
+        monkeypatch.setattr(COWCDetection, "md5s", md5s)
         root = str(tmp_path)
         split = request.param
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return COWCDetection(root, split, transforms, download=True, checksum=True)
 
     def test_getitem(self, dataset: COWC) -> None:

--- a/tests/datasets/test_cv4a_kenya_crop_type.py
+++ b/tests/datasets/test_cv4a_kenya_crop_type.py
@@ -44,7 +44,7 @@ class TestCV4AKenyaCropType:
         )
         monkeypatch.setattr(CV4AKenyaCropType, "dates", ["20190606"])
         root = str(tmp_path)
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return CV4AKenyaCropType(
             root,
             transforms=transforms,

--- a/tests/datasets/test_cv4a_kenya_crop_type.py
+++ b/tests/datasets/test_cv4a_kenya_crop_type.py
@@ -5,7 +5,7 @@ import glob
 import os
 import shutil
 from pathlib import Path
-from typing import Generator
+
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/datasets/test_cv4a_kenya_crop_type.py
+++ b/tests/datasets/test_cv4a_kenya_crop_type.py
@@ -33,7 +33,7 @@ def fetch(dataset_id: str, **kwargs: str) -> Dataset:
 class TestCV4AKenyaCropType:
     @pytest.fixture
     def dataset(
-        self, monkeypatch: Generator[MonkeyPatch, None, None], tmp_path: Path
+        self, monkeypatch: MonkeyPatch, tmp_path: Path
     ) -> CV4AKenyaCropType:
         radiant_mlhub = pytest.importorskip("radiant_mlhub", minversion="0.2.1")
         monkeypatch.setattr(radiant_mlhub.Dataset, "fetch", fetch)

--- a/tests/datasets/test_cv4a_kenya_crop_type.py
+++ b/tests/datasets/test_cv4a_kenya_crop_type.py
@@ -32,9 +32,7 @@ def fetch(dataset_id: str, **kwargs: str) -> Dataset:
 
 class TestCV4AKenyaCropType:
     @pytest.fixture
-    def dataset(
-        self, monkeypatch: MonkeyPatch, tmp_path: Path
-    ) -> CV4AKenyaCropType:
+    def dataset(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> CV4AKenyaCropType:
         radiant_mlhub = pytest.importorskip("radiant_mlhub", minversion="0.2.1")
         monkeypatch.setattr(radiant_mlhub.Dataset, "fetch", fetch)
         source_md5 = "7f4dcb3f33743dddd73f453176308bfb"

--- a/tests/datasets/test_cv4a_kenya_crop_type.py
+++ b/tests/datasets/test_cv4a_kenya_crop_type.py
@@ -36,25 +36,17 @@ class TestCV4AKenyaCropType:
         self, monkeypatch: Generator[MonkeyPatch, None, None], tmp_path: Path
     ) -> CV4AKenyaCropType:
         radiant_mlhub = pytest.importorskip("radiant_mlhub", minversion="0.2.1")
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            radiant_mlhub.Dataset, "fetch", fetch
-        )
+        monkeypatch.setattr(radiant_mlhub.Dataset, "fetch", fetch)
         source_md5 = "7f4dcb3f33743dddd73f453176308bfb"
         labels_md5 = "95fc59f1d94a85ec00931d4d1280bec9"
-        monkeypatch.setitem(  # type: ignore[attr-defined]
-            CV4AKenyaCropType.image_meta, "md5", source_md5
-        )
-        monkeypatch.setitem(  # type: ignore[attr-defined]
-            CV4AKenyaCropType.target_meta, "md5", labels_md5
-        )
-        monkeypatch.setattr(  # type: ignore[attr-defined]
+        monkeypatch.setitem(CV4AKenyaCropType.image_meta, "md5", source_md5)
+        monkeypatch.setitem(CV4AKenyaCropType.target_meta, "md5", labels_md5)
+        monkeypatch.setattr(
             CV4AKenyaCropType, "tile_names", ["ref_african_crops_kenya_02_tile_00"]
         )
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            CV4AKenyaCropType, "dates", ["20190606"]
-        )
+        monkeypatch.setattr(CV4AKenyaCropType, "dates", ["20190606"])
         root = str(tmp_path)
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return CV4AKenyaCropType(
             root,
             transforms=transforms,

--- a/tests/datasets/test_cv4a_kenya_crop_type.py
+++ b/tests/datasets/test_cv4a_kenya_crop_type.py
@@ -6,7 +6,6 @@ import os
 import shutil
 from pathlib import Path
 
-
 import matplotlib.pyplot as plt
 import pytest
 import torch

--- a/tests/datasets/test_cyclone.py
+++ b/tests/datasets/test_cyclone.py
@@ -32,7 +32,7 @@ class TestTropicalCycloneWindEstimation:
     @pytest.fixture(params=["train", "test"])
     def dataset(
         self,
-        monkeypatch: Generator[MonkeyPatch, None, None],
+        monkeypatch: MonkeyPatch,
         tmp_path: Path,
         request: SubRequest,
     ) -> TropicalCycloneWindEstimation:

--- a/tests/datasets/test_cyclone.py
+++ b/tests/datasets/test_cyclone.py
@@ -49,7 +49,7 @@ class TestTropicalCycloneWindEstimation:
         monkeypatch.setattr(TropicalCycloneWindEstimation, "size", 1)
         root = str(tmp_path)
         split = request.param
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return TropicalCycloneWindEstimation(
             root, split, transforms, download=True, api_key="", checksum=True
         )

--- a/tests/datasets/test_cyclone.py
+++ b/tests/datasets/test_cyclone.py
@@ -5,7 +5,7 @@ import glob
 import os
 import shutil
 from pathlib import Path
-from typing import Generator
+
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/datasets/test_cyclone.py
+++ b/tests/datasets/test_cyclone.py
@@ -37,9 +37,7 @@ class TestTropicalCycloneWindEstimation:
         request: SubRequest,
     ) -> TropicalCycloneWindEstimation:
         radiant_mlhub = pytest.importorskip("radiant_mlhub", minversion="0.2.1")
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            radiant_mlhub.Dataset, "fetch", fetch
-        )
+        monkeypatch.setattr(radiant_mlhub.Dataset, "fetch", fetch)
         md5s = {
             "train": {
                 "source": "2b818e0a0873728dabf52c7054a0ce4c",
@@ -50,15 +48,11 @@ class TestTropicalCycloneWindEstimation:
                 "labels": "3ca4243eff39b87c73e05ec8db1824bf",
             },
         }
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            TropicalCycloneWindEstimation, "md5s", md5s
-        )
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            TropicalCycloneWindEstimation, "size", 1
-        )
+        monkeypatch.setattr(TropicalCycloneWindEstimation, "md5s", md5s)
+        monkeypatch.setattr(TropicalCycloneWindEstimation, "size", 1)
         root = str(tmp_path)
         split = request.param
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return TropicalCycloneWindEstimation(
             root, split, transforms, download=True, api_key="", checksum=True
         )
@@ -98,8 +92,6 @@ class TestTropicalCycloneWindEstimation:
         plt.close()
 
         sample = dataset[0]
-        sample["prediction"] = torch.tensor(  # type: ignore[attr-defined]
-            sample["label"]
-        )
+        sample["prediction"] = torch.tensor(sample["label"])
         dataset.plot(sample)
         plt.close()

--- a/tests/datasets/test_cyclone.py
+++ b/tests/datasets/test_cyclone.py
@@ -31,10 +31,7 @@ def fetch(collection_id: str, **kwargs: str) -> Dataset:
 class TestTropicalCycloneWindEstimation:
     @pytest.fixture(params=["train", "test"])
     def dataset(
-        self,
-        monkeypatch: MonkeyPatch,
-        tmp_path: Path,
-        request: SubRequest,
+        self, monkeypatch: MonkeyPatch, tmp_path: Path, request: SubRequest
     ) -> TropicalCycloneWindEstimation:
         radiant_mlhub = pytest.importorskip("radiant_mlhub", minversion="0.2.1")
         monkeypatch.setattr(radiant_mlhub.Dataset, "fetch", fetch)

--- a/tests/datasets/test_cyclone.py
+++ b/tests/datasets/test_cyclone.py
@@ -6,7 +6,6 @@ import os
 import shutil
 from pathlib import Path
 
-
 import matplotlib.pyplot as plt
 import pytest
 import torch

--- a/tests/datasets/test_dfc2022.py
+++ b/tests/datasets/test_dfc2022.py
@@ -5,7 +5,6 @@ import os
 import shutil
 from pathlib import Path
 
-
 import matplotlib.pyplot as plt
 import pytest
 import torch

--- a/tests/datasets/test_dfc2022.py
+++ b/tests/datasets/test_dfc2022.py
@@ -4,7 +4,7 @@
 import os
 import shutil
 from pathlib import Path
-from typing import Generator
+
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/datasets/test_dfc2022.py
+++ b/tests/datasets/test_dfc2022.py
@@ -19,7 +19,7 @@ from torchgeo.datasets import DFC2022
 class TestDFC2022:
     @pytest.fixture(params=["train", "train-unlabeled", "val"])
     def dataset(
-        self, monkeypatch: Generator[MonkeyPatch, None, None], request: SubRequest
+        self, monkeypatch: MonkeyPatch, request: SubRequest
     ) -> DFC2022:
         monkeypatch.setitem(
             DFC2022.metadata["train"], "md5", "6e380c4fa659d05ca93be71b50cacd90"

--- a/tests/datasets/test_dfc2022.py
+++ b/tests/datasets/test_dfc2022.py
@@ -21,20 +21,20 @@ class TestDFC2022:
     def dataset(
         self, monkeypatch: Generator[MonkeyPatch, None, None], request: SubRequest
     ) -> DFC2022:
-        monkeypatch.setitem(  # type: ignore[attr-defined]
+        monkeypatch.setitem(
             DFC2022.metadata["train"], "md5", "6e380c4fa659d05ca93be71b50cacd90"
         )
-        monkeypatch.setitem(  # type: ignore[attr-defined]
+        monkeypatch.setitem(
             DFC2022.metadata["train-unlabeled"],
             "md5",
             "b2bf3839323d4eae636f198921442945",
         )
-        monkeypatch.setitem(  # type: ignore[attr-defined]
+        monkeypatch.setitem(
             DFC2022.metadata["val"], "md5", "e018dc6865bd3086738038fff27b818a"
         )
         root = os.path.join("tests", "data", "dfc2022")
         split = request.param
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return DFC2022(root, split, transforms, checksum=True)
 
     def test_getitem(self, dataset: DFC2022) -> None:

--- a/tests/datasets/test_dfc2022.py
+++ b/tests/datasets/test_dfc2022.py
@@ -32,7 +32,7 @@ class TestDFC2022:
         )
         root = os.path.join("tests", "data", "dfc2022")
         split = request.param
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return DFC2022(root, split, transforms, checksum=True)
 
     def test_getitem(self, dataset: DFC2022) -> None:

--- a/tests/datasets/test_dfc2022.py
+++ b/tests/datasets/test_dfc2022.py
@@ -18,9 +18,7 @@ from torchgeo.datasets import DFC2022
 
 class TestDFC2022:
     @pytest.fixture(params=["train", "train-unlabeled", "val"])
-    def dataset(
-        self, monkeypatch: MonkeyPatch, request: SubRequest
-    ) -> DFC2022:
+    def dataset(self, monkeypatch: MonkeyPatch, request: SubRequest) -> DFC2022:
         monkeypatch.setitem(
             DFC2022.metadata["train"], "md5", "6e380c4fa659d05ca93be71b50cacd90"
         )

--- a/tests/datasets/test_enviroatlas.py
+++ b/tests/datasets/test_enviroatlas.py
@@ -52,7 +52,7 @@ class TestEnviroAtlas:
             ["pittsburgh_pa-2010_1m-train_tiles-debuffered", "spatial_index.geojson"],
         )
         root = str(tmp_path)
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return EnviroAtlas(
             root,
             layers=request.param[0],

--- a/tests/datasets/test_enviroatlas.py
+++ b/tests/datasets/test_enviroatlas.py
@@ -5,7 +5,6 @@ import os
 import shutil
 from pathlib import Path
 
-
 import matplotlib.pyplot as plt
 import pytest
 import torch

--- a/tests/datasets/test_enviroatlas.py
+++ b/tests/datasets/test_enviroatlas.py
@@ -4,7 +4,7 @@
 import os
 import shutil
 from pathlib import Path
-from typing import Generator
+
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/datasets/test_enviroatlas.py
+++ b/tests/datasets/test_enviroatlas.py
@@ -42,24 +42,20 @@ class TestEnviroAtlas:
         monkeypatch: Generator[MonkeyPatch, None, None],
         tmp_path: Path,
     ) -> EnviroAtlas:
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            torchgeo.datasets.enviroatlas, "download_url", download_url
-        )
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            EnviroAtlas, "md5", "071ec65c611e1d4915a5247bffb5ad87"
-        )
-        monkeypatch.setattr(  # type: ignore[attr-defined]
+        monkeypatch.setattr(torchgeo.datasets.enviroatlas, "download_url", download_url)
+        monkeypatch.setattr(EnviroAtlas, "md5", "071ec65c611e1d4915a5247bffb5ad87")
+        monkeypatch.setattr(
             EnviroAtlas,
             "url",
             os.path.join("tests", "data", "enviroatlas", "enviroatlas_lotp.zip"),
         )
-        monkeypatch.setattr(  # type: ignore[attr-defined]
+        monkeypatch.setattr(
             EnviroAtlas,
             "files",
             ["pittsburgh_pa-2010_1m-train_tiles-debuffered", "spatial_index.geojson"],
         )
         root = str(tmp_path)
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return EnviroAtlas(
             root,
             layers=request.param[0],

--- a/tests/datasets/test_enviroatlas.py
+++ b/tests/datasets/test_enviroatlas.py
@@ -37,10 +37,7 @@ class TestEnviroAtlas:
         ]
     )
     def dataset(
-        self,
-        request: SubRequest,
-        monkeypatch: MonkeyPatch,
-        tmp_path: Path,
+        self, request: SubRequest, monkeypatch: MonkeyPatch, tmp_path: Path
     ) -> EnviroAtlas:
         monkeypatch.setattr(torchgeo.datasets.enviroatlas, "download_url", download_url)
         monkeypatch.setattr(EnviroAtlas, "md5", "071ec65c611e1d4915a5247bffb5ad87")

--- a/tests/datasets/test_enviroatlas.py
+++ b/tests/datasets/test_enviroatlas.py
@@ -39,7 +39,7 @@ class TestEnviroAtlas:
     def dataset(
         self,
         request: SubRequest,
-        monkeypatch: Generator[MonkeyPatch, None, None],
+        monkeypatch: MonkeyPatch,
         tmp_path: Path,
     ) -> EnviroAtlas:
         monkeypatch.setattr(torchgeo.datasets.enviroatlas, "download_url", download_url)

--- a/tests/datasets/test_esri2020.py
+++ b/tests/datasets/test_esri2020.py
@@ -5,7 +5,6 @@ import os
 import shutil
 from pathlib import Path
 
-
 import matplotlib.pyplot as plt
 import pytest
 import torch

--- a/tests/datasets/test_esri2020.py
+++ b/tests/datasets/test_esri2020.py
@@ -4,7 +4,7 @@
 import os
 import shutil
 from pathlib import Path
-from typing import Generator
+
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/datasets/test_esri2020.py
+++ b/tests/datasets/test_esri2020.py
@@ -26,23 +26,21 @@ class TestEsri2020:
     def dataset(
         self, monkeypatch: Generator[MonkeyPatch, None, None], tmp_path: Path
     ) -> Esri2020:
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            torchgeo.datasets.esri2020, "download_url", download_url
-        )
+        monkeypatch.setattr(torchgeo.datasets.esri2020, "download_url", download_url)
         zipfile = "io-lulc-model-001-v01-composite-v03-supercell-v02-clip-v01.zip"
-        monkeypatch.setattr(Esri2020, "zipfile", zipfile)  # type: ignore[attr-defined]
+        monkeypatch.setattr(Esri2020, "zipfile", zipfile)
 
         md5 = "34aec55538694171c7b605b0cc0d0138"
-        monkeypatch.setattr(Esri2020, "md5", md5)  # type: ignore[attr-defined]
+        monkeypatch.setattr(Esri2020, "md5", md5)
         url = os.path.join(
             "tests",
             "data",
             "esri2020",
             "io-lulc-model-001-v01-composite-v03-supercell-v02-clip-v01.zip",
         )
-        monkeypatch.setattr(Esri2020, "url", url)  # type: ignore[attr-defined]
+        monkeypatch.setattr(Esri2020, "url", url)
         root = str(tmp_path)
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return Esri2020(root, transforms=transforms, download=True, checksum=True)
 
     def test_getitem(self, dataset: Esri2020) -> None:

--- a/tests/datasets/test_esri2020.py
+++ b/tests/datasets/test_esri2020.py
@@ -38,7 +38,7 @@ class TestEsri2020:
         )
         monkeypatch.setattr(Esri2020, "url", url)
         root = str(tmp_path)
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return Esri2020(root, transforms=transforms, download=True, checksum=True)
 
     def test_getitem(self, dataset: Esri2020) -> None:

--- a/tests/datasets/test_esri2020.py
+++ b/tests/datasets/test_esri2020.py
@@ -23,9 +23,7 @@ def download_url(url: str, root: str, *args: str, **kwargs: str) -> None:
 
 class TestEsri2020:
     @pytest.fixture
-    def dataset(
-        self, monkeypatch: MonkeyPatch, tmp_path: Path
-    ) -> Esri2020:
+    def dataset(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> Esri2020:
         monkeypatch.setattr(torchgeo.datasets.esri2020, "download_url", download_url)
         zipfile = "io-lulc-model-001-v01-composite-v03-supercell-v02-clip-v01.zip"
         monkeypatch.setattr(Esri2020, "zipfile", zipfile)

--- a/tests/datasets/test_esri2020.py
+++ b/tests/datasets/test_esri2020.py
@@ -24,7 +24,7 @@ def download_url(url: str, root: str, *args: str, **kwargs: str) -> None:
 class TestEsri2020:
     @pytest.fixture
     def dataset(
-        self, monkeypatch: Generator[MonkeyPatch, None, None], tmp_path: Path
+        self, monkeypatch: MonkeyPatch, tmp_path: Path
     ) -> Esri2020:
         monkeypatch.setattr(torchgeo.datasets.esri2020, "download_url", download_url)
         zipfile = "io-lulc-model-001-v01-composite-v03-supercell-v02-clip-v01.zip"

--- a/tests/datasets/test_etci2021.py
+++ b/tests/datasets/test_etci2021.py
@@ -5,7 +5,6 @@ import os
 import shutil
 from pathlib import Path
 
-
 import matplotlib.pyplot as plt
 import pytest
 import torch

--- a/tests/datasets/test_etci2021.py
+++ b/tests/datasets/test_etci2021.py
@@ -4,7 +4,7 @@
 import os
 import shutil
 from pathlib import Path
-from typing import Generator
+
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/datasets/test_etci2021.py
+++ b/tests/datasets/test_etci2021.py
@@ -47,7 +47,7 @@ class TestETCI2021:
                 "url": os.path.join(data_dir, "test_without_ref_labels.zip"),
             },
         }
-        monkeypatch.setattr(ETCI2021, "metadata", metadata)  # noqa: E501
+        monkeypatch.setattr(ETCI2021, "metadata", metadata)
         root = str(tmp_path)
         split = request.param
         transforms = nn.Identity()  # type: ignore[no-untyped-call]

--- a/tests/datasets/test_etci2021.py
+++ b/tests/datasets/test_etci2021.py
@@ -29,9 +29,7 @@ class TestETCI2021:
         tmp_path: Path,
         request: SubRequest,
     ) -> ETCI2021:
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            torchgeo.datasets.utils, "download_url", download_url
-        )
+        monkeypatch.setattr(torchgeo.datasets.utils, "download_url", download_url)
         data_dir = os.path.join("tests", "data", "etci2021")
         metadata = {
             "train": {
@@ -53,10 +51,10 @@ class TestETCI2021:
                 "url": os.path.join(data_dir, "test_without_ref_labels.zip"),
             },
         }
-        monkeypatch.setattr(ETCI2021, "metadata", metadata)  # type: ignore[attr-defined]   # noqa: E501
+        monkeypatch.setattr(ETCI2021, "metadata", metadata)  # noqa: E501
         root = str(tmp_path)
         split = request.param
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return ETCI2021(root, split, transforms, download=True, checksum=True)
 
     def test_getitem(self, dataset: ETCI2021) -> None:

--- a/tests/datasets/test_etci2021.py
+++ b/tests/datasets/test_etci2021.py
@@ -25,7 +25,7 @@ class TestETCI2021:
     @pytest.fixture(params=["train", "val", "test"])
     def dataset(
         self,
-        monkeypatch: Generator[MonkeyPatch, None, None],
+        monkeypatch: MonkeyPatch,
         tmp_path: Path,
         request: SubRequest,
     ) -> ETCI2021:

--- a/tests/datasets/test_etci2021.py
+++ b/tests/datasets/test_etci2021.py
@@ -51,7 +51,7 @@ class TestETCI2021:
         monkeypatch.setattr(ETCI2021, "metadata", metadata)  # noqa: E501
         root = str(tmp_path)
         split = request.param
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return ETCI2021(root, split, transforms, download=True, checksum=True)
 
     def test_getitem(self, dataset: ETCI2021) -> None:

--- a/tests/datasets/test_etci2021.py
+++ b/tests/datasets/test_etci2021.py
@@ -24,10 +24,7 @@ def download_url(url: str, root: str, *args: str) -> None:
 class TestETCI2021:
     @pytest.fixture(params=["train", "val", "test"])
     def dataset(
-        self,
-        monkeypatch: MonkeyPatch,
-        tmp_path: Path,
-        request: SubRequest,
+        self, monkeypatch: MonkeyPatch, tmp_path: Path, request: SubRequest
     ) -> ETCI2021:
         monkeypatch.setattr(torchgeo.datasets.utils, "download_url", download_url)
         data_dir = os.path.join("tests", "data", "etci2021")

--- a/tests/datasets/test_eudem.py
+++ b/tests/datasets/test_eudem.py
@@ -18,9 +18,7 @@ from torchgeo.datasets import EUDEM, BoundingBox, IntersectionDataset, UnionData
 
 class TestEUDEM:
     @pytest.fixture
-    def dataset(
-        self, monkeypatch: MonkeyPatch, tmp_path: Path
-    ) -> EUDEM:
+    def dataset(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> EUDEM:
 
         md5s = {"eu_dem_v11_E30N10.zip": "ef148466c02197a08be169eaad186591"}
         monkeypatch.setattr(EUDEM, "md5s", md5s)

--- a/tests/datasets/test_eudem.py
+++ b/tests/datasets/test_eudem.py
@@ -5,7 +5,6 @@ import os
 import shutil
 from pathlib import Path
 
-
 import matplotlib.pyplot as plt
 import pytest
 import torch

--- a/tests/datasets/test_eudem.py
+++ b/tests/datasets/test_eudem.py
@@ -4,7 +4,7 @@
 import os
 import shutil
 from pathlib import Path
-from typing import Generator
+
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/datasets/test_eudem.py
+++ b/tests/datasets/test_eudem.py
@@ -19,7 +19,7 @@ from torchgeo.datasets import EUDEM, BoundingBox, IntersectionDataset, UnionData
 class TestEUDEM:
     @pytest.fixture
     def dataset(
-        self, monkeypatch: Generator[MonkeyPatch, None, None], tmp_path: Path
+        self, monkeypatch: MonkeyPatch, tmp_path: Path
     ) -> EUDEM:
 
         md5s = {"eu_dem_v11_E30N10.zip": "ef148466c02197a08be169eaad186591"}

--- a/tests/datasets/test_eudem.py
+++ b/tests/datasets/test_eudem.py
@@ -23,11 +23,11 @@ class TestEUDEM:
     ) -> EUDEM:
 
         md5s = {"eu_dem_v11_E30N10.zip": "ef148466c02197a08be169eaad186591"}
-        monkeypatch.setattr(EUDEM, "md5s", md5s)  # type: ignore[attr-defined]
+        monkeypatch.setattr(EUDEM, "md5s", md5s)
         zipfile = os.path.join("tests", "data", "eudem", "eu_dem_v11_E30N10.zip")
         shutil.copy(zipfile, tmp_path)
         root = str(tmp_path)
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return EUDEM(root, transforms=transforms)
 
     def test_getitem(self, dataset: EUDEM) -> None:

--- a/tests/datasets/test_eudem.py
+++ b/tests/datasets/test_eudem.py
@@ -25,7 +25,7 @@ class TestEUDEM:
         zipfile = os.path.join("tests", "data", "eudem", "eu_dem_v11_E30N10.zip")
         shutil.copy(zipfile, tmp_path)
         root = str(tmp_path)
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return EUDEM(root, transforms=transforms)
 
     def test_getitem(self, dataset: EUDEM) -> None:

--- a/tests/datasets/test_eurosat.py
+++ b/tests/datasets/test_eurosat.py
@@ -25,10 +25,7 @@ def download_url(url: str, root: str, *args: str, **kwargs: str) -> None:
 class TestEuroSAT:
     @pytest.fixture(params=["train", "val", "test"])
     def dataset(
-        self,
-        monkeypatch: MonkeyPatch,
-        tmp_path: Path,
-        request: SubRequest,
+        self, monkeypatch: MonkeyPatch, tmp_path: Path, request: SubRequest
     ) -> EuroSAT:
         monkeypatch.setattr(torchgeo.datasets.eurosat, "download_url", download_url)
         md5 = "aa051207b0547daba0ac6af57808d68e"

--- a/tests/datasets/test_eurosat.py
+++ b/tests/datasets/test_eurosat.py
@@ -5,7 +5,6 @@ import os
 import shutil
 from pathlib import Path
 
-
 import matplotlib.pyplot as plt
 import pytest
 import torch

--- a/tests/datasets/test_eurosat.py
+++ b/tests/datasets/test_eurosat.py
@@ -4,7 +4,7 @@
 import os
 import shutil
 from pathlib import Path
-from typing import Generator
+
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/datasets/test_eurosat.py
+++ b/tests/datasets/test_eurosat.py
@@ -26,7 +26,7 @@ class TestEuroSAT:
     @pytest.fixture(params=["train", "val", "test"])
     def dataset(
         self,
-        monkeypatch: Generator[MonkeyPatch, None, None],
+        monkeypatch: MonkeyPatch,
         tmp_path: Path,
         request: SubRequest,
     ) -> EuroSAT:

--- a/tests/datasets/test_eurosat.py
+++ b/tests/datasets/test_eurosat.py
@@ -30,14 +30,12 @@ class TestEuroSAT:
         tmp_path: Path,
         request: SubRequest,
     ) -> EuroSAT:
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            torchgeo.datasets.eurosat, "download_url", download_url
-        )
+        monkeypatch.setattr(torchgeo.datasets.eurosat, "download_url", download_url)
         md5 = "aa051207b0547daba0ac6af57808d68e"
-        monkeypatch.setattr(EuroSAT, "md5", md5)  # type: ignore[attr-defined]
+        monkeypatch.setattr(EuroSAT, "md5", md5)
         url = os.path.join("tests", "data", "eurosat", "EuroSATallBands.zip")
-        monkeypatch.setattr(EuroSAT, "url", url)  # type: ignore[attr-defined]
-        monkeypatch.setattr(  # type: ignore[attr-defined]
+        monkeypatch.setattr(EuroSAT, "url", url)
+        monkeypatch.setattr(
             EuroSAT,
             "split_urls",
             {
@@ -46,7 +44,7 @@ class TestEuroSAT:
                 "test": os.path.join("tests", "data", "eurosat", "eurosat-test.txt"),
             },
         )
-        monkeypatch.setattr(  # type: ignore[attr-defined]
+        monkeypatch.setattr(
             EuroSAT,
             "split_md5s",
             {
@@ -57,7 +55,7 @@ class TestEuroSAT:
         )
         root = str(tmp_path)
         split = request.param
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return EuroSAT(
             root=root, split=split, transforms=transforms, download=True, checksum=True
         )

--- a/tests/datasets/test_eurosat.py
+++ b/tests/datasets/test_eurosat.py
@@ -52,7 +52,7 @@ class TestEuroSAT:
         )
         root = str(tmp_path)
         split = request.param
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return EuroSAT(
             root=root, split=split, transforms=transforms, download=True, checksum=True
         )

--- a/tests/datasets/test_fair1m.py
+++ b/tests/datasets/test_fair1m.py
@@ -5,7 +5,6 @@ import os
 import shutil
 from pathlib import Path
 
-
 import matplotlib.pyplot as plt
 import pytest
 import torch

--- a/tests/datasets/test_fair1m.py
+++ b/tests/datasets/test_fair1m.py
@@ -4,7 +4,7 @@
 import os
 import shutil
 from pathlib import Path
-from typing import Generator
+
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/datasets/test_fair1m.py
+++ b/tests/datasets/test_fair1m.py
@@ -19,9 +19,9 @@ class TestFAIR1M:
     @pytest.fixture
     def dataset(self, monkeypatch: Generator[MonkeyPatch, None, None]) -> FAIR1M:
         md5s = ["f278aba757de9079225db42107e09e30", "aca59017207141951b53e91795d8179e"]
-        monkeypatch.setattr(FAIR1M, "md5s", md5s)  # type: ignore[attr-defined]
+        monkeypatch.setattr(FAIR1M, "md5s", md5s)
         root = os.path.join("tests", "data", "fair1m")
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return FAIR1M(root, transforms)
 
     def test_getitem(self, dataset: FAIR1M) -> None:

--- a/tests/datasets/test_fair1m.py
+++ b/tests/datasets/test_fair1m.py
@@ -21,7 +21,7 @@ class TestFAIR1M:
         md5s = ["f278aba757de9079225db42107e09e30", "aca59017207141951b53e91795d8179e"]
         monkeypatch.setattr(FAIR1M, "md5s", md5s)
         root = os.path.join("tests", "data", "fair1m")
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return FAIR1M(root, transforms)
 
     def test_getitem(self, dataset: FAIR1M) -> None:

--- a/tests/datasets/test_fair1m.py
+++ b/tests/datasets/test_fair1m.py
@@ -17,7 +17,7 @@ from torchgeo.datasets import FAIR1M
 
 class TestFAIR1M:
     @pytest.fixture
-    def dataset(self, monkeypatch: Generator[MonkeyPatch, None, None]) -> FAIR1M:
+    def dataset(self, monkeypatch: MonkeyPatch) -> FAIR1M:
         md5s = ["f278aba757de9079225db42107e09e30", "aca59017207141951b53e91795d8179e"]
         monkeypatch.setattr(FAIR1M, "md5s", md5s)
         root = os.path.join("tests", "data", "fair1m")

--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -147,7 +147,7 @@ class TestRasterDataset:
     def naip(self, request: SubRequest) -> NAIP:
         root = os.path.join("tests", "data", "naip")
         crs = CRS.from_epsg(3005)
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         cache = request.param
         return NAIP(root, crs=crs, transforms=transforms, cache=cache)
 
@@ -155,7 +155,7 @@ class TestRasterDataset:
     def sentinel(self, request: SubRequest) -> Sentinel2:
         root = os.path.join("tests", "data", "sentinel2")
         bands = ["B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B09", "B11"]
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         cache = request.param
         return Sentinel2(root, bands=bands, transforms=transforms, cache=cache)
 
@@ -180,7 +180,7 @@ class TestRasterDataset:
         x = custom_dtype_ds[custom_dtype_ds.bounds]
         assert isinstance(x, dict)
         assert isinstance(x["image"], torch.Tensor)
-        assert x["image"].dtype == torch.int64  # type: ignore[attr-defined]
+        assert x["image"].dtype == torch.int64
 
     def test_invalid_query(self, sentinel: Sentinel2) -> None:
         query = BoundingBox(0, 0, 0, 0, 0, 0)
@@ -204,7 +204,7 @@ class TestVectorDataset:
     @pytest.fixture
     def dataset(self) -> CanadianBuildingFootprints:
         root = os.path.join("tests", "data", "cbf")
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return CanadianBuildingFootprints(root, res=0.1, transforms=transforms)
 
     def test_getitem(self, dataset: CanadianBuildingFootprints) -> None:
@@ -272,7 +272,7 @@ class TestVisionDataset:
 class TestVisionClassificationDataset:
     @pytest.fixture(scope="class")
     def dataset(self, root: str) -> VisionClassificationDataset:
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return VisionClassificationDataset(root, transforms=transforms)
 
     @pytest.fixture(scope="class")

--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -147,7 +147,7 @@ class TestRasterDataset:
     def naip(self, request: SubRequest) -> NAIP:
         root = os.path.join("tests", "data", "naip")
         crs = CRS.from_epsg(3005)
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         cache = request.param
         return NAIP(root, crs=crs, transforms=transforms, cache=cache)
 
@@ -155,7 +155,7 @@ class TestRasterDataset:
     def sentinel(self, request: SubRequest) -> Sentinel2:
         root = os.path.join("tests", "data", "sentinel2")
         bands = ["B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B09", "B11"]
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         cache = request.param
         return Sentinel2(root, bands=bands, transforms=transforms, cache=cache)
 
@@ -204,7 +204,7 @@ class TestVectorDataset:
     @pytest.fixture
     def dataset(self) -> CanadianBuildingFootprints:
         root = os.path.join("tests", "data", "cbf")
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return CanadianBuildingFootprints(root, res=0.1, transforms=transforms)
 
     def test_getitem(self, dataset: CanadianBuildingFootprints) -> None:
@@ -272,7 +272,7 @@ class TestVisionDataset:
 class TestVisionClassificationDataset:
     @pytest.fixture(scope="class")
     def dataset(self, root: str) -> VisionClassificationDataset:
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return VisionClassificationDataset(root, transforms=transforms)
 
     @pytest.fixture(scope="class")

--- a/tests/datasets/test_gid15.py
+++ b/tests/datasets/test_gid15.py
@@ -5,7 +5,6 @@ import os
 import shutil
 from pathlib import Path
 
-
 import matplotlib.pyplot as plt
 import pytest
 import torch

--- a/tests/datasets/test_gid15.py
+++ b/tests/datasets/test_gid15.py
@@ -4,7 +4,7 @@
 import os
 import shutil
 from pathlib import Path
-from typing import Generator
+
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/datasets/test_gid15.py
+++ b/tests/datasets/test_gid15.py
@@ -25,7 +25,7 @@ class TestGID15:
     @pytest.fixture(params=["train", "val", "test"])
     def dataset(
         self,
-        monkeypatch: Generator[MonkeyPatch, None, None],
+        monkeypatch: MonkeyPatch,
         tmp_path: Path,
         request: SubRequest,
     ) -> GID15:

--- a/tests/datasets/test_gid15.py
+++ b/tests/datasets/test_gid15.py
@@ -24,10 +24,7 @@ def download_url(url: str, root: str, *args: str) -> None:
 class TestGID15:
     @pytest.fixture(params=["train", "val", "test"])
     def dataset(
-        self,
-        monkeypatch: MonkeyPatch,
-        tmp_path: Path,
-        request: SubRequest,
+        self, monkeypatch: MonkeyPatch, tmp_path: Path, request: SubRequest
     ) -> GID15:
         monkeypatch.setattr(torchgeo.datasets.utils, "download_url", download_url)
         md5 = "3d5b1373ef9a3084ec493b9b2056fe07"

--- a/tests/datasets/test_gid15.py
+++ b/tests/datasets/test_gid15.py
@@ -29,16 +29,14 @@ class TestGID15:
         tmp_path: Path,
         request: SubRequest,
     ) -> GID15:
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            torchgeo.datasets.utils, "download_url", download_url
-        )
+        monkeypatch.setattr(torchgeo.datasets.utils, "download_url", download_url)
         md5 = "3d5b1373ef9a3084ec493b9b2056fe07"
-        monkeypatch.setattr(GID15, "md5", md5)  # type: ignore[attr-defined]
+        monkeypatch.setattr(GID15, "md5", md5)
         url = os.path.join("tests", "data", "gid15", "gid-15.zip")
-        monkeypatch.setattr(GID15, "url", url)  # type: ignore[attr-defined]
+        monkeypatch.setattr(GID15, "url", url)
         root = str(tmp_path)
         split = request.param
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return GID15(root, split, transforms, download=True, checksum=True)
 
     def test_getitem(self, dataset: GID15) -> None:
@@ -73,12 +71,10 @@ class TestGID15:
 
         if dataset.split != "test":
             sample = dataset[0]
-            sample["prediction"] = torch.clone(  # type: ignore[attr-defined]
-                sample["mask"]
-            )
+            sample["prediction"] = torch.clone(sample["mask"])
             dataset.plot(sample, suptitle="Prediction")
         else:
             sample = dataset[0]
-            sample["prediction"] = torch.ones((1, 1))  # type: ignore[attr-defined]
+            sample["prediction"] = torch.ones((1, 1))
             dataset.plot(sample)
         plt.close()

--- a/tests/datasets/test_gid15.py
+++ b/tests/datasets/test_gid15.py
@@ -33,7 +33,7 @@ class TestGID15:
         monkeypatch.setattr(GID15, "url", url)
         root = str(tmp_path)
         split = request.param
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return GID15(root, split, transforms, download=True, checksum=True)
 
     def test_getitem(self, dataset: GID15) -> None:

--- a/tests/datasets/test_globbiomass.py
+++ b/tests/datasets/test_globbiomass.py
@@ -38,7 +38,7 @@ class TestGlobBiomass:
 
         monkeypatch.setattr(GlobBiomass, "md5s", md5s)
         root = str(tmp_path)
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return GlobBiomass(root, transforms=transforms, checksum=True)
 
     def test_getitem(self, dataset: GlobBiomass) -> None:

--- a/tests/datasets/test_globbiomass.py
+++ b/tests/datasets/test_globbiomass.py
@@ -5,7 +5,6 @@ import os
 import shutil
 from pathlib import Path
 
-
 import matplotlib.pyplot as plt
 import pytest
 import torch

--- a/tests/datasets/test_globbiomass.py
+++ b/tests/datasets/test_globbiomass.py
@@ -4,7 +4,7 @@
 import os
 import shutil
 from pathlib import Path
-from typing import Generator
+
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/datasets/test_globbiomass.py
+++ b/tests/datasets/test_globbiomass.py
@@ -23,9 +23,7 @@ from torchgeo.datasets import (
 
 class TestGlobBiomass:
     @pytest.fixture
-    def dataset(
-        self, monkeypatch: MonkeyPatch, tmp_path: Path
-    ) -> GlobBiomass:
+    def dataset(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> GlobBiomass:
         shutil.copy(
             os.path.join("tests", "data", "globbiomass", "N00E020_agb.zip"), tmp_path
         )

--- a/tests/datasets/test_globbiomass.py
+++ b/tests/datasets/test_globbiomass.py
@@ -38,9 +38,9 @@ class TestGlobBiomass:
             "N00E020_gsv.zip": "e79bf051ac5d659cb21c566c53ce7b98",
         }
 
-        monkeypatch.setattr(GlobBiomass, "md5s", md5s)  # type: ignore[attr-defined]
+        monkeypatch.setattr(GlobBiomass, "md5s", md5s)
         root = str(tmp_path)
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return GlobBiomass(root, transforms=transforms, checksum=True)
 
     def test_getitem(self, dataset: GlobBiomass) -> None:

--- a/tests/datasets/test_globbiomass.py
+++ b/tests/datasets/test_globbiomass.py
@@ -24,7 +24,7 @@ from torchgeo.datasets import (
 class TestGlobBiomass:
     @pytest.fixture
     def dataset(
-        self, monkeypatch: Generator[MonkeyPatch, None, None], tmp_path: Path
+        self, monkeypatch: MonkeyPatch, tmp_path: Path
     ) -> GlobBiomass:
         shutil.copy(
             os.path.join("tests", "data", "globbiomass", "N00E020_agb.zip"), tmp_path

--- a/tests/datasets/test_idtrees.py
+++ b/tests/datasets/test_idtrees.py
@@ -31,7 +31,7 @@ class TestIDTReeS:
     @pytest.fixture(params=zip(["train", "test", "test"], ["task1", "task1", "task2"]))
     def dataset(
         self,
-        monkeypatch: Generator[MonkeyPatch, None, None],
+        monkeypatch: MonkeyPatch,
         tmp_path: Path,
         request: SubRequest,
     ) -> IDTReeS:
@@ -57,7 +57,7 @@ class TestIDTReeS:
 
     @pytest.fixture(params=["pandas", "laspy", "open3d"])
     def mock_missing_module(
-        self, monkeypatch: Generator[MonkeyPatch, None, None], request: SubRequest
+        self, monkeypatch: MonkeyPatch, request: SubRequest
     ) -> str:
         import_orig = builtins.__import__
         package = str(request.param)

--- a/tests/datasets/test_idtrees.py
+++ b/tests/datasets/test_idtrees.py
@@ -7,7 +7,7 @@ import os
 import shutil
 import sys
 from pathlib import Path
-from typing import Any, Generator
+from typing import Any
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/datasets/test_idtrees.py
+++ b/tests/datasets/test_idtrees.py
@@ -30,10 +30,7 @@ def download_url(url: str, root: str, *args: str, **kwargs: str) -> None:
 class TestIDTReeS:
     @pytest.fixture(params=zip(["train", "test", "test"], ["task1", "task1", "task2"]))
     def dataset(
-        self,
-        monkeypatch: MonkeyPatch,
-        tmp_path: Path,
-        request: SubRequest,
+        self, monkeypatch: MonkeyPatch, tmp_path: Path, request: SubRequest
     ) -> IDTReeS:
         monkeypatch.setattr(torchgeo.datasets.idtrees, "download_url", download_url)
         data_dir = os.path.join("tests", "data", "idtrees")
@@ -56,9 +53,7 @@ class TestIDTReeS:
         return IDTReeS(root, split, task, transforms, download=True, checksum=True)
 
     @pytest.fixture(params=["pandas", "laspy", "open3d"])
-    def mock_missing_module(
-        self, monkeypatch: MonkeyPatch, request: SubRequest
-    ) -> str:
+    def mock_missing_module(self, monkeypatch: MonkeyPatch, request: SubRequest) -> str:
         import_orig = builtins.__import__
         package = str(request.param)
 

--- a/tests/datasets/test_idtrees.py
+++ b/tests/datasets/test_idtrees.py
@@ -35,9 +35,7 @@ class TestIDTReeS:
         tmp_path: Path,
         request: SubRequest,
     ) -> IDTReeS:
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            torchgeo.datasets.idtrees, "download_url", download_url
-        )
+        monkeypatch.setattr(torchgeo.datasets.idtrees, "download_url", download_url)
         data_dir = os.path.join("tests", "data", "idtrees")
         metadata = {
             "train": {
@@ -52,9 +50,9 @@ class TestIDTReeS:
             },
         }
         split, task = request.param
-        monkeypatch.setattr(IDTReeS, "metadata", metadata)  # type: ignore[attr-defined]
+        monkeypatch.setattr(IDTReeS, "metadata", metadata)
         root = str(tmp_path)
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return IDTReeS(root, split, task, transforms, download=True, checksum=True)
 
     @pytest.fixture(params=["pandas", "laspy", "open3d"])
@@ -69,9 +67,7 @@ class TestIDTReeS:
                 raise ImportError()
             return import_orig(name, *args, **kwargs)
 
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            builtins, "__import__", mocked_import
-        )
+        monkeypatch.setattr(builtins, "__import__", mocked_import)
         return package
 
     def test_getitem(self, dataset: IDTReeS) -> None:

--- a/tests/datasets/test_idtrees.py
+++ b/tests/datasets/test_idtrees.py
@@ -49,7 +49,7 @@ class TestIDTReeS:
         split, task = request.param
         monkeypatch.setattr(IDTReeS, "metadata", metadata)
         root = str(tmp_path)
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return IDTReeS(root, split, task, transforms, download=True, checksum=True)
 
     @pytest.fixture(params=["pandas", "laspy", "open3d"])

--- a/tests/datasets/test_inria.py
+++ b/tests/datasets/test_inria.py
@@ -18,7 +18,7 @@ from torchgeo.datasets import InriaAerialImageLabeling
 class TestInriaAerialImageLabeling:
     @pytest.fixture(params=["train", "test"])
     def dataset(
-        self, request: SubRequest, monkeypatch: Generator[MonkeyPatch, None, None]
+        self, request: SubRequest, monkeypatch: MonkeyPatch
     ) -> InriaAerialImageLabeling:
 
         root = os.path.join("tests", "data", "inria")

--- a/tests/datasets/test_inria.py
+++ b/tests/datasets/test_inria.py
@@ -4,7 +4,6 @@
 import os
 import shutil
 
-
 import matplotlib.pyplot as plt
 import pytest
 import torch

--- a/tests/datasets/test_inria.py
+++ b/tests/datasets/test_inria.py
@@ -23,10 +23,8 @@ class TestInriaAerialImageLabeling:
 
         root = os.path.join("tests", "data", "inria")
         test_md5 = "f23caf363389ef59de55fad11197c161"
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            InriaAerialImageLabeling, "md5", test_md5
-        )
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        monkeypatch.setattr(InriaAerialImageLabeling, "md5", test_md5)
+        transforms = nn.Identity()
         return InriaAerialImageLabeling(
             root, split=request.param, transforms=transforms, checksum=True
         )

--- a/tests/datasets/test_inria.py
+++ b/tests/datasets/test_inria.py
@@ -24,7 +24,7 @@ class TestInriaAerialImageLabeling:
         root = os.path.join("tests", "data", "inria")
         test_md5 = "f23caf363389ef59de55fad11197c161"
         monkeypatch.setattr(InriaAerialImageLabeling, "md5", test_md5)
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return InriaAerialImageLabeling(
             root, split=request.param, transforms=transforms, checksum=True
         )

--- a/tests/datasets/test_inria.py
+++ b/tests/datasets/test_inria.py
@@ -3,7 +3,7 @@
 
 import os
 import shutil
-from typing import Generator
+
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/datasets/test_landcoverai.py
+++ b/tests/datasets/test_landcoverai.py
@@ -26,7 +26,7 @@ class TestLandCoverAI:
     @pytest.fixture(params=["train", "val", "test"])
     def dataset(
         self,
-        monkeypatch: Generator[MonkeyPatch, None, None],
+        monkeypatch: MonkeyPatch,
         tmp_path: Path,
         request: SubRequest,
     ) -> LandCoverAI:
@@ -60,7 +60,7 @@ class TestLandCoverAI:
         LandCoverAI(root=dataset.root, download=True)
 
     def test_already_downloaded(
-        self, monkeypatch: Generator[MonkeyPatch, None, None], tmp_path: Path
+        self, monkeypatch: MonkeyPatch, tmp_path: Path
     ) -> None:
         sha256 = "ce84fa0e8d89b461c66fba4e78aa5a860e2871722c4a9ca8c2384eae1521c7c8"
         monkeypatch.setattr(LandCoverAI, "sha256", sha256)

--- a/tests/datasets/test_landcoverai.py
+++ b/tests/datasets/test_landcoverai.py
@@ -5,7 +5,6 @@ import os
 import shutil
 from pathlib import Path
 
-
 import matplotlib.pyplot as plt
 import pytest
 import torch

--- a/tests/datasets/test_landcoverai.py
+++ b/tests/datasets/test_landcoverai.py
@@ -25,10 +25,7 @@ def download_url(url: str, root: str, *args: str, **kwargs: str) -> None:
 class TestLandCoverAI:
     @pytest.fixture(params=["train", "val", "test"])
     def dataset(
-        self,
-        monkeypatch: MonkeyPatch,
-        tmp_path: Path,
-        request: SubRequest,
+        self, monkeypatch: MonkeyPatch, tmp_path: Path, request: SubRequest
     ) -> LandCoverAI:
         monkeypatch.setattr(torchgeo.datasets.landcoverai, "download_url", download_url)
         md5 = "46108372402292213789342d58929708"
@@ -59,9 +56,7 @@ class TestLandCoverAI:
     def test_already_extracted(self, dataset: LandCoverAI) -> None:
         LandCoverAI(root=dataset.root, download=True)
 
-    def test_already_downloaded(
-        self, monkeypatch: MonkeyPatch, tmp_path: Path
-    ) -> None:
+    def test_already_downloaded(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
         sha256 = "ce84fa0e8d89b461c66fba4e78aa5a860e2871722c4a9ca8c2384eae1521c7c8"
         monkeypatch.setattr(LandCoverAI, "sha256", sha256)
         url = os.path.join("tests", "data", "landcoverai", "landcover.ai.v1.zip")

--- a/tests/datasets/test_landcoverai.py
+++ b/tests/datasets/test_landcoverai.py
@@ -4,7 +4,7 @@
 import os
 import shutil
 from pathlib import Path
-from typing import Generator
+
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/datasets/test_landcoverai.py
+++ b/tests/datasets/test_landcoverai.py
@@ -36,7 +36,7 @@ class TestLandCoverAI:
         monkeypatch.setattr(LandCoverAI, "sha256", sha256)
         root = str(tmp_path)
         split = request.param
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return LandCoverAI(root, split, transforms, download=True, checksum=True)
 
     def test_getitem(self, dataset: LandCoverAI) -> None:

--- a/tests/datasets/test_landcoverai.py
+++ b/tests/datasets/test_landcoverai.py
@@ -30,18 +30,16 @@ class TestLandCoverAI:
         tmp_path: Path,
         request: SubRequest,
     ) -> LandCoverAI:
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            torchgeo.datasets.landcoverai, "download_url", download_url
-        )
+        monkeypatch.setattr(torchgeo.datasets.landcoverai, "download_url", download_url)
         md5 = "46108372402292213789342d58929708"
-        monkeypatch.setattr(LandCoverAI, "md5", md5)  # type: ignore[attr-defined]
+        monkeypatch.setattr(LandCoverAI, "md5", md5)
         url = os.path.join("tests", "data", "landcoverai", "landcover.ai.v1.zip")
-        monkeypatch.setattr(LandCoverAI, "url", url)  # type: ignore[attr-defined]
+        monkeypatch.setattr(LandCoverAI, "url", url)
         sha256 = "ce84fa0e8d89b461c66fba4e78aa5a860e2871722c4a9ca8c2384eae1521c7c8"
-        monkeypatch.setattr(LandCoverAI, "sha256", sha256)  # type: ignore[attr-defined]
+        monkeypatch.setattr(LandCoverAI, "sha256", sha256)
         root = str(tmp_path)
         split = request.param
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return LandCoverAI(root, split, transforms, download=True, checksum=True)
 
     def test_getitem(self, dataset: LandCoverAI) -> None:
@@ -65,7 +63,7 @@ class TestLandCoverAI:
         self, monkeypatch: Generator[MonkeyPatch, None, None], tmp_path: Path
     ) -> None:
         sha256 = "ce84fa0e8d89b461c66fba4e78aa5a860e2871722c4a9ca8c2384eae1521c7c8"
-        monkeypatch.setattr(LandCoverAI, "sha256", sha256)  # type: ignore[attr-defined]
+        monkeypatch.setattr(LandCoverAI, "sha256", sha256)
         url = os.path.join("tests", "data", "landcoverai", "landcover.ai.v1.zip")
         root = str(tmp_path)
         shutil.copy(url, root)

--- a/tests/datasets/test_landsat.py
+++ b/tests/datasets/test_landsat.py
@@ -18,12 +18,10 @@ from torchgeo.datasets import BoundingBox, IntersectionDataset, Landsat8, UnionD
 class TestLandsat8:
     @pytest.fixture
     def dataset(self, monkeypatch: Generator[MonkeyPatch, None, None]) -> Landsat8:
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            plt, "show", lambda *args: None
-        )
+        monkeypatch.setattr(plt, "show", lambda *args: None)
         root = os.path.join("tests", "data", "landsat8")
         bands = ["B1", "B2", "B3", "B4", "B5", "B6", "B7"]
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return Landsat8(root, bands=bands, transforms=transforms)
 
     def test_separate_files(self, dataset: Landsat8) -> None:

--- a/tests/datasets/test_landsat.py
+++ b/tests/datasets/test_landsat.py
@@ -4,7 +4,6 @@
 import os
 from pathlib import Path
 
-
 import matplotlib.pyplot as plt
 import pytest
 import torch

--- a/tests/datasets/test_landsat.py
+++ b/tests/datasets/test_landsat.py
@@ -3,7 +3,7 @@
 
 import os
 from pathlib import Path
-from typing import Generator
+
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/datasets/test_landsat.py
+++ b/tests/datasets/test_landsat.py
@@ -21,7 +21,7 @@ class TestLandsat8:
         monkeypatch.setattr(plt, "show", lambda *args: None)
         root = os.path.join("tests", "data", "landsat8")
         bands = ["B1", "B2", "B3", "B4", "B5", "B6", "B7"]
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return Landsat8(root, bands=bands, transforms=transforms)
 
     def test_separate_files(self, dataset: Landsat8) -> None:

--- a/tests/datasets/test_landsat.py
+++ b/tests/datasets/test_landsat.py
@@ -17,7 +17,7 @@ from torchgeo.datasets import BoundingBox, IntersectionDataset, Landsat8, UnionD
 
 class TestLandsat8:
     @pytest.fixture
-    def dataset(self, monkeypatch: Generator[MonkeyPatch, None, None]) -> Landsat8:
+    def dataset(self, monkeypatch: MonkeyPatch) -> Landsat8:
         monkeypatch.setattr(plt, "show", lambda *args: None)
         root = os.path.join("tests", "data", "landsat8")
         bands = ["B1", "B2", "B3", "B4", "B5", "B6", "B7"]

--- a/tests/datasets/test_levircd.py
+++ b/tests/datasets/test_levircd.py
@@ -5,7 +5,6 @@ import os
 import shutil
 from pathlib import Path
 
-
 import matplotlib.pyplot as plt
 import pytest
 import torch

--- a/tests/datasets/test_levircd.py
+++ b/tests/datasets/test_levircd.py
@@ -25,7 +25,7 @@ class TestLEVIRCDPlus:
     @pytest.fixture(params=["train", "test"])
     def dataset(
         self,
-        monkeypatch: Generator[MonkeyPatch, None, None],
+        monkeypatch: MonkeyPatch,
         tmp_path: Path,
         request: SubRequest,
     ) -> LEVIRCDPlus:

--- a/tests/datasets/test_levircd.py
+++ b/tests/datasets/test_levircd.py
@@ -4,7 +4,7 @@
 import os
 import shutil
 from pathlib import Path
-from typing import Generator
+
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/datasets/test_levircd.py
+++ b/tests/datasets/test_levircd.py
@@ -33,7 +33,7 @@ class TestLEVIRCDPlus:
         monkeypatch.setattr(LEVIRCDPlus, "url", url)
         root = str(tmp_path)
         split = request.param
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return LEVIRCDPlus(root, split, transforms, download=True, checksum=True)
 
     def test_getitem(self, dataset: LEVIRCDPlus) -> None:

--- a/tests/datasets/test_levircd.py
+++ b/tests/datasets/test_levircd.py
@@ -24,10 +24,7 @@ def download_url(url: str, root: str, *args: str) -> None:
 class TestLEVIRCDPlus:
     @pytest.fixture(params=["train", "test"])
     def dataset(
-        self,
-        monkeypatch: MonkeyPatch,
-        tmp_path: Path,
-        request: SubRequest,
+        self, monkeypatch: MonkeyPatch, tmp_path: Path, request: SubRequest
     ) -> LEVIRCDPlus:
         monkeypatch.setattr(torchgeo.datasets.utils, "download_url", download_url)
         md5 = "1adf156f628aa32fb2e8fe6cada16c04"

--- a/tests/datasets/test_levircd.py
+++ b/tests/datasets/test_levircd.py
@@ -29,16 +29,14 @@ class TestLEVIRCDPlus:
         tmp_path: Path,
         request: SubRequest,
     ) -> LEVIRCDPlus:
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            torchgeo.datasets.utils, "download_url", download_url
-        )
+        monkeypatch.setattr(torchgeo.datasets.utils, "download_url", download_url)
         md5 = "1adf156f628aa32fb2e8fe6cada16c04"
-        monkeypatch.setattr(LEVIRCDPlus, "md5", md5)  # type: ignore[attr-defined]
+        monkeypatch.setattr(LEVIRCDPlus, "md5", md5)
         url = os.path.join("tests", "data", "levircd", "LEVIR-CD+.zip")
-        monkeypatch.setattr(LEVIRCDPlus, "url", url)  # type: ignore[attr-defined]
+        monkeypatch.setattr(LEVIRCDPlus, "url", url)
         root = str(tmp_path)
         split = request.param
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return LEVIRCDPlus(root, split, transforms, download=True, checksum=True)
 
     def test_getitem(self, dataset: LEVIRCDPlus) -> None:

--- a/tests/datasets/test_loveda.py
+++ b/tests/datasets/test_loveda.py
@@ -5,7 +5,6 @@ import os
 import shutil
 from pathlib import Path
 
-
 import matplotlib.pyplot as plt
 import pytest
 import torch

--- a/tests/datasets/test_loveda.py
+++ b/tests/datasets/test_loveda.py
@@ -4,7 +4,7 @@
 import os
 import shutil
 from pathlib import Path
-from typing import Generator
+
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/datasets/test_loveda.py
+++ b/tests/datasets/test_loveda.py
@@ -24,10 +24,7 @@ def download_url(url: str, root: str, *args: str) -> None:
 class TestLoveDA:
     @pytest.fixture(params=["train", "val", "test"])
     def dataset(
-        self,
-        monkeypatch: MonkeyPatch,
-        tmp_path: Path,
-        request: SubRequest,
+        self, monkeypatch: MonkeyPatch, tmp_path: Path, request: SubRequest
     ) -> LoveDA:
         monkeypatch.setattr(torchgeo.datasets.utils, "download_url", download_url)
         md5 = "3d5b1373ef9a3084ec493b9b2056fe07"

--- a/tests/datasets/test_loveda.py
+++ b/tests/datasets/test_loveda.py
@@ -25,7 +25,7 @@ class TestLoveDA:
     @pytest.fixture(params=["train", "val", "test"])
     def dataset(
         self,
-        monkeypatch: Generator[MonkeyPatch, None, None],
+        monkeypatch: MonkeyPatch,
         tmp_path: Path,
         request: SubRequest,
     ) -> LoveDA:

--- a/tests/datasets/test_loveda.py
+++ b/tests/datasets/test_loveda.py
@@ -51,7 +51,7 @@ class TestLoveDA:
 
         root = str(tmp_path)
         split = request.param
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return LoveDA(
             root=root, split=split, transforms=transforms, download=True, checksum=True
         )

--- a/tests/datasets/test_loveda.py
+++ b/tests/datasets/test_loveda.py
@@ -29,9 +29,7 @@ class TestLoveDA:
         tmp_path: Path,
         request: SubRequest,
     ) -> LoveDA:
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            torchgeo.datasets.utils, "download_url", download_url
-        )
+        monkeypatch.setattr(torchgeo.datasets.utils, "download_url", download_url)
         md5 = "3d5b1373ef9a3084ec493b9b2056fe07"
 
         info_dict = {
@@ -52,13 +50,11 @@ class TestLoveDA:
             },
         }
 
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            LoveDA, "info_dict", info_dict
-        )
+        monkeypatch.setattr(LoveDA, "info_dict", info_dict)
 
         root = str(tmp_path)
         split = request.param
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return LoveDA(
             root=root, split=split, transforms=transforms, download=True, checksum=True
         )

--- a/tests/datasets/test_naip.py
+++ b/tests/datasets/test_naip.py
@@ -18,11 +18,9 @@ from torchgeo.datasets import NAIP, BoundingBox, IntersectionDataset, UnionDatas
 class TestNAIP:
     @pytest.fixture
     def dataset(self, monkeypatch: Generator[MonkeyPatch, None, None]) -> NAIP:
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            plt, "show", lambda *args: None
-        )
+        monkeypatch.setattr(plt, "show", lambda *args: None)
         root = os.path.join("tests", "data", "naip")
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return NAIP(root, transforms=transforms)
 
     def test_getitem(self, dataset: NAIP) -> None:

--- a/tests/datasets/test_naip.py
+++ b/tests/datasets/test_naip.py
@@ -20,7 +20,7 @@ class TestNAIP:
     def dataset(self, monkeypatch: MonkeyPatch) -> NAIP:
         monkeypatch.setattr(plt, "show", lambda *args: None)
         root = os.path.join("tests", "data", "naip")
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return NAIP(root, transforms=transforms)
 
     def test_getitem(self, dataset: NAIP) -> None:

--- a/tests/datasets/test_naip.py
+++ b/tests/datasets/test_naip.py
@@ -17,7 +17,7 @@ from torchgeo.datasets import NAIP, BoundingBox, IntersectionDataset, UnionDatas
 
 class TestNAIP:
     @pytest.fixture
-    def dataset(self, monkeypatch: Generator[MonkeyPatch, None, None]) -> NAIP:
+    def dataset(self, monkeypatch: MonkeyPatch) -> NAIP:
         monkeypatch.setattr(plt, "show", lambda *args: None)
         root = os.path.join("tests", "data", "naip")
         transforms = nn.Identity()

--- a/tests/datasets/test_naip.py
+++ b/tests/datasets/test_naip.py
@@ -4,7 +4,6 @@
 import os
 from pathlib import Path
 
-
 import matplotlib.pyplot as plt
 import pytest
 import torch

--- a/tests/datasets/test_naip.py
+++ b/tests/datasets/test_naip.py
@@ -3,7 +3,7 @@
 
 import os
 from pathlib import Path
-from typing import Generator
+
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/datasets/test_nasa_marine_debris.py
+++ b/tests/datasets/test_nasa_marine_debris.py
@@ -29,9 +29,7 @@ def fetch(dataset_id: str, **kwargs: str) -> Dataset:
 
 class TestNASAMarineDebris:
     @pytest.fixture()
-    def dataset(
-        self, monkeypatch: MonkeyPatch, tmp_path: Path
-    ) -> NASAMarineDebris:
+    def dataset(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> NASAMarineDebris:
         radiant_mlhub = pytest.importorskip("radiant_mlhub", minversion="0.2.1")
         monkeypatch.setattr(radiant_mlhub.Dataset, "fetch", fetch)
         md5s = ["fe8698d1e68b3f24f0b86b04419a797d", "d8084f5a72778349e07ac90ec1e1d990"]

--- a/tests/datasets/test_nasa_marine_debris.py
+++ b/tests/datasets/test_nasa_marine_debris.py
@@ -33,15 +33,11 @@ class TestNASAMarineDebris:
         self, monkeypatch: Generator[MonkeyPatch, None, None], tmp_path: Path
     ) -> NASAMarineDebris:
         radiant_mlhub = pytest.importorskip("radiant_mlhub", minversion="0.2.1")
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            radiant_mlhub.Dataset, "fetch", fetch
-        )
+        monkeypatch.setattr(radiant_mlhub.Dataset, "fetch", fetch)
         md5s = ["fe8698d1e68b3f24f0b86b04419a797d", "d8084f5a72778349e07ac90ec1e1d990"]
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            NASAMarineDebris, "md5s", md5s
-        )
+        monkeypatch.setattr(NASAMarineDebris, "md5s", md5s)
         root = str(tmp_path)
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return NASAMarineDebris(root, transforms, download=True, checksum=True)
 
     def test_getitem(self, dataset: NASAMarineDebris) -> None:

--- a/tests/datasets/test_nasa_marine_debris.py
+++ b/tests/datasets/test_nasa_marine_debris.py
@@ -5,7 +5,7 @@ import glob
 import os
 import shutil
 from pathlib import Path
-from typing import Generator
+
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/datasets/test_nasa_marine_debris.py
+++ b/tests/datasets/test_nasa_marine_debris.py
@@ -30,7 +30,7 @@ def fetch(dataset_id: str, **kwargs: str) -> Dataset:
 class TestNASAMarineDebris:
     @pytest.fixture()
     def dataset(
-        self, monkeypatch: Generator[MonkeyPatch, None, None], tmp_path: Path
+        self, monkeypatch: MonkeyPatch, tmp_path: Path
     ) -> NASAMarineDebris:
         radiant_mlhub = pytest.importorskip("radiant_mlhub", minversion="0.2.1")
         monkeypatch.setattr(radiant_mlhub.Dataset, "fetch", fetch)

--- a/tests/datasets/test_nasa_marine_debris.py
+++ b/tests/datasets/test_nasa_marine_debris.py
@@ -35,7 +35,7 @@ class TestNASAMarineDebris:
         md5s = ["fe8698d1e68b3f24f0b86b04419a797d", "d8084f5a72778349e07ac90ec1e1d990"]
         monkeypatch.setattr(NASAMarineDebris, "md5s", md5s)
         root = str(tmp_path)
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return NASAMarineDebris(root, transforms, download=True, checksum=True)
 
     def test_getitem(self, dataset: NASAMarineDebris) -> None:

--- a/tests/datasets/test_nasa_marine_debris.py
+++ b/tests/datasets/test_nasa_marine_debris.py
@@ -6,7 +6,6 @@ import os
 import shutil
 from pathlib import Path
 
-
 import matplotlib.pyplot as plt
 import pytest
 import torch

--- a/tests/datasets/test_nwpu.py
+++ b/tests/datasets/test_nwpu.py
@@ -31,7 +31,7 @@ class TestVHR10:
     @pytest.fixture(params=["positive", "negative"])
     def dataset(
         self,
-        monkeypatch: Generator[MonkeyPatch, None, None],
+        monkeypatch: MonkeyPatch,
         tmp_path: Path,
         request: SubRequest,
     ) -> VHR10:
@@ -53,7 +53,7 @@ class TestVHR10:
 
     @pytest.fixture
     def mock_missing_module(
-        self, monkeypatch: Generator[MonkeyPatch, None, None]
+        self, monkeypatch: MonkeyPatch
     ) -> None:
         import_orig = builtins.__import__
 

--- a/tests/datasets/test_nwpu.py
+++ b/tests/datasets/test_nwpu.py
@@ -45,7 +45,7 @@ class TestVHR10:
         monkeypatch.setitem(VHR10.target_meta, "md5", md5)
         root = str(tmp_path)
         split = request.param
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return VHR10(root, split, transforms, download=True, checksum=True)
 
     @pytest.fixture

--- a/tests/datasets/test_nwpu.py
+++ b/tests/datasets/test_nwpu.py
@@ -30,10 +30,7 @@ def download_url(url: str, root: str, *args: str) -> None:
 class TestVHR10:
     @pytest.fixture(params=["positive", "negative"])
     def dataset(
-        self,
-        monkeypatch: MonkeyPatch,
-        tmp_path: Path,
-        request: SubRequest,
+        self, monkeypatch: MonkeyPatch, tmp_path: Path, request: SubRequest
     ) -> VHR10:
         pytest.importorskip("rarfile", minversion="3")
         monkeypatch.setattr(torchgeo.datasets.nwpu, "download_url", download_url)
@@ -52,9 +49,7 @@ class TestVHR10:
         return VHR10(root, split, transforms, download=True, checksum=True)
 
     @pytest.fixture
-    def mock_missing_module(
-        self, monkeypatch: MonkeyPatch
-    ) -> None:
+    def mock_missing_module(self, monkeypatch: MonkeyPatch) -> None:
         import_orig = builtins.__import__
 
         def mocked_import(name: str, *args: Any, **kwargs: Any) -> Any:

--- a/tests/datasets/test_nwpu.py
+++ b/tests/datasets/test_nwpu.py
@@ -6,7 +6,7 @@ import os
 import shutil
 import sys
 from pathlib import Path
-from typing import Any, Generator
+from typing import Any
 
 import pytest
 import torch

--- a/tests/datasets/test_nwpu.py
+++ b/tests/datasets/test_nwpu.py
@@ -36,23 +36,19 @@ class TestVHR10:
         request: SubRequest,
     ) -> VHR10:
         pytest.importorskip("rarfile", minversion="3")
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            torchgeo.datasets.nwpu, "download_url", download_url
-        )
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            torchgeo.datasets.utils, "download_url", download_url
-        )
+        monkeypatch.setattr(torchgeo.datasets.nwpu, "download_url", download_url)
+        monkeypatch.setattr(torchgeo.datasets.utils, "download_url", download_url)
         url = os.path.join("tests", "data", "vhr10", "NWPU VHR-10 dataset.rar")
-        monkeypatch.setitem(VHR10.image_meta, "url", url)  # type: ignore[attr-defined]
+        monkeypatch.setitem(VHR10.image_meta, "url", url)
         md5 = "e5c38351bd948479fe35a71136aedbc4"
-        monkeypatch.setitem(VHR10.image_meta, "md5", md5)  # type: ignore[attr-defined]
+        monkeypatch.setitem(VHR10.image_meta, "md5", md5)
         url = os.path.join("tests", "data", "vhr10", "annotations.json")
-        monkeypatch.setitem(VHR10.target_meta, "url", url)  # type: ignore[attr-defined]
+        monkeypatch.setitem(VHR10.target_meta, "url", url)
         md5 = "16fc6aa597a19179dad84151cc221873"
-        monkeypatch.setitem(VHR10.target_meta, "md5", md5)  # type: ignore[attr-defined]
+        monkeypatch.setitem(VHR10.target_meta, "md5", md5)
         root = str(tmp_path)
         split = request.param
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return VHR10(root, split, transforms, download=True, checksum=True)
 
     @pytest.fixture
@@ -66,9 +62,7 @@ class TestVHR10:
                 raise ImportError()
             return import_orig(name, *args, **kwargs)
 
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            builtins, "__import__", mocked_import
-        )
+        monkeypatch.setattr(builtins, "__import__", mocked_import)
 
     def test_getitem(self, dataset: VHR10) -> None:
         x = dataset[0]

--- a/tests/datasets/test_openbuildings.py
+++ b/tests/datasets/test_openbuildings.py
@@ -30,7 +30,7 @@ pytest.importorskip("pandas", minversion="0.19.1")
 class TestOpenBuildings:
     @pytest.fixture
     def dataset(
-        self, monkeypatch: Generator[MonkeyPatch, None, None], tmp_path: Path
+        self, monkeypatch: MonkeyPatch, tmp_path: Path
     ) -> OpenBuildings:
 
         root = str(tmp_path)
@@ -49,7 +49,7 @@ class TestOpenBuildings:
 
     @pytest.fixture(params=["pandas"])
     def mock_missing_module(
-        self, monkeypatch: Generator[MonkeyPatch, None, None], request: SubRequest
+        self, monkeypatch: MonkeyPatch, request: SubRequest
     ) -> str:
         import_orig = builtins.__import__
         package = str(request.param)

--- a/tests/datasets/test_openbuildings.py
+++ b/tests/datasets/test_openbuildings.py
@@ -29,9 +29,7 @@ pytest.importorskip("pandas", minversion="0.19.1")
 
 class TestOpenBuildings:
     @pytest.fixture
-    def dataset(
-        self, monkeypatch: MonkeyPatch, tmp_path: Path
-    ) -> OpenBuildings:
+    def dataset(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> OpenBuildings:
 
         root = str(tmp_path)
         shutil.copy(
@@ -48,9 +46,7 @@ class TestOpenBuildings:
         return OpenBuildings(root=root, transforms=transforms)
 
     @pytest.fixture(params=["pandas"])
-    def mock_missing_module(
-        self, monkeypatch: MonkeyPatch, request: SubRequest
-    ) -> str:
+    def mock_missing_module(self, monkeypatch: MonkeyPatch, request: SubRequest) -> str:
         import_orig = builtins.__import__
         package = str(request.param)
 

--- a/tests/datasets/test_openbuildings.py
+++ b/tests/datasets/test_openbuildings.py
@@ -43,8 +43,8 @@ class TestOpenBuildings:
 
         md5s = {"000_buildings.csv.gz": "20aeeec9d45a0ce4d772a26e0bcbc25f"}
 
-        monkeypatch.setattr(OpenBuildings, "md5s", md5s)  # type: ignore[attr-defined]
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        monkeypatch.setattr(OpenBuildings, "md5s", md5s)
+        transforms = nn.Identity()
         return OpenBuildings(root=root, transforms=transforms)
 
     @pytest.fixture(params=["pandas"])
@@ -59,9 +59,7 @@ class TestOpenBuildings:
                 raise ImportError()
             return import_orig(name, *args, **kwargs)
 
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            builtins, "__import__", mocked_import
-        )
+        monkeypatch.setattr(builtins, "__import__", mocked_import)
         return package
 
     def test_mock_missing_module(

--- a/tests/datasets/test_openbuildings.py
+++ b/tests/datasets/test_openbuildings.py
@@ -42,7 +42,7 @@ class TestOpenBuildings:
         md5s = {"000_buildings.csv.gz": "20aeeec9d45a0ce4d772a26e0bcbc25f"}
 
         monkeypatch.setattr(OpenBuildings, "md5s", md5s)
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return OpenBuildings(root=root, transforms=transforms)
 
     @pytest.fixture(params=["pandas"])

--- a/tests/datasets/test_openbuildings.py
+++ b/tests/datasets/test_openbuildings.py
@@ -6,7 +6,7 @@ import json
 import os
 import shutil
 from pathlib import Path
-from typing import Any, Generator
+from typing import Any
 
 import matplotlib.pyplot as plt
 import pandas as pd

--- a/tests/datasets/test_oscd.py
+++ b/tests/datasets/test_oscd.py
@@ -6,7 +6,6 @@ import os
 import shutil
 from pathlib import Path
 
-
 import pytest
 import torch
 import torch.nn as nn

--- a/tests/datasets/test_oscd.py
+++ b/tests/datasets/test_oscd.py
@@ -5,7 +5,7 @@ import glob
 import os
 import shutil
 from pathlib import Path
-from typing import Generator
+
 
 import pytest
 import torch

--- a/tests/datasets/test_oscd.py
+++ b/tests/datasets/test_oscd.py
@@ -65,7 +65,7 @@ class TestOSCD:
 
         bands, split = request.param
         root = str(tmp_path)
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return OSCD(
             root, split, bands, transforms=transforms, download=True, checksum=True
         )

--- a/tests/datasets/test_oscd.py
+++ b/tests/datasets/test_oscd.py
@@ -27,7 +27,7 @@ class TestOSCD:
     @pytest.fixture(params=zip(["all", "rgb"], ["train", "test"]))
     def dataset(
         self,
-        monkeypatch: Generator[MonkeyPatch, None, None],
+        monkeypatch: MonkeyPatch,
         tmp_path: Path,
         request: SubRequest,
     ) -> OSCD:

--- a/tests/datasets/test_oscd.py
+++ b/tests/datasets/test_oscd.py
@@ -26,10 +26,7 @@ def download_url(url: str, root: str, *args: str, **kwargs: str) -> None:
 class TestOSCD:
     @pytest.fixture(params=zip(["all", "rgb"], ["train", "test"]))
     def dataset(
-        self,
-        monkeypatch: MonkeyPatch,
-        tmp_path: Path,
-        request: SubRequest,
+        self, monkeypatch: MonkeyPatch, tmp_path: Path, request: SubRequest
     ) -> OSCD:
         monkeypatch.setattr(torchgeo.datasets.oscd, "download_url", download_url)
         md5s = {

--- a/tests/datasets/test_oscd.py
+++ b/tests/datasets/test_oscd.py
@@ -31,9 +31,7 @@ class TestOSCD:
         tmp_path: Path,
         request: SubRequest,
     ) -> OSCD:
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            torchgeo.datasets.oscd, "download_url", download_url
-        )
+        monkeypatch.setattr(torchgeo.datasets.oscd, "download_url", download_url)
         md5s = {
             "Onera Satellite Change Detection dataset - Images.zip": (
                 "fb4e3f54c3a31fd3f21f98cad4ddfb74"
@@ -45,7 +43,7 @@ class TestOSCD:
                 "ca0ba73ba66d06fa4903e269ef12eb50"
             ),
         }
-        monkeypatch.setattr(OSCD, "md5s", md5s)  # type: ignore[attr-defined]
+        monkeypatch.setattr(OSCD, "md5s", md5s)
         urls = {
             "Onera Satellite Change Detection dataset - Images.zip": os.path.join(
                 "tests",
@@ -66,11 +64,11 @@ class TestOSCD:
                 "Onera Satellite Change Detection dataset - Test Labels.zip",
             ),
         }
-        monkeypatch.setattr(OSCD, "urls", urls)  # type: ignore[attr-defined]
+        monkeypatch.setattr(OSCD, "urls", urls)
 
         bands, split = request.param
         root = str(tmp_path)
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return OSCD(
             root, split, bands, transforms=transforms, download=True, checksum=True
         )

--- a/tests/datasets/test_patternnet.py
+++ b/tests/datasets/test_patternnet.py
@@ -5,7 +5,6 @@ import os
 import shutil
 from pathlib import Path
 
-
 import matplotlib.pyplot as plt
 import pytest
 import torch

--- a/tests/datasets/test_patternnet.py
+++ b/tests/datasets/test_patternnet.py
@@ -23,7 +23,7 @@ def download_url(url: str, root: str, *args: str, **kwargs: str) -> None:
 class TestPatternNet:
     @pytest.fixture(params=["train", "test"])
     def dataset(
-        self, monkeypatch: Generator[MonkeyPatch, None, None], tmp_path: Path
+        self, monkeypatch: MonkeyPatch, tmp_path: Path
     ) -> PatternNet:
         monkeypatch.setattr(torchgeo.datasets.patternnet, "download_url", download_url)
         md5 = "5649754c78219a2c19074ff93666cc61"

--- a/tests/datasets/test_patternnet.py
+++ b/tests/datasets/test_patternnet.py
@@ -4,7 +4,7 @@
 import os
 import shutil
 from pathlib import Path
-from typing import Generator
+
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/datasets/test_patternnet.py
+++ b/tests/datasets/test_patternnet.py
@@ -25,15 +25,13 @@ class TestPatternNet:
     def dataset(
         self, monkeypatch: Generator[MonkeyPatch, None, None], tmp_path: Path
     ) -> PatternNet:
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            torchgeo.datasets.patternnet, "download_url", download_url
-        )
+        monkeypatch.setattr(torchgeo.datasets.patternnet, "download_url", download_url)
         md5 = "5649754c78219a2c19074ff93666cc61"
-        monkeypatch.setattr(PatternNet, "md5", md5)  # type: ignore[attr-defined]
+        monkeypatch.setattr(PatternNet, "md5", md5)
         url = os.path.join("tests", "data", "patternnet", "PatternNet.zip")
-        monkeypatch.setattr(PatternNet, "url", url)  # type: ignore[attr-defined]
+        monkeypatch.setattr(PatternNet, "url", url)
         root = str(tmp_path)
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return PatternNet(root, transforms, download=True, checksum=True)
 
     def test_getitem(self, dataset: PatternNet) -> None:

--- a/tests/datasets/test_patternnet.py
+++ b/tests/datasets/test_patternnet.py
@@ -29,7 +29,7 @@ class TestPatternNet:
         url = os.path.join("tests", "data", "patternnet", "PatternNet.zip")
         monkeypatch.setattr(PatternNet, "url", url)
         root = str(tmp_path)
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return PatternNet(root, transforms, download=True, checksum=True)
 
     def test_getitem(self, dataset: PatternNet) -> None:

--- a/tests/datasets/test_patternnet.py
+++ b/tests/datasets/test_patternnet.py
@@ -22,9 +22,7 @@ def download_url(url: str, root: str, *args: str, **kwargs: str) -> None:
 
 class TestPatternNet:
     @pytest.fixture(params=["train", "test"])
-    def dataset(
-        self, monkeypatch: MonkeyPatch, tmp_path: Path
-    ) -> PatternNet:
+    def dataset(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> PatternNet:
         monkeypatch.setattr(torchgeo.datasets.patternnet, "download_url", download_url)
         md5 = "5649754c78219a2c19074ff93666cc61"
         monkeypatch.setattr(PatternNet, "md5", md5)

--- a/tests/datasets/test_potsdam.py
+++ b/tests/datasets/test_potsdam.py
@@ -5,7 +5,6 @@ import os
 import shutil
 from pathlib import Path
 
-
 import matplotlib.pyplot as plt
 import pytest
 import torch

--- a/tests/datasets/test_potsdam.py
+++ b/tests/datasets/test_potsdam.py
@@ -4,7 +4,7 @@
 import os
 import shutil
 from pathlib import Path
-from typing import Generator
+
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/datasets/test_potsdam.py
+++ b/tests/datasets/test_potsdam.py
@@ -19,7 +19,7 @@ from torchgeo.datasets import Potsdam2D
 class TestPotsdam2D:
     @pytest.fixture(params=["train", "test"])
     def dataset(
-        self, monkeypatch: Generator[MonkeyPatch, None, None], request: SubRequest
+        self, monkeypatch: MonkeyPatch, request: SubRequest
     ) -> Potsdam2D:
         md5s = ["e47175da529c5844052c7d483b483a30", "0cb795003a01154a72db7efaabbc76ae"]
         splits = {

--- a/tests/datasets/test_potsdam.py
+++ b/tests/datasets/test_potsdam.py
@@ -28,7 +28,7 @@ class TestPotsdam2D:
         monkeypatch.setattr(Potsdam2D, "splits", splits)
         root = os.path.join("tests", "data", "potsdam")
         split = request.param
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return Potsdam2D(root, split, transforms, checksum=True)
 
     def test_getitem(self, dataset: Potsdam2D) -> None:

--- a/tests/datasets/test_potsdam.py
+++ b/tests/datasets/test_potsdam.py
@@ -26,11 +26,11 @@ class TestPotsdam2D:
             "train": ["top_potsdam_2_10", "top_potsdam_2_11"],
             "test": ["top_potsdam_5_15", "top_potsdam_6_15"],
         }
-        monkeypatch.setattr(Potsdam2D, "md5s", md5s)  # type: ignore[attr-defined]
-        monkeypatch.setattr(Potsdam2D, "splits", splits)  # type: ignore[attr-defined]
+        monkeypatch.setattr(Potsdam2D, "md5s", md5s)
+        monkeypatch.setattr(Potsdam2D, "splits", splits)
         root = os.path.join("tests", "data", "potsdam")
         split = request.param
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return Potsdam2D(root, split, transforms, checksum=True)
 
     def test_getitem(self, dataset: Potsdam2D) -> None:

--- a/tests/datasets/test_potsdam.py
+++ b/tests/datasets/test_potsdam.py
@@ -18,9 +18,7 @@ from torchgeo.datasets import Potsdam2D
 
 class TestPotsdam2D:
     @pytest.fixture(params=["train", "test"])
-    def dataset(
-        self, monkeypatch: MonkeyPatch, request: SubRequest
-    ) -> Potsdam2D:
+    def dataset(self, monkeypatch: MonkeyPatch, request: SubRequest) -> Potsdam2D:
         md5s = ["e47175da529c5844052c7d483b483a30", "0cb795003a01154a72db7efaabbc76ae"]
         splits = {
             "train": ["top_potsdam_2_10", "top_potsdam_2_11"],

--- a/tests/datasets/test_resisc45.py
+++ b/tests/datasets/test_resisc45.py
@@ -27,7 +27,7 @@ class TestRESISC45:
     @pytest.fixture(params=["train", "val", "test"])
     def dataset(
         self,
-        monkeypatch: Generator[MonkeyPatch, None, None],
+        monkeypatch: MonkeyPatch,
         tmp_path: Path,
         request: SubRequest,
     ) -> RESISC45:

--- a/tests/datasets/test_resisc45.py
+++ b/tests/datasets/test_resisc45.py
@@ -6,7 +6,6 @@ import shutil
 import sys
 from pathlib import Path
 
-
 import matplotlib.pyplot as plt
 import pytest
 import torch

--- a/tests/datasets/test_resisc45.py
+++ b/tests/datasets/test_resisc45.py
@@ -57,7 +57,7 @@ class TestRESISC45:
         )
         root = str(tmp_path)
         split = request.param
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return RESISC45(root, split, transforms, download=True, checksum=True)
 
     def test_getitem(self, dataset: RESISC45) -> None:

--- a/tests/datasets/test_resisc45.py
+++ b/tests/datasets/test_resisc45.py
@@ -33,14 +33,12 @@ class TestRESISC45:
     ) -> RESISC45:
         pytest.importorskip("rarfile", minversion="3")
 
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            torchgeo.datasets.resisc45, "download_url", download_url
-        )
+        monkeypatch.setattr(torchgeo.datasets.resisc45, "download_url", download_url)
         md5 = "5895dea3757ba88707d52f5521c444d3"
-        monkeypatch.setattr(RESISC45, "md5", md5)  # type: ignore[attr-defined]
+        monkeypatch.setattr(RESISC45, "md5", md5)
         url = os.path.join("tests", "data", "resisc45", "NWPU-RESISC45.rar")
-        monkeypatch.setattr(RESISC45, "url", url)  # type: ignore[attr-defined]
-        monkeypatch.setattr(  # type: ignore[attr-defined]
+        monkeypatch.setattr(RESISC45, "url", url)
+        monkeypatch.setattr(
             RESISC45,
             "split_urls",
             {
@@ -51,7 +49,7 @@ class TestRESISC45:
                 "test": os.path.join("tests", "data", "resisc45", "resisc45-test.txt"),
             },
         )
-        monkeypatch.setattr(  # type: ignore[attr-defined]
+        monkeypatch.setattr(
             RESISC45,
             "split_md5s",
             {
@@ -62,7 +60,7 @@ class TestRESISC45:
         )
         root = str(tmp_path)
         split = request.param
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return RESISC45(root, split, transforms, download=True, checksum=True)
 
     def test_getitem(self, dataset: RESISC45) -> None:

--- a/tests/datasets/test_resisc45.py
+++ b/tests/datasets/test_resisc45.py
@@ -5,7 +5,7 @@ import os
 import shutil
 import sys
 from pathlib import Path
-from typing import Generator
+
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/datasets/test_resisc45.py
+++ b/tests/datasets/test_resisc45.py
@@ -26,10 +26,7 @@ def download_url(url: str, root: str, *args: str, **kwargs: str) -> None:
 class TestRESISC45:
     @pytest.fixture(params=["train", "val", "test"])
     def dataset(
-        self,
-        monkeypatch: MonkeyPatch,
-        tmp_path: Path,
-        request: SubRequest,
+        self, monkeypatch: MonkeyPatch, tmp_path: Path, request: SubRequest
     ) -> RESISC45:
         pytest.importorskip("rarfile", minversion="3")
 

--- a/tests/datasets/test_seco.py
+++ b/tests/datasets/test_seco.py
@@ -31,10 +31,8 @@ class TestSeasonalContrastS2:
         tmp_path: Path,
         request: SubRequest,
     ) -> SeasonalContrastS2:
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            torchgeo.datasets.seco, "download_url", download_url
-        )
-        monkeypatch.setattr(  # type: ignore[attr-defined]
+        monkeypatch.setattr(torchgeo.datasets.seco, "download_url", download_url)
+        monkeypatch.setattr(
             SeasonalContrastS2,
             "md5s",
             {
@@ -42,7 +40,7 @@ class TestSeasonalContrastS2:
                 "1m": "3bb3fcf90f5de7d5781ce0cb85fd20af",
             },
         )
-        monkeypatch.setattr(  # type: ignore[attr-defined]
+        monkeypatch.setattr(
             SeasonalContrastS2,
             "urls",
             {
@@ -52,7 +50,7 @@ class TestSeasonalContrastS2:
         )
         root = str(tmp_path)
         version, bands = request.param
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return SeasonalContrastS2(
             root, version, bands, transforms, download=True, checksum=True
         )
@@ -105,5 +103,5 @@ class TestSeasonalContrastS2:
             plt.close()
 
             with pytest.raises(ValueError, match="doesn't support plotting"):
-                x["prediction"] = torch.tensor(1)  # type: ignore[attr-defined]
+                x["prediction"] = torch.tensor(1)
                 dataset.plot(x)

--- a/tests/datasets/test_seco.py
+++ b/tests/datasets/test_seco.py
@@ -27,7 +27,7 @@ class TestSeasonalContrastS2:
     @pytest.fixture(params=zip(["100k", "1m"], [["B1"], SeasonalContrastS2.ALL_BANDS]))
     def dataset(
         self,
-        monkeypatch: Generator[MonkeyPatch, None, None],
+        monkeypatch: MonkeyPatch,
         tmp_path: Path,
         request: SubRequest,
     ) -> SeasonalContrastS2:

--- a/tests/datasets/test_seco.py
+++ b/tests/datasets/test_seco.py
@@ -26,10 +26,7 @@ def download_url(url: str, root: str, *args: str, **kwargs: str) -> None:
 class TestSeasonalContrastS2:
     @pytest.fixture(params=zip(["100k", "1m"], [["B1"], SeasonalContrastS2.ALL_BANDS]))
     def dataset(
-        self,
-        monkeypatch: MonkeyPatch,
-        tmp_path: Path,
-        request: SubRequest,
+        self, monkeypatch: MonkeyPatch, tmp_path: Path, request: SubRequest
     ) -> SeasonalContrastS2:
         monkeypatch.setattr(torchgeo.datasets.seco, "download_url", download_url)
         monkeypatch.setattr(

--- a/tests/datasets/test_seco.py
+++ b/tests/datasets/test_seco.py
@@ -5,7 +5,7 @@ import glob
 import os
 import shutil
 from pathlib import Path
-from typing import Generator
+
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/datasets/test_seco.py
+++ b/tests/datasets/test_seco.py
@@ -47,7 +47,7 @@ class TestSeasonalContrastS2:
         )
         root = str(tmp_path)
         version, bands = request.param
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return SeasonalContrastS2(
             root, version, bands, transforms, download=True, checksum=True
         )

--- a/tests/datasets/test_seco.py
+++ b/tests/datasets/test_seco.py
@@ -6,7 +6,6 @@ import os
 import shutil
 from pathlib import Path
 
-
 import matplotlib.pyplot as plt
 import pytest
 import torch

--- a/tests/datasets/test_sen12ms.py
+++ b/tests/datasets/test_sen12ms.py
@@ -19,7 +19,7 @@ from torchgeo.datasets import SEN12MS
 class TestSEN12MS:
     @pytest.fixture(params=["train", "test"])
     def dataset(
-        self, monkeypatch: Generator[MonkeyPatch, None, None], request: SubRequest
+        self, monkeypatch: MonkeyPatch, request: SubRequest
     ) -> SEN12MS:
         md5s = [
             "b7d9e183a460979e997b443517a78ded",

--- a/tests/datasets/test_sen12ms.py
+++ b/tests/datasets/test_sen12ms.py
@@ -4,7 +4,6 @@
 import os
 from pathlib import Path
 
-
 import matplotlib.pyplot as plt
 import pytest
 import torch

--- a/tests/datasets/test_sen12ms.py
+++ b/tests/datasets/test_sen12ms.py
@@ -38,10 +38,10 @@ class TestSEN12MS:
             "02d5128ac1fc2bf8762091b4f319762d",
         ]
 
-        monkeypatch.setattr(SEN12MS, "md5s", md5s)  # type: ignore[attr-defined]
+        monkeypatch.setattr(SEN12MS, "md5s", md5s)
         root = os.path.join("tests", "data", "sen12ms")
         split = request.param
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return SEN12MS(root, split, transforms=transforms, checksum=True)
 
     def test_getitem(self, dataset: SEN12MS) -> None:

--- a/tests/datasets/test_sen12ms.py
+++ b/tests/datasets/test_sen12ms.py
@@ -3,7 +3,7 @@
 
 import os
 from pathlib import Path
-from typing import Generator
+
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/datasets/test_sen12ms.py
+++ b/tests/datasets/test_sen12ms.py
@@ -18,9 +18,7 @@ from torchgeo.datasets import SEN12MS
 
 class TestSEN12MS:
     @pytest.fixture(params=["train", "test"])
-    def dataset(
-        self, monkeypatch: MonkeyPatch, request: SubRequest
-    ) -> SEN12MS:
+    def dataset(self, monkeypatch: MonkeyPatch, request: SubRequest) -> SEN12MS:
         md5s = [
             "b7d9e183a460979e997b443517a78ded",
             "7131dbb098c832fff84c2b8a0c8f1126",

--- a/tests/datasets/test_sen12ms.py
+++ b/tests/datasets/test_sen12ms.py
@@ -39,7 +39,7 @@ class TestSEN12MS:
         monkeypatch.setattr(SEN12MS, "md5s", md5s)
         root = os.path.join("tests", "data", "sen12ms")
         split = request.param
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return SEN12MS(root, split, transforms=transforms, checksum=True)
 
     def test_getitem(self, dataset: SEN12MS) -> None:

--- a/tests/datasets/test_sentinel.py
+++ b/tests/datasets/test_sentinel.py
@@ -30,7 +30,7 @@ class TestSentinel2:
             "B09",
             "B11",
         ]
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return Sentinel2(root, bands=bands, transforms=transforms)
 
     def test_separate_files(self, dataset: Sentinel2) -> None:

--- a/tests/datasets/test_sentinel.py
+++ b/tests/datasets/test_sentinel.py
@@ -30,7 +30,7 @@ class TestSentinel2:
             "B09",
             "B11",
         ]
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return Sentinel2(root, bands=bands, transforms=transforms)
 
     def test_separate_files(self, dataset: Sentinel2) -> None:

--- a/tests/datasets/test_so2sat.py
+++ b/tests/datasets/test_so2sat.py
@@ -29,10 +29,10 @@ class TestSo2Sat:
             "test": "9a3bbe181b038d4e51f122c4be3c569e",
         }
 
-        monkeypatch.setattr(So2Sat, "md5s", md5s)  # type: ignore[attr-defined]
+        monkeypatch.setattr(So2Sat, "md5s", md5s)
         root = os.path.join("tests", "data", "so2sat")
         split = request.param
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return So2Sat(root=root, split=split, transforms=transforms, checksum=True)
 
     @pytest.fixture
@@ -46,9 +46,7 @@ class TestSo2Sat:
                 raise ImportError()
             return import_orig(name, *args, **kwargs)
 
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            builtins, "__import__", mocked_import
-        )
+        monkeypatch.setattr(builtins, "__import__", mocked_import)
 
     def test_getitem(self, dataset: So2Sat) -> None:
         x = dataset[0]

--- a/tests/datasets/test_so2sat.py
+++ b/tests/datasets/test_so2sat.py
@@ -20,9 +20,7 @@ pytest.importorskip("h5py")
 
 class TestSo2Sat:
     @pytest.fixture(params=["train", "validation", "test"])
-    def dataset(
-        self, monkeypatch: MonkeyPatch, request: SubRequest
-    ) -> So2Sat:
+    def dataset(self, monkeypatch: MonkeyPatch, request: SubRequest) -> So2Sat:
         md5s = {
             "train": "82e0f2d51766b89cb905dbaf8275eb5b",
             "validation": "bf292ae4737c1698b1a3c6f5e742e0e1",
@@ -36,9 +34,7 @@ class TestSo2Sat:
         return So2Sat(root=root, split=split, transforms=transforms, checksum=True)
 
     @pytest.fixture
-    def mock_missing_module(
-        self, monkeypatch: MonkeyPatch
-    ) -> None:
+    def mock_missing_module(self, monkeypatch: MonkeyPatch) -> None:
         import_orig = builtins.__import__
 
         def mocked_import(name: str, *args: Any, **kwargs: Any) -> Any:

--- a/tests/datasets/test_so2sat.py
+++ b/tests/datasets/test_so2sat.py
@@ -30,7 +30,7 @@ class TestSo2Sat:
         monkeypatch.setattr(So2Sat, "md5s", md5s)
         root = os.path.join("tests", "data", "so2sat")
         split = request.param
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return So2Sat(root=root, split=split, transforms=transforms, checksum=True)
 
     @pytest.fixture

--- a/tests/datasets/test_so2sat.py
+++ b/tests/datasets/test_so2sat.py
@@ -21,7 +21,7 @@ pytest.importorskip("h5py")
 class TestSo2Sat:
     @pytest.fixture(params=["train", "validation", "test"])
     def dataset(
-        self, monkeypatch: Generator[MonkeyPatch, None, None], request: SubRequest
+        self, monkeypatch: MonkeyPatch, request: SubRequest
     ) -> So2Sat:
         md5s = {
             "train": "82e0f2d51766b89cb905dbaf8275eb5b",
@@ -37,7 +37,7 @@ class TestSo2Sat:
 
     @pytest.fixture
     def mock_missing_module(
-        self, monkeypatch: Generator[MonkeyPatch, None, None]
+        self, monkeypatch: MonkeyPatch
     ) -> None:
         import_orig = builtins.__import__
 

--- a/tests/datasets/test_so2sat.py
+++ b/tests/datasets/test_so2sat.py
@@ -4,7 +4,7 @@
 import builtins
 import os
 from pathlib import Path
-from typing import Any, Generator
+from typing import Any
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/datasets/test_spacenet.py
+++ b/tests/datasets/test_spacenet.py
@@ -6,7 +6,7 @@ import itertools
 import os
 import shutil
 from pathlib import Path
-from typing import Generator
+
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/datasets/test_spacenet.py
+++ b/tests/datasets/test_spacenet.py
@@ -235,7 +235,7 @@ class TestSpaceNet5:
 
     def test_getitem(self, dataset: SpaceNet5) -> None:
         # Iterate over all elements to maximize coverage
-        samples = [i for i in dataset]
+        samples = [dataset[i] for i in range(len(dataset))]
         x = samples[0]
         assert isinstance(x, dict)
         assert isinstance(x["image"], torch.Tensor)

--- a/tests/datasets/test_spacenet.py
+++ b/tests/datasets/test_spacenet.py
@@ -39,7 +39,7 @@ class TestSpaceNet1:
     def dataset(
         self,
         request: SubRequest,
-        monkeypatch: Generator[MonkeyPatch, None, None],
+        monkeypatch: MonkeyPatch,
         tmp_path: Path,
     ) -> SpaceNet1:
         radiant_mlhub = pytest.importorskip("radiant_mlhub", minversion="0.2.1")
@@ -88,7 +88,7 @@ class TestSpaceNet2:
     def dataset(
         self,
         request: SubRequest,
-        monkeypatch: Generator[MonkeyPatch, None, None],
+        monkeypatch: MonkeyPatch,
         tmp_path: Path,
     ) -> SpaceNet2:
         radiant_mlhub = pytest.importorskip("radiant_mlhub", minversion="0.2.1")
@@ -154,7 +154,7 @@ class TestSpaceNet4:
     def dataset(
         self,
         request: SubRequest,
-        monkeypatch: Generator[MonkeyPatch, None, None],
+        monkeypatch: MonkeyPatch,
         tmp_path: Path,
     ) -> SpaceNet4:
         radiant_mlhub = pytest.importorskip("radiant_mlhub", minversion="0.2.1")
@@ -222,7 +222,7 @@ class TestSpaceNet5:
     def dataset(
         self,
         request: SubRequest,
-        monkeypatch: Generator[MonkeyPatch, None, None],
+        monkeypatch: MonkeyPatch,
         tmp_path: Path,
     ) -> SpaceNet5:
         radiant_mlhub = pytest.importorskip("radiant_mlhub", minversion="0.2.1")
@@ -290,7 +290,7 @@ class TestSpaceNet7:
     def dataset(
         self,
         request: SubRequest,
-        monkeypatch: Generator[MonkeyPatch, None, None],
+        monkeypatch: MonkeyPatch,
         tmp_path: Path,
     ) -> SpaceNet7:
         radiant_mlhub = pytest.importorskip("radiant_mlhub", minversion="0.2.1")

--- a/tests/datasets/test_spacenet.py
+++ b/tests/datasets/test_spacenet.py
@@ -43,17 +43,13 @@ class TestSpaceNet1:
         tmp_path: Path,
     ) -> SpaceNet1:
         radiant_mlhub = pytest.importorskip("radiant_mlhub", minversion="0.2.1")
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            radiant_mlhub.Collection, "fetch", fetch_collection
-        )
+        monkeypatch.setattr(radiant_mlhub.Collection, "fetch", fetch_collection)
         test_md5 = {"sn1_AOI_1_RIO": "829652022c2df4511ee4ae05bc290250"}
 
         # Refer https://github.com/python/mypy/issues/1032
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            SpaceNet1, "collection_md5_dict", test_md5
-        )
+        monkeypatch.setattr(SpaceNet1, "collection_md5_dict", test_md5)
         root = str(tmp_path)
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return SpaceNet1(
             root, image=request.param, transforms=transforms, download=True, api_key=""
         )
@@ -96,9 +92,7 @@ class TestSpaceNet2:
         tmp_path: Path,
     ) -> SpaceNet2:
         radiant_mlhub = pytest.importorskip("radiant_mlhub", minversion="0.2.1")
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            radiant_mlhub.Collection, "fetch", fetch_collection
-        )
+        monkeypatch.setattr(radiant_mlhub.Collection, "fetch", fetch_collection)
         test_md5 = {
             "sn2_AOI_2_Vegas": "b3236f58604a9d746c4e09b3e487e427",
             "sn2_AOI_3_Paris": "811e6a26fdeb8be445fed99769fa52c5",
@@ -106,11 +100,9 @@ class TestSpaceNet2:
             "sn2_AOI_5_Khartoum": "435535120414b74165aa87f051c3a2b3",
         }
 
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            SpaceNet2, "collection_md5_dict", test_md5
-        )
+        monkeypatch.setattr(SpaceNet2, "collection_md5_dict", test_md5)
         root = str(tmp_path)
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return SpaceNet2(
             root,
             image=request.param,
@@ -166,18 +158,14 @@ class TestSpaceNet4:
         tmp_path: Path,
     ) -> SpaceNet4:
         radiant_mlhub = pytest.importorskip("radiant_mlhub", minversion="0.2.1")
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            radiant_mlhub.Collection, "fetch", fetch_collection
-        )
+        monkeypatch.setattr(radiant_mlhub.Collection, "fetch", fetch_collection)
         test_md5 = {"sn4_AOI_6_Atlanta": "ea37c2d87e2c3a1d8b2a7c2230080d46"}
 
         test_angles = ["nadir", "off-nadir", "very-off-nadir"]
 
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            SpaceNet4, "collection_md5_dict", test_md5
-        )
+        monkeypatch.setattr(SpaceNet4, "collection_md5_dict", test_md5)
         root = str(tmp_path)
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return SpaceNet4(
             root,
             image=request.param,
@@ -238,19 +226,15 @@ class TestSpaceNet5:
         tmp_path: Path,
     ) -> SpaceNet5:
         radiant_mlhub = pytest.importorskip("radiant_mlhub", minversion="0.2.1")
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            radiant_mlhub.Collection, "fetch", fetch_collection
-        )
+        monkeypatch.setattr(radiant_mlhub.Collection, "fetch", fetch_collection)
         test_md5 = {
             "sn5_AOI_7_Moscow": "e0d5f41f1b6b0ee7696c15e5ff3141f5",
             "sn5_AOI_8_Mumbai": "ab898700ee586a137af492b84a08e662",
         }
 
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            SpaceNet5, "collection_md5_dict", test_md5
-        )
+        monkeypatch.setattr(SpaceNet5, "collection_md5_dict", test_md5)
         root = str(tmp_path)
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return SpaceNet5(
             root,
             image=request.param[0],
@@ -263,7 +247,7 @@ class TestSpaceNet5:
 
     def test_getitem(self, dataset: SpaceNet5) -> None:
         # Iterate over all elements to maximize coverage
-        samples = [i for i in dataset]  # type: ignore[attr-defined]
+        samples = [i for i in dataset]
         x = samples[0]
         assert isinstance(x, dict)
         assert isinstance(x["image"], torch.Tensor)
@@ -310,20 +294,16 @@ class TestSpaceNet7:
         tmp_path: Path,
     ) -> SpaceNet7:
         radiant_mlhub = pytest.importorskip("radiant_mlhub", minversion="0.2.1")
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            radiant_mlhub.Collection, "fetch", fetch_collection
-        )
+        monkeypatch.setattr(radiant_mlhub.Collection, "fetch", fetch_collection)
         test_md5 = {
             "sn7_train_source": "254fd6b16e350b071137b2658332091f",
             "sn7_train_labels": "05befe86b037a3af75c7143553033664",
             "sn7_test_source": "37d98d44a9da39657ed4b7beee22a21e",
         }
 
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            SpaceNet7, "collection_md5_dict", test_md5
-        )
+        monkeypatch.setattr(SpaceNet7, "collection_md5_dict", test_md5)
         root = str(tmp_path)
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return SpaceNet7(
             root, split=request.param, transforms=transforms, download=True, api_key=""
         )

--- a/tests/datasets/test_spacenet.py
+++ b/tests/datasets/test_spacenet.py
@@ -7,7 +7,6 @@ import os
 import shutil
 from pathlib import Path
 
-
 import matplotlib.pyplot as plt
 import pytest
 import torch

--- a/tests/datasets/test_spacenet.py
+++ b/tests/datasets/test_spacenet.py
@@ -46,7 +46,7 @@ class TestSpaceNet1:
         # Refer https://github.com/python/mypy/issues/1032
         monkeypatch.setattr(SpaceNet1, "collection_md5_dict", test_md5)
         root = str(tmp_path)
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return SpaceNet1(
             root, image=request.param, transforms=transforms, download=True, api_key=""
         )
@@ -96,7 +96,7 @@ class TestSpaceNet2:
 
         monkeypatch.setattr(SpaceNet2, "collection_md5_dict", test_md5)
         root = str(tmp_path)
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return SpaceNet2(
             root,
             image=request.param,
@@ -156,7 +156,7 @@ class TestSpaceNet4:
 
         monkeypatch.setattr(SpaceNet4, "collection_md5_dict", test_md5)
         root = str(tmp_path)
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return SpaceNet4(
             root,
             image=request.param,
@@ -222,7 +222,7 @@ class TestSpaceNet5:
 
         monkeypatch.setattr(SpaceNet5, "collection_md5_dict", test_md5)
         root = str(tmp_path)
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return SpaceNet5(
             root,
             image=request.param[0],
@@ -288,7 +288,7 @@ class TestSpaceNet7:
 
         monkeypatch.setattr(SpaceNet7, "collection_md5_dict", test_md5)
         root = str(tmp_path)
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return SpaceNet7(
             root, split=request.param, transforms=transforms, download=True, api_key=""
         )

--- a/tests/datasets/test_spacenet.py
+++ b/tests/datasets/test_spacenet.py
@@ -37,10 +37,7 @@ def fetch_collection(collection_id: str, **kwargs: str) -> Collection:
 class TestSpaceNet1:
     @pytest.fixture(params=["rgb", "8band"])
     def dataset(
-        self,
-        request: SubRequest,
-        monkeypatch: MonkeyPatch,
-        tmp_path: Path,
+        self, request: SubRequest, monkeypatch: MonkeyPatch, tmp_path: Path
     ) -> SpaceNet1:
         radiant_mlhub = pytest.importorskip("radiant_mlhub", minversion="0.2.1")
         monkeypatch.setattr(radiant_mlhub.Collection, "fetch", fetch_collection)
@@ -86,10 +83,7 @@ class TestSpaceNet1:
 class TestSpaceNet2:
     @pytest.fixture(params=["PAN", "MS", "PS-MS", "PS-RGB"])
     def dataset(
-        self,
-        request: SubRequest,
-        monkeypatch: MonkeyPatch,
-        tmp_path: Path,
+        self, request: SubRequest, monkeypatch: MonkeyPatch, tmp_path: Path
     ) -> SpaceNet2:
         radiant_mlhub = pytest.importorskip("radiant_mlhub", minversion="0.2.1")
         monkeypatch.setattr(radiant_mlhub.Collection, "fetch", fetch_collection)
@@ -152,10 +146,7 @@ class TestSpaceNet2:
 class TestSpaceNet4:
     @pytest.fixture(params=["PAN", "MS", "PS-RGBNIR"])
     def dataset(
-        self,
-        request: SubRequest,
-        monkeypatch: MonkeyPatch,
-        tmp_path: Path,
+        self, request: SubRequest, monkeypatch: MonkeyPatch, tmp_path: Path
     ) -> SpaceNet4:
         radiant_mlhub = pytest.importorskip("radiant_mlhub", minversion="0.2.1")
         monkeypatch.setattr(radiant_mlhub.Collection, "fetch", fetch_collection)
@@ -220,10 +211,7 @@ class TestSpaceNet5:
         params=itertools.product(["PAN", "MS", "PS-MS", "PS-RGB"], [False, True])
     )
     def dataset(
-        self,
-        request: SubRequest,
-        monkeypatch: MonkeyPatch,
-        tmp_path: Path,
+        self, request: SubRequest, monkeypatch: MonkeyPatch, tmp_path: Path
     ) -> SpaceNet5:
         radiant_mlhub = pytest.importorskip("radiant_mlhub", minversion="0.2.1")
         monkeypatch.setattr(radiant_mlhub.Collection, "fetch", fetch_collection)
@@ -288,10 +276,7 @@ class TestSpaceNet5:
 class TestSpaceNet7:
     @pytest.fixture(params=["train", "test"])
     def dataset(
-        self,
-        request: SubRequest,
-        monkeypatch: MonkeyPatch,
-        tmp_path: Path,
+        self, request: SubRequest, monkeypatch: MonkeyPatch, tmp_path: Path
     ) -> SpaceNet7:
         radiant_mlhub = pytest.importorskip("radiant_mlhub", minversion="0.2.1")
         monkeypatch.setattr(radiant_mlhub.Collection, "fetch", fetch_collection)

--- a/tests/datasets/test_ucmerced.py
+++ b/tests/datasets/test_ucmerced.py
@@ -30,14 +30,12 @@ class TestUCMerced:
         tmp_path: Path,
         request: SubRequest,
     ) -> UCMerced:
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            torchgeo.datasets.ucmerced, "download_url", download_url
-        )
+        monkeypatch.setattr(torchgeo.datasets.ucmerced, "download_url", download_url)
         md5 = "a42ef8779469d196d8f2971ee135f030"
-        monkeypatch.setattr(UCMerced, "md5", md5)  # type: ignore[attr-defined]
+        monkeypatch.setattr(UCMerced, "md5", md5)
         url = os.path.join("tests", "data", "ucmerced", "UCMerced_LandUse.zip")
-        monkeypatch.setattr(UCMerced, "url", url)  # type: ignore[attr-defined]
-        monkeypatch.setattr(  # type: ignore[attr-defined]
+        monkeypatch.setattr(UCMerced, "url", url)
+        monkeypatch.setattr(
             UCMerced,
             "split_urls",
             {
@@ -48,7 +46,7 @@ class TestUCMerced:
                 "test": os.path.join("tests", "data", "ucmerced", "uc_merced-test.txt"),
             },
         )
-        monkeypatch.setattr(  # type: ignore[attr-defined]
+        monkeypatch.setattr(
             UCMerced,
             "split_md5s",
             {
@@ -59,7 +57,7 @@ class TestUCMerced:
         )
         root = str(tmp_path)
         split = request.param
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return UCMerced(root, split, transforms, download=True, checksum=True)
 
     def test_getitem(self, dataset: UCMerced) -> None:

--- a/tests/datasets/test_ucmerced.py
+++ b/tests/datasets/test_ucmerced.py
@@ -5,7 +5,6 @@ import os
 import shutil
 from pathlib import Path
 
-
 import matplotlib.pyplot as plt
 import pytest
 import torch

--- a/tests/datasets/test_ucmerced.py
+++ b/tests/datasets/test_ucmerced.py
@@ -25,10 +25,7 @@ def download_url(url: str, root: str, *args: str, **kwargs: str) -> None:
 class TestUCMerced:
     @pytest.fixture(params=["train", "val", "test"])
     def dataset(
-        self,
-        monkeypatch: MonkeyPatch,
-        tmp_path: Path,
-        request: SubRequest,
+        self, monkeypatch: MonkeyPatch, tmp_path: Path, request: SubRequest
     ) -> UCMerced:
         monkeypatch.setattr(torchgeo.datasets.ucmerced, "download_url", download_url)
         md5 = "a42ef8779469d196d8f2971ee135f030"

--- a/tests/datasets/test_ucmerced.py
+++ b/tests/datasets/test_ucmerced.py
@@ -4,7 +4,7 @@
 import os
 import shutil
 from pathlib import Path
-from typing import Generator
+
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/datasets/test_ucmerced.py
+++ b/tests/datasets/test_ucmerced.py
@@ -54,7 +54,7 @@ class TestUCMerced:
         )
         root = str(tmp_path)
         split = request.param
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return UCMerced(root, split, transforms, download=True, checksum=True)
 
     def test_getitem(self, dataset: UCMerced) -> None:

--- a/tests/datasets/test_ucmerced.py
+++ b/tests/datasets/test_ucmerced.py
@@ -26,7 +26,7 @@ class TestUCMerced:
     @pytest.fixture(params=["train", "val", "test"])
     def dataset(
         self,
-        monkeypatch: Generator[MonkeyPatch, None, None],
+        monkeypatch: MonkeyPatch,
         tmp_path: Path,
         request: SubRequest,
     ) -> UCMerced:

--- a/tests/datasets/test_usavars.py
+++ b/tests/datasets/test_usavars.py
@@ -51,7 +51,7 @@ class TestUSAVars:
         monkeypatch.setattr(USAVars, "label_urls", label_urls)
 
         root = str(tmp_path)
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
 
         return USAVars(root, transforms=transforms, download=True, checksum=True)
 

--- a/tests/datasets/test_usavars.py
+++ b/tests/datasets/test_usavars.py
@@ -34,15 +34,13 @@ class TestUSAVars:
         request: SubRequest,
     ) -> USAVars:
 
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            torchgeo.datasets.usavars, "download_url", download_url
-        )
+        monkeypatch.setattr(torchgeo.datasets.usavars, "download_url", download_url)
 
         md5 = "b504580a00bdc27097d5421dec50481b"
-        monkeypatch.setattr(USAVars, "md5", md5)  # type: ignore[attr-defined]
+        monkeypatch.setattr(USAVars, "md5", md5)
 
         data_url = os.path.join("tests", "data", "usavars", "uar.zip")
-        monkeypatch.setattr(USAVars, "data_url", data_url)  # type: ignore[attr-defined]
+        monkeypatch.setattr(USAVars, "data_url", data_url)
 
         label_urls = {
             "elevation": os.path.join("tests", "data", "usavars", "elevation.csv"),
@@ -53,12 +51,10 @@ class TestUSAVars:
             "roads": os.path.join("tests", "data", "usavars", "roads.csv"),
             "housing": os.path.join("tests", "data", "usavars", "housing.csv"),
         }
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            USAVars, "label_urls", label_urls
-        )
+        monkeypatch.setattr(USAVars, "label_urls", label_urls)
 
         root = str(tmp_path)
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
 
         return USAVars(root, transforms=transforms, download=True, checksum=True)
 
@@ -114,9 +110,7 @@ class TestUSAVars:
                 raise ImportError()
             return import_orig(name, *args, **kwargs)
 
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            builtins, "__import__", mocked_import
-        )
+        monkeypatch.setattr(builtins, "__import__", mocked_import)
         return package
 
     def test_mock_missing_module(

--- a/tests/datasets/test_usavars.py
+++ b/tests/datasets/test_usavars.py
@@ -29,7 +29,7 @@ class TestUSAVars:
     @pytest.fixture()
     def dataset(
         self,
-        monkeypatch: Generator[MonkeyPatch, None, None],
+        monkeypatch: MonkeyPatch,
         tmp_path: Path,
         request: SubRequest,
     ) -> USAVars:
@@ -100,7 +100,7 @@ class TestUSAVars:
 
     @pytest.fixture(params=["pandas"])
     def mock_missing_module(
-        self, monkeypatch: Generator[MonkeyPatch, None, None], request: SubRequest
+        self, monkeypatch: MonkeyPatch, request: SubRequest
     ) -> str:
         import_orig = builtins.__import__
         package = str(request.param)

--- a/tests/datasets/test_usavars.py
+++ b/tests/datasets/test_usavars.py
@@ -28,10 +28,7 @@ def download_url(url: str, root: str, *args: str, **kwargs: str) -> None:
 class TestUSAVars:
     @pytest.fixture()
     def dataset(
-        self,
-        monkeypatch: MonkeyPatch,
-        tmp_path: Path,
-        request: SubRequest,
+        self, monkeypatch: MonkeyPatch, tmp_path: Path, request: SubRequest
     ) -> USAVars:
 
         monkeypatch.setattr(torchgeo.datasets.usavars, "download_url", download_url)
@@ -99,9 +96,7 @@ class TestUSAVars:
             USAVars(str(tmp_path))
 
     @pytest.fixture(params=["pandas"])
-    def mock_missing_module(
-        self, monkeypatch: MonkeyPatch, request: SubRequest
-    ) -> str:
+    def mock_missing_module(self, monkeypatch: MonkeyPatch, request: SubRequest) -> str:
         import_orig = builtins.__import__
         package = str(request.param)
 

--- a/tests/datasets/test_usavars.py
+++ b/tests/datasets/test_usavars.py
@@ -5,7 +5,7 @@ import builtins
 import os
 import shutil
 from pathlib import Path
-from typing import Any, Generator
+from typing import Any
 
 import pytest
 import torch

--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -45,9 +45,7 @@ def mock_missing_module(monkeypatch: Generator[MonkeyPatch, None, None]) -> None
             raise ImportError()
         return import_orig(name, *args, **kwargs)
 
-    monkeypatch.setattr(  # type: ignore[attr-defined]
-        builtins, "__import__", mocked_import
-    )
+    monkeypatch.setattr(builtins, "__import__", mocked_import)
 
 
 class Dataset:
@@ -130,9 +128,7 @@ def test_unsupported_scheme() -> None:
 def test_download_and_extract_archive(
     tmp_path: Path, monkeypatch: Generator[MonkeyPatch, None, None]
 ) -> None:
-    monkeypatch.setattr(  # type: ignore[attr-defined]
-        torchgeo.datasets.utils, "download_url", download_url
-    )
+    monkeypatch.setattr(torchgeo.datasets.utils, "download_url", download_url)
     download_and_extract_archive(
         os.path.join("tests", "data", "landcoverai", "landcover.ai.v1.zip"),
         str(tmp_path),
@@ -143,9 +139,7 @@ def test_download_radiant_mlhub_dataset(
     tmp_path: Path, monkeypatch: Generator[MonkeyPatch, None, None]
 ) -> None:
     radiant_mlhub = pytest.importorskip("radiant_mlhub", minversion="0.2.1")
-    monkeypatch.setattr(  # type: ignore[attr-defined]
-        radiant_mlhub.Dataset, "fetch", fetch_dataset
-    )
+    monkeypatch.setattr(radiant_mlhub.Dataset, "fetch", fetch_dataset)
     download_radiant_mlhub_dataset("", str(tmp_path))
 
 
@@ -153,9 +147,7 @@ def test_download_radiant_mlhub_collection(
     tmp_path: Path, monkeypatch: Generator[MonkeyPatch, None, None]
 ) -> None:
     radiant_mlhub = pytest.importorskip("radiant_mlhub", minversion="0.2.1")
-    monkeypatch.setattr(  # type: ignore[attr-defined]
-        radiant_mlhub.Collection, "fetch", fetch_collection
-    )
+    monkeypatch.setattr(radiant_mlhub.Collection, "fetch", fetch_collection)
     download_radiant_mlhub_collection("", str(tmp_path))
 
 
@@ -497,49 +489,31 @@ class TestCollateFunctionsMatchingKeys:
     @pytest.fixture(scope="class")
     def samples(self) -> List[Dict[str, Any]]:
         return [
-            {
-                "image": torch.tensor([1, 2, 0]),  # type: ignore[attr-defined]
-                "crs": CRS.from_epsg(2000),
-            },
-            {
-                "image": torch.tensor([0, 0, 3]),  # type: ignore[attr-defined]
-                "crs": CRS.from_epsg(2001),
-            },
+            {"image": torch.tensor([1, 2, 0]), "crs": CRS.from_epsg(2000)},
+            {"image": torch.tensor([0, 0, 3]), "crs": CRS.from_epsg(2001)},
         ]
 
     def test_stack_unbind_samples(self, samples: List[Dict[str, Any]]) -> None:
         sample = stack_samples(samples)
-        assert sample["image"].size() == torch.Size(  # type: ignore[attr-defined]
-            [2, 3]
-        )
-        assert torch.allclose(  # type: ignore[attr-defined]
-            sample["image"],
-            torch.tensor([[1, 2, 0], [0, 0, 3]]),  # type: ignore[attr-defined]
-        )
+        assert sample["image"].size() == torch.Size([2, 3])
+        assert torch.allclose(sample["image"], torch.tensor([[1, 2, 0], [0, 0, 3]]))
         assert sample["crs"] == [CRS.from_epsg(2000), CRS.from_epsg(2001)]
 
         new_samples = unbind_samples(sample)
         for i in range(2):
-            assert torch.allclose(  # type: ignore[attr-defined]
-                samples[i]["image"], new_samples[i]["image"]
-            )
+            assert torch.allclose(samples[i]["image"], new_samples[i]["image"])
             assert samples[i]["crs"] == new_samples[i]["crs"]
 
     def test_concat_samples(self, samples: List[Dict[str, Any]]) -> None:
         sample = concat_samples(samples)
-        assert sample["image"].size() == torch.Size([6])  # type: ignore[attr-defined]
-        assert torch.allclose(  # type: ignore[attr-defined]
-            sample["image"],
-            torch.tensor([1, 2, 0, 0, 0, 3]),  # type: ignore[attr-defined]
-        )
+        assert sample["image"].size() == torch.Size([6])
+        assert torch.allclose(sample["image"], torch.tensor([1, 2, 0, 0, 0, 3]))
         assert sample["crs"] == CRS.from_epsg(2000)
 
     def test_merge_samples(self, samples: List[Dict[str, Any]]) -> None:
         sample = merge_samples(samples)
-        assert sample["image"].size() == torch.Size([3])  # type: ignore[attr-defined]
-        assert torch.allclose(  # type: ignore[attr-defined]
-            sample["image"], torch.tensor([1, 2, 3])  # type: ignore[attr-defined]
-        )
+        assert sample["image"].size() == torch.Size([3])
+        assert torch.allclose(sample["image"], torch.tensor([1, 2, 3]))
         assert sample["crs"] == CRS.from_epsg(2001)
 
 
@@ -547,64 +521,40 @@ class TestCollateFunctionsDifferingKeys:
     @pytest.fixture(scope="class")
     def samples(self) -> List[Dict[str, Any]]:
         return [
-            {
-                "image": torch.tensor([1, 2, 0]),  # type: ignore[attr-defined]
-                "crs1": CRS.from_epsg(2000),
-            },
-            {
-                "mask": torch.tensor([0, 0, 3]),  # type: ignore[attr-defined]
-                "crs2": CRS.from_epsg(2001),
-            },
+            {"image": torch.tensor([1, 2, 0]), "crs1": CRS.from_epsg(2000)},
+            {"mask": torch.tensor([0, 0, 3]), "crs2": CRS.from_epsg(2001)},
         ]
 
     def test_stack_unbind_samples(self, samples: List[Dict[str, Any]]) -> None:
         sample = stack_samples(samples)
-        assert sample["image"].size() == torch.Size(  # type: ignore[attr-defined]
-            [1, 3]
-        )
-        assert sample["mask"].size() == torch.Size([1, 3])  # type: ignore[attr-defined]
-        assert torch.allclose(  # type: ignore[attr-defined]
-            sample["image"], torch.tensor([[1, 2, 0]])  # type: ignore[attr-defined]
-        )
-        assert torch.allclose(  # type: ignore[attr-defined]
-            sample["mask"], torch.tensor([[0, 0, 3]])  # type: ignore[attr-defined]
-        )
+        assert sample["image"].size() == torch.Size([1, 3])
+        assert sample["mask"].size() == torch.Size([1, 3])
+        assert torch.allclose(sample["image"], torch.tensor([[1, 2, 0]]))
+        assert torch.allclose(sample["mask"], torch.tensor([[0, 0, 3]]))
         assert sample["crs1"] == [CRS.from_epsg(2000)]
         assert sample["crs2"] == [CRS.from_epsg(2001)]
 
         new_samples = unbind_samples(sample)
-        assert torch.allclose(  # type: ignore[attr-defined]
-            samples[0]["image"], new_samples[0]["image"]
-        )
+        assert torch.allclose(samples[0]["image"], new_samples[0]["image"])
         assert samples[0]["crs1"] == new_samples[0]["crs1"]
-        assert torch.allclose(  # type: ignore[attr-defined]
-            samples[1]["mask"], new_samples[0]["mask"]
-        )
+        assert torch.allclose(samples[1]["mask"], new_samples[0]["mask"])
         assert samples[1]["crs2"] == new_samples[0]["crs2"]
 
     def test_concat_samples(self, samples: List[Dict[str, Any]]) -> None:
         sample = concat_samples(samples)
-        assert sample["image"].size() == torch.Size([3])  # type: ignore[attr-defined]
-        assert sample["mask"].size() == torch.Size([3])  # type: ignore[attr-defined]
-        assert torch.allclose(  # type: ignore[attr-defined]
-            sample["image"], torch.tensor([1, 2, 0])  # type: ignore[attr-defined]
-        )
-        assert torch.allclose(  # type: ignore[attr-defined]
-            sample["mask"], torch.tensor([0, 0, 3])  # type: ignore[attr-defined]
-        )
+        assert sample["image"].size() == torch.Size([3])
+        assert sample["mask"].size() == torch.Size([3])
+        assert torch.allclose(sample["image"], torch.tensor([1, 2, 0]))
+        assert torch.allclose(sample["mask"], torch.tensor([0, 0, 3]))
         assert sample["crs1"] == CRS.from_epsg(2000)
         assert sample["crs2"] == CRS.from_epsg(2001)
 
     def test_merge_samples(self, samples: List[Dict[str, Any]]) -> None:
         sample = merge_samples(samples)
-        assert sample["image"].size() == torch.Size([3])  # type: ignore[attr-defined]
-        assert sample["mask"].size() == torch.Size([3])  # type: ignore[attr-defined]
-        assert torch.allclose(  # type: ignore[attr-defined]
-            sample["image"], torch.tensor([1, 2, 0])  # type: ignore[attr-defined]
-        )
-        assert torch.allclose(  # type: ignore[attr-defined]
-            sample["mask"], torch.tensor([0, 0, 3])  # type: ignore[attr-defined]
-        )
+        assert sample["image"].size() == torch.Size([3])
+        assert sample["mask"].size() == torch.Size([3])
+        assert torch.allclose(sample["image"], torch.tensor([1, 2, 0]))
+        assert torch.allclose(sample["mask"], torch.tensor([0, 0, 3]))
         assert sample["crs1"] == CRS.from_epsg(2000)
         assert sample["crs2"] == CRS.from_epsg(2001)
 

--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -37,7 +37,7 @@ from torchgeo.datasets.utils import (
 
 
 @pytest.fixture
-def mock_missing_module(monkeypatch: Generator[MonkeyPatch, None, None]) -> None:
+def mock_missing_module(monkeypatch: MonkeyPatch) -> None:
     import_orig = builtins.__import__
 
     def mocked_import(name: str, *args: Any, **kwargs: Any) -> Any:
@@ -126,7 +126,7 @@ def test_unsupported_scheme() -> None:
 
 
 def test_download_and_extract_archive(
-    tmp_path: Path, monkeypatch: Generator[MonkeyPatch, None, None]
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ) -> None:
     monkeypatch.setattr(torchgeo.datasets.utils, "download_url", download_url)
     download_and_extract_archive(
@@ -136,7 +136,7 @@ def test_download_and_extract_archive(
 
 
 def test_download_radiant_mlhub_dataset(
-    tmp_path: Path, monkeypatch: Generator[MonkeyPatch, None, None]
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ) -> None:
     radiant_mlhub = pytest.importorskip("radiant_mlhub", minversion="0.2.1")
     monkeypatch.setattr(radiant_mlhub.Dataset, "fetch", fetch_dataset)
@@ -144,7 +144,7 @@ def test_download_radiant_mlhub_dataset(
 
 
 def test_download_radiant_mlhub_collection(
-    tmp_path: Path, monkeypatch: Generator[MonkeyPatch, None, None]
+    tmp_path: Path, monkeypatch: MonkeyPatch
 ) -> None:
     radiant_mlhub = pytest.importorskip("radiant_mlhub", minversion="0.2.1")
     monkeypatch.setattr(radiant_mlhub.Collection, "fetch", fetch_collection)

--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -11,7 +11,7 @@ import shutil
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, Generator, List, Tuple
+from typing import Any, Dict, List, Tuple
 
 import numpy as np
 import pytest

--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -125,9 +125,7 @@ def test_unsupported_scheme() -> None:
         extract_archive("foo.bar")
 
 
-def test_download_and_extract_archive(
-    tmp_path: Path, monkeypatch: MonkeyPatch
-) -> None:
+def test_download_and_extract_archive(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setattr(torchgeo.datasets.utils, "download_url", download_url)
     download_and_extract_archive(
         os.path.join("tests", "data", "landcoverai", "landcover.ai.v1.zip"),

--- a/tests/datasets/test_vaihingen.py
+++ b/tests/datasets/test_vaihingen.py
@@ -5,7 +5,6 @@ import os
 import shutil
 from pathlib import Path
 
-
 import matplotlib.pyplot as plt
 import pytest
 import torch

--- a/tests/datasets/test_vaihingen.py
+++ b/tests/datasets/test_vaihingen.py
@@ -4,7 +4,7 @@
 import os
 import shutil
 from pathlib import Path
-from typing import Generator
+
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/datasets/test_vaihingen.py
+++ b/tests/datasets/test_vaihingen.py
@@ -26,11 +26,11 @@ class TestVaihingen2D:
             "train": ["top_mosaic_09cm_area1.tif", "top_mosaic_09cm_area11.tif"],
             "test": ["top_mosaic_09cm_area6.tif", "top_mosaic_09cm_area24.tif"],
         }
-        monkeypatch.setattr(Vaihingen2D, "md5s", md5s)  # type: ignore[attr-defined]
-        monkeypatch.setattr(Vaihingen2D, "splits", splits)  # type: ignore[attr-defined]
+        monkeypatch.setattr(Vaihingen2D, "md5s", md5s)
+        monkeypatch.setattr(Vaihingen2D, "splits", splits)
         root = os.path.join("tests", "data", "vaihingen")
         split = request.param
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return Vaihingen2D(root, split, transforms, checksum=True)
 
     def test_getitem(self, dataset: Vaihingen2D) -> None:

--- a/tests/datasets/test_vaihingen.py
+++ b/tests/datasets/test_vaihingen.py
@@ -18,9 +18,7 @@ from torchgeo.datasets import Vaihingen2D
 
 class TestVaihingen2D:
     @pytest.fixture(params=["train", "test"])
-    def dataset(
-        self, monkeypatch: MonkeyPatch, request: SubRequest
-    ) -> Vaihingen2D:
+    def dataset(self, monkeypatch: MonkeyPatch, request: SubRequest) -> Vaihingen2D:
         md5s = ["c15fbff78d307e51c73f609c0859afc3", "ec2c0a5149f2371479b38cf8cfbab961"]
         splits = {
             "train": ["top_mosaic_09cm_area1.tif", "top_mosaic_09cm_area11.tif"],

--- a/tests/datasets/test_vaihingen.py
+++ b/tests/datasets/test_vaihingen.py
@@ -19,7 +19,7 @@ from torchgeo.datasets import Vaihingen2D
 class TestVaihingen2D:
     @pytest.fixture(params=["train", "test"])
     def dataset(
-        self, monkeypatch: Generator[MonkeyPatch, None, None], request: SubRequest
+        self, monkeypatch: MonkeyPatch, request: SubRequest
     ) -> Vaihingen2D:
         md5s = ["c15fbff78d307e51c73f609c0859afc3", "ec2c0a5149f2371479b38cf8cfbab961"]
         splits = {

--- a/tests/datasets/test_vaihingen.py
+++ b/tests/datasets/test_vaihingen.py
@@ -28,7 +28,7 @@ class TestVaihingen2D:
         monkeypatch.setattr(Vaihingen2D, "splits", splits)
         root = os.path.join("tests", "data", "vaihingen")
         split = request.param
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return Vaihingen2D(root, split, transforms, checksum=True)
 
     def test_getitem(self, dataset: Vaihingen2D) -> None:

--- a/tests/datasets/test_xview2.py
+++ b/tests/datasets/test_xview2.py
@@ -5,7 +5,6 @@ import os
 import shutil
 from pathlib import Path
 
-
 import matplotlib.pyplot as plt
 import pytest
 import torch

--- a/tests/datasets/test_xview2.py
+++ b/tests/datasets/test_xview2.py
@@ -4,7 +4,7 @@
 import os
 import shutil
 from pathlib import Path
-from typing import Generator
+
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/datasets/test_xview2.py
+++ b/tests/datasets/test_xview2.py
@@ -21,7 +21,7 @@ class TestXView2:
     def dataset(
         self, monkeypatch: Generator[MonkeyPatch, None, None], request: SubRequest
     ) -> XView2:
-        monkeypatch.setattr(  # type: ignore[attr-defined]
+        monkeypatch.setattr(
             XView2,
             "metadata",
             {
@@ -39,7 +39,7 @@ class TestXView2:
         )
         root = os.path.join("tests", "data", "xview2")
         split = request.param
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return XView2(root, split, transforms, checksum=True)
 
     def test_getitem(self, dataset: XView2) -> None:

--- a/tests/datasets/test_xview2.py
+++ b/tests/datasets/test_xview2.py
@@ -37,7 +37,7 @@ class TestXView2:
         )
         root = os.path.join("tests", "data", "xview2")
         split = request.param
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return XView2(root, split, transforms, checksum=True)
 
     def test_getitem(self, dataset: XView2) -> None:

--- a/tests/datasets/test_xview2.py
+++ b/tests/datasets/test_xview2.py
@@ -19,7 +19,7 @@ from torchgeo.datasets import XView2
 class TestXView2:
     @pytest.fixture(params=["train", "test"])
     def dataset(
-        self, monkeypatch: Generator[MonkeyPatch, None, None], request: SubRequest
+        self, monkeypatch: MonkeyPatch, request: SubRequest
     ) -> XView2:
         monkeypatch.setattr(
             XView2,

--- a/tests/datasets/test_xview2.py
+++ b/tests/datasets/test_xview2.py
@@ -18,9 +18,7 @@ from torchgeo.datasets import XView2
 
 class TestXView2:
     @pytest.fixture(params=["train", "test"])
-    def dataset(
-        self, monkeypatch: MonkeyPatch, request: SubRequest
-    ) -> XView2:
+    def dataset(self, monkeypatch: MonkeyPatch, request: SubRequest) -> XView2:
         monkeypatch.setattr(
             XView2,
             "metadata",

--- a/tests/datasets/test_zuericrop.py
+++ b/tests/datasets/test_zuericrop.py
@@ -25,9 +25,7 @@ def download_url(url: str, root: str, *args: str, **kwargs: str) -> None:
 
 class TestZueriCrop:
     @pytest.fixture
-    def dataset(
-        self, monkeypatch: MonkeyPatch, tmp_path: Path
-    ) -> ZueriCrop:
+    def dataset(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> ZueriCrop:
         monkeypatch.setattr(torchgeo.datasets.zuericrop, "download_url", download_url)
         data_dir = os.path.join("tests", "data", "zuericrop")
         urls = [
@@ -42,9 +40,7 @@ class TestZueriCrop:
         return ZueriCrop(root=root, transforms=transforms, download=True, checksum=True)
 
     @pytest.fixture
-    def mock_missing_module(
-        self, monkeypatch: MonkeyPatch
-    ) -> None:
+    def mock_missing_module(self, monkeypatch: MonkeyPatch) -> None:
         import_orig = builtins.__import__
 
         def mocked_import(name: str, *args: Any, **kwargs: Any) -> Any:

--- a/tests/datasets/test_zuericrop.py
+++ b/tests/datasets/test_zuericrop.py
@@ -28,19 +28,17 @@ class TestZueriCrop:
     def dataset(
         self, monkeypatch: Generator[MonkeyPatch, None, None], tmp_path: Path
     ) -> ZueriCrop:
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            torchgeo.datasets.zuericrop, "download_url", download_url
-        )
+        monkeypatch.setattr(torchgeo.datasets.zuericrop, "download_url", download_url)
         data_dir = os.path.join("tests", "data", "zuericrop")
         urls = [
             os.path.join(data_dir, "ZueriCrop.hdf5"),
             os.path.join(data_dir, "labels.csv"),
         ]
         md5s = ["1635231df67f3d25f4f1e62c98e221a4", "5118398c7a5bbc246f5f6bb35d8d529b"]
-        monkeypatch.setattr(ZueriCrop, "urls", urls)  # type: ignore[attr-defined]
-        monkeypatch.setattr(ZueriCrop, "md5s", md5s)  # type: ignore[attr-defined]
+        monkeypatch.setattr(ZueriCrop, "urls", urls)
+        monkeypatch.setattr(ZueriCrop, "md5s", md5s)
         root = str(tmp_path)
-        transforms = nn.Identity()  # type: ignore[attr-defined]
+        transforms = nn.Identity()
         return ZueriCrop(root=root, transforms=transforms, download=True, checksum=True)
 
     @pytest.fixture
@@ -54,9 +52,7 @@ class TestZueriCrop:
                 raise ImportError()
             return import_orig(name, *args, **kwargs)
 
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            builtins, "__import__", mocked_import
-        )
+        monkeypatch.setattr(builtins, "__import__", mocked_import)
 
     def test_getitem(self, dataset: ZueriCrop) -> None:
         x = dataset[0]

--- a/tests/datasets/test_zuericrop.py
+++ b/tests/datasets/test_zuericrop.py
@@ -36,7 +36,7 @@ class TestZueriCrop:
         monkeypatch.setattr(ZueriCrop, "urls", urls)
         monkeypatch.setattr(ZueriCrop, "md5s", md5s)
         root = str(tmp_path)
-        transforms = nn.Identity()
+        transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return ZueriCrop(root=root, transforms=transforms, download=True, checksum=True)
 
     @pytest.fixture

--- a/tests/datasets/test_zuericrop.py
+++ b/tests/datasets/test_zuericrop.py
@@ -5,7 +5,7 @@ import builtins
 import os
 import shutil
 from pathlib import Path
-from typing import Any, Generator
+from typing import Any
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/datasets/test_zuericrop.py
+++ b/tests/datasets/test_zuericrop.py
@@ -26,7 +26,7 @@ def download_url(url: str, root: str, *args: str, **kwargs: str) -> None:
 class TestZueriCrop:
     @pytest.fixture
     def dataset(
-        self, monkeypatch: Generator[MonkeyPatch, None, None], tmp_path: Path
+        self, monkeypatch: MonkeyPatch, tmp_path: Path
     ) -> ZueriCrop:
         monkeypatch.setattr(torchgeo.datasets.zuericrop, "download_url", download_url)
         data_dir = os.path.join("tests", "data", "zuericrop")
@@ -43,7 +43,7 @@ class TestZueriCrop:
 
     @pytest.fixture
     def mock_missing_module(
-        self, monkeypatch: Generator[MonkeyPatch, None, None]
+        self, monkeypatch: MonkeyPatch
     ) -> None:
         import_orig = builtins.__import__
 

--- a/tests/losses/test_qr.py
+++ b/tests/losses/test_qr.py
@@ -9,12 +9,12 @@ from torchgeo.losses import QRLoss, RQLoss
 class TestQRLosses:
     def test_loss_on_prior_simple(self) -> None:
         probs = torch.rand(2, 4, 10, 10)
-        log_probs = torch.log(probs)  # type: ignore[attr-defined]
+        log_probs = torch.log(probs)
         targets = torch.rand(2, 4, 10, 10)
         QRLoss()(log_probs, targets)
 
     def test_loss_on_prior_reversed_kl_simple(self) -> None:
         probs = torch.rand(2, 4, 10, 10)
-        log_probs = torch.log(probs)  # type: ignore[attr-defined]
+        log_probs = torch.log(probs)
         targets = torch.rand(2, 4, 10, 10)
         RQLoss()(log_probs, targets)

--- a/tests/models/test_rcf.py
+++ b/tests/models/test_rcf.py
@@ -34,9 +34,9 @@ class TestRCF:
 
     def test_biases(self) -> None:
         model = RCF(features=24, bias=10)
-        assert torch.all(model.biases == 10)  # type: ignore[attr-defined]
+        assert torch.all(model.biases == 10)
 
     def test_seed(self) -> None:
         weights1 = RCF(seed=1).weights
         weights2 = RCF(seed=1).weights
-        assert torch.allclose(weights1, weights2)  # type: ignore[attr-defined]
+        assert torch.allclose(weights1, weights2)

--- a/tests/models/test_resnet.py
+++ b/tests/models/test_resnet.py
@@ -32,7 +32,7 @@ def load_state_dict_from_file(
     [(resnet50, "sentinel2", "all", 10, 17)],
 )
 def test_resnet(
-    monkeypatch: Generator[MonkeyPatch, None, None],
+    monkeypatch: MonkeyPatch,
     tmp_path: Path,
     model_class: Module,
     sensor: str,

--- a/tests/models/test_resnet.py
+++ b/tests/models/test_resnet.py
@@ -49,15 +49,13 @@ def test_resnet(
         "sentinel2": {"all": {"resnet50": str(tmp_path / "resnet50-sentinel2-2.pt")}}
     }
 
-    monkeypatch.setattr(  # type: ignore[attr-defined]
-        torchgeo.models.resnet, "MODEL_URLS", new_model_urls
-    )
-    monkeypatch.setattr(  # type: ignore[attr-defined]
+    monkeypatch.setattr(torchgeo.models.resnet, "MODEL_URLS", new_model_urls)
+    monkeypatch.setattr(
         torchgeo.models.resnet, "load_state_dict_from_url", load_state_dict_from_file
     )
 
     model = model_class(sensor, bands, pretrained=True)
-    x = torch.zeros(1, in_channels, 256, 256)  # type: ignore[attr-defined]
+    x = torch.zeros(1, in_channels, 256, 256)
     y = model(x)
     assert isinstance(y, torch.Tensor)
-    assert y.size() == torch.Size([1, 17])  # type: ignore[attr-defined]
+    assert y.size() == torch.Size([1, 17])

--- a/tests/models/test_resnet.py
+++ b/tests/models/test_resnet.py
@@ -3,7 +3,7 @@
 
 import os
 from pathlib import Path
-from typing import Any, Generator, Optional
+from typing import Any, Optional
 
 import pytest
 import torch

--- a/tests/trainers/test_byol.py
+++ b/tests/trainers/test_byol.py
@@ -21,7 +21,7 @@ class TestBYOL:
     def test_custom_augment_fn(self) -> None:
         encoder = resnet18()
         layer = encoder.conv1
-        new_layer = nn.Conv2d(  # type: ignore[attr-defined]
+        new_layer = nn.Conv2d(
             in_channels=4,
             out_channels=layer.out_channels,
             kernel_size=layer.kernel_size,

--- a/tests/trainers/test_classification.py
+++ b/tests/trainers/test_classification.py
@@ -56,9 +56,7 @@ class TestClassificationTask:
         datamodule = classname(**datamodule_kwargs)
 
         # Instantiate model
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            timm, "create_model", create_model
-        )
+        monkeypatch.setattr(timm, "create_model", create_model)
         model_kwargs = conf_dict["module"]
         model = ClassificationTask(**model_kwargs)
 
@@ -151,9 +149,7 @@ class TestMultiLabelClassificationTask:
         datamodule = classname(**datamodule_kwargs)
 
         # Instantiate model
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            timm, "create_model", create_model
-        )
+        monkeypatch.setattr(timm, "create_model", create_model)
         model_kwargs = conf_dict["module"]
         model = MultiLabelClassificationTask(**model_kwargs)
 

--- a/tests/trainers/test_classification.py
+++ b/tests/trainers/test_classification.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 import os
-from typing import Any, Dict, Generator, Type, cast
+from typing import Any, Dict, Type, cast
 
 import pytest
 import timm

--- a/tests/trainers/test_classification.py
+++ b/tests/trainers/test_classification.py
@@ -39,10 +39,7 @@ class TestClassificationTask:
         ],
     )
     def test_trainer(
-        self,
-        monkeypatch: MonkeyPatch,
-        name: str,
-        classname: Type[LightningDataModule],
+        self, monkeypatch: MonkeyPatch, name: str, classname: Type[LightningDataModule]
     ) -> None:
         if name.startswith("so2sat"):
             pytest.importorskip("h5py")
@@ -135,10 +132,7 @@ class TestMultiLabelClassificationTask:
         ],
     )
     def test_trainer(
-        self,
-        monkeypatch: MonkeyPatch,
-        name: str,
-        classname: Type[LightningDataModule],
+        self, monkeypatch: MonkeyPatch, name: str, classname: Type[LightningDataModule]
     ) -> None:
         conf = OmegaConf.load(os.path.join("tests", "conf", name + ".yaml"))
         conf_dict = OmegaConf.to_object(conf.experiment)

--- a/tests/trainers/test_classification.py
+++ b/tests/trainers/test_classification.py
@@ -40,7 +40,7 @@ class TestClassificationTask:
     )
     def test_trainer(
         self,
-        monkeypatch: Generator[MonkeyPatch, None, None],
+        monkeypatch: MonkeyPatch,
         name: str,
         classname: Type[LightningDataModule],
     ) -> None:
@@ -136,7 +136,7 @@ class TestMultiLabelClassificationTask:
     )
     def test_trainer(
         self,
-        monkeypatch: Generator[MonkeyPatch, None, None],
+        monkeypatch: MonkeyPatch,
         name: str,
         classname: Type[LightningDataModule],
     ) -> None:

--- a/tests/trainers/test_segmentation.py
+++ b/tests/trainers/test_segmentation.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 import os
-from typing import Any, Dict, Generator, Type, cast
+from typing import Any, Dict, Type, cast
 
 import pytest
 import segmentation_models_pytorch as smp

--- a/tests/trainers/test_segmentation.py
+++ b/tests/trainers/test_segmentation.py
@@ -45,10 +45,7 @@ class TestSemanticSegmentationTask:
         ],
     )
     def test_trainer(
-        self,
-        monkeypatch: MonkeyPatch,
-        name: str,
-        classname: Type[LightningDataModule],
+        self, monkeypatch: MonkeyPatch, name: str, classname: Type[LightningDataModule]
     ) -> None:
         if name == "naipchesapeake":
             pytest.importorskip("zipfile_deflate64")

--- a/tests/trainers/test_segmentation.py
+++ b/tests/trainers/test_segmentation.py
@@ -62,10 +62,8 @@ class TestSemanticSegmentationTask:
         datamodule = classname(**datamodule_kwargs)
 
         # Instantiate model
-        monkeypatch.setattr(smp, "Unet", create_model)  # type: ignore[attr-defined]
-        monkeypatch.setattr(  # type: ignore[attr-defined]
-            smp, "DeepLabV3Plus", create_model
-        )
+        monkeypatch.setattr(smp, "Unet", create_model)
+        monkeypatch.setattr(smp, "DeepLabV3Plus", create_model)
         model_kwargs = conf_dict["module"]
         model = SemanticSegmentationTask(**model_kwargs)
 

--- a/tests/trainers/test_segmentation.py
+++ b/tests/trainers/test_segmentation.py
@@ -46,7 +46,7 @@ class TestSemanticSegmentationTask:
     )
     def test_trainer(
         self,
-        monkeypatch: Generator[MonkeyPatch, None, None],
+        monkeypatch: MonkeyPatch,
         name: str,
         classname: Type[LightningDataModule],
     ) -> None:

--- a/tests/trainers/test_utils.py
+++ b/tests/trainers/test_utils.py
@@ -22,16 +22,14 @@ class ClassificationTestModel(Module):
         self, in_chans: int = 3, num_classes: int = 1000, **kwargs: Any
     ) -> None:
         super().__init__()
-        self.conv1 = nn.Conv2d(  # type: ignore[attr-defined]
-            in_channels=in_chans, out_channels=1, kernel_size=1
-        )
-        self.pool = nn.AdaptiveAvgPool2d((1, 1))  # type: ignore[attr-defined]
-        self.fc = nn.Linear(1, num_classes)  # type: ignore[attr-defined]
+        self.conv1 = nn.Conv2d(in_channels=in_chans, out_channels=1, kernel_size=1)
+        self.pool = nn.AdaptiveAvgPool2d((1, 1))
+        self.fc = nn.Linear(1, num_classes)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         x = self.conv1(x)
         x = self.pool(x)
-        x = torch.flatten(x, 1)  # type: ignore[attr-defined]
+        x = torch.flatten(x, 1)
         x = self.fc(x)
         return x
 
@@ -46,7 +44,7 @@ class SegmentationTestModel(Module):
         self, in_channels: int = 3, classes: int = 1000, **kwargs: Any
     ) -> None:
         super().__init__()
-        self.conv1 = nn.Conv2d(  # type: ignore[attr-defined]
+        self.conv1 = nn.Conv2d(
             in_channels=in_channels, out_channels=classes, kernel_size=1, padding=0
         )
 
@@ -80,7 +78,7 @@ def test_load_state_dict_unequal_input_channels(checkpoint: str, model: Module) 
     expected_in_channels = state_dict["conv1.weight"].shape[1]
 
     in_channels = 7
-    model.conv1 = nn.Conv2d(  # type: ignore[attr-defined]
+    model.conv1 = nn.Conv2d(
         in_channels, out_channels=64, kernel_size=7, stride=1, padding=2, bias=False
     )
 
@@ -98,9 +96,7 @@ def test_load_state_dict_unequal_classes(checkpoint: str, model: Module) -> None
 
     num_classes = 10
     in_features = model.fc.in_features  # type: ignore[union-attr]
-    model.fc = nn.Linear(  # type: ignore[attr-defined]
-        in_features, out_features=num_classes
-    )
+    model.fc = nn.Linear(in_features, out_features=num_classes)
 
     warning = (
         f"num classes {num_classes} != num classes in pretrained model"
@@ -111,17 +107,13 @@ def test_load_state_dict_unequal_classes(checkpoint: str, model: Module) -> None
 
 
 def test_reinit_initial_conv_layer() -> None:
-    conv_layer = nn.Conv2d(  # type: ignore[attr-defined]
-        3, 5, kernel_size=3, stride=2, padding=1, bias=True
-    )
+    conv_layer = nn.Conv2d(3, 5, kernel_size=3, stride=2, padding=1, bias=True)
     initial_weights = conv_layer.weight.data.clone()
 
     new_conv_layer = reinit_initial_conv_layer(conv_layer, 4, keep_rgb_weights=True)
 
     out_channels, in_channels, k1, k2 = new_conv_layer.weight.shape
-    assert torch.allclose(  # type: ignore[attr-defined]
-        initial_weights, new_conv_layer.weight.data[:, :3, :, :]
-    )
+    assert torch.allclose(initial_weights, new_conv_layer.weight.data[:, :3, :, :])
     assert out_channels == 5
     assert in_channels == 4
     assert k1 == 3 and k2 == 3

--- a/tests/trainers/test_utils.py
+++ b/tests/trainers/test_utils.py
@@ -95,7 +95,7 @@ def test_load_state_dict_unequal_classes(checkpoint: str, model: Module) -> None
     expected_num_classes = state_dict["fc.weight"].shape[0]
 
     num_classes = 10
-    in_features = model.fc.in_features
+    in_features = cast(int, cast(nn.Module, model.fc).in_features)
     model.fc = nn.Linear(in_features, out_features=num_classes)
 
     warning = (

--- a/tests/trainers/test_utils.py
+++ b/tests/trainers/test_utils.py
@@ -95,7 +95,7 @@ def test_load_state_dict_unequal_classes(checkpoint: str, model: Module) -> None
     expected_num_classes = state_dict["fc.weight"].shape[0]
 
     num_classes = 10
-    in_features = model.fc.in_features  # type: ignore[union-attr]
+    in_features = model.fc.in_features
     model.fc = nn.Linear(in_features, out_features=num_classes)
 
     warning = (

--- a/tests/transforms/test_indices.py
+++ b/tests/transforms/test_indices.py
@@ -25,29 +25,17 @@ from torchgeo.transforms import (
 @pytest.fixture
 def sample() -> Dict[str, Tensor]:
     return {
-        "image": torch.tensor(  # type: ignore[attr-defined]
-            [[[1, 2, 3], [4, 5, 6], [7, 8, 9]]],
-            dtype=torch.float,  # type: ignore[attr-defined]
-        ),
-        "mask": torch.tensor(  # type: ignore[attr-defined]
-            [[0, 0, 1], [0, 1, 1], [1, 1, 1]],
-            dtype=torch.long,  # type: ignore[attr-defined]
-        ),
+        "image": torch.tensor([[[1, 2, 3], [4, 5, 6], [7, 8, 9]]], dtype=torch.float),
+        "mask": torch.tensor([[0, 0, 1], [0, 1, 1], [1, 1, 1]], dtype=torch.long),
     }
 
 
 @pytest.fixture
 def batch() -> Dict[str, Tensor]:
     return {
-        "image": torch.tensor(  # type: ignore[attr-defined]
-            [[[[1, 2, 3], [4, 5, 6], [7, 8, 9]]]],
-            dtype=torch.float,  # type: ignore[attr-defined]
-        ),
-        "mask": torch.tensor(  # type: ignore[attr-defined]
-            [[[[0, 0, 1], [0, 1, 1], [1, 1, 1]]]],
-            dtype=torch.long,  # type: ignore[attr-defined]
-        ),
-        "labels": torch.tensor([[0, 1]]),  # type: ignore[attr-defined]
+        "image": torch.tensor([[[[1, 2, 3], [4, 5, 6], [7, 8, 9]]]], dtype=torch.float),
+        "mask": torch.tensor([[[[0, 0, 1], [0, 1, 1], [1, 1, 1]]]], dtype=torch.long),
+        "labels": torch.tensor([[0, 1]]),
     }
 
 

--- a/tests/transforms/test_transforms.py
+++ b/tests/transforms/test_transforms.py
@@ -18,28 +18,19 @@ pytest.importorskip("kornia", minversion="0.6.3")
 @pytest.fixture
 def batch_gray() -> Dict[str, Tensor]:
     return {
-        "image": torch.tensor(  # type: ignore[attr-defined]
-            [[[[1, 2, 3], [4, 5, 6], [7, 8, 9]]]],
-            dtype=torch.float,  # type: ignore[attr-defined]
-        ),
-        "mask": torch.tensor(  # type: ignore[attr-defined]
-            [[[[0, 0, 1], [0, 1, 1], [1, 1, 1]]]],
-            dtype=torch.long,  # type: ignore[attr-defined]
-        ),
+        "image": torch.tensor([[[[1, 2, 3], [4, 5, 6], [7, 8, 9]]]], dtype=torch.float),
+        "mask": torch.tensor([[[[0, 0, 1], [0, 1, 1], [1, 1, 1]]]], dtype=torch.long),
         # This is a list of 4 (y,x) points of the corners of a bounding box.
         # kornia expects something with (B, 4, 2) shape
-        "boxes": torch.tensor(  # type: ignore[attr-defined]
-            [[[0, 0], [0, 1], [1, 1], [1, 0]]],
-            dtype=torch.float,  # type: ignore[attr-defined]
-        ),
-        "labels": torch.tensor([[0, 1]]),  # type: ignore[attr-defined]
+        "boxes": torch.tensor([[[0, 0], [0, 1], [1, 1], [1, 0]]], dtype=torch.float),
+        "labels": torch.tensor([[0, 1]]),
     }
 
 
 @pytest.fixture
 def batch_rgb() -> Dict[str, Tensor]:
     return {
-        "image": torch.tensor(  # type: ignore[attr-defined]
+        "image": torch.tensor(
             [
                 [
                     [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
@@ -47,24 +38,18 @@ def batch_rgb() -> Dict[str, Tensor]:
                     [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
                 ]
             ],
-            dtype=torch.float,  # type: ignore[attr-defined]
+            dtype=torch.float,
         ),
-        "mask": torch.tensor(  # type: ignore[attr-defined]
-            [[[[0, 0, 1], [0, 1, 1], [1, 1, 1]]]],
-            dtype=torch.long,  # type: ignore[attr-defined]
-        ),
-        "boxes": torch.tensor(  # type: ignore[attr-defined]
-            [[[0, 0], [0, 1], [1, 1], [1, 0]]],
-            dtype=torch.float,  # type: ignore[attr-defined]
-        ),
-        "labels": torch.tensor([[0, 1]]),  # type: ignore[attr-defined]
+        "mask": torch.tensor([[[[0, 0, 1], [0, 1, 1], [1, 1, 1]]]], dtype=torch.long),
+        "boxes": torch.tensor([[[0, 0], [0, 1], [1, 1], [1, 0]]], dtype=torch.float),
+        "labels": torch.tensor([[0, 1]]),
     }
 
 
 @pytest.fixture
 def batch_multispectral() -> Dict[str, Tensor]:
     return {
-        "image": torch.tensor(  # type: ignore[attr-defined]
+        "image": torch.tensor(
             [
                 [
                     [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
@@ -74,42 +59,27 @@ def batch_multispectral() -> Dict[str, Tensor]:
                     [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
                 ]
             ],
-            dtype=torch.float,  # type: ignore[attr-defined]
+            dtype=torch.float,
         ),
-        "mask": torch.tensor(  # type: ignore[attr-defined]
-            [[[[0, 0, 1], [0, 1, 1], [1, 1, 1]]]],
-            dtype=torch.long,  # type: ignore[attr-defined]
-        ),
-        "boxes": torch.tensor(  # type: ignore[attr-defined]
-            [[[0, 0], [0, 1], [1, 1], [1, 0]]],
-            dtype=torch.float,  # type: ignore[attr-defined]
-        ),
-        "labels": torch.tensor([[0, 1]]),  # type: ignore[attr-defined]
+        "mask": torch.tensor([[[[0, 0, 1], [0, 1, 1], [1, 1, 1]]]], dtype=torch.long),
+        "boxes": torch.tensor([[[0, 0], [0, 1], [1, 1], [1, 0]]], dtype=torch.float),
+        "labels": torch.tensor([[0, 1]]),
     }
 
 
 def assert_matching(output: Dict[str, Tensor], expected: Dict[str, Tensor]) -> None:
     for key in expected:
         err = f"output[{key}] != expected[{key}]"
-        equal = torch.allclose(output[key], expected[key])  # type: ignore[attr-defined]
+        equal = torch.allclose(output[key], expected[key])
         assert equal, err
 
 
 def test_augmentation_sequential_gray(batch_gray: Dict[str, Tensor]) -> None:
     expected = {
-        "image": torch.tensor(  # type: ignore[attr-defined]
-            [[[[3, 2, 1], [6, 5, 4], [9, 8, 7]]]],
-            dtype=torch.float,  # type: ignore[attr-defined]
-        ),
-        "mask": torch.tensor(  # type: ignore[attr-defined]
-            [[[[1, 0, 0], [1, 1, 0], [1, 1, 1]]]],
-            dtype=torch.long,  # type: ignore[attr-defined]
-        ),
-        "boxes": torch.tensor(  # type: ignore[attr-defined]
-            [[[1, 0], [2, 0], [2, 1], [1, 1]]],
-            dtype=torch.float,  # type: ignore[attr-defined]
-        ),
-        "labels": torch.tensor([[0, 1]]),  # type: ignore[attr-defined]
+        "image": torch.tensor([[[[3, 2, 1], [6, 5, 4], [9, 8, 7]]]], dtype=torch.float),
+        "mask": torch.tensor([[[[1, 0, 0], [1, 1, 0], [1, 1, 1]]]], dtype=torch.long),
+        "boxes": torch.tensor([[[1, 0], [2, 0], [2, 1], [1, 1]]], dtype=torch.float),
+        "labels": torch.tensor([[0, 1]]),
     }
     augs = transforms.AugmentationSequential(
         K.RandomHorizontalFlip(p=1.0), data_keys=["image", "mask", "boxes"]
@@ -120,7 +90,7 @@ def test_augmentation_sequential_gray(batch_gray: Dict[str, Tensor]) -> None:
 
 def test_augmentation_sequential_rgb(batch_rgb: Dict[str, Tensor]) -> None:
     expected = {
-        "image": torch.tensor(  # type: ignore[attr-defined]
+        "image": torch.tensor(
             [
                 [
                     [[3, 2, 1], [6, 5, 4], [9, 8, 7]],
@@ -128,17 +98,11 @@ def test_augmentation_sequential_rgb(batch_rgb: Dict[str, Tensor]) -> None:
                     [[3, 2, 1], [6, 5, 4], [9, 8, 7]],
                 ]
             ],
-            dtype=torch.float,  # type: ignore[attr-defined]
+            dtype=torch.float,
         ),
-        "mask": torch.tensor(  # type: ignore[attr-defined]
-            [[[[1, 0, 0], [1, 1, 0], [1, 1, 1]]]],
-            dtype=torch.long,  # type: ignore[attr-defined]
-        ),
-        "boxes": torch.tensor(  # type: ignore[attr-defined]
-            [[[1, 0], [2, 0], [2, 1], [1, 1]]],
-            dtype=torch.float,  # type: ignore[attr-defined]
-        ),
-        "labels": torch.tensor([[0, 1]]),  # type: ignore[attr-defined]
+        "mask": torch.tensor([[[[1, 0, 0], [1, 1, 0], [1, 1, 1]]]], dtype=torch.long),
+        "boxes": torch.tensor([[[1, 0], [2, 0], [2, 1], [1, 1]]], dtype=torch.float),
+        "labels": torch.tensor([[0, 1]]),
     }
     augs = transforms.AugmentationSequential(
         K.RandomHorizontalFlip(p=1.0), data_keys=["image", "mask", "boxes"]
@@ -151,7 +115,7 @@ def test_augmentation_sequential_multispectral(
     batch_multispectral: Dict[str, Tensor]
 ) -> None:
     expected = {
-        "image": torch.tensor(  # type: ignore[attr-defined]
+        "image": torch.tensor(
             [
                 [
                     [[3, 2, 1], [6, 5, 4], [9, 8, 7]],
@@ -161,17 +125,11 @@ def test_augmentation_sequential_multispectral(
                     [[3, 2, 1], [6, 5, 4], [9, 8, 7]],
                 ]
             ],
-            dtype=torch.float,  # type: ignore[attr-defined]
+            dtype=torch.float,
         ),
-        "mask": torch.tensor(  # type: ignore[attr-defined]
-            [[[[1, 0, 0], [1, 1, 0], [1, 1, 1]]]],
-            dtype=torch.long,  # type: ignore[attr-defined]
-        ),
-        "boxes": torch.tensor(  # type: ignore[attr-defined]
-            [[[1, 0], [2, 0], [2, 1], [1, 1]]],
-            dtype=torch.float,  # type: ignore[attr-defined]
-        ),
-        "labels": torch.tensor([[0, 1]]),  # type: ignore[attr-defined]
+        "mask": torch.tensor([[[[1, 0, 0], [1, 1, 0], [1, 1, 1]]]], dtype=torch.long),
+        "boxes": torch.tensor([[[1, 0], [2, 0], [2, 1], [1, 1]]], dtype=torch.float),
+        "labels": torch.tensor([[0, 1]]),
     }
     augs = transforms.AugmentationSequential(
         K.RandomHorizontalFlip(p=1.0), data_keys=["image", "mask", "boxes"]
@@ -184,7 +142,7 @@ def test_augmentation_sequential_image_only(
     batch_multispectral: Dict[str, Tensor]
 ) -> None:
     expected = {
-        "image": torch.tensor(  # type: ignore[attr-defined]
+        "image": torch.tensor(
             [
                 [
                     [[3, 2, 1], [6, 5, 4], [9, 8, 7]],
@@ -194,17 +152,11 @@ def test_augmentation_sequential_image_only(
                     [[3, 2, 1], [6, 5, 4], [9, 8, 7]],
                 ]
             ],
-            dtype=torch.float,  # type: ignore[attr-defined]
+            dtype=torch.float,
         ),
-        "mask": torch.tensor(  # type: ignore[attr-defined]
-            [[[[0, 0, 1], [0, 1, 1], [1, 1, 1]]]],
-            dtype=torch.long,  # type: ignore[attr-defined]
-        ),
-        "boxes": torch.tensor(  # type: ignore[attr-defined]
-            [[[0, 0], [0, 1], [1, 1], [1, 0]]],
-            dtype=torch.float,  # type: ignore[attr-defined]
-        ),
-        "labels": torch.tensor([[0, 1]]),  # type: ignore[attr-defined]
+        "mask": torch.tensor([[[[0, 0, 1], [0, 1, 1], [1, 1, 1]]]], dtype=torch.long),
+        "boxes": torch.tensor([[[0, 0], [0, 1], [1, 1], [1, 0]]], dtype=torch.float),
+        "labels": torch.tensor([[0, 1]]),
     }
     augs = transforms.AugmentationSequential(
         K.RandomHorizontalFlip(p=1.0), data_keys=["image"]
@@ -217,7 +169,7 @@ def test_sequential_transforms_augmentations(
     batch_multispectral: Dict[str, Tensor]
 ) -> None:
     expected = {
-        "image": torch.tensor(  # type: ignore[attr-defined]
+        "image": torch.tensor(
             [
                 [
                     [[3, 2, 1], [6, 5, 4], [9, 8, 7]],
@@ -232,19 +184,13 @@ def test_sequential_transforms_augmentations(
                     [[0, 0, 0], [0, 0, 0], [0, 0, 0]],
                 ]
             ],
-            dtype=torch.float,  # type: ignore[attr-defined]
+            dtype=torch.float,
         ),
-        "mask": torch.tensor(  # type: ignore[attr-defined]
-            [[[[1, 0, 0], [1, 1, 0], [1, 1, 1]]]],
-            dtype=torch.long,  # type: ignore[attr-defined]
-        ),
-        "boxes": torch.tensor(  # type: ignore[attr-defined]
-            [[[1, 0], [2, 0], [2, 1], [1, 1]]],
-            dtype=torch.float,  # type: ignore[attr-defined]
-        ),
-        "labels": torch.tensor([[0, 1]]),  # type: ignore[attr-defined]
+        "mask": torch.tensor([[[[1, 0, 0], [1, 1, 0], [1, 1, 1]]]], dtype=torch.long),
+        "boxes": torch.tensor([[[1, 0], [2, 0], [2, 1], [1, 1]]], dtype=torch.float),
+        "labels": torch.tensor([[0, 1]]),
     }
-    train_transforms = nn.Sequential(  # type: ignore[attr-defined]
+    train_transforms = nn.Sequential(
         indices.AppendNBR(index_nir=0, index_swir=0),
         indices.AppendNDBI(index_swir=0, index_nir=0),
         indices.AppendNDSI(index_green=0, index_swir=0),

--- a/torchgeo/datamodules/bigearthnet.py
+++ b/torchgeo/datamodules/bigearthnet.py
@@ -26,10 +26,10 @@ class BigEarthNetDataModule(pl.LightningDataModule):
 
     # (VV, VH, B01, B02, B03, B04, B05, B06, B07, B08, B8A, B09, B11, B12)
     # min/max band statistics computed on 100k random samples
-    band_mins_raw = torch.tensor(  # type: ignore[attr-defined]
+    band_mins_raw = torch.tensor(
         [-70.0, -72.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0]
     )
-    band_maxs_raw = torch.tensor(  # type: ignore[attr-defined]
+    band_maxs_raw = torch.tensor(
         [
             31.0,
             35.0,
@@ -50,10 +50,10 @@ class BigEarthNetDataModule(pl.LightningDataModule):
 
     # min/max band statistics computed by percentile clipping the
     # above to samples to [2, 98]
-    band_mins = torch.tensor(  # type: ignore[attr-defined]
+    band_mins = torch.tensor(
         [-48.0, -42.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
     )
-    band_maxs = torch.tensor(  # type: ignore[attr-defined]
+    band_maxs = torch.tensor(
         [
             6.0,
             16.0,
@@ -111,9 +111,7 @@ class BigEarthNetDataModule(pl.LightningDataModule):
         """Transform a single sample from the Dataset."""
         sample["image"] = sample["image"].float()
         sample["image"] = (sample["image"] - self.mins) / (self.maxs - self.mins)
-        sample["image"] = torch.clip(  # type: ignore[attr-defined]
-            sample["image"], min=0.0, max=1.0
-        )
+        sample["image"] = torch.clip(sample["image"], min=0.0, max=1.0)
         return sample
 
     def prepare_data(self) -> None:

--- a/torchgeo/datamodules/chesapeake.py
+++ b/torchgeo/datamodules/chesapeake.py
@@ -205,10 +205,8 @@ class ChesapeakeCVPRDataModule(LightningDataModule):
             num_channels, height, width = sample["image"].shape
 
             if height < size or width < size:
-                sample["image"] = torch.zeros(  # type: ignore[attr-defined]
-                    (num_channels, size, size)
-                )
-                sample["mask"] = torch.zeros((size, size))  # type: ignore[attr-defined]
+                sample["image"] = torch.zeros((num_channels, size, size))
+                sample["mask"] = torch.zeros((size, size))
 
             return sample
 

--- a/torchgeo/datamodules/cowc.py
+++ b/torchgeo/datamodules/cowc.py
@@ -128,4 +128,4 @@ class COWCCountingDataModule(pl.LightningDataModule):
 
         .. versionadded:: 0.2
         """
-        return self.val_dataset.dataset.plot(*args, **kwargs)
+        return self.test_dataset.plot(*args, **kwargs)

--- a/torchgeo/datamodules/cowc.py
+++ b/torchgeo/datamodules/cowc.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Optional
 
 import matplotlib.pyplot as plt
 import pytorch_lightning as pl
-from torch import Generator  # type: ignore[attr-defined]
+from torch import Generator
 from torch.utils.data import DataLoader, random_split
 
 from ..datasets import COWCCounting

--- a/torchgeo/datamodules/cyclone.py
+++ b/torchgeo/datamodules/cyclone.py
@@ -64,9 +64,7 @@ class CycloneDataModule(pl.LightningDataModule):
         sample["image"] = (
             sample["image"].unsqueeze(0).repeat(3, 1, 1)
         )  # convert to 3 channel
-        sample["label"] = torch.as_tensor(  # type: ignore[attr-defined]
-            sample["label"]
-        ).float()
+        sample["label"] = torch.as_tensor(sample["label"]).float()
 
         return sample
 

--- a/torchgeo/datamodules/etci2021.py
+++ b/torchgeo/datamodules/etci2021.py
@@ -151,4 +151,4 @@ class ETCI2021DataModule(pl.LightningDataModule):
 
     def plot(self, *args: Any, **kwargs: Any) -> plt.Figure:
         """Run :meth:`torchgeo.datasets.ETCI2021.plot`."""
-        return self.val_dataset.plot(*args, **kwargs)
+        return self.test_dataset.plot(*args, **kwargs)

--- a/torchgeo/datamodules/etci2021.py
+++ b/torchgeo/datamodules/etci2021.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Optional
 import matplotlib.pyplot as plt
 import pytorch_lightning as pl
 import torch
-from torch import Generator  # type: ignore[attr-defined]
+from torch import Generator
 from torch.utils.data import DataLoader, random_split
 from torchvision.transforms import Normalize
 
@@ -24,11 +24,11 @@ class ETCI2021DataModule(pl.LightningDataModule):
     .. versionadded:: 0.2
     """
 
-    band_means = torch.tensor(  # type: ignore[attr-defined]
+    band_means = torch.tensor(
         [0.52253931, 0.52253931, 0.52253931, 0.61221701, 0.61221701, 0.61221701, 0]
     )
 
-    band_stds = torch.tensor(  # type: ignore[attr-defined]
+    band_stds = torch.tensor(
         [0.35221376, 0.35221376, 0.35221376, 0.37364622, 0.37364622, 0.37364622, 1]
     )
 
@@ -72,9 +72,7 @@ class ETCI2021DataModule(pl.LightningDataModule):
         flood_mask = sample["mask"][1]
         flood_mask = (flood_mask > 0).long()
 
-        sample["image"] = torch.cat(  # type: ignore[attr-defined]
-            [image, water_mask], dim=0
-        ).float()
+        sample["image"] = torch.cat([image, water_mask], dim=0).float()
         sample["image"] /= 255.0
         sample["image"] = self.norm(sample["image"])
         sample["mask"] = flood_mask

--- a/torchgeo/datamodules/eurosat.py
+++ b/torchgeo/datamodules/eurosat.py
@@ -22,7 +22,7 @@ class EuroSATDataModule(pl.LightningDataModule):
     .. versionadded:: 0.2
     """
 
-    band_means = torch.tensor(  # type: ignore[attr-defined]
+    band_means = torch.tensor(
         [
             1354.40546513,
             1118.24399958,
@@ -40,7 +40,7 @@ class EuroSATDataModule(pl.LightningDataModule):
         ]
     )
 
-    band_stds = torch.tensor(  # type: ignore[attr-defined]
+    band_stds = torch.tensor(
         [
             245.71762908,
             333.00778264,

--- a/torchgeo/datamodules/landcoverai.py
+++ b/torchgeo/datamodules/landcoverai.py
@@ -52,6 +52,7 @@ class LandCoverAIDataModule(pl.LightningDataModule):
         """
         if (
             hasattr(self, "trainer")
+            and self.trainer is not None
             and hasattr(self.trainer, "training")
             and self.trainer.training
         ):

--- a/torchgeo/datamodules/landcoverai.py
+++ b/torchgeo/datamodules/landcoverai.py
@@ -53,7 +53,7 @@ class LandCoverAIDataModule(pl.LightningDataModule):
         if (
             hasattr(self, "trainer")
             and hasattr(self.trainer, "training")
-            and self.trainer.training  # type: ignore[union-attr]
+            and self.trainer.training
         ):
             # Kornia expects masks to be floats with a channel dimension
             x = batch["image"]

--- a/torchgeo/datamodules/oscd.py
+++ b/torchgeo/datamodules/oscd.py
@@ -26,7 +26,7 @@ class OSCDDataModule(pl.LightningDataModule):
     .. versionadded:: 0.2
     """
 
-    band_means = torch.tensor(  # type: ignore[attr-defined]
+    band_means = torch.tensor(
         [
             1583.0741,
             1374.3202,
@@ -44,7 +44,7 @@ class OSCDDataModule(pl.LightningDataModule):
         ]
     )
 
-    band_stds = torch.tensor(  # type: ignore[attr-defined]
+    band_stds = torch.tensor(
         [
             52.1937,
             83.4168,
@@ -114,9 +114,7 @@ class OSCDDataModule(pl.LightningDataModule):
         sample["image"] = sample["image"].float()
         sample["mask"] = sample["mask"]
         sample["image"] = self.norm(sample["image"])
-        sample["image"] = torch.flatten(  # type: ignore[attr-defined]
-            sample["image"], 0, 1
-        )
+        sample["image"] = torch.flatten(sample["image"], 0, 1)
         return sample
 
     def prepare_data(self) -> None:
@@ -187,12 +185,8 @@ class OSCDDataModule(pl.LightningDataModule):
             r_batch: Dict[str, Any] = default_collate(  # type: ignore[no-untyped-call]
                 batch
             )
-            r_batch["image"] = torch.flatten(  # type: ignore[attr-defined]
-                r_batch["image"], 0, 1
-            )
-            r_batch["mask"] = torch.flatten(  # type: ignore[attr-defined]
-                r_batch["mask"], 0, 1
-            )
+            r_batch["image"] = torch.flatten(r_batch["image"], 0, 1)
+            r_batch["mask"] = torch.flatten(r_batch["mask"], 0, 1)
             return r_batch
 
         return DataLoader(

--- a/torchgeo/datamodules/resisc45.py
+++ b/torchgeo/datamodules/resisc45.py
@@ -61,7 +61,7 @@ class RESISC45DataModule(pl.LightningDataModule):
         if (
             hasattr(self, "trainer")
             and hasattr(self.trainer, "training")
-            and self.trainer.training  # type: ignore[union-attr]
+            and self.trainer.training
         ):
             x = batch["image"]
 

--- a/torchgeo/datamodules/resisc45.py
+++ b/torchgeo/datamodules/resisc45.py
@@ -25,13 +25,9 @@ class RESISC45DataModule(pl.LightningDataModule):
     Uses the train/val/test splits from the dataset.
     """
 
-    band_means = torch.tensor(  # type: ignore[attr-defined]
-        [0.36820969, 0.38083247, 0.34341029]
-    )
+    band_means = torch.tensor([0.36820969, 0.38083247, 0.34341029])
 
-    band_stds = torch.tensor(  # type: ignore[attr-defined]
-        [0.20339924, 0.18524736, 0.18455448]
-    )
+    band_stds = torch.tensor([0.20339924, 0.18524736, 0.18455448])
 
     def __init__(
         self, root_dir: str, batch_size: int = 64, num_workers: int = 0, **kwargs: Any

--- a/torchgeo/datamodules/resisc45.py
+++ b/torchgeo/datamodules/resisc45.py
@@ -60,6 +60,7 @@ class RESISC45DataModule(pl.LightningDataModule):
         """
         if (
             hasattr(self, "trainer")
+            and self.trainer is not None
             and hasattr(self.trainer, "training")
             and self.trainer.training
         ):

--- a/torchgeo/datamodules/sen12ms.py
+++ b/torchgeo/datamodules/sen12ms.py
@@ -29,7 +29,7 @@ class SEN12MSDataModule(pl.LightningDataModule):
 
     #: Mapping from the IGBP class definitions to the DFC2020, taken from the dataloader
     #: here https://github.com/lukasliebel/dfc2020_baseline.
-    DFC2020_CLASS_MAPPING = torch.tensor(  # type: ignore[attr-defined]
+    DFC2020_CLASS_MAPPING = torch.tensor(
         [
             0,  # maps 0s to 0
             1,  # maps 1s to 1
@@ -102,9 +102,7 @@ class SEN12MSDataModule(pl.LightningDataModule):
             sample["image"][:] = sample["image"][:].clamp(0, 10000) / 10000
 
         sample["mask"] = sample["mask"][0, :, :].long()
-        sample["mask"] = torch.take(  # type: ignore[attr-defined]
-            self.DFC2020_CLASS_MAPPING, sample["mask"]
-        )
+        sample["mask"] = torch.take(self.DFC2020_CLASS_MAPPING, sample["mask"])
 
         return sample
 

--- a/torchgeo/datamodules/so2sat.py
+++ b/torchgeo/datamodules/so2sat.py
@@ -23,7 +23,7 @@ class So2SatDataModule(pl.LightningDataModule):
     Uses the train/val/test splits from the dataset.
     """
 
-    band_means = torch.tensor(  # type: ignore[attr-defined]
+    band_means = torch.tensor(
         [
             -3.591224256609313e-05,
             -7.658561276843396e-06,
@@ -46,7 +46,7 @@ class So2SatDataModule(pl.LightningDataModule):
         ]
     ).reshape(18, 1, 1)
 
-    band_stds = torch.tensor(  # type: ignore[attr-defined]
+    band_stds = torch.tensor(
         [
             0.17555201137417686,
             0.17556463274968204,

--- a/torchgeo/datamodules/ucmerced.py
+++ b/torchgeo/datamodules/ucmerced.py
@@ -25,9 +25,9 @@ class UCMercedDataModule(pl.LightningDataModule):
     Uses random train/val/test splits.
     """
 
-    band_means = torch.tensor([0, 0, 0])  # type: ignore[attr-defined]
+    band_means = torch.tensor([0, 0, 0])
 
-    band_stds = torch.tensor([1, 1, 1])  # type: ignore[attr-defined]
+    band_stds = torch.tensor([1, 1, 1])
 
     def __init__(
         self, root_dir: str, batch_size: int = 64, num_workers: int = 0, **kwargs: Any

--- a/torchgeo/datamodules/utils.py
+++ b/torchgeo/datamodules/utils.py
@@ -5,11 +5,13 @@
 
 from typing import Any, List, Optional
 
-from torch.utils.data import Dataset, Subset, random_split
+from torch.utils.data import Subset, random_split
+
+from ..datasets import VisionDataset
 
 
 def dataset_split(
-    dataset: Dataset[Any], val_pct: float, test_pct: Optional[float] = None
+    dataset: VisionDataset[Any], val_pct: float, test_pct: Optional[float] = None
 ) -> List[Subset[Any]]:
     """Split a torch Dataset into train/val/test sets.
 

--- a/torchgeo/datamodules/utils.py
+++ b/torchgeo/datamodules/utils.py
@@ -3,15 +3,17 @@
 
 """Common datamodule utilities."""
 
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Union
 
-from torch.utils.data import Subset, random_split
+from torch.utils.data import Subset, TensorDataset, random_split
 
 from ..datasets import VisionDataset
 
 
 def dataset_split(
-    dataset: VisionDataset[Any], val_pct: float, test_pct: Optional[float] = None
+    dataset: Union[TensorDataset, VisionDataset],
+    val_pct: float,
+    test_pct: Optional[float] = None,
 ) -> List[Subset[Any]]:
     """Split a torch Dataset into train/val/test sets.
 

--- a/torchgeo/datasets/advance.py
+++ b/torchgeo/datasets/advance.py
@@ -133,7 +133,7 @@ class ADVANCE(VisionDataset):
         image = self._load_image(files["image"])
         audio = self._load_target(files["audio"])
         cls_label = self.class_to_idx[files["cls"]]
-        label = torch.tensor(cls_label, dtype=torch.long)  # type: ignore[attr-defined]
+        label = torch.tensor(cls_label, dtype=torch.long)
         sample = {"image": image, "audio": audio, "label": label}
 
         if self.transforms is not None:
@@ -178,7 +178,7 @@ class ADVANCE(VisionDataset):
         """
         with Image.open(path) as img:
             array: "np.typing.NDArray[np.int_]" = np.array(img.convert("RGB"))
-            tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
+            tensor = torch.from_numpy(array)
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))
             return tensor
@@ -200,7 +200,7 @@ class ADVANCE(VisionDataset):
             )
 
         array = wavfile.read(path)[1]
-        tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
+        tensor = torch.from_numpy(array)
         tensor = tensor.unsqueeze(0)
         return tensor
 

--- a/torchgeo/datasets/benin_cashews.py
+++ b/torchgeo/datasets/benin_cashews.py
@@ -247,8 +247,8 @@ class BeninSmallHolderCashews(VisionDataset):
         sample = {
             "image": img,
             "mask": labels,
-            "x": torch.tensor(x),  # type: ignore[attr-defined]
-            "y": torch.tensor(y),  # type: ignore[attr-defined]
+            "x": torch.tensor(x),
+            "y": torch.tensor(y),
             "transform": transform,
             "crs": crs,
         }
@@ -301,12 +301,12 @@ class BeninSmallHolderCashews(VisionDataset):
         if self.verbose:
             print("Loading all imagery")
 
-        img: Tensor = torch.zeros(  # type: ignore[attr-defined]
+        img = torch.zeros(
             len(self.dates),
             len(bands),
             self.tile_height,
             self.tile_width,
-            dtype=torch.float32,  # type: ignore[attr-defined]
+            dtype=torch.float32,
         )
 
         for date_index, date in enumerate(self.dates):
@@ -340,11 +340,8 @@ class BeninSmallHolderCashews(VisionDataset):
         if self.verbose:
             print(f"Loading imagery at {date}")
 
-        img: Tensor = torch.zeros(  # type: ignore[attr-defined]
-            len(bands),
-            self.tile_height,
-            self.tile_width,
-            dtype=torch.float32,  # type: ignore[attr-defined]
+        img = torch.zeros(
+            len(bands), self.tile_height, self.tile_width, dtype=torch.float32
         )
         for band_index, band_name in enumerate(self.bands):
             filepath = os.path.join(
@@ -357,7 +354,7 @@ class BeninSmallHolderCashews(VisionDataset):
                 transform = src.transform  # same transform for every bands
                 crs = src.crs
                 array = src.read().astype(np.float32)
-                img[band_index] = torch.from_numpy(array)  # type: ignore[attr-defined]
+                img[band_index] = torch.from_numpy(array)
 
         return img, transform, crs
 
@@ -385,7 +382,7 @@ class BeninSmallHolderCashews(VisionDataset):
             dtype=np.uint8,
         )
 
-        mask: Tensor = torch.from_numpy(mask_data).long()  # type: ignore[attr-defined]
+        mask = torch.from_numpy(mask_data).long()
         return mask
 
     def _check_integrity(self) -> bool:

--- a/torchgeo/datasets/bigearthnet.py
+++ b/torchgeo/datasets/bigearthnet.py
@@ -420,8 +420,8 @@ class BigEarthNet(VisionDataset):
 
         # Map 43 to 19 class labels
         if self.num_classes == 19:
-            indices = [self.label_converter[idx] for idx in indices]
-            indices = [idx for idx in indices if idx is not None]
+            indices_optional = [self.label_converter.get(idx) for idx in indices]
+            indices = [idx for idx in indices_optional if idx is not None]
 
         target = torch.zeros(self.num_classes, dtype=torch.long)
         target[indices] = 1

--- a/torchgeo/datasets/bigearthnet.py
+++ b/torchgeo/datasets/bigearthnet.py
@@ -420,9 +420,7 @@ class BigEarthNet(VisionDataset):
 
         # Map 43 to 19 class labels
         if self.num_classes == 19:
-            indices = [
-                self.label_converter.get(idx) for idx in indices  # type: ignore[misc]
-            ]
+            indices = [self.label_converter[idx] for idx in indices]
             indices = [idx for idx in indices if idx is not None]
 
         target = torch.zeros(self.num_classes, dtype=torch.long)

--- a/torchgeo/datasets/bigearthnet.py
+++ b/torchgeo/datasets/bigearthnet.py
@@ -394,7 +394,7 @@ class BigEarthNet(VisionDataset):
                 )
                 images.append(array)
         arrays: "np.typing.NDArray[np.int_]" = np.stack(images, axis=0)
-        tensor: Tensor = torch.from_numpy(arrays)  # type: ignore[attr-defined]
+        tensor = torch.from_numpy(arrays)
         return tensor
 
     def _load_target(self, index: int) -> Tensor:
@@ -425,9 +425,7 @@ class BigEarthNet(VisionDataset):
             ]
             indices = [idx for idx in indices if idx is not None]
 
-        target: Tensor = torch.zeros(  # type: ignore[attr-defined]
-            self.num_classes, dtype=torch.long  # type: ignore[attr-defined]
-        )
+        target = torch.zeros(self.num_classes, dtype=torch.long)
         target[indices] = 1
         return target
 

--- a/torchgeo/datasets/chesapeake.py
+++ b/torchgeo/datasets/chesapeake.py
@@ -636,10 +636,8 @@ class ChesapeakeCVPR(GeoDataset):
         sample["image"] = np.concatenate(sample["image"], axis=0)
         sample["mask"] = np.concatenate(sample["mask"], axis=0)
 
-        sample["image"] = torch.from_numpy(  # type: ignore[attr-defined]
-            sample["image"]
-        )
-        sample["mask"] = torch.from_numpy(sample["mask"])  # type: ignore[attr-defined]
+        sample["image"] = torch.from_numpy(sample["image"])
+        sample["mask"] = torch.from_numpy(sample["mask"])
 
         if self.transforms is not None:
             sample = self.transforms(sample)

--- a/torchgeo/datasets/cowc.py
+++ b/torchgeo/datasets/cowc.py
@@ -147,7 +147,7 @@ class COWC(VisionDataset, abc.ABC):
         filename = os.path.join(self.root, self.images[index])
         with Image.open(filename) as img:
             array: "np.typing.NDArray[np.int_]" = np.array(img)
-            tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
+            tensor = torch.from_numpy(array)
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))
             return tensor
@@ -162,7 +162,7 @@ class COWC(VisionDataset, abc.ABC):
             the target
         """
         target = int(self.targets[index])
-        tensor: Tensor = torch.tensor(target)  # type: ignore[attr-defined]
+        tensor = torch.tensor(target)
         return tensor
 
     def _check_integrity(self) -> bool:

--- a/torchgeo/datasets/cv4a_kenya_crop_type.py
+++ b/torchgeo/datasets/cv4a_kenya_crop_type.py
@@ -192,9 +192,9 @@ class CV4AKenyaCropType(VisionDataset):
             "image": img,
             "mask": labels,
             "field_ids": field_ids,
-            "tile_index": torch.tensor(tile_index),  # type: ignore[attr-defined]
-            "x": torch.tensor(x),  # type: ignore[attr-defined]
-            "y": torch.tensor(y),  # type: ignore[attr-defined]
+            "tile_index": torch.tensor(tile_index),
+            "x": torch.tensor(x),
+            "y": torch.tensor(y),
         }
 
         if self.transforms is not None:
@@ -234,11 +234,11 @@ class CV4AKenyaCropType(VisionDataset):
 
         with Image.open(os.path.join(directory, "labels.tif")) as img:
             array: "np.typing.NDArray[np.int_]" = np.array(img)
-            labels: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
+            labels = torch.from_numpy(array)
 
         with Image.open(os.path.join(directory, "field_ids.tif")) as img:
             array = np.array(img)
-            field_ids: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
+            field_ids = torch.from_numpy(array)
 
         return (labels, field_ids)
 
@@ -281,12 +281,12 @@ class CV4AKenyaCropType(VisionDataset):
         if self.verbose:
             print(f"Loading all imagery for {tile_name}")
 
-        img: Tensor = torch.zeros(  # type: ignore[attr-defined]
+        img = torch.zeros(
             len(self.dates),
             len(bands),
             self.tile_height,
             self.tile_width,
-            dtype=torch.float32,  # type: ignore[attr-defined]
+            dtype=torch.float32,
         )
 
         for date_index, date in enumerate(self.dates):
@@ -319,11 +319,8 @@ class CV4AKenyaCropType(VisionDataset):
         if self.verbose:
             print(f"Loading imagery for {tile_name} at {date}")
 
-        img: Tensor = torch.zeros(  # type: ignore[attr-defined]
-            len(bands),
-            self.tile_height,
-            self.tile_width,
-            dtype=torch.float32,  # type: ignore[attr-defined]
+        img = torch.zeros(
+            len(bands), self.tile_height, self.tile_width, dtype=torch.float32
         )
         for band_index, band_name in enumerate(self.bands):
             filepath = os.path.join(
@@ -334,7 +331,7 @@ class CV4AKenyaCropType(VisionDataset):
             )
             with Image.open(filepath) as band_img:
                 array: "np.typing.NDArray[np.int_]" = np.array(band_img)
-                img[band_index] = torch.from_numpy(array)  # type: ignore[attr-defined]
+                img[band_index] = torch.from_numpy(array)
 
         return img
 

--- a/torchgeo/datasets/cyclone.py
+++ b/torchgeo/datasets/cyclone.py
@@ -147,7 +147,7 @@ class TropicalCycloneWindEstimation(VisionDataset):
             array: "np.typing.NDArray[np.int_]" = np.array(img)
             if len(array.shape) == 3:
                 array = array[:, :, 0]
-            tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
+            tensor = torch.from_numpy(array)
             return tensor
 
     def _load_features(self, directory: str) -> Dict[str, Any]:

--- a/torchgeo/datasets/dfc2022.py
+++ b/torchgeo/datasets/dfc2022.py
@@ -175,7 +175,7 @@ class DFC2022(VisionDataset):
         files = self.files[index]
         image = self._load_image(files["image"])
         dem = self._load_image(files["dem"], shape=image.shape[1:])
-        image = torch.cat(tensors=[image, dem], dim=0)  # type: ignore[attr-defined]
+        image = torch.cat(tensors=[image, dem], dim=0)
 
         sample = {"image": image}
 
@@ -235,7 +235,7 @@ class DFC2022(VisionDataset):
             array: "np.typing.NDArray[np.float_]" = f.read(
                 out_shape=shape, out_dtype="float32", resampling=Resampling.bilinear
             )
-            tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
+            tensor = torch.from_numpy(array)
             return tensor
 
     def _load_target(self, path: str) -> Tensor:
@@ -251,8 +251,8 @@ class DFC2022(VisionDataset):
             array: "np.typing.NDArray[np.int_]" = f.read(
                 indexes=1, out_dtype="int32", resampling=Resampling.bilinear
             )
-            tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
-            tensor = tensor.to(torch.long)  # type: ignore[attr-defined]
+            tensor = torch.from_numpy(array)
+            tensor = tensor.to(torch.long)
             return tensor
 
     def _verify(self) -> None:
@@ -310,7 +310,7 @@ class DFC2022(VisionDataset):
         """
         ncols = 2
         image = sample["image"][:3]
-        image = image.to(torch.uint8)  # type: ignore[attr-defined]
+        image = image.to(torch.uint8)
         image = image.permute(1, 2, 0).numpy()
 
         dem = sample["image"][-1].numpy()

--- a/torchgeo/datasets/enviroatlas.py
+++ b/torchgeo/datasets/enviroatlas.py
@@ -402,10 +402,8 @@ class EnviroAtlas(GeoDataset):
         sample["image"] = np.concatenate(sample["image"], axis=0)
         sample["mask"] = np.concatenate(sample["mask"], axis=0)
 
-        sample["image"] = torch.from_numpy(  # type: ignore[attr-defined]
-            sample["image"]
-        )
-        sample["mask"] = torch.from_numpy(sample["mask"])  # type: ignore[attr-defined]
+        sample["image"] = torch.from_numpy(sample["image"])
+        sample["mask"] = torch.from_numpy(sample["mask"])
 
         if self.transforms is not None:
             sample = self.transforms(sample)

--- a/torchgeo/datasets/etci2021.py
+++ b/torchgeo/datasets/etci2021.py
@@ -138,7 +138,7 @@ class ETCI2021(VisionDataset):
         else:
             mask = water_mask.unsqueeze(0)
 
-        image = torch.cat(tensors=[vv, vh], dim=0)  # type: ignore[attr-defined]
+        image = torch.cat(tensors=[vv, vh], dim=0)
         sample = {"image": image, "mask": mask}
 
         if self.transforms is not None:
@@ -205,7 +205,7 @@ class ETCI2021(VisionDataset):
         filename = os.path.join(path)
         with Image.open(filename) as img:
             array: "np.typing.NDArray[np.int_]" = np.array(img.convert("RGB"))
-            tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
+            tensor = torch.from_numpy(array)
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))
             return tensor
@@ -222,9 +222,9 @@ class ETCI2021(VisionDataset):
         filename = os.path.join(path)
         with Image.open(filename) as img:
             array: "np.typing.NDArray[np.int_]" = np.array(img.convert("L"))
-            tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
-            tensor = torch.clamp(tensor, min=0, max=1)  # type: ignore[attr-defined]
-            tensor = tensor.to(torch.long)  # type: ignore[attr-defined]
+            tensor = torch.from_numpy(array)
+            tensor = torch.clamp(tensor, min=0, max=1)
+            tensor = tensor.to(torch.long)
             return tensor
 
     def _check_integrity(self) -> bool:

--- a/torchgeo/datasets/etci2021.py
+++ b/torchgeo/datasets/etci2021.py
@@ -274,14 +274,17 @@ class ETCI2021(VisionDataset):
         """
         vv = np.rollaxis(sample["image"][:3].numpy(), 0, 3)
         vh = np.rollaxis(sample["image"][3:].numpy(), 0, 3)
-        water_mask = sample["mask"][0].numpy()
+        mask = sample["mask"].squeeze(0)
 
-        showing_flood_mask = sample["mask"].shape[0] > 1
+        showing_flood_mask = mask.shape[0] == 2
         showing_predictions = "prediction" in sample
         num_panels = 3
         if showing_flood_mask:
-            flood_mask = sample["mask"][1].numpy()
+            water_mask = mask[0].numpy()
+            flood_mask = mask[1].numpy()
             num_panels += 1
+        else:
+            water_mask = mask.numpy()
 
         if showing_predictions:
             predictions = sample["prediction"].numpy()

--- a/torchgeo/datasets/eurosat.py
+++ b/torchgeo/datasets/eurosat.py
@@ -168,9 +168,7 @@ class EuroSAT(VisionClassificationDataset):
         """
         image, label = self._load_image(index)
 
-        image = torch.index_select(  # type: ignore[attr-defined]
-            image, dim=0, index=self.band_indices
-        )
+        image = torch.index_select(image, dim=0, index=self.band_indices)
         sample = {"image": image, "label": label}
 
         if self.transforms is not None:

--- a/torchgeo/datasets/fair1m.py
+++ b/torchgeo/datasets/fair1m.py
@@ -219,7 +219,7 @@ class FAIR1M(VisionDataset):
         path = os.path.join(self.root, self.image_root, path)
         with Image.open(path) as img:
             array: "np.typing.NDArray[np.int_]" = np.array(img.convert("RGB"))
-            tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
+            tensor = torch.from_numpy(array)
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))
             return tensor
@@ -237,8 +237,8 @@ class FAIR1M(VisionDataset):
             the target bounding boxes and labels
         """
         labels_list = [self.classes[label]["id"] for label in labels]
-        boxes = torch.tensor(points).to(torch.float)  # type: ignore[attr-defined]
-        labels = torch.tensor(labels_list)  # type: ignore[attr-defined]
+        boxes = torch.tensor(points).to(torch.float)
+        labels = torch.tensor(labels_list)
         return boxes, cast(Tensor, labels)
 
     def _verify(self) -> None:

--- a/torchgeo/datasets/fair1m.py
+++ b/torchgeo/datasets/fair1m.py
@@ -5,7 +5,7 @@
 
 import glob
 import os
-from typing import Any, Callable, Dict, List, Optional, Tuple, cast
+from typing import Any, Callable, Dict, List, Optional, Tuple
 from xml.etree import ElementTree
 
 import matplotlib.patches as patches
@@ -238,8 +238,8 @@ class FAIR1M(VisionDataset):
         """
         labels_list = [self.classes[label]["id"] for label in labels]
         boxes = torch.tensor(points).to(torch.float)
-        labels = torch.tensor(labels_list)
-        return boxes, cast(Tensor, labels)
+        labels_tensor = torch.tensor(labels_list)
+        return boxes, labels_tensor
 
     def _verify(self) -> None:
         """Verify the integrity of the dataset.

--- a/torchgeo/datasets/fair1m.py
+++ b/torchgeo/datasets/fair1m.py
@@ -5,8 +5,8 @@
 
 import glob
 import os
-from typing import Any, Callable, Dict, List, Optional, Tuple
-from xml.etree import ElementTree
+from typing import Any, Callable, Dict, List, Optional, Tuple, cast
+from xml.etree.ElementTree import Element, parse
 
 import matplotlib.patches as patches
 import matplotlib.pyplot as plt
@@ -28,21 +28,25 @@ def parse_pascal_voc(path: str) -> Dict[str, Any]:
     Returns:
         dict of image filename, points, and class labels
     """
-    et = ElementTree.parse(path)
+    et = parse(path)
     element = et.getroot()
-    filename = element.find("source").find("filename").text  # type: ignore[union-attr]
+    source = cast(Element, element.find("source"))
+    filename = cast(Element, source.find("filename")).text
     labels, points = [], []
-    for obj in element.find("objects").findall("object"):  # type: ignore[union-attr]
-        obj_points = [
-            p for p in obj.find("points").findall("point")  # type: ignore[union-attr]
-        ]
-        obj_points = [p.text.split(",") for p in obj_points]  # type: ignore[union-attr]
-        obj_points = [
-            (float(p1), float(p2)) for p1, p2 in obj_points  # type: ignore[arg-type]
-        ]
-        label = obj.find("possibleresult").find("name").text  # type: ignore[union-attr]
+    objects = cast(Element, element.find("objects"))
+    for obj in objects.findall("object"):
+        elm_points = cast(Element, obj.find("points"))
+        lis_points = elm_points.findall("point")
+        str_points = []
+        for point in lis_points:
+            text = cast(str, point.text)
+            str_points.append(text.split(","))
+        tup_points = [(float(p1), float(p2)) for p1, p2 in str_points]
+        possibleresult = cast(Element, obj.find("possibleresult"))
+        name = cast(Element, possibleresult.find("name"))
+        label = name.text
         labels.append(label)
-        points.append(obj_points)
+        points.append(tup_points)
     return dict(filename=filename, points=points, labels=labels)
 
 

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -503,7 +503,7 @@ class RasterDataset(GeoDataset):
         else:
             return src
 
-    def plot(self, data) -> None:
+    def plot(self, data: Tensor) -> None:
         """Plot a data sample.
 
         Args:
@@ -672,7 +672,7 @@ class VectorDataset(GeoDataset):
 
         return sample
 
-    def plot(self, data) -> None:
+    def plot(self, data: Tensor) -> None:
         """Plot a data sample.
 
         Args:

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -424,7 +424,7 @@ class RasterDataset(GeoDataset):
                     filepath = glob.glob(os.path.join(directory, filename))[0]
                     band_filepaths.append(filepath)
                 data_list.append(self._merge_files(band_filepaths, query))
-            data = torch.cat(data_list)  # type: ignore[attr-defined]
+            data = torch.cat(data_list)
         else:
             data = self._merge_files(filepaths, query)
 
@@ -469,7 +469,7 @@ class RasterDataset(GeoDataset):
         elif dest.dtype == np.uint32:
             dest = dest.astype(np.int64)
 
-        tensor: Tensor = torch.tensor(dest)  # type: ignore[attr-defined]
+        tensor = torch.tensor(dest)
         return tensor
 
     @functools.lru_cache(maxsize=128)
@@ -503,7 +503,7 @@ class RasterDataset(GeoDataset):
         else:
             return src
 
-    def plot(self, data: Tensor) -> None:
+    def plot(self, data) -> None:
         """Plot a data sample.
 
         Args:
@@ -665,18 +665,14 @@ class VectorDataset(GeoDataset):
             shapes, out_shape=(int(height), int(width)), transform=transform
         )
 
-        sample = {
-            "mask": torch.tensor(masks),  # type: ignore[attr-defined]
-            "crs": self.crs,
-            "bbox": query,
-        }
+        sample = {"mask": torch.tensor(masks), "crs": self.crs, "bbox": query}
 
         if self.transforms is not None:
             sample = self.transforms(sample)
 
         return sample
 
-    def plot(self, data: Tensor) -> None:
+    def plot(self, data) -> None:
         """Plot a data sample.
 
         Args:
@@ -805,10 +801,10 @@ class VisionClassificationDataset(VisionDataset, ImageFolder):  # type: ignore[m
         """
         img, label = ImageFolder.__getitem__(self, index)
         array: "np.typing.NDArray[np.int_]" = np.array(img)
-        tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
+        tensor = torch.from_numpy(array)
         # Convert from HxWxC to CxHxW
         tensor = tensor.permute((2, 0, 1))
-        label = torch.tensor(label)  # type: ignore[attr-defined]
+        label = torch.tensor(label)
         return tensor, label
 
 

--- a/torchgeo/datasets/gid15.py
+++ b/torchgeo/datasets/gid15.py
@@ -192,7 +192,7 @@ class GID15(VisionDataset):
         filename = os.path.join(path)
         with Image.open(filename) as img:
             array: "np.typing.NDArray[np.int_]" = np.array(img.convert("RGB"))
-            tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
+            tensor = torch.from_numpy(array)
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))
             return tensor
@@ -209,8 +209,8 @@ class GID15(VisionDataset):
         filename = os.path.join(path)
         with Image.open(filename) as img:
             array: "np.typing.NDArray[np.int_]" = np.array(img.convert("L"))
-            tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
-            tensor = tensor.to(torch.long)  # type: ignore[attr-defined]
+            tensor = torch.from_numpy(array)
+            tensor = tensor.to(torch.long)
             return tensor
 
     def _check_integrity(self) -> bool:

--- a/torchgeo/datasets/globbiomass.py
+++ b/torchgeo/datasets/globbiomass.py
@@ -189,7 +189,7 @@ class GlobBiomass(RasterDataset):
         std_error_paths = [f for f in filepaths if "err" in f]
         std_err_mask = self._merge_files(std_error_paths, query)
 
-        mask = torch.cat((mask, std_err_mask), dim=0)  # type: ignore[attr-defined]
+        mask = torch.cat((mask, std_err_mask), dim=0)
 
         sample = {"mask": mask, "crs": self.crs, "bbox": query}
 

--- a/torchgeo/datasets/idtrees.py
+++ b/torchgeo/datasets/idtrees.py
@@ -239,7 +239,7 @@ class IDTReeS(VisionDataset):
         """
         with rasterio.open(path) as f:
             array = f.read(out_shape=self.image_size, resampling=Resampling.bilinear)
-        tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
+        tensor = torch.from_numpy(array)
         return tensor
 
     def _load_las(self, path: str) -> Tensor:
@@ -255,7 +255,7 @@ class IDTReeS(VisionDataset):
 
         las = laspy.read(path)
         array: "np.typing.NDArray[np.int_]" = np.stack([las.x, las.y, las.z], axis=0)
-        tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
+        tensor = torch.from_numpy(array)
         return tensor
 
     def _load_boxes(self, path: str) -> Tensor:
@@ -294,7 +294,7 @@ class IDTReeS(VisionDataset):
                 ymax = max([coord[1] for coord in coords])
                 boxes.append([xmin, ymin, xmax, ymax])
 
-        tensor: Tensor = torch.tensor(boxes)  # type: ignore[attr-defined]
+        tensor = torch.tensor(boxes)
         return tensor
 
     def _load_target(self, path: str) -> Tensor:
@@ -313,7 +313,7 @@ class IDTReeS(VisionDataset):
         # Load object labels
         classes = self.labels[indices]["taxonID"].tolist()
         labels = [self.class2idx[c] for c in classes]
-        tensor: Tensor = torch.tensor(labels)  # type: ignore[attr-defined]
+        tensor = torch.tensor(labels)
         return tensor
 
     def _load(self, root: str) -> Tuple[List[str], Dict[int, Dict[str, Any]], Any]:
@@ -448,7 +448,7 @@ class IDTReeS(VisionDataset):
         """
         assert len(hsi_indices) == 3
 
-        def normalize(x: Tensor) -> Tensor:
+        def normalize(x) -> Tensor:
             return (x - x.min()) / (x.max() - x.min())
 
         ncols = 3

--- a/torchgeo/datasets/idtrees.py
+++ b/torchgeo/datasets/idtrees.py
@@ -448,7 +448,7 @@ class IDTReeS(VisionDataset):
         """
         assert len(hsi_indices) == 3
 
-        def normalize(x) -> Tensor:
+        def normalize(x: Tensor) -> Tensor:
             return (x - x.min()) / (x.max() - x.min())
 
         ncols = 3

--- a/torchgeo/datasets/idtrees.py
+++ b/torchgeo/datasets/idtrees.py
@@ -202,7 +202,7 @@ class IDTReeS(VisionDataset):
             data and label at that index
         """
         path = self.images[index]
-        image = self._load_image(path).to(torch.uint8)  # type:ignore[attr-defined]
+        image = self._load_image(path).to(torch.uint8)
         hsi = self._load_image(path.replace("RGB", "HSI"))
         chm = self._load_image(path.replace("RGB", "CHM"))
         las = self._load_las(path.replace("RGB", "LAS").replace(".tif", ".las"))

--- a/torchgeo/datasets/inria.py
+++ b/torchgeo/datasets/inria.py
@@ -121,7 +121,7 @@ class InriaAerialImageLabeling(VisionDataset):
         """
         with rio.open(path) as img:
             array = img.read().astype(np.int32)
-            tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
+            tensor = torch.from_numpy(array)
             return tensor
 
     def _load_target(self, path: str) -> Tensor:
@@ -136,7 +136,7 @@ class InriaAerialImageLabeling(VisionDataset):
         with rio.open(path) as img:
             array = img.read().astype(np.int32)
             array = np.clip(array, 0, 1)
-            mask: Tensor = torch.from_numpy(array[0])  # type: ignore[attr-defined]
+            mask = torch.from_numpy(array[0])
             return mask
 
     def __len__(self) -> int:

--- a/torchgeo/datasets/landcoverai.py
+++ b/torchgeo/datasets/landcoverai.py
@@ -149,7 +149,7 @@ class LandCoverAI(VisionDataset):
         filename = os.path.join(self.root, "output", id_ + ".jpg")
         with Image.open(filename) as img:
             array: "np.typing.NDArray[np.int_]" = np.array(img)
-            tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
+            tensor = torch.from_numpy(array)
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))
             return tensor
@@ -167,7 +167,7 @@ class LandCoverAI(VisionDataset):
         filename = os.path.join(self.root, "output", id_ + "_m.png")
         with Image.open(filename) as img:
             array: "np.typing.NDArray[np.int_]" = np.array(img.convert("L"))
-            tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
+            tensor = torch.from_numpy(array)
             return tensor
 
     def _verify(self) -> None:

--- a/torchgeo/datasets/levircd.py
+++ b/torchgeo/datasets/levircd.py
@@ -157,7 +157,7 @@ class LEVIRCDPlus(VisionDataset):
         filename = os.path.join(path)
         with Image.open(filename) as img:
             array: "np.typing.NDArray[np.int_]" = np.array(img.convert("RGB"))
-            tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
+            tensor = torch.from_numpy(array)
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))
             return tensor
@@ -174,9 +174,9 @@ class LEVIRCDPlus(VisionDataset):
         filename = os.path.join(path)
         with Image.open(filename) as img:
             array: "np.typing.NDArray[np.int_]" = np.array(img.convert("L"))
-            tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
-            tensor = torch.clamp(tensor, min=0, max=1)  # type: ignore[attr-defined]
-            tensor = tensor.to(torch.long)  # type: ignore[attr-defined]
+            tensor = torch.from_numpy(array)
+            tensor = torch.clamp(tensor, min=0, max=1)
+            tensor = tensor.to(torch.long)
             return tensor
 
     def _check_integrity(self) -> bool:

--- a/torchgeo/datasets/loveda.py
+++ b/torchgeo/datasets/loveda.py
@@ -215,7 +215,7 @@ class LoveDA(VisionDataset):
         filename = os.path.join(path)
         with Image.open(filename) as img:
             array: "np.typing.NDArray[np.int_]" = np.array(img.convert("RGB"))
-            tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
+            tensor = torch.from_numpy(array)
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))
             return tensor
@@ -232,8 +232,8 @@ class LoveDA(VisionDataset):
         filename = os.path.join(path)
         with Image.open(filename) as img:
             array: "np.typing.NDArray[np.int_]" = np.array(img.convert("L"))
-            tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
-            tensor = tensor.to(torch.long)  # type: ignore[attr-defined]
+            tensor = torch.from_numpy(array)
+            tensor = tensor.to(torch.long)
             return tensor
 
     def _check_integrity(self) -> bool:

--- a/torchgeo/datasets/nasa_marine_debris.py
+++ b/torchgeo/datasets/nasa_marine_debris.py
@@ -123,7 +123,7 @@ class NASAMarineDebris(VisionDataset):
         """
         with rasterio.open(path) as f:
             array = f.read()
-        tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
+        tensor = torch.from_numpy(array)
         return tensor
 
     def _load_target(self, path: str) -> Tensor:
@@ -138,7 +138,7 @@ class NASAMarineDebris(VisionDataset):
         array = np.load(path)
         # boxes contain unecessary value of 1 after xyxy coords
         array = array[:, :4]
-        tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
+        tensor = torch.from_numpy(array)
         return tensor
 
     def _load_files(self) -> List[Dict[str, str]]:

--- a/torchgeo/datasets/nwpu.py
+++ b/torchgeo/datasets/nwpu.py
@@ -175,7 +175,7 @@ class VHR10(VisionDataset):
         )
         with Image.open(filename) as img:
             array: "np.typing.NDArray[np.int_]" = np.array(img)
-            tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
+            tensor = torch.from_numpy(array)
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))
             return tensor

--- a/torchgeo/datasets/openbuildings.py
+++ b/torchgeo/datasets/openbuildings.py
@@ -325,11 +325,9 @@ class OpenBuildings(VectorDataset):
             masks = rasterio.features.rasterize(
                 shapes, out_shape=(int(height), int(width)), transform=transform
             )
-            masks = torch.tensor(masks).unsqueeze(0)  # type: ignore[attr-defined]
+            masks = torch.tensor(masks).unsqueeze(0)
         else:
-            masks = torch.zeros(  # type: ignore[attr-defined]
-                size=(1, int(height), int(width))
-            )
+            masks = torch.zeros(size=(1, int(height), int(width)))
 
         sample = {"mask": masks, "crs": self.crs, "bbox": query}
 

--- a/torchgeo/datasets/oscd.py
+++ b/torchgeo/datasets/oscd.py
@@ -291,7 +291,7 @@ class OSCD(VisionDataset):
 
         rgb_inds = [3, 2, 1] if self.bands == "all" else [0, 1, 2]
 
-        def get_masked(img) -> "np.typing.NDArray[np.uint8]":
+        def get_masked(img: Tensor) -> "np.typing.NDArray[np.uint8]":
             rgb_img = img[rgb_inds].float().numpy()
             per02 = np.percentile(rgb_img, 2)
             per98 = np.percentile(rgb_img, 98)

--- a/torchgeo/datasets/oscd.py
+++ b/torchgeo/datasets/oscd.py
@@ -203,7 +203,7 @@ class OSCD(VisionDataset):
             with Image.open(path) as img:
                 images.append(np.array(img))
         array: "np.typing.NDArray[np.int_]" = np.stack(images, axis=0).astype(np.int_)
-        tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
+        tensor = torch.from_numpy(array)
         return tensor
 
     def _load_target(self, path: str) -> Tensor:
@@ -218,9 +218,9 @@ class OSCD(VisionDataset):
         filename = os.path.join(path)
         with Image.open(filename) as img:
             array: "np.typing.NDArray[np.int_]" = np.array(img.convert("L"))
-            tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
-            tensor = torch.clamp(tensor, min=0, max=1)  # type: ignore[attr-defined]
-            tensor = tensor.to(torch.long)  # type: ignore[attr-defined]
+            tensor = torch.from_numpy(array)
+            tensor = torch.clamp(tensor, min=0, max=1)
+            tensor = tensor.to(torch.long)
             return tensor
 
     def _verify(self) -> None:
@@ -291,7 +291,7 @@ class OSCD(VisionDataset):
 
         rgb_inds = [3, 2, 1] if self.bands == "all" else [0, 1, 2]
 
-        def get_masked(img: Tensor) -> "np.typing.NDArray[np.uint8]":
+        def get_masked(img) -> "np.typing.NDArray[np.uint8]":
             rgb_img = img[rgb_inds].float().numpy()
             per02 = np.percentile(rgb_img, 2)
             per98 = np.percentile(rgb_img, 98)
@@ -299,7 +299,7 @@ class OSCD(VisionDataset):
                 np.uint8
             )
             array: "np.typing.NDArray[np.uint8]" = draw_semantic_segmentation_masks(
-                torch.from_numpy(rgb_img),  # type: ignore[attr-defined]
+                torch.from_numpy(rgb_img),
                 sample["mask"],
                 alpha=alpha,
                 colors=self.colormap,

--- a/torchgeo/datasets/potsdam.py
+++ b/torchgeo/datasets/potsdam.py
@@ -187,7 +187,7 @@ class Potsdam2D(VisionDataset):
         path = self.files[index]["image"]
         with rasterio.open(path) as f:
             array = f.read()
-            tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
+            tensor = torch.from_numpy(array)
             return tensor
 
     def _load_target(self, index: int) -> Tensor:
@@ -203,9 +203,9 @@ class Potsdam2D(VisionDataset):
         with Image.open(path) as img:
             array: "np.typing.NDArray[np.uint8]" = np.array(img.convert("RGB"))
             array = rgb_to_mask(array, self.colormap)
-            tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
+            tensor = torch.from_numpy(array)
             # Convert from HxWxC to CxHxW
-            tensor = tensor.to(torch.long)  # type: ignore[attr-defined]
+            tensor = tensor.to(torch.long)
         return tensor
 
     def _verify(self) -> None:

--- a/torchgeo/datasets/seco.py
+++ b/torchgeo/datasets/seco.py
@@ -184,9 +184,7 @@ class SeasonalContrastS2(VisionDataset):
                         pil_image.resize((264, 264), resample=Image.BILINEAR)
                     )
                 all_data.append(band_data)
-        image = torch.from_numpy(  # type: ignore[attr-defined]
-            np.stack(all_data, axis=0)
-        )
+        image = torch.from_numpy(np.stack(all_data, axis=0))
         return cast(Tensor, image)
 
     def _verify(self) -> None:

--- a/torchgeo/datasets/seco.py
+++ b/torchgeo/datasets/seco.py
@@ -5,7 +5,7 @@
 
 import os
 from collections import defaultdict
-from typing import Callable, Dict, List, Optional, cast
+from typing import Callable, Dict, List, Optional
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -185,7 +185,7 @@ class SeasonalContrastS2(VisionDataset):
                     )
                 all_data.append(band_data)
         image = torch.from_numpy(np.stack(all_data, axis=0))
-        return cast(Tensor, image)
+        return image
 
     def _verify(self) -> None:
         """Verify the integrity of the dataset.

--- a/torchgeo/datasets/sen12ms.py
+++ b/torchgeo/datasets/sen12ms.py
@@ -192,7 +192,7 @@ class SEN12MS(VisionDataset):
         assert split in ["train", "test"]
 
         self._validate_bands(bands)
-        self.band_indices = torch.tensor(  # type: ignore[attr-defined]
+        self.band_indices = torch.tensor(
             [self.band_names.index(b) for b in bands]
         ).long()
         self.bands = bands
@@ -227,10 +227,8 @@ class SEN12MS(VisionDataset):
         s1 = self._load_raster(filename, "s1")
         s2 = self._load_raster(filename, "s2")
 
-        image = torch.cat(tensors=[s1, s2], dim=0)  # type: ignore[attr-defined]
-        image = torch.index_select(  # type: ignore[attr-defined]
-            image, dim=0, index=self.band_indices
-        )
+        image = torch.cat(tensors=[s1, s2], dim=0)
+        image = torch.index_select(image, dim=0, index=self.band_indices)
 
         sample: Dict[str, Tensor] = {"image": image, "mask": lc}
 
@@ -269,7 +267,7 @@ class SEN12MS(VisionDataset):
             )
         ) as f:
             array = f.read().astype(np.int32)
-            tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
+            tensor = torch.from_numpy(array)
             return tensor
 
     def _validate_bands(self, bands: Sequence[str]) -> None:

--- a/torchgeo/datasets/sentinel.py
+++ b/torchgeo/datasets/sentinel.py
@@ -131,7 +131,7 @@ class Sentinel2(Sentinel):
                 raise ValueError("Dataset doesn't contain some of the RGB bands")
 
         image = sample["image"][rgb_indices].permute(1, 2, 0)
-        image = torch.clamp(image / 3000, min=0, max=1)  # type: ignore[attr-defined]
+        image = torch.clamp(image / 3000, min=0, max=1)
 
         fig, ax = plt.subplots(1, 1, figsize=(4, 4))
 

--- a/torchgeo/datasets/so2sat.py
+++ b/torchgeo/datasets/so2sat.py
@@ -214,20 +214,15 @@ class So2Sat(VisionDataset):
             s2 = np.take(s2, indices=self.s2_band_indices, axis=2)
 
             # convert one-hot encoding to int64 then torch int
-            label = torch.tensor(  # type: ignore[attr-defined]
-                f["label"][index].argmax()
-            )
+            label = torch.tensor(f["label"][index].argmax())
 
             s1 = np.rollaxis(s1, 2, 0)  # convert to CxHxW format
             s2 = np.rollaxis(s2, 2, 0)  # convert to CxHxW format
 
-            s1 = torch.from_numpy(s1)  # type: ignore[attr-defined]
-            s2 = torch.from_numpy(s2)  # type: ignore[attr-defined]
+            s1 = torch.from_numpy(s1)
+            s2 = torch.from_numpy(s2)
 
-        sample = {
-            "image": torch.cat([s1, s2]),  # type: ignore[attr-defined]
-            "label": label,
-        }
+        sample = {"image": torch.cat([s1, s2]), "label": label}
 
         if self.transforms is not None:
             sample = self.transforms(sample)

--- a/torchgeo/datasets/spacenet.py
+++ b/torchgeo/datasets/spacenet.py
@@ -150,7 +150,7 @@ class SpaceNet(VisionDataset, abc.ABC):
         filename = os.path.join(path)
         with rio.open(filename) as img:
             array = img.read().astype(np.int32)
-            tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
+            tensor = torch.from_numpy(array)
             return tensor, img.transform, img.crs
 
     def _load_mask(
@@ -195,7 +195,7 @@ class SpaceNet(VisionDataset, abc.ABC):
                 dtype=np.uint8,
             )
 
-        mask: Tensor = torch.from_numpy(mask_data).long()  # type: ignore[attr-defined]
+        mask = torch.from_numpy(mask_data).long()
 
         return mask
 
@@ -937,7 +937,7 @@ class SpaceNet5(SpaceNet):
                 dtype=np.uint8,
             )
 
-        mask: Tensor = torch.from_numpy(mask_data).long()  # type: ignore[attr-defined]
+        mask = torch.from_numpy(mask_data).long()
         return mask
 
     def plot(

--- a/torchgeo/datasets/usavars.py
+++ b/torchgeo/datasets/usavars.py
@@ -177,7 +177,7 @@ class USAVars(VisionDataset):
         """
         with rasterio.open(path) as f:
             array: "np.typing.NDArray[np.int_]" = f.read()
-            tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
+            tensor = torch.from_numpy(array)
             return tensor
 
     def _verify(self) -> None:

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -625,8 +625,8 @@ def sort_sentinel2_bands(x: str) -> str:
 
 
 def draw_semantic_segmentation_masks(
-    image,
-    mask,
+    image: Tensor,
+    mask: Tensor,
     alpha: float = 0.5,
     colors: Optional[Sequence[Union[str, Tuple[int, int, int]]]] = None,
 ) -> "np.typing.NDArray[np.uint8]":

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -548,7 +548,7 @@ def concat_samples(samples: Iterable[Dict[Any, Any]]) -> Dict[Any, Any]:
     collated: Dict[Any, Any] = _list_dict_to_dict_list(samples)
     for key, value in collated.items():
         if isinstance(value[0], Tensor):
-            collated[key] = torch.cat(value)  # type: ignore[attr-defined]
+            collated[key] = torch.cat(value)
         else:
             collated[key] = value[0]
     return collated
@@ -573,9 +573,7 @@ def merge_samples(samples: Iterable[Dict[Any, Any]]) -> Dict[Any, Any]:
             if key in collated and isinstance(value, Tensor):
                 # Take the maximum so that nodata values (zeros) get replaced
                 # by data values whenever possible
-                collated[key] = torch.maximum(  # type: ignore[attr-defined]
-                    collated[key], value
-                )
+                collated[key] = torch.maximum(collated[key], value)
             else:
                 collated[key] = value
     return collated
@@ -627,8 +625,8 @@ def sort_sentinel2_bands(x: str) -> str:
 
 
 def draw_semantic_segmentation_masks(
-    image: Tensor,
-    mask: Tensor,
+    image,
+    mask,
     alpha: float = 0.5,
     colors: Optional[Sequence[Union[str, Tuple[int, int, int]]]] = None,
 ) -> "np.typing.NDArray[np.uint8]":
@@ -645,7 +643,7 @@ def draw_semantic_segmentation_masks(
         a version of ``image`` overlayed with the colors given by ``mask`` and
             ``colors``
     """
-    classes = torch.unique(mask)  # type: ignore[attr-defined]
+    classes = torch.unique(mask)
     classes = classes[1:]
     class_masks = mask == classes[:, None, None]
     img = draw_segmentation_masks(

--- a/torchgeo/datasets/vaihingen.py
+++ b/torchgeo/datasets/vaihingen.py
@@ -185,7 +185,7 @@ class Vaihingen2D(VisionDataset):
         path = self.files[index]["image"]
         with Image.open(path) as img:
             array: "np.typing.NDArray[np.int_]" = np.array(img.convert("RGB"))
-            tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
+            tensor = torch.from_numpy(array)
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))
         return tensor
@@ -203,9 +203,9 @@ class Vaihingen2D(VisionDataset):
         with Image.open(path) as img:
             array: "np.typing.NDArray[np.uint8]" = np.array(img.convert("RGB"))
             array = rgb_to_mask(array, self.colormap)
-            tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
+            tensor = torch.from_numpy(array)
             # Convert from HxWxC to CxHxW
-            tensor = tensor.to(torch.long)  # type: ignore[attr-defined]
+            tensor = tensor.to(torch.long)
         return tensor
 
     def _verify(self) -> None:

--- a/torchgeo/datasets/xview.py
+++ b/torchgeo/datasets/xview.py
@@ -158,7 +158,7 @@ class XView2(VisionDataset):
         filename = os.path.join(path)
         with Image.open(filename) as img:
             array: "np.typing.NDArray[np.int_]" = np.array(img.convert("RGB"))
-            tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
+            tensor = torch.from_numpy(array)
             # Convert from HxWxC to CxHxW
             tensor = tensor.permute((2, 0, 1))
             return tensor
@@ -175,8 +175,8 @@ class XView2(VisionDataset):
         filename = os.path.join(path)
         with Image.open(filename) as img:
             array: "np.typing.NDArray[np.int_]" = np.array(img.convert("L"))
-            tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
-            tensor = tensor.to(torch.long)  # type: ignore[attr-defined]
+            tensor = torch.from_numpy(array)
+            tensor = tensor.to(torch.long)
             return tensor
 
     def _verify(self) -> None:

--- a/torchgeo/datasets/zuericrop.py
+++ b/torchgeo/datasets/zuericrop.py
@@ -83,7 +83,7 @@ class ZueriCrop(VisionDataset):
                 don't match
         """
         self._validate_bands(bands)
-        self.band_indices = torch.tensor(  # type: ignore[attr-defined]
+        self.band_indices = torch.tensor(
             [self.band_names.index(b) for b in bands]
         ).long()
 
@@ -148,12 +148,10 @@ class ZueriCrop(VisionDataset):
         with h5py.File(self.filepath, "r") as f:
             array = f["data"][index, ...]
 
-        tensor: Tensor = torch.from_numpy(array)  # type: ignore[attr-defined]
+        tensor = torch.from_numpy(array)
         # Convert from TxHxWxC to TxCxHxW
         tensor = tensor.permute((0, 3, 1, 2))
-        tensor = torch.index_select(  # type: ignore[attr-defined]
-            tensor, dim=1, index=self.band_indices
-        )
+        tensor = torch.index_select(tensor, dim=1, index=self.band_indices)
         return tensor
 
     def _load_target(self, index: int) -> Tuple[Tensor, Tensor, Tensor]:
@@ -171,40 +169,40 @@ class ZueriCrop(VisionDataset):
             mask_array = f["gt"][index, ...]
             instance_array = f["gt_instance"][index, ...]
 
-        mask_tensor = torch.from_numpy(mask_array)  # type: ignore[attr-defined]
-        instance_tensor = torch.from_numpy(instance_array)  # type: ignore[attr-defined]
+        mask_tensor = torch.from_numpy(mask_array)
+        instance_tensor = torch.from_numpy(instance_array)
 
         # Convert from HxWxC to CxHxW
         mask_tensor = mask_tensor.permute((2, 0, 1))
         instance_tensor = instance_tensor.permute((2, 0, 1))
 
         # Convert instance mask of N instances to N binary instance masks
-        instance_ids = torch.unique(instance_tensor)  # type: ignore[attr-defined]
+        instance_ids = torch.unique(instance_tensor)
         # Exclude a mask for unknown/background
         instance_ids = instance_ids[instance_ids != 0]
         instance_ids = instance_ids[:, None, None]
-        masks: Tensor = instance_tensor == instance_ids
+        masks = instance_tensor == instance_ids
 
         # Parse labels for each instance
         labels_list = []
         for mask in masks:
             label = mask_tensor[mask[None, :, :]]
-            label = torch.unique(label)[0]  # type: ignore[attr-defined]
+            label = torch.unique(label)[0]
             labels_list.append(label)
 
         # Get bounding boxes for each instance
         boxes_list = []
         for mask in masks:
-            pos = torch.where(mask)  # type: ignore[attr-defined]
-            xmin = torch.min(pos[1])  # type: ignore[attr-defined]
-            xmax = torch.max(pos[1])  # type: ignore[attr-defined]
-            ymin = torch.min(pos[0])  # type: ignore[attr-defined]
-            ymax = torch.max(pos[0])  # type: ignore[attr-defined]
+            pos = torch.where(mask)
+            xmin = torch.min(pos[1])
+            xmax = torch.max(pos[1])
+            ymin = torch.min(pos[0])
+            ymax = torch.max(pos[0])
             boxes_list.append([xmin, ymin, xmax, ymax])
 
-        masks = masks.to(torch.uint8)  # type: ignore[attr-defined]
-        boxes = torch.tensor(boxes_list).to(torch.float)  # type: ignore[attr-defined]
-        labels = torch.tensor(labels_list).to(torch.long)  # type: ignore[attr-defined]
+        masks = masks.to(torch.uint8)
+        boxes = torch.tensor(boxes_list).to(torch.float)
+        labels = torch.tensor(labels_list).to(torch.long)
 
         return masks, boxes, labels
 
@@ -292,18 +290,15 @@ class ZueriCrop(VisionDataset):
         ncols = 2
         image, mask = sample["image"][time_step, rgb_indices], sample["mask"]
 
-        image = torch.tensor(  # type: ignore[attr-defined]
-            percentile_normalization(image.numpy()) * 255,
-            dtype=torch.uint8,  # type: ignore[attr-defined]
+        image = torch.tensor(
+            percentile_normalization(image.numpy()) * 255, dtype=torch.uint8
         )
 
-        mask = torch.argmax(mask, dim=0)  # type: ignore[attr-defined]
+        mask = torch.argmax(mask, dim=0)
 
         if "prediction" in sample:
             ncols += 1
-            preds = torch.argmax(  # type: ignore[attr-defined]
-                sample["prediction"], dim=0
-            )
+            preds = torch.argmax(sample["prediction"], dim=0)
 
         fig, axs = plt.subplots(ncols=ncols, figsize=(10, 10 * ncols))
 

--- a/torchgeo/losses/qr.py
+++ b/torchgeo/losses/qr.py
@@ -32,11 +32,9 @@ class QRLoss(Module):
         """
         q = probs
         q_bar = q.mean(dim=(0, 2, 3))
-        qbar_log_S = (q_bar * torch.log(q_bar)).sum()  # type: ignore[attr-defined]
+        qbar_log_S = (q_bar * torch.log(q_bar)).sum()
 
-        q_log_p = torch.einsum(  # type: ignore[attr-defined]
-            "bcxy,bcxy->bxy", q, torch.log(target)  # type: ignore[attr-defined]
-        ).mean()
+        q_log_p = torch.einsum("bcxy,bcxy->bxy", q, torch.log(target)).mean()
 
         loss = qbar_log_S - q_log_p
         return cast(torch.Tensor, loss)
@@ -69,10 +67,6 @@ class RQLoss(Module):
         ).clamp_min(1e-12).expand_as(q)
         r = F.normalize(z * target, p=1, dim=1)
 
-        loss = torch.einsum(  # type: ignore[attr-defined]
-            "bcxy,bcxy->bxy",
-            r,
-            torch.log(r) - torch.log(q),  # type: ignore[attr-defined]
-        ).mean()
+        loss = torch.einsum("bcxy,bcxy->bxy", r, torch.log(r) - torch.log(q)).mean()
 
         return cast(torch.Tensor, loss)

--- a/torchgeo/losses/qr.py
+++ b/torchgeo/losses/qr.py
@@ -34,7 +34,9 @@ class QRLoss(Module):
         q_bar = q.mean(dim=(0, 2, 3))
         qbar_log_S = (q_bar * torch.log(q_bar)).sum()
 
-        q_log_p = torch.einsum("bcxy,bcxy->bxy", q, torch.log(target)).mean()
+        q_log_p = torch.einsum(  # type: ignore[no-untyped-call]
+            "bcxy,bcxy->bxy", q, torch.log(target)
+        ).mean()
 
         loss = qbar_log_S - q_log_p
         return cast(torch.Tensor, loss)
@@ -67,6 +69,8 @@ class RQLoss(Module):
         ).clamp_min(1e-12).expand_as(q)
         r = F.normalize(z * target, p=1, dim=1)
 
-        loss = torch.einsum("bcxy,bcxy->bxy", r, torch.log(r) - torch.log(q)).mean()
+        loss = torch.einsum(  # type: ignore[no-untyped-call]
+            "bcxy,bcxy->bxy", r, torch.log(r) - torch.log(q)
+        ).mean()
 
         return cast(torch.Tensor, loss)

--- a/torchgeo/models/changestar.py
+++ b/torchgeo/models/changestar.py
@@ -68,7 +68,7 @@ class ChangeMixin(Module):
 
         self.convs = nn.modules.Sequential(*layers)
 
-    def forward(self, bi_feature: Tensor) -> List[Tensor]:
+    def forward(self, bi_feature) -> List[Tensor]:
         """Forward pass of the model.
 
         Args:
@@ -78,14 +78,10 @@ class ChangeMixin(Module):
             a list of bidirected output predictions
         """
         batch_size = bi_feature.size(0)
-        t1t2 = torch.cat(  # type: ignore[attr-defined]
-            [bi_feature[:, 0, :, :, :], bi_feature[:, 1, :, :, :]], dim=1
-        )
-        t2t1 = torch.cat(  # type: ignore[attr-defined]
-            [bi_feature[:, 1, :, :, :], bi_feature[:, 0, :, :, :]], dim=1
-        )
+        t1t2 = torch.cat([bi_feature[:, 0, :, :, :], bi_feature[:, 1, :, :, :]], dim=1)
+        t2t1 = torch.cat([bi_feature[:, 1, :, :, :], bi_feature[:, 0, :, :, :]], dim=1)
 
-        c1221 = self.convs(torch.cat([t1t2, t2t1], dim=0))  # type: ignore[attr-defined]
+        c1221 = self.convs(torch.cat([t1t2, t2t1], dim=0))
         c12, c21 = torch.split(
             c1221, batch_size, dim=0
         )  # type: ignore[no-untyped-call]
@@ -139,7 +135,7 @@ class ChangeStar(Module):
             raise ValueError(f"Unknown inference_mode: {inference_mode}")
         self.inference_mode = inference_mode
 
-    def forward(self, x: Tensor) -> Dict[str, Tensor]:
+    def forward(self, x) -> Dict[str, Tensor]:
         """Forward pass of the model.
 
         Args:

--- a/torchgeo/models/changestar.py
+++ b/torchgeo/models/changestar.py
@@ -68,7 +68,7 @@ class ChangeMixin(Module):
 
         self.convs = nn.modules.Sequential(*layers)
 
-    def forward(self, bi_feature) -> List[Tensor]:
+    def forward(self, bi_feature: Tensor) -> List[Tensor]:
         """Forward pass of the model.
 
         Args:
@@ -135,7 +135,7 @@ class ChangeStar(Module):
             raise ValueError(f"Unknown inference_mode: {inference_mode}")
         self.inference_mode = inference_mode
 
-    def forward(self, x) -> Dict[str, Tensor]:
+    def forward(self, x: Tensor) -> Dict[str, Tensor]:
         """Forward pass of the model.
 
         Args:

--- a/torchgeo/models/farseg.py
+++ b/torchgeo/models/farseg.py
@@ -80,7 +80,7 @@ class FarSeg(Module):
         self.fsr = _FSRelation(max_channels, [256] * 4, 256)
         self.decoder = _LightWeightDecoder(256, 128, classes)
 
-    def forward(self, x) -> Tensor:
+    def forward(self, x: Tensor) -> Tensor:
         """Forward pass of the model.
 
         Args:
@@ -162,7 +162,7 @@ class _FSRelation(Module):
 
         self.normalizer = Sigmoid()
 
-    def forward(self, scene_feature, features: List[Tensor]) -> List[Tensor]:
+    def forward(self, scene_feature: Tensor, features: List[Tensor]) -> List[Tensor]:
         """Forward pass of the model."""
         # [N, C, H, W]
         content_feats = [

--- a/torchgeo/models/farseg.py
+++ b/torchgeo/models/farseg.py
@@ -80,7 +80,7 @@ class FarSeg(Module):
         self.fsr = _FSRelation(max_channels, [256] * 4, 256)
         self.decoder = _LightWeightDecoder(256, 128, classes)
 
-    def forward(self, x: Tensor) -> Tensor:
+    def forward(self, x) -> Tensor:
         """Forward pass of the model.
 
         Args:
@@ -162,7 +162,7 @@ class _FSRelation(Module):
 
         self.normalizer = Sigmoid()
 
-    def forward(self, scene_feature: Tensor, features: List[Tensor]) -> List[Tensor]:
+    def forward(self, scene_feature, features: List[Tensor]) -> List[Tensor]:
         """Forward pass of the model."""
         # [N, C, H, W]
         content_feats = [

--- a/torchgeo/models/fcn.py
+++ b/torchgeo/models/fcn.py
@@ -58,7 +58,7 @@ class FCN(Module):
             num_filters, classes, kernel_size=1, stride=1, padding=0
         )
 
-    def forward(self, x) -> Tensor:
+    def forward(self, x: Tensor) -> Tensor:
         """Forward pass of the model."""
         x = self.backbone(x)
         x = self.last(x)

--- a/torchgeo/models/fcn.py
+++ b/torchgeo/models/fcn.py
@@ -58,7 +58,7 @@ class FCN(Module):
             num_filters, classes, kernel_size=1, stride=1, padding=0
         )
 
-    def forward(self, x: Tensor) -> Tensor:
+    def forward(self, x) -> Tensor:
         """Forward pass of the model."""
         x = self.backbone(x)
         x = self.last(x)

--- a/torchgeo/models/fcsiam.py
+++ b/torchgeo/models/fcsiam.py
@@ -95,7 +95,7 @@ class FCSiamConc(SegmentationModel):  # type: ignore[misc]
         self.name = "u-{}".format(encoder_name)
         self.initialize()
 
-    def forward(self, x) -> Tensor:
+    def forward(self, x: Tensor) -> Tensor:
         """Forward pass of the model.
 
         Args:
@@ -162,7 +162,7 @@ class FCSiamDiff(Unet):  # type: ignore[misc]
         kwargs["aux_params"] = None
         super().__init__(*args, **kwargs)
 
-    def forward(self, x) -> Tensor:
+    def forward(self, x: Tensor) -> Tensor:
         """Forward pass of the model.
 
         Args:

--- a/torchgeo/models/fcsiam.py
+++ b/torchgeo/models/fcsiam.py
@@ -95,7 +95,7 @@ class FCSiamConc(SegmentationModel):  # type: ignore[misc]
         self.name = "u-{}".format(encoder_name)
         self.initialize()
 
-    def forward(self, x: Tensor) -> Tensor:
+    def forward(self, x) -> Tensor:
         """Forward pass of the model.
 
         Args:
@@ -108,12 +108,12 @@ class FCSiamConc(SegmentationModel):  # type: ignore[misc]
         x2 = x[:, 1]
         features1, features2 = self.encoder(x1), self.encoder(x2)
         features = [
-            torch.cat([features2[i], features1[i]], dim=1)  # type: ignore[attr-defined]
+            torch.cat([features2[i], features1[i]], dim=1)
             for i in range(1, len(features1))
         ]
         features.insert(0, features2[0])
         decoder_output = self.decoder(*features)
-        masks: Tensor = self.segmentation_head(decoder_output)
+        masks = self.segmentation_head(decoder_output)
         return masks
 
 
@@ -162,7 +162,7 @@ class FCSiamDiff(Unet):  # type: ignore[misc]
         kwargs["aux_params"] = None
         super().__init__(*args, **kwargs)
 
-    def forward(self, x: Tensor) -> Tensor:
+    def forward(self, x) -> Tensor:
         """Forward pass of the model.
 
         Args:
@@ -177,5 +177,5 @@ class FCSiamDiff(Unet):  # type: ignore[misc]
         features = [features2[i] - features1[i] for i in range(1, len(features1))]
         features.insert(0, features2[0])
         decoder_output = self.decoder(*features)
-        masks: Tensor = self.segmentation_head(decoder_output)
+        masks = self.segmentation_head(decoder_output)
         return masks

--- a/torchgeo/models/fcsiam.py
+++ b/torchgeo/models/fcsiam.py
@@ -113,7 +113,7 @@ class FCSiamConc(SegmentationModel):  # type: ignore[misc]
         ]
         features.insert(0, features2[0])
         decoder_output = self.decoder(*features)
-        masks = self.segmentation_head(decoder_output)
+        masks: Tensor = self.segmentation_head(decoder_output)
         return masks
 
 
@@ -177,5 +177,5 @@ class FCSiamDiff(Unet):  # type: ignore[misc]
         features = [features2[i] - features1[i] for i in range(1, len(features1))]
         features.insert(0, features2[0])
         decoder_output = self.decoder(*features)
-        masks = self.segmentation_head(decoder_output)
+        masks: Tensor = self.segmentation_head(decoder_output)
         return masks

--- a/torchgeo/models/rcf.py
+++ b/torchgeo/models/rcf.py
@@ -3,7 +3,7 @@
 
 """Implementation of a random convolutional feature projection model."""
 
-from typing import Optional, cast
+from typing import Optional
 
 import torch
 import torch.nn.functional as F
@@ -76,7 +76,7 @@ class RCF(Module):
             "biases", torch.zeros(features // 2, requires_grad=False) + bias
         )
 
-    def forward(self, x) -> Tensor:
+    def forward(self, x: Tensor) -> Tensor:
         """Forward pass of the RCF model.
 
         Args:
@@ -99,8 +99,8 @@ class RCF(Module):
 
         if len(x1a.shape) == 1:  # case where we passed a single input
             output = torch.cat((x1a, x1b), dim=0)
-            return cast(Tensor, output)
+            return output
         else:  # case where we passed a batch of > 1 inputs
             assert len(x1a.shape) == 2
             output = torch.cat((x1a, x1b), dim=1)
-            return cast(Tensor, output)
+            return output

--- a/torchgeo/models/rcf.py
+++ b/torchgeo/models/rcf.py
@@ -55,9 +55,7 @@ class RCF(Module):
         if seed is None:
             generator = None
         else:
-            generator = torch.Generator().manual_seed(  # type: ignore[attr-defined]
-                seed
-            )
+            generator = torch.Generator().manual_seed(seed)
 
         # We register the weight and bias tensors as "buffers". This does two things:
         # makes them behave correctly when we call .to(...) on the module, and makes
@@ -75,14 +73,10 @@ class RCF(Module):
             ),
         )
         self.register_buffer(
-            "biases",
-            torch.zeros(  # type: ignore[attr-defined]
-                features // 2, requires_grad=False
-            )
-            + bias,
+            "biases", torch.zeros(features // 2, requires_grad=False) + bias
         )
 
-    def forward(self, x: Tensor) -> Tensor:
+    def forward(self, x) -> Tensor:
         """Forward pass of the RCF model.
 
         Args:
@@ -104,9 +98,9 @@ class RCF(Module):
         x1b = F.adaptive_avg_pool2d(x1b, (1, 1)).squeeze()
 
         if len(x1a.shape) == 1:  # case where we passed a single input
-            output = torch.cat((x1a, x1b), dim=0)  # type: ignore[attr-defined]
+            output = torch.cat((x1a, x1b), dim=0)
             return cast(Tensor, output)
         else:  # case where we passed a batch of > 1 inputs
             assert len(x1a.shape) == 2
-            output = torch.cat((x1a, x1b), dim=1)  # type: ignore[attr-defined]
+            output = torch.cat((x1a, x1b), dim=1)
             return cast(Tensor, output)

--- a/torchgeo/models/rcf.py
+++ b/torchgeo/models/rcf.py
@@ -25,6 +25,9 @@ class RCF(Module):
         This Module is *not* trainable. It is only used as a feature extractor.
     """
 
+    weights: Tensor
+    biases: Tensor
+
     def __init__(
         self,
         in_channels: int = 4,

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -55,7 +55,7 @@ def _resnet(
     model = ResNet(block, layers, NUM_CLASSES[sensor], **kwargs)
 
     # Replace the first layer with the correct number of input channels
-    model.conv1 = nn.Conv2d(  # type: ignore[attr-defined]
+    model.conv1 = nn.Conv2d(
         IN_CHANNELS[sensor][bands],
         out_channels=64,
         kernel_size=7,

--- a/torchgeo/trainers/byol.py
+++ b/torchgeo/trainers/byol.py
@@ -402,16 +402,17 @@ class BYOLTask(LightningModule):
         }
 
     def training_step(self, *args: Any, **kwargs: Any) -> Tensor:
-        """Training step - reports BYOL loss.
+        """Compute and return the training loss.
 
         Args:
-            batch: current batch
-            batch_idx: index of current batch
+            batch: the output of your DataLoader
+            batch_idx: the index of this batch
 
         Returns:
             training loss
         """
-        batch, batch_idx = args
+        batch = args[0]
+        batch_idx = args[1]
         x = batch["image"]
         with torch.no_grad():
             x1, x2 = self.model.augment(x), self.model.augment(x)
@@ -427,13 +428,14 @@ class BYOLTask(LightningModule):
         return loss
 
     def validation_step(self, *args: Any, **kwargs: Any) -> None:
-        """Logs iteration level validation loss.
+        """Compute validation loss.
 
         Args:
-            batch: current batch
-            batch_idx: index of current batch
+            batch: the output of your DataLoader
+            batch_idx: the index of this batch
         """
-        batch, batch_idx = args
+        batch = args[0]
+        batch_idx = args[1]
         x = batch["image"]
         x1, x2 = self.model.augment(x), self.model.augment(x)
         pred1, pred2 = self.forward(x1), self.forward(x2)

--- a/torchgeo/trainers/byol.py
+++ b/torchgeo/trainers/byol.py
@@ -406,13 +406,11 @@ class BYOLTask(LightningModule):
 
         Args:
             batch: the output of your DataLoader
-            batch_idx: the index of this batch
 
         Returns:
             training loss
         """
         batch = args[0]
-        batch_idx = args[1]
         x = batch["image"]
         with torch.no_grad():
             x1, x2 = self.model.augment(x), self.model.augment(x)
@@ -432,10 +430,8 @@ class BYOLTask(LightningModule):
 
         Args:
             batch: the output of your DataLoader
-            batch_idx: the index of this batch
         """
         batch = args[0]
-        batch_idx = args[1]
         x = batch["image"]
         x1, x2 = self.model.augment(x), self.model.augment(x)
         pred1, pred2 = self.forward(x1), self.forward(x2)

--- a/torchgeo/trainers/byol.py
+++ b/torchgeo/trainers/byol.py
@@ -4,7 +4,7 @@
 """BYOL tasks."""
 
 import random
-from typing import Any, Callable, Dict, Optional, Tuple, Union, cast
+from typing import Any, Callable, Dict, Optional, Tuple, cast
 
 import torch
 import torch.nn.functional as F
@@ -159,7 +159,7 @@ class EncoderWrapper(Module):
         model: Module,
         projection_size: int = 256,
         hidden_size: int = 4096,
-        layer: Union[str, int] = -2,
+        layer: int = -2,
     ) -> None:
         """Initializes EncoderWrapper.
 
@@ -213,7 +213,7 @@ class EncoderWrapper(Module):
 
     def _register_hook(self) -> None:
         """Register a hook for layer that we will extract features from."""
-        layer = list(self.model.children())[self.layer]  # type: ignore[index]
+        layer = list(self.model.children())[self.layer]
         layer.register_forward_hook(self._hook)
 
     def forward(self, x: Tensor) -> Tensor:
@@ -244,7 +244,7 @@ class BYOL(Module):
         self,
         model: Module,
         image_size: Tuple[int, int] = (256, 256),
-        hidden_layer: Union[str, int] = -2,
+        hidden_layer: int = -2,
         in_channels: int = 4,
         projection_size: int = 256,
         hidden_size: int = 4096,
@@ -334,15 +334,13 @@ class BYOLTask(LightningModule):
         # initialize the weights from new channel with the red channel weights
         copy_weights = 0
         # Copying the weights from the old to the new layer
-        new_layer.weight[:, : layer.in_channels, :, :].data[
-            ...  # type: ignore[index]
-        ] = Variable(layer.weight.clone(), requires_grad=True)
+        new_layer.weight[:, : layer.in_channels, :, :].data[:] = Variable(
+            layer.weight.clone(), requires_grad=True
+        )
         # Copying the weights of the old layer to the extra channels
         for i in range(in_channels - layer.in_channels):
             channel = layer.in_channels + i
-            new_layer.weight[:, channel : channel + 1, :, :].data[
-                ...  # type: ignore[index]
-            ] = Variable(
+            new_layer.weight[:, channel : channel + 1, :, :].data[:] = Variable(
                 layer.weight[:, copy_weights : copy_weights + 1, ::].clone(),
                 requires_grad=True,
             )

--- a/torchgeo/trainers/classification.py
+++ b/torchgeo/trainers/classification.py
@@ -134,13 +134,11 @@ class ClassificationTask(pl.LightningModule):
 
         Args:
             batch: the output of your DataLoader
-            batch_idx: the index of this batch
 
         Returns:
             training loss
         """
         batch = args[0]
-        batch_idx = args[1]
         x = batch["image"]
         y = batch["label"]
         y_hat = self.forward(x)
@@ -212,10 +210,8 @@ class ClassificationTask(pl.LightningModule):
 
         Args:
             batch: the output of your DataLoader
-            batch_idx: the index of this batch
         """
         batch = args[0]
-        batch_idx = args[1]
         x = batch["image"]
         y = batch["label"]
         y_hat = self.forward(x)
@@ -317,13 +313,11 @@ class MultiLabelClassificationTask(ClassificationTask):
 
         Args:
             batch: the output of your DataLoader
-            batch_idx: the index of this batch
 
         Returns:
             training loss
         """
         batch = args[0]
-        batch_idx = args[1]
         x = batch["image"]
         y = batch["label"]
         y_hat = self.forward(x)
@@ -377,10 +371,8 @@ class MultiLabelClassificationTask(ClassificationTask):
 
         Args:
             batch: the output of your DataLoader
-            batch_idx: the index of this batch
         """
         batch = args[0]
-        batch_idx = args[1]
         x = batch["image"]
         y = batch["label"]
         y_hat = self.forward(x)

--- a/torchgeo/trainers/classification.py
+++ b/torchgeo/trainers/classification.py
@@ -130,16 +130,17 @@ class ClassificationTask(pl.LightningModule):
         return self.model(*args, **kwargs)
 
     def training_step(self, *args: Any, **kwargs: Any) -> Tensor:
-        """Training step.
+        """Compute and return the training loss.
 
         Args:
-            batch: Current batch
-            batch_idx: Index of current batch
+            batch: the output of your DataLoader
+            batch_idx: the index of this batch
 
         Returns:
             training loss
         """
-        batch, batch_idx = args
+        batch = args[0]
+        batch_idx = args[1]
         x = batch["image"]
         y = batch["label"]
         y_hat = self.forward(x)
@@ -164,13 +165,14 @@ class ClassificationTask(pl.LightningModule):
         self.train_metrics.reset()
 
     def validation_step(self, *args: Any, **kwargs: Any) -> None:
-        """Validation step.
+        """Compute validation loss and log example predictions.
 
         Args:
-            batch: Current batch
-            batch_idx: Index of current batch
+            batch: the output of your DataLoader
+            batch_idx: the index of this batch
         """
-        batch, batch_idx = args
+        batch = args[0]
+        batch_idx = args[1]
         x = batch["image"]
         y = batch["label"]
         y_hat = self.forward(x)
@@ -206,13 +208,14 @@ class ClassificationTask(pl.LightningModule):
         self.val_metrics.reset()
 
     def test_step(self, *args: Any, **kwargs: Any) -> None:
-        """Test step.
+        """Compute test loss.
 
         Args:
-            batch: Current batch
-            batch_idx: Index of current batch
+            batch: the output of your DataLoader
+            batch_idx: the index of this batch
         """
-        batch, batch_idx = args
+        batch = args[0]
+        batch_idx = args[1]
         x = batch["image"]
         y = batch["label"]
         y_hat = self.forward(x)
@@ -310,16 +313,17 @@ class MultiLabelClassificationTask(ClassificationTask):
         self.test_metrics = self.train_metrics.clone(prefix="test_")
 
     def training_step(self, *args: Any, **kwargs: Any) -> Tensor:
-        """Training step.
+        """Compute and return the training loss.
 
         Args:
-            batch: Current batch
-            batch_idx: Index of current batch
+            batch: the output of your DataLoader
+            batch_idx: the index of this batch
 
         Returns:
             training loss
         """
-        batch, batch_idx = args
+        batch = args[0]
+        batch_idx = args[1]
         x = batch["image"]
         y = batch["label"]
         y_hat = self.forward(x)
@@ -335,13 +339,14 @@ class MultiLabelClassificationTask(ClassificationTask):
         return cast(Tensor, loss)
 
     def validation_step(self, *args: Any, **kwargs: Any) -> None:
-        """Validation step.
+        """Compute validation loss and log example predictions.
 
         Args:
-            batch: Current batch
-            batch_idx: Index of current batch
+            batch: the output of your DataLoader
+            batch_idx: the index of this batch
         """
-        batch, batch_idx = args
+        batch = args[0]
+        batch_idx = args[1]
         x = batch["image"]
         y = batch["label"]
         y_hat = self.forward(x)
@@ -368,13 +373,14 @@ class MultiLabelClassificationTask(ClassificationTask):
                 pass
 
     def test_step(self, *args: Any, **kwargs: Any) -> None:
-        """Test step.
+        """Compute test loss.
 
         Args:
-            batch: Current batch
-            batch_idx: Index of current batch
+            batch: the output of your DataLoader
+            batch_idx: the index of this batch
         """
-        batch, batch_idx = args
+        batch = args[0]
+        batch_idx = args[1]
         x = batch["image"]
         y = batch["label"]
         y_hat = self.forward(x)

--- a/torchgeo/trainers/classification.py
+++ b/torchgeo/trainers/classification.py
@@ -75,7 +75,7 @@ class ClassificationTask(pl.LightningModule):
         self.config_model()
 
         if self.hparams["loss"] == "ce":
-            self.loss = nn.CrossEntropyLoss()  # type: ignore[attr-defined]
+            self.loss = nn.CrossEntropyLoss()
         elif self.hparams["loss"] == "jaccard":
             self.loss = JaccardLoss(mode="multiclass")
         elif self.hparams["loss"] == "focal":
@@ -115,7 +115,7 @@ class ClassificationTask(pl.LightningModule):
         self.val_metrics = self.train_metrics.clone(prefix="val_")
         self.test_metrics = self.train_metrics.clone(prefix="test_")
 
-    def forward(self, x: Tensor) -> Any:  # type: ignore[override]
+    def forward(self, x) -> Any:  # type: ignore[override]
         """Forward pass of the model.
 
         Args:
@@ -182,7 +182,7 @@ class ClassificationTask(pl.LightningModule):
 
         if batch_idx < 10:
             try:
-                datamodule = self.trainer.datamodule  # type: ignore[attr-defined]
+                datamodule = self.trainer.datamodule
                 batch["prediction"] = y_hat_hard
                 for key in ["image", "label", "prediction"]:
                     batch[key] = batch[key].cpu()
@@ -262,7 +262,7 @@ class MultiLabelClassificationTask(ClassificationTask):
         self.config_model()
 
         if self.hparams["loss"] == "bce":
-            self.loss = nn.BCEWithLogitsLoss()  # type: ignore[attr-defined]
+            self.loss = nn.BCEWithLogitsLoss()
         else:
             raise ValueError(f"Loss type '{self.hparams['loss']}' is not valid.")
 
@@ -318,9 +318,9 @@ class MultiLabelClassificationTask(ClassificationTask):
         x = batch["image"]
         y = batch["label"]
         y_hat = self.forward(x)
-        y_hat_hard = torch.softmax(y_hat, dim=-1)  # type: ignore[attr-defined]
+        y_hat_hard = torch.softmax(y_hat, dim=-1)
 
-        loss = self.loss(y_hat, y.to(torch.float))  # type: ignore[attr-defined]
+        loss = self.loss(y_hat, y.to(torch.float))
 
         # by default, the train step logs every `log_every_n_steps` steps where
         # `log_every_n_steps` is a parameter to the `Trainer` object
@@ -341,16 +341,16 @@ class MultiLabelClassificationTask(ClassificationTask):
         x = batch["image"]
         y = batch["label"]
         y_hat = self.forward(x)
-        y_hat_hard = torch.softmax(y_hat, dim=-1)  # type: ignore[attr-defined]
+        y_hat_hard = torch.softmax(y_hat, dim=-1)
 
-        loss = self.loss(y_hat, y.to(torch.float))  # type: ignore[attr-defined]
+        loss = self.loss(y_hat, y.to(torch.float))
 
         self.log("val_loss", loss, on_step=False, on_epoch=True)
         self.val_metrics(y_hat_hard, y)
 
         if batch_idx < 10:
             try:
-                datamodule = self.trainer.datamodule  # type: ignore[attr-defined]
+                datamodule = self.trainer.datamodule
                 batch["prediction"] = y_hat_hard
                 for key in ["image", "label", "prediction"]:
                     batch[key] = batch[key].cpu()
@@ -375,9 +375,9 @@ class MultiLabelClassificationTask(ClassificationTask):
         x = batch["image"]
         y = batch["label"]
         y_hat = self.forward(x)
-        y_hat_hard = torch.softmax(y_hat, dim=-1)  # type: ignore[attr-defined]
+        y_hat_hard = torch.softmax(y_hat, dim=-1)
 
-        loss = self.loss(y_hat, y.to(torch.float))  # type: ignore[attr-defined]
+        loss = self.loss(y_hat, y.to(torch.float))
 
         # by default, the test and validation steps only log per *epoch*
         self.log("test_loss", loss, on_step=False, on_epoch=True)

--- a/torchgeo/trainers/regression.py
+++ b/torchgeo/trainers/regression.py
@@ -31,9 +31,7 @@ class RegressionTask(pl.LightningModule):
         if self.hparams["model"] == "resnet18":
             self.model = models.resnet18(pretrained=self.hparams["pretrained"])
             in_features = self.model.fc.in_features
-            self.model.fc = nn.Linear(  # type: ignore[attr-defined]
-                in_features, out_features=1
-            )
+            self.model.fc = nn.Linear(in_features, out_features=1)
         else:
             raise ValueError(f"Model type '{self.hparams['model']}' is not valid.")
 
@@ -56,7 +54,7 @@ class RegressionTask(pl.LightningModule):
         self.val_metrics = self.train_metrics.clone(prefix="val_")
         self.test_metrics = self.train_metrics.clone(prefix="test_")
 
-    def forward(self, x: Tensor) -> Any:  # type: ignore[override]
+    def forward(self, x) -> Any:  # type: ignore[override]
         """Forward pass of the model."""
         return self.model(x)
 
@@ -111,7 +109,7 @@ class RegressionTask(pl.LightningModule):
 
         if batch_idx < 10:
             try:
-                datamodule = self.trainer.datamodule  # type: ignore[attr-defined]
+                datamodule = self.trainer.datamodule
                 batch["prediction"] = y_hat
                 for key in ["image", "label", "prediction"]:
                     batch[key] = batch[key].cpu()

--- a/torchgeo/trainers/regression.py
+++ b/torchgeo/trainers/regression.py
@@ -73,13 +73,11 @@ class RegressionTask(pl.LightningModule):
 
         Args:
             batch: the output of your DataLoader
-            batch_idx: the index of this batch
 
         Returns:
             training loss
         """
         batch = args[0]
-        batch_idx = args[1]
         x = batch["image"]
         y = batch["label"].view(-1, 1)
         y_hat = self.forward(x)
@@ -146,10 +144,8 @@ class RegressionTask(pl.LightningModule):
 
         Args:
             batch: the output of your DataLoader
-            batch_idx: the index of this batch
         """
         batch = args[0]
-        batch_idx = args[1]
         x = batch["image"]
         y = batch["label"].view(-1, 1)
         y_hat = self.forward(x)

--- a/torchgeo/trainers/regression.py
+++ b/torchgeo/trainers/regression.py
@@ -69,16 +69,17 @@ class RegressionTask(pl.LightningModule):
         return self.model(*args, **kwargs)
 
     def training_step(self, *args: Any, **kwargs: Any) -> Tensor:
-        """Training step with an MSE loss.
+        """Compute and return the training loss.
 
         Args:
-            batch: Current batch
-            batch_idx: Index of current batch
+            batch: the output of your DataLoader
+            batch_idx: the index of this batch
 
         Returns:
             training loss
         """
-        batch, batch_idx = args
+        batch = args[0]
+        batch_idx = args[1]
         x = batch["image"]
         y = batch["label"].view(-1, 1)
         y_hat = self.forward(x)
@@ -100,13 +101,14 @@ class RegressionTask(pl.LightningModule):
         self.train_metrics.reset()
 
     def validation_step(self, *args: Any, **kwargs: Any) -> None:
-        """Validation step.
+        """Compute validation loss and log example predictions.
 
         Args:
-            batch: Current batch
-            batch_idx: Index of current batch
+            batch: the output of your DataLoader
+            batch_idx: the index of this batch
         """
-        batch, batch_idx = args
+        batch = args[0]
+        batch_idx = args[1]
         x = batch["image"]
         y = batch["label"].view(-1, 1)
         y_hat = self.forward(x)
@@ -140,13 +142,14 @@ class RegressionTask(pl.LightningModule):
         self.val_metrics.reset()
 
     def test_step(self, *args: Any, **kwargs: Any) -> None:
-        """Test step.
+        """Compute test loss.
 
         Args:
-            batch: Current batch
-            batch_idx: Index of current batch
+            batch: the output of your DataLoader
+            batch_idx: the index of this batch
         """
-        batch, batch_idx = args
+        batch = args[0]
+        batch_idx = args[1]
         x = batch["image"]
         y = batch["label"].view(-1, 1)
         y_hat = self.forward(x)

--- a/torchgeo/trainers/segmentation.py
+++ b/torchgeo/trainers/segmentation.py
@@ -124,13 +124,11 @@ class SemanticSegmentationTask(LightningModule):
 
         Args:
             batch: the output of your DataLoader
-            batch_idx: the index of this batch
 
         Returns:
             training loss
         """
         batch = args[0]
-        batch_idx = args[1]
         x = batch["image"]
         y = batch["mask"]
         y_hat = self.forward(x)
@@ -202,10 +200,8 @@ class SemanticSegmentationTask(LightningModule):
 
         Args:
             batch: the output of your DataLoader
-            batch_idx: the index of this batch
         """
         batch = args[0]
-        batch_idx = args[1]
         x = batch["image"]
         y = batch["mask"]
         y_hat = self.forward(x)

--- a/torchgeo/trainers/segmentation.py
+++ b/torchgeo/trainers/segmentation.py
@@ -53,7 +53,7 @@ class SemanticSegmentationTask(LightningModule):
             )
 
         if self.hparams["loss"] == "ce":
-            self.loss = nn.CrossEntropyLoss(  # type: ignore[attr-defined]
+            self.loss = nn.CrossEntropyLoss(
                 ignore_index=-1000 if self.ignore_zeros is None else 0
             )
         elif self.hparams["loss"] == "jaccard":
@@ -106,7 +106,7 @@ class SemanticSegmentationTask(LightningModule):
         self.val_metrics = self.train_metrics.clone(prefix="val_")
         self.test_metrics = self.train_metrics.clone(prefix="test_")
 
-    def forward(self, x: Tensor) -> Any:  # type: ignore[override]
+    def forward(self, x) -> Any:  # type: ignore[override]
         """Forward pass of the model.
 
         Args:
@@ -176,7 +176,7 @@ class SemanticSegmentationTask(LightningModule):
 
         if batch_idx < 10:
             try:
-                datamodule = self.trainer.datamodule  # type: ignore[attr-defined]
+                datamodule = self.trainer.datamodule
                 batch["prediction"] = y_hat_hard
                 for key in ["image", "mask", "prediction"]:
                     batch[key] = batch[key].cpu()

--- a/torchgeo/trainers/segmentation.py
+++ b/torchgeo/trainers/segmentation.py
@@ -120,16 +120,17 @@ class SemanticSegmentationTask(LightningModule):
         return self.model(*args, **kwargs)
 
     def training_step(self, *args: Any, **kwargs: Any) -> Tensor:
-        """Training step - reports average accuracy and average JaccardIndex.
+        """Compute and return the training loss.
 
         Args:
-            batch: Current batch
-            batch_idx: Index of current batch
+            batch: the output of your DataLoader
+            batch_idx: the index of this batch
 
         Returns:
             training loss
         """
-        batch, batch_idx = args
+        batch = args[0]
+        batch_idx = args[1]
         x = batch["image"]
         y = batch["mask"]
         y_hat = self.forward(x)
@@ -154,16 +155,14 @@ class SemanticSegmentationTask(LightningModule):
         self.train_metrics.reset()
 
     def validation_step(self, *args: Any, **kwargs: Any) -> None:
-        """Validation step - reports average accuracy and average JaccardIndex.
-
-        Logs the first 10 validation samples to tensorboard as images with 3 subplots
-        showing the image, mask, and predictions.
+        """Compute validation loss and log example predictions.
 
         Args:
-            batch: Current batch
-            batch_idx: Index of current batch
+            batch: the output of your DataLoader
+            batch_idx: the index of this batch
         """
-        batch, batch_idx = args
+        batch = args[0]
+        batch_idx = args[1]
         x = batch["image"]
         y = batch["mask"]
         y_hat = self.forward(x)
@@ -199,13 +198,14 @@ class SemanticSegmentationTask(LightningModule):
         self.val_metrics.reset()
 
     def test_step(self, *args: Any, **kwargs: Any) -> None:
-        """Test step identical to the validation step.
+        """Compute test loss.
 
         Args:
-            batch: Current batch
-            batch_idx: Index of current batch
+            batch: the output of your DataLoader
+            batch_idx: the index of this batch
         """
-        batch, batch_idx = args
+        batch = args[0]
+        batch_idx = args[1]
         x = batch["image"]
         y = batch["mask"]
         y_hat = self.forward(x)

--- a/torchgeo/trainers/utils.py
+++ b/torchgeo/trainers/utils.py
@@ -5,7 +5,7 @@
 
 import warnings
 from collections import OrderedDict
-from typing import Dict, Optional, Tuple, Union
+from typing import Dict, Optional, Tuple, Union, cast
 
 import torch
 import torch.nn as nn
@@ -74,9 +74,9 @@ def load_state_dict(model: Module, state_dict: Dict[str, Tensor]) -> Module:
         If input channels in model != pretrained model input channels
         If num output classes in model != pretrained model num classes
     """
-    in_channels = model.conv1.in_channels
+    in_channels = cast(nn.Module, model.conv1).in_channels
     expected_in_channels = state_dict["conv1.weight"].shape[1]
-    num_classes = model.fc.out_features
+    num_classes = cast(nn.Module, model.fc).out_features
     expected_num_classes = state_dict["fc.weight"].shape[0]
 
     if in_channels != expected_in_channels:
@@ -126,8 +126,7 @@ def reinit_initial_conv_layer(
     if keep_rgb_weights:
         w_old = layer.weight.data[:, :3, :, :].clone()
         if use_bias:
-            # mypy doesn't realize that bias isn't None here...
-            b_old = layer.bias.data.clone()
+            b_old = cast(Tensor, layer.bias).data.clone()
 
     updated_stride = layer.stride if new_stride is None else new_stride
     updated_padding = layer.padding if new_padding is None else new_padding
@@ -150,6 +149,6 @@ def reinit_initial_conv_layer(
     if keep_rgb_weights:
         new_layer.weight.data[:, :3, :, :] = w_old
         if use_bias:
-            new_layer.bias.data = b_old
+            cast(Tensor, new_layer.bias).data = b_old
 
     return new_layer

--- a/torchgeo/trainers/utils.py
+++ b/torchgeo/trainers/utils.py
@@ -4,7 +4,8 @@
 """Common trainer utilities."""
 
 import warnings
-from typing import Optional, OrderedDict, Tuple, Union, cast
+from collections import OrderedDict
+from typing import Optional, Tuple, Union, cast
 
 import torch
 import torch.nn as nn
@@ -17,7 +18,7 @@ Module.__module__ = "nn.Module"
 Conv2d.__module__ = "nn.Conv2d"
 
 
-def extract_encoder(path: str) -> Tuple[str, OrderedDict[str, Tensor]]:
+def extract_encoder(path: str) -> Tuple[str, "OrderedDict"[str, Tensor]]:
     """Extracts an encoder from a pytorch lightning checkpoint file.
 
     Args:
@@ -59,7 +60,7 @@ def extract_encoder(path: str) -> Tuple[str, OrderedDict[str, Tensor]]:
     return name, state_dict
 
 
-def load_state_dict(model: Module, state_dict: OrderedDict[str, Tensor]) -> Module:
+def load_state_dict(model: Module, state_dict: "OrderedDict"[str, Tensor]) -> Module:
     """Load pretrained resnet weights to a model.
 
     Args:

--- a/torchgeo/trainers/utils.py
+++ b/torchgeo/trainers/utils.py
@@ -4,8 +4,7 @@
 """Common trainer utilities."""
 
 import warnings
-from collections import OrderedDict
-from typing import Dict, Optional, Tuple, Union, cast
+from typing import Optional, OrderedDict, Tuple, Union, cast
 
 import torch
 import torch.nn as nn
@@ -18,7 +17,7 @@ Module.__module__ = "nn.Module"
 Conv2d.__module__ = "nn.Conv2d"
 
 
-def extract_encoder(path: str) -> Tuple[str, Dict[str, Tensor]]:
+def extract_encoder(path: str) -> Tuple[str, OrderedDict[str, Tensor]]:
     """Extracts an encoder from a pytorch lightning checkpoint file.
 
     Args:
@@ -60,7 +59,7 @@ def extract_encoder(path: str) -> Tuple[str, Dict[str, Tensor]]:
     return name, state_dict
 
 
-def load_state_dict(model: Module, state_dict: Dict[str, Tensor]) -> Module:
+def load_state_dict(model: Module, state_dict: OrderedDict[str, Tensor]) -> Module:
     """Load pretrained resnet weights to a model.
 
     Args:
@@ -93,7 +92,7 @@ def load_state_dict(model: Module, state_dict: Dict[str, Tensor]) -> Module:
         )
         del state_dict["fc.weight"], state_dict["fc.bias"]
 
-    model.load_state_dict(state_dict, strict=False)  # type: ignore[arg-type]
+    model.load_state_dict(state_dict, strict=False)
 
     return model
 

--- a/torchgeo/trainers/utils.py
+++ b/torchgeo/trainers/utils.py
@@ -74,9 +74,9 @@ def load_state_dict(model: Module, state_dict: Dict[str, Tensor]) -> Module:
         If input channels in model != pretrained model input channels
         If num output classes in model != pretrained model num classes
     """
-    in_channels = model.conv1.in_channels  # type: ignore[union-attr]
+    in_channels = model.conv1.in_channels
     expected_in_channels = state_dict["conv1.weight"].shape[1]
-    num_classes = model.fc.out_features  # type: ignore[union-attr]
+    num_classes = model.fc.out_features
     expected_num_classes = state_dict["fc.weight"].shape[0]
 
     if in_channels != expected_in_channels:
@@ -127,7 +127,7 @@ def reinit_initial_conv_layer(
         w_old = layer.weight.data[:, :3, :, :].clone()
         if use_bias:
             # mypy doesn't realize that bias isn't None here...
-            b_old = layer.bias.data.clone()  # type: ignore[union-attr]
+            b_old = layer.bias.data.clone()
 
     updated_stride = layer.stride if new_stride is None else new_stride
     updated_padding = layer.padding if new_padding is None else new_padding
@@ -150,6 +150,6 @@ def reinit_initial_conv_layer(
     if keep_rgb_weights:
         new_layer.weight.data[:, :3, :, :] = w_old
         if use_bias:
-            new_layer.bias.data = b_old  # type: ignore[union-attr]
+            new_layer.bias.data = b_old
 
     return new_layer

--- a/torchgeo/trainers/utils.py
+++ b/torchgeo/trainers/utils.py
@@ -32,7 +32,7 @@ def extract_encoder(path: str) -> Tuple[str, Dict[str, Tensor]]:
             checkpoint['hyper_parameters']
     """
     checkpoint = torch.load(  # type: ignore[no-untyped-call]
-        path, map_location=torch.device("cpu")  # type: ignore[attr-defined]
+        path, map_location=torch.device("cpu")
     )
 
     if "classification_model" in checkpoint["hyper_parameters"]:

--- a/torchgeo/trainers/utils.py
+++ b/torchgeo/trainers/utils.py
@@ -18,7 +18,7 @@ Module.__module__ = "nn.Module"
 Conv2d.__module__ = "nn.Conv2d"
 
 
-def extract_encoder(path: str) -> Tuple[str, "OrderedDict"[str, Tensor]]:
+def extract_encoder(path: str) -> Tuple[str, "OrderedDict[str, Tensor]"]:
     """Extracts an encoder from a pytorch lightning checkpoint file.
 
     Args:
@@ -60,7 +60,7 @@ def extract_encoder(path: str) -> Tuple[str, "OrderedDict"[str, Tensor]]:
     return name, state_dict
 
 
-def load_state_dict(model: Module, state_dict: "OrderedDict"[str, Tensor]) -> Module:
+def load_state_dict(model: Module, state_dict: "OrderedDict[str, Tensor]") -> Module:
     """Load pretrained resnet weights to a model.
 
     Args:

--- a/torchgeo/transforms/indices.py
+++ b/torchgeo/transforms/indices.py
@@ -46,7 +46,7 @@ class AppendNormalizedDifferenceIndex(Module):
         self.index_a = index_a
         self.index_b = index_b
 
-    def _compute_index(self, band_a: Tensor, band_b: Tensor) -> Tensor:
+    def _compute_index(self, band_a, band_b) -> Tensor:
         """Compute normalized difference index.
 
         Args:
@@ -74,9 +74,7 @@ class AppendNormalizedDifferenceIndex(Module):
             )
             index = index.unsqueeze(self.dim)
 
-            sample["image"] = torch.cat(  # type: ignore[attr-defined]
-                [sample["image"], index], dim=self.dim
-            )
+            sample["image"] = torch.cat([sample["image"], index], dim=self.dim)
 
         return sample
 
@@ -329,7 +327,7 @@ class AppendTriBandNormalizedDifferenceIndex(Module):
         self.index_b = index_b
         self.index_c = index_c
 
-    def _compute_index(self, band_a: Tensor, band_b: Tensor, band_c: Tensor) -> Tensor:
+    def _compute_index(self, band_a, band_b, band_c) -> Tensor:
         """Compute tri-band normalized difference index.
 
         Args:
@@ -359,8 +357,6 @@ class AppendTriBandNormalizedDifferenceIndex(Module):
             )
             index = index.unsqueeze(self.dim)
 
-            sample["image"] = torch.cat(  # type: ignore[attr-defined]
-                [sample["image"], index], dim=self.dim
-            )
+            sample["image"] = torch.cat([sample["image"], index], dim=self.dim)
 
         return sample

--- a/torchgeo/transforms/indices.py
+++ b/torchgeo/transforms/indices.py
@@ -46,7 +46,7 @@ class AppendNormalizedDifferenceIndex(Module):
         self.index_a = index_a
         self.index_b = index_b
 
-    def _compute_index(self, band_a, band_b) -> Tensor:
+    def _compute_index(self, band_a: Tensor, band_b: Tensor) -> Tensor:
         """Compute normalized difference index.
 
         Args:
@@ -327,7 +327,7 @@ class AppendTriBandNormalizedDifferenceIndex(Module):
         self.index_b = index_b
         self.index_c = index_c
 
-    def _compute_index(self, band_a, band_b, band_c) -> Tensor:
+    def _compute_index(self, band_a: Tensor, band_b: Tensor, band_c: Tensor) -> Tensor:
         """Compute tri-band normalized difference index.
 
         Args:

--- a/torchgeo/transforms/transforms.py
+++ b/torchgeo/transforms/transforms.py
@@ -51,12 +51,10 @@ class AugmentationSequential(Module):
         # Kornia augmentations require masks & boxes to be float
         if "mask" in self.data_keys:
             mask_dtype = sample["mask"].dtype
-            sample["mask"] = sample["mask"].to(torch.float)  # type:ignore[attr-defined]
+            sample["mask"] = sample["mask"].to(torch.float)
         if "boxes" in self.data_keys:
             boxes_dtype = sample["boxes"].dtype
-            sample["boxes"] = sample["boxes"].to(
-                torch.float  # type:ignore[attr-defined]
-            )
+            sample["boxes"] = sample["boxes"].to(torch.float)
 
         inputs = [sample[k] for k in self.data_keys]
         outputs_list: Union[Tensor, List[Tensor]] = self.augs(*inputs)


### PR DESCRIPTION
PyTorch 1.11 added type hints for most of the library. This PR removes type ignores for the majority of PyTorch functions and fixes other random typing mistakes I found along the way.

Closes #266 (no longer needed)