### PR TITLE
Fix integration tests on macOS/Windows

### DIFF
--- a/tests/samplers/test_batch.py
+++ b/tests/samplers/test_batch.py
@@ -39,7 +39,9 @@ class CustomGeoDataset(GeoDataset):
 class TestBatchGeoSampler:
     @pytest.fixture(scope="class")
     def dataset(self) -> CustomGeoDataset:
-        return CustomGeoDataset()
+        ds = CustomGeoDataset()
+        ds.index.insert(0, (0, 100, 200, 300, 400, 500))
+        return ds
 
     @pytest.fixture(scope="function")
     def sampler(self) -> CustomBatchGeoSampler:

--- a/tests/samplers/test_single.py
+++ b/tests/samplers/test_single.py
@@ -39,7 +39,9 @@ class CustomGeoDataset(GeoDataset):
 class TestGeoSampler:
     @pytest.fixture(scope="class")
     def dataset(self) -> CustomGeoDataset:
-        return CustomGeoDataset()
+        ds = CustomGeoDataset()
+        ds.index.insert(0, (0, 100, 200, 300, 400, 500))
+        return ds
 
     @pytest.fixture(scope="function")
     def sampler(self) -> CustomGeoSampler:


### PR DESCRIPTION
Turns out the tests were failing not because we weren't pickling properly but because the index was empty.

Closes #349