### PR TITLE
CI: h5py now provides Windows wheels

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -59,7 +59,7 @@ jobs:
       if: ${{ runner.os == 'Windows' }}
     - name: Install conda dependencies (Windows)
       run: |
-        conda install 'fiona>=1.5' h5py 'rasterio>=1.0.16'
+        conda install 'fiona>=1.5' 'rasterio>=1.0.16'
         conda list
         conda info
       if: ${{ runner.os == 'Windows' }}


### PR DESCRIPTION
h5py now provides Windows wheels, so we shouldn't have to install it with conda anymore.