### PR TITLE
Type hints: PEP 561 compliance

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -63,6 +63,9 @@ install_requires =
 python_requires = >= 3.7
 packages = find:
 
+[options.package_data]
+torchgeo = py.typed
+
 [options.packages.find]
 include = torchgeo*
 


### PR DESCRIPTION
Although TorchGeo has type hints, mypy isn't actually able to find them. For example, if you `pip install torchgeo`, then run `mypy` on the following file:
```python
from torchgeo.datasets import Sentinel2

ds = Sentinel2()
```
you'll see the following error:
```console
$ mypy test.py 
test.py:1: error: Skipping analyzing "torchgeo.datasets": module is installed, but missing library stubs or py.typed marker
test.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
Found 1 error in 1 file (checked 1 source file)
```
It turns out that you have to explicitly tell mypy that your library has type hints by adding an empty `py.typed` file to the repo. You also need to tell setuptools to copy this file into both the sdist and wheel. See the following resources:

* [PEP 561](https://peps.python.org/pep-0561/)
* [mypy error docs](https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-library-stubs-or-py-typed-marker)
* [mypy PEP 561 docs](https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages)