### PR TITLE
Revert "Fix PyTorch + setuptools bug"

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -59,9 +59,7 @@ jobs:
       if: ${{ runner.os == 'Windows' }}
     - name: Install conda dependencies (Windows)
       run: |
-        # PyTorch isn't compatible with setuptools 59.6+, pin for now until new PyTorch release
-        # https://github.com/pytorch/pytorch/pull/69904
-        conda install 'fiona>=1.5' h5py 'rasterio>=1.0.16' 'setuptools<59.6'
+        conda install 'fiona>=1.5' h5py 'rasterio>=1.0.16'
         conda list
         conda info
       if: ${{ runner.os == 'Windows' }}


### PR DESCRIPTION
Reverts microsoft/torchgeo#357

New PyTorch version has been released so this workaround is no longer needed.