### PR TITLE
Landsat: add support for all Level-1 and Level-2 products

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ In this example, we show how easy it is to work with geospatial data and to samp
 
 ```python
 landsat7 = Landsat7(root="...")
-landsat8 = Landsat8(root="...", bands=["B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9"])
+landsat8 = Landsat8(root="...", bands=Landsat8.all_bands[1:-2])
 landsat = landsat7 | landsat8
 ```
 

--- a/tests/datasets/test_landsat.py
+++ b/tests/datasets/test_landsat.py
@@ -17,7 +17,7 @@ class TestLandsat8:
     @pytest.fixture
     def dataset(self, monkeypatch: MonkeyPatch) -> Landsat8:
         root = os.path.join("tests", "data", "landsat8")
-        bands = ["B1", "B2", "B3", "B4", "B5", "B6", "B7"]
+        bands = ["SR_B1", "SR_B2", "SR_B3", "SR_B4", "SR_B5", "SR_B6", "SR_B7"]
         transforms = nn.Identity()  # type: ignore[no-untyped-call]
         return Landsat8(root, bands=bands, transforms=transforms)
 

--- a/torchgeo/datasets/landsat.py
+++ b/torchgeo/datasets/landsat.py
@@ -24,7 +24,7 @@ class Landsat(RasterDataset, abc.ABC):
 
     # https://www.usgs.gov/faqs/what-naming-convention-landsat-collections-level-1-scenes
     # https://www.usgs.gov/faqs/what-naming-convention-landsat-collection-2-level-1-and-level-2-scenes
-    filename_glob = ""
+    filename_glob = "L*"
     filename_regex = r"""
         ^L
         (?P<sensor>[COTEM])
@@ -36,9 +36,8 @@ class Landsat(RasterDataset, abc.ABC):
         _(?P<processing_date>\d{8})
         _(?P<collection_number>\d{2})
         _(?P<collection_category>[A-Z0-9]{2})
-        _SR
-        _(?P<band>B\d+)
-        \..*$
+        _(?P<band>[A-Z0-9_]+)
+        \.
     """
 
     # https://www.usgs.gov/faqs/what-are-band-designations-landsat-satellites
@@ -73,6 +72,7 @@ class Landsat(RasterDataset, abc.ABC):
             FileNotFoundError: if no files are found in ``root``
         """
         self.bands = bands if bands else self.all_bands
+        self.filename_glob = self.filename_glob.format(self.bands[0])
 
         super().__init__(root, crs, res, transforms, cache)
 
@@ -80,73 +80,73 @@ class Landsat(RasterDataset, abc.ABC):
 class Landsat1(Landsat):
     """Landsat 1 Multispectral Scanner (MSS)."""
 
-    filename_glob = "LM01_*_SR_B4.*"
+    filename_glob = "LM01_*_{}.*"
 
-    all_bands = ["B4", "B5", "B6", "B7"]
-    rgb_bands = ["B6", "B5", "B4"]
+    all_bands = ["SR_B4", "SR_B5", "SR_B6", "SR_B7"]
+    rgb_bands = ["SR_B6", "SR_B5", "SR_B4"]
 
 
 class Landsat2(Landsat1):
     """Landsat 2 Multispectral Scanner (MSS)."""
 
-    filename_glob = "LM02_*_SR_B4.*"
+    filename_glob = "LM02_*_{}.*"
 
 
 class Landsat3(Landsat1):
     """Landsat 3 Multispectral Scanner (MSS)."""
 
-    filename_glob = "LM03_*_SR_B4.*"
+    filename_glob = "LM03_*_{}.*"
 
 
 class Landsat4MSS(Landsat):
     """Landsat 4 Multispectral Scanner (MSS)."""
 
-    filename_glob = "LM04_*_SR_B1.*"
+    filename_glob = "LM04_*_{}.*"
 
-    all_bands = ["B1", "B2", "B3", "B4"]
-    rgb_bands = ["B3", "B2", "B1"]
+    all_bands = ["SR_B1", "SR_B2", "SR_B3", "SR_B4"]
+    rgb_bands = ["SR_B3", "SR_B2", "SR_B1"]
 
 
 class Landsat4TM(Landsat):
     """Landsat 4 Thematic Mapper (TM)."""
 
-    filename_glob = "LT04_*_SR_B1.*"
+    filename_glob = "LT04_*_{}.*"
 
-    all_bands = ["B1", "B2", "B3", "B4", "B5", "B6", "B7"]
-    rgb_bands = ["B3", "B2", "B1"]
+    all_bands = ["SR_B1", "SR_B2", "SR_B3", "SR_B4", "SR_B5", "SR_B6", "SR_B7"]
+    rgb_bands = ["SR_B3", "SR_B2", "SR_B1"]
 
 
 class Landsat5MSS(Landsat4MSS):
     """Landsat 4 Multispectral Scanner (MSS)."""
 
-    filename_glob = "LM04_*_SR_B1.*"
+    filename_glob = "LM04_*_{}.*"
 
 
 class Landsat5TM(Landsat4TM):
     """Landsat 5 Thematic Mapper (TM)."""
 
-    filename_glob = "LT05_*_SR_B1.*"
+    filename_glob = "LT05_*_{}.*"
 
 
 class Landsat7(Landsat):
     """Landsat 7 Enhanced Thematic Mapper Plus (ETM+)."""
 
-    filename_glob = "LE07_*_SR_B1.*"
+    filename_glob = "LE07_*_{}.*"
 
-    all_bands = ["B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8"]
-    rgb_bands = ["B3", "B2", "B1"]
+    all_bands = ["SR_B1", "SR_B2", "SR_B3", "SR_B4", "SR_B5", "SR_B6", "SR_B7", "SR_B8"]
+    rgb_bands = ["SR_B3", "SR_B2", "SR_B1"]
 
 
 class Landsat8(Landsat):
     """Landsat 8 Operational Land Imager (OLI) and Thermal Infrared Sensor (TIRS)."""
 
-    filename_glob = "LC08_*_SR_B2.*"
+    filename_glob = "LC08_*_{}.*"
 
-    all_bands = ["B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11"]
-    rgb_bands = ["B4", "B3", "B2"]
+    all_bands = ["SR_B1", "SR_B2", "SR_B3", "SR_B4", "SR_B5", "SR_B6", "SR_B7", "SR_B8", "SR_B9", "SR_B10", "SR_B11"]
+    rgb_bands = ["SR_B4", "SR_B3", "SR_B2"]
 
 
 class Landsat9(Landsat8):
     """Landsat 9 Operational Land Imager (OLI) and Thermal Infrared Sensor (TIRS)."""
 
-    filename_glob = "LC09_*_SR_B2.*"
+    filename_glob = "LC09_*_{}.*"

--- a/torchgeo/datasets/landsat.py
+++ b/torchgeo/datasets/landsat.py
@@ -17,14 +17,12 @@ class Landsat(RasterDataset, abc.ABC):
     `Landsat <https://landsat.gsfc.nasa.gov/>`_ is a joint NASA/USGS program,
     providing the longest continuous space-based record of Earth's land in existence.
 
-    If you use this dataset in your research, please cite it using the following format:
+    If you use this dataset in your research, please cite the following paper:
 
-    * https://www.usgs.gov/centers/eros/data-citation
+    * https://doi.org/10.1109/LGRS.2005.857030
     """
 
