### PR TITLE
gitattributes: allow diff of test data

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
 # Do not change line endings on test data, it will change the MD5
-/tests/data/*/** binary
+/tests/data/*/** -text
 # Test data generation files are fine though
-/tests/data/**/data.py text diff
+/tests/data/**/data.py text

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 # Do not change line endings on test data, it will change the MD5
 /tests/data/*/** binary
+# Test data generation files are fine though
+/tests/data/**/data.py text diff


### PR DESCRIPTION
This allows `git diff` to show changes to text files in `tests/data`. 

Previously, we treated all test files as `binary` (equivalent to `-text -diff`). This resulted in useless diffs like:
```console
$ git diff
diff --git a/tests/data/cowc_counting/data.py b/tests/data/cowc_counting/data.py
index b612f92..c5ef84a 100755
Binary files a/tests/data/cowc_counting/data.py and b/tests/data/cowc_counting/data.py differ
```

However, `-text` is sufficient to prevent line endings from being changed (necessary for stable cross-platform checksums). Now, all text files diff properly. I also added back line ending changes to `data.py` since we never need to checksum that.