### PR TITLE
setup.cfg: no longer need hack for pre-release black

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -95,7 +95,7 @@ datasets =
 # Optional developer requirements
 style =
     # black 21+ required for Python 3.9 support
-    black>=21.4b0
+    black>=21
     # flake8 3.8+ depends on pyflakes 2.2+, which fixes a bug with mypy error code ignores:
     # https://github.com/PyCQA/pyflakes/pull/455
     flake8>=3.8


### PR DESCRIPTION
Previously we had to specify the exact version to use in order to work around a bug with pip and pre-release versions. Black is no longer pre-release so this hack should no longer be needed.