### PR TITLE
Triplet sampling for RasterDataset

### DIFF
--- a/torchgeo/samplers/__init__.py
+++ b/torchgeo/samplers/__init__.py
@@ -3,7 +3,7 @@
 
 """TorchGeo samplers."""
 
-from .batch import BatchGeoSampler, RandomBatchGeoSampler
+from .batch import BatchGeoSampler, RandomBatchGeoSampler, TripletBatchGeoSampler
 from .constants import Units
 from .single import GeoSampler, GridGeoSampler, PreChippedGeoSampler, RandomGeoSampler
 


### PR DESCRIPTION
DRAFT: Adding [Tile2Vec](https://arxiv.org/abs/1805.02855) to torchgeo.

At the moment a `TripletBatchGeoSampler` in `batch.py` for triplet sampling as described in Tile2Vec has been implemented.

The anchor patch is sampled randomly, while the positive and negative patches are sampled based on a neighborhood around the centerpoint of the anchor patch. The midpoint of the positive patch lies in this neighborhood whereas the negative patch's midpoint lies outside.

The current approach changes `RasterDataset` to allow the triplets to be sampled at the same time without using a special `collate_fn`. This allows for other types of triplets to be sampled; e.g., using more negative samples.

Another approach would be to use a specific `collate_fn` to stack the samples after the dataset retrieves them. If the `sampler` yields anchor, positive, negative in order the `collate_fn` could stack them based on [0::3], [1::3], [2::3]. However, this introduces another specific function which has to be used in combination with the sampler.

Original discussion in issue #523.