### PR TITLE
Add PreChippedGeoSampler for pre-chipped geospatial datasets

### DIFF
--- a/docs/api/samplers.rst
+++ b/docs/api/samplers.rst
@@ -32,6 +32,11 @@ Grid Geo Sampler
 
 .. autoclass:: GridGeoSampler
 
+Pre-chipped Geo Sampler
+^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autoclass:: PreChippedGeoSampler
+
 Batch Samplers
 --------------
 

--- a/tests/samplers/test_single.py
+++ b/tests/samplers/test_single.py
@@ -11,7 +11,13 @@ from rasterio.crs import CRS
 from torch.utils.data import DataLoader
 
 from torchgeo.datasets import BoundingBox, GeoDataset, stack_samples
-from torchgeo.samplers import GeoSampler, GridGeoSampler, PreChippedGeoSampler, RandomGeoSampler, Units
+from torchgeo.samplers import (
+    GeoSampler,
+    GridGeoSampler,
+    PreChippedGeoSampler,
+    RandomGeoSampler,
+    Units,
+)
 
 
 class CustomGeoSampler(GeoSampler):

--- a/tests/samplers/test_single.py
+++ b/tests/samplers/test_single.py
@@ -207,7 +207,7 @@ class TestPreChippedGeoSampler:
 
     @pytest.fixture(scope="function")
     def sampler(self, dataset: CustomGeoDataset) -> PreChippedGeoSampler:
-        return PreChippedGeoSampler(dataset)
+        return PreChippedGeoSampler(dataset, shuffle=True)
 
     def test_iter(self, sampler: GridGeoSampler) -> None:
         for _ in sampler:

--- a/tests/samplers/test_single.py
+++ b/tests/samplers/test_single.py
@@ -11,7 +11,7 @@ from rasterio.crs import CRS
 from torch.utils.data import DataLoader
 
 from torchgeo.datasets import BoundingBox, GeoDataset, stack_samples
-from torchgeo.samplers import GeoSampler, GridGeoSampler, RandomGeoSampler, Units
+from torchgeo.samplers import GeoSampler, GridGeoSampler, PreChippedGeoSampler, RandomGeoSampler, Units
 
 
 class CustomGeoSampler(GeoSampler):
@@ -183,6 +183,51 @@ class TestGridGeoSampler:
     @pytest.mark.parametrize("num_workers", [0, 1, 2])
     def test_dataloader(
         self, dataset: CustomGeoDataset, sampler: GridGeoSampler, num_workers: int
+    ) -> None:
+        dl = DataLoader(
+            dataset, sampler=sampler, num_workers=num_workers, collate_fn=stack_samples
+        )
+        for _ in dl:
+            continue
+
+
+class TestPreChippedGeoSampler:
+    @pytest.fixture(scope="class")
+    def dataset(self) -> CustomGeoDataset:
+        ds = CustomGeoDataset()
+        ds.index.insert(0, (0, 20, 0, 20, 0, 20))
+        ds.index.insert(1, (0, 30, 0, 30, 0, 30))
+        return ds
+
+    @pytest.fixture(scope="function")
+    def sampler(self, dataset: CustomGeoDataset) -> PreChippedGeoSampler:
+        return PreChippedGeoSampler(dataset)
+
+    def test_iter(self, sampler: GridGeoSampler) -> None:
+        for _ in sampler:
+            continue
+
+    def test_len(self, sampler: GridGeoSampler) -> None:
+        assert len(sampler) == 2
+
+    def test_roi(self, dataset: CustomGeoDataset) -> None:
+        roi = BoundingBox(5, 15, 5, 15, 5, 15)
+        sampler = PreChippedGeoSampler(dataset, roi=roi)
+        for query in sampler:
+            assert query == roi
+
+    def test_point_data(self) -> None:
+        ds = CustomGeoDataset()
+        ds.index.insert(0, (0, 0, 0, 0, 0, 0))
+        ds.index.insert(1, (1, 1, 1, 1, 1, 1))
+        sampler = PreChippedGeoSampler(ds)
+        for _ in sampler:
+            continue
+
+    @pytest.mark.slow
+    @pytest.mark.parametrize("num_workers", [0, 1, 2])
+    def test_dataloader(
+        self, dataset: CustomGeoDataset, sampler: PreChippedGeoSampler, num_workers: int
     ) -> None:
         dl = DataLoader(
             dataset, sampler=sampler, num_workers=num_workers, collate_fn=stack_samples

--- a/torchgeo/samplers/__init__.py
+++ b/torchgeo/samplers/__init__.py
@@ -5,11 +5,12 @@
 
 from .batch import BatchGeoSampler, RandomBatchGeoSampler
 from .constants import Units
-from .single import GeoSampler, GridGeoSampler, RandomGeoSampler
+from .single import GeoSampler, GridGeoSampler, PreChippedGeoSampler, RandomGeoSampler
 
 __all__ = (
     # Samplers
     "GridGeoSampler",
+    "PreChippedGeoSampler",
     "RandomGeoSampler",
     # Batch samplers
     "RandomBatchGeoSampler",

--- a/torchgeo/samplers/single.py
+++ b/torchgeo/samplers/single.py
@@ -5,7 +5,7 @@
 
 import abc
 import random
-from typing import Iterator, Optional, Tuple, Union
+from typing import Callable, Iterable, Iterator, Optional, Tuple, Union
 
 import torch
 from rtree.index import Index, Property
@@ -286,7 +286,7 @@ class PreChippedGeoSampler(GeoSampler):
         Returns:
             (minx, maxx, miny, maxy, mint, maxt) coordinates to index a dataset
         """
-        generator = range
+        generator: Callable[[int], Iterable[int]] = range
         if self.shuffle:
             generator = torch.randperm
 

--- a/torchgeo/samplers/single.py
+++ b/torchgeo/samplers/single.py
@@ -252,9 +252,9 @@ class PreChippedGeoSampler(GeoSampler):
 
     This sampler should not be used with :class:`~torchgeo.datasets.VisionDataset`.
     You may encounter problems when using an :term:`ROI <region of interest (ROI)>`
-    that partially intersects with one of the file bounding boxes, or when using an
-    :class:`~torchgeo.datasets.IntersectionDataset`. These issues can be solved by
-    adding padding.
+    that partially intersects with one of the file bounding boxes, when using an
+    :class:`~torchgeo.datasets.IntersectionDataset`, or when each file is in a
+    different CRS. These issues can be solved by adding padding.
     """
 
     def __init__(


### PR DESCRIPTION
### Rationale

Many existing `VisionDatasets` actually contain geospatial metadata. These datasets should be converted to `GeoDatasets` (#83). However, `GeoDatasets` are a bit more complicated than `VisionDatasets` and require a `GeoSampler` to use. This PR adds a `PreChippedGeoSampler` to make this transition easier.

### Implementation

For `VisionDatasets`, sampling is quite simple:
```python
train_dataset = ...
train_dataloader = DataLoader(train_dataset, shuffle=True)

test_dataset = ...
test_dataloader = DataLoader(test_dataset)
```
However, it was much trickier to get the same behavior for `GeoDatasets`. Previously, a user would need to do something like:
```python
SIZE = 256  # size of each image

train_dataset = ...
train_sampler = RandomGeoSampler(train_dataset, size=SIZE, length=len(train_dataset))
train_dataloader = DataLoader(train_dataset, sampler=train_sampler)

test_dataset = ...
test_sampler = GridGeoSampler(test_dataset, size=SIZE, stride=SIZE)
test_dataloader = DataLoader(test_dataset, sampler=test_sampler)
```
Crucially, this requires the user to know the size of each image, to explicitly specify the number of images in the train dataset, and to be clever with stride. With this PR, users can instead use:
```python
train_dataset = ...
train_sampler = PreChippedGeoSampler(train_dataset, shuffle=True)
train_dataloader = DataLoader(train_dataset, sampler=train_sampler)

test_dataset = ...
test_sampler = PreChippedGeoSampler(test_dataset)
test_dataloader = DataLoader(test_dataset, sampler=test_sampler)
```
This is almost as simple as `VisionDataset` sampling and probably about as good as we're going to get.

This may be of interest to @recursix @RitwikGupta @ashnair1. I think #409 is the only remaining bottleneck preventing us from converting more `VisionDatasets` to `GeoDatasets`.