### PR TITLE
Fix error when using other than 4 channel images with BYOL task

### DIFF
--- a/torchgeo/trainers/byol.py
+++ b/torchgeo/trainers/byol.py
@@ -347,7 +347,7 @@ class BYOLTask(LightningModule):
             )
 
         encoder.conv1 = new_layer
-        self.model = BYOL(encoder, image_size=(256, 256))
+        self.model = BYOL(encoder, in_channels=in_channels, image_size=(256, 256))
 
     def __init__(self, **kwargs: Any) -> None:
         """Initialize a LightningModule for pre-training a model with BYOL.


### PR DESCRIPTION
To avoid shape errors, we pass the `in_channels` argument from `BYOLTask` to `BYOL`.