### PR TITLE
Fix PyTorch Lightning 1.6 type hints

### DIFF
--- a/tests/trainers/test_classification.py
+++ b/tests/trainers/test_classification.py
@@ -76,7 +76,7 @@ class TestClassificationTask:
         model = ClassificationTask(**model_kwargs)
 
         # Instantiate trainer
-        trainer = Trainer(logger=None, fast_dev_run=True, log_every_n_steps=1)
+        trainer = Trainer(logger=False, fast_dev_run=True, log_every_n_steps=1)
         trainer.fit(model=model, datamodule=datamodule)
 
     @pytest.fixture
@@ -166,7 +166,7 @@ class TestMultiLabelClassificationTask:
         model = MultiLabelClassificationTask(**model_kwargs)
 
         # Instantiate trainer
-        trainer = Trainer(logger=None, fast_dev_run=True, log_every_n_steps=1)
+        trainer = Trainer(logger=False, fast_dev_run=True, log_every_n_steps=1)
         trainer.fit(model=model, datamodule=datamodule)
 
     @pytest.fixture

--- a/tests/trainers/test_regression.py
+++ b/tests/trainers/test_regression.py
@@ -53,7 +53,7 @@ class TestRegressionTask:
         model = RegressionTask(**model_kwargs)
 
         # Instantiate trainer
-        trainer = Trainer(logger=None, fast_dev_run=True, log_every_n_steps=1)
+        trainer = Trainer(logger=False, fast_dev_run=True, log_every_n_steps=1)
         trainer.fit(model=model, datamodule=datamodule)
 
     def test_invalid_model(self) -> None:

--- a/tests/trainers/test_segmentation.py
+++ b/tests/trainers/test_segmentation.py
@@ -83,7 +83,7 @@ class TestSemanticSegmentationTask:
         model = SemanticSegmentationTask(**model_kwargs)
 
         # Instantiate trainer
-        trainer = Trainer(logger=None, fast_dev_run=True, log_every_n_steps=1)
+        trainer = Trainer(logger=False, fast_dev_run=True, log_every_n_steps=1)
         trainer.fit(model=model, datamodule=datamodule)
 
     @pytest.fixture

--- a/torchgeo/trainers/classification.py
+++ b/torchgeo/trainers/classification.py
@@ -189,13 +189,13 @@ class ClassificationTask(pl.LightningModule):
 
         if batch_idx < 10:
             try:
-                datamodule = self.trainer.datamodule  # type: ignore[attr-defined]
+                datamodule = self.trainer.datamodule  # type: ignore[union-attr]
                 batch["prediction"] = y_hat_hard
                 for key in ["image", "label", "prediction"]:
                     batch[key] = batch[key].cpu()
                 sample = unbind_samples(batch)[0]
                 fig = datamodule.plot(sample)
-                summary_writer = self.logger.experiment
+                summary_writer = self.logger.experiment  # type: ignore[union-attr]
                 summary_writer.add_figure(
                     f"image/{batch_idx}", fig, global_step=self.global_step
                 )
@@ -358,13 +358,13 @@ class MultiLabelClassificationTask(ClassificationTask):
 
         if batch_idx < 10:
             try:
-                datamodule = self.trainer.datamodule  # type: ignore[attr-defined]
+                datamodule = self.trainer.datamodule  # type: ignore[union-attr]
                 batch["prediction"] = y_hat_hard
                 for key in ["image", "label", "prediction"]:
                     batch[key] = batch[key].cpu()
                 sample = unbind_samples(batch)[0]
                 fig = datamodule.plot(sample)
-                summary_writer = self.logger.experiment
+                summary_writer = self.logger.experiment  # type: ignore[union-attr]
                 summary_writer.add_figure(
                     f"image/{batch_idx}", fig, global_step=self.global_step
                 )

--- a/torchgeo/trainers/regression.py
+++ b/torchgeo/trainers/regression.py
@@ -117,13 +117,13 @@ class RegressionTask(pl.LightningModule):
 
         if batch_idx < 10:
             try:
-                datamodule = self.trainer.datamodule  # type: ignore[attr-defined]
+                datamodule = self.trainer.datamodule  # type: ignore[union-attr]
                 batch["prediction"] = y_hat
                 for key in ["image", "label", "prediction"]:
                     batch[key] = batch[key].cpu()
                 sample = unbind_samples(batch)[0]
                 fig = datamodule.plot(sample)
-                summary_writer = self.logger.experiment
+                summary_writer = self.logger.experiment  # type: ignore[union-attr]
                 summary_writer.add_figure(
                     f"image/{batch_idx}", fig, global_step=self.global_step
                 )

--- a/torchgeo/trainers/segmentation.py
+++ b/torchgeo/trainers/segmentation.py
@@ -174,13 +174,13 @@ class SemanticSegmentationTask(LightningModule):
 
         if batch_idx < 10:
             try:
-                datamodule = self.trainer.datamodule  # type: ignore[attr-defined]
+                datamodule = self.trainer.datamodule  # type: ignore[union-attr]
                 batch["prediction"] = y_hat_hard
                 for key in ["image", "mask", "prediction"]:
                     batch[key] = batch[key].cpu()
                 sample = unbind_samples(batch)[0]
                 fig = datamodule.plot(sample)
-                summary_writer = self.logger.experiment
+                summary_writer = self.logger.experiment  # type: ignore[union-attr]
                 summary_writer.add_figure(
                     f"image/{batch_idx}", fig, global_step=self.global_step
                 )


### PR DESCRIPTION
PyTorch Lightning 1.6.0 was released today and includes better type hints, causing our mypy tests to fail. This PR updates some things related to PL 1.6.

The reason that these type ignores are needed (and the try-except is needed) is that all model/datamodule/trainer attributes are optional. We could instead replace the try-except with a `hasattr(...)` for literally every attribute, but that gets cumbersome pretty quickly. I may do this in the future, but for now, the try-except protects us.