-    # https://www.usgs.gov/faqs/what-naming-convention-landsat-collections-level-1-scenes
-    # https://www.usgs.gov/faqs/what-naming-convention-landsat-collection-2-level-1-and-level-2-scenes
-    filename_glob = "L*"
+    # https://www.usgs.gov/landsat-missions/landsat-collection-2
     filename_regex = r"""
         ^L
         (?P<sensor>[COTEM])
@@ -39,10 +37,6 @@ class Landsat(RasterDataset, abc.ABC):
         _(?P<band>[A-Z0-9_]+)
         \.
     """
-
-    # https://www.usgs.gov/faqs/what-are-band-designations-landsat-satellites
-    all_bands: List[str] = []
-    rgb_bands: List[str] = []
 
     separate_files = True
 
@@ -142,7 +136,19 @@ class Landsat8(Landsat):
 
     filename_glob = "LC08_*_{}.*"
 
-    all_bands = ["SR_B1", "SR_B2", "SR_B3", "SR_B4", "SR_B5", "SR_B6", "SR_B7", "SR_B8", "SR_B9", "SR_B10", "SR_B11"]
+    all_bands = [
+        "SR_B1",
+        "SR_B2",
+        "SR_B3",
+        "SR_B4",
+        "SR_B5",
+        "SR_B6",
+        "SR_B7",
+        "SR_B8",
+        "SR_B9",
+        "SR_B10",
+        "SR_B11",
+    ]
     rgb_bands = ["SR_B4", "SR_B3", "SR_B2"]
 
 

--- a/torchgeo/datasets/landsat.py
+++ b/torchgeo/datasets/landsat.py
@@ -4,7 +4,7 @@
 """Landsat datasets."""
 
 import abc
-from typing import Any, Callable, Dict, List, Optional, Sequence
+from typing import Any, Callable, Dict, Optional, Sequence
 
 from rasterio.crs import CRS
 
@@ -17,10 +17,18 @@ class Landsat(RasterDataset, abc.ABC):
     `Landsat <https://landsat.gsfc.nasa.gov/>`_ is a joint NASA/USGS program,
     providing the longest continuous space-based record of Earth's land in existence.
 
-    If you use this dataset in your research, please cite the following paper:
+    If you use this dataset in your research, please cite it using the following format:
 
-    * https://doi.org/10.1109/LGRS.2005.857030
-    """
+    * https://www.usgs.gov/centers/eros/data-citation
+
+    If you use any of the following Level-2 products, there may be additional citation
+    requirements, including papers you can cite. See the "Citation Information" section
+    of the following pages:
+
+    * `Surface Temperature <https://www.usgs.gov/landsat-missions/landsat-collection-2-surface-temperature>`_
+    * `Surface Reflectance <https://www.usgs.gov/landsat-missions/landsat-collection-2-surface-reflectance>`_
+    * `U.S. Analysis Ready Data <https://www.usgs.gov/landsat-missions/landsat-collection-2-us-analysis-ready-data>`_
+    """  # noqa: E501
 
     # https://www.usgs.gov/landsat-missions/landsat-collection-2
     filename_regex = r"""


### PR DESCRIPTION
Previously, our Landsat datasets only supported Level-2 Surface Reflectance products. This PR allows our datasets to also support Level-1, Level-2 Surface Temperature, Level-2 U.S. Analysis Data, Quality Assurance, etc. products.

I _think_ most users use Level-2 Surface Reflectance data, so our current `bands` default is best. We don't currently test to ensure that the `bands` passed to a dataset are valid, but we could if someone wants to dig through all the docs and determine all possible files for each mission.

Also fixes a couple other issues:

* Found more detailed citation info for Level-2 products
* Fix bug where no files would be found when the band we chose to put into the `filename_glob` was not included in `bands`

Fixes #492