### PR TITLE
Fix loading encoder weights trained with BYOL

### DIFF
--- a/tests/trainers/conftest.py
+++ b/tests/trainers/conftest.py
@@ -25,7 +25,7 @@ def state_dict(model: Module) -> Dict[str, Tensor]:
     return model.state_dict()
 
 
-@pytest.fixture(params=["classification_model", "encoder"])
+@pytest.fixture(params=["classification_model", "encoder_name"])
 def checkpoint(
     state_dict: Dict[str, Tensor], request: SubRequest, tmp_path: Path
 ) -> str:

--- a/torchgeo/trainers/utils.py
+++ b/torchgeo/trainers/utils.py
@@ -42,8 +42,8 @@ def extract_encoder(path: str) -> Tuple[str, "OrderedDict[str, Tensor]"]:
         state_dict = OrderedDict(
             {k.replace("model.", ""): v for k, v in state_dict.items()}
         )
-    elif "encoder" in checkpoint["hyper_parameters"]:
-        name = checkpoint["hyper_parameters"]["encoder"]
+    elif "encoder_name" in checkpoint["hyper_parameters"]:
+        name = checkpoint["hyper_parameters"]["encoder_name"]
         state_dict = checkpoint["state_dict"]
         state_dict = OrderedDict(
             {k: v for k, v in state_dict.items() if "model.encoder.model" in k}


### PR DESCRIPTION
When loading a model trained with BYOLTask using the "weights" parameter in ClassificationTask, the following error occurs:

```
Traceback (most recent call last):                                  
File "finetune_ssl_on_eurosat.py", line 14, in <module>                     
    task = ClassificationTask(classification_model="resnet50", loss="ce",
File "/torchgeo/torchgeo/trainers/classification.py", line 103, in __init__
    self.config_task()
File "/torchgeo/torchgeo/trainers/classification.py", line 77, in config_task
    self.config_model()
File "/torchgeo/torchgeo/trainers/classification.py", line 66, in config_model
    name, state_dict = utils.extract_encoder(self.hyperparams["weights"])
File "/torchgeo/torchgeo/trainers/utils.py", line 55, in extract_encoder                       
raise ValueError(
ValueError: Unknown checkpoint task. Only encoder or classification_model extraction is supported 
```

The `extract_encoder` function is looking for the `encoder` key in the loaded dict, when it seems like it should be looking for `encoder_name`. This PR fixes this and allows to load a model trained with BYOLTask in ClassificationTask for fine-tuning.
 