### PR TITLE
Default FCSiam models to random init for tests

### DIFF
--- a/tests/models/test_fcsiam.py
+++ b/tests/models/test_fcsiam.py
@@ -19,7 +19,7 @@ class TestFCSiamConc:
     def test_in_channels(self, b: int, c: int) -> None:
         classes = 2
         t, h, w = 2, 64, 64
-        model = FCSiamConc(in_channels=c, classes=classes)
+        model = FCSiamConc(in_channels=c, classes=classes, encoder_weights=None)
         x = torch.randn(b, t, c, h, w)
         y = model(x)
         assert y.shape == (b, classes, h, w)
@@ -28,7 +28,7 @@ class TestFCSiamConc:
     @pytest.mark.parametrize("b, classes", list(itertools.product(BATCH_SIZE, CLASSES)))
     def test_classes(self, b: int, classes: int) -> None:
         t, c, h, w = 2, 3, 64, 64
-        model = FCSiamConc(in_channels=3, classes=classes)
+        model = FCSiamConc(in_channels=3, classes=classes, encoder_weights=None)
         x = torch.randn(b, t, c, h, w)
         y = model(x)
         assert y.shape == (b, classes, h, w)
@@ -40,7 +40,7 @@ class TestFCSiamDiff:
     def test_in_channels(self, b: int, c: int) -> None:
         classes = 2
         t, h, w = 2, 64, 64
-        model = FCSiamDiff(in_channels=c, classes=classes)
+        model = FCSiamDiff(in_channels=c, classes=classes, encoder_weights=None)
         x = torch.randn(b, t, c, h, w)
         y = model(x)
         assert y.shape == (b, classes, h, w)
@@ -49,7 +49,7 @@ class TestFCSiamDiff:
     @pytest.mark.parametrize("b, classes", list(itertools.product(BATCH_SIZE, CLASSES)))
     def test_classes(self, b: int, classes: int) -> None:
         t, c, h, w = 2, 3, 64, 64
-        model = FCSiamDiff(in_channels=3, classes=classes)
+        model = FCSiamDiff(in_channels=3, classes=classes, encoder_weights=None)
         x = torch.randn(b, t, c, h, w)
         y = model(x)
         assert y.shape == (b, classes, h, w)


### PR DESCRIPTION
This PR fixes the requirement for FCSiam model tests to have internet access. Tested with wifi and ethernet disabled.

Closes #495 