### PR TITLE
git pre-commit: run pyupgrade first

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,10 @@
 repos:
+    -   repo: https://github.com/asottile/pyupgrade
+        rev: v2.31.1
+        hooks:
+        -   id: pyupgrade
+            args: [--py37-plus]
+
     -   repo: https://github.com/pycqa/isort
         rev: 5.10.1
         hooks:
@@ -10,12 +16,6 @@ repos:
         hooks:
         -   id: black
             args: [--skip-magic-trailing-comma]
-
-    -   repo: https://github.com/asottile/pyupgrade
-        rev: v2.31.1
-        hooks:
-        -   id: pyupgrade
-            args: [--py37-plus]
 
     -   repo: https://gitlab.com/pycqa/flake8.git
         rev: 3.9.2


### PR DESCRIPTION
I'm assuming this list is ordered. `pyupgrade` can cause formatting changes that require `black` to be re-run, so it should be run first.

@ashnair1