### PR TITLE
Chesapeake: skip all tests if zipfile_deflate64 missing

### DIFF
--- a/tests/datasets/test_chesapeake.py
+++ b/tests/datasets/test_chesapeake.py
@@ -28,9 +28,10 @@ def download_url(url: str, root: str, *args: str, **kwargs: str) -> None:
 
 
 class TestChesapeake13:
+    pytest.importorskip("zipfile_deflate64")
+
     @pytest.fixture
     def dataset(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> Chesapeake13:
-        pytest.importorskip("zipfile_deflate64")
         monkeypatch.setattr(torchgeo.datasets.chesapeake, "download_url", download_url)
         md5 = "fe35a615b8e749b21270472aa98bb42c"
         monkeypatch.setattr(Chesapeake13, "md5", md5)


### PR DESCRIPTION
Discovered this during the 0.2.1 release prep. Already backported to the releases/v0.2 branch.

The `test_already_downloaded` test was failing when `zipfile_deflate64` isn't installed because this test doesn't use the fixture.