### PR TITLE
Update md5sum of the s1 data file

### DIFF
--- a/torchgeo/datasets/bigearthnet.py
+++ b/torchgeo/datasets/bigearthnet.py
@@ -245,7 +245,7 @@ class BigEarthNet(VisionDataset):
     metadata = {
         "s1": {
             "url": "http://bigearth.net/downloads/BigEarthNet-S1-v1.0.tar.gz",
-            "md5": "5a64e9ce38deb036a435a7b59494924c",
+            "md5": "94ced73440dea8c7b9645ee738c5a172",
             "filename": "BigEarthNet-S1-v1.0.tar.gz",
             "directory": "BigEarthNet-S1-v1.0",
         },


### PR DESCRIPTION
Md5 value for file BigEarthNet-S1-v1.0.tar.gz seems like incorrect which causes code to download the whole data from scratch even though it exists.

```
$ cat BigEarthNet-S1-v1.0.tar.gz.md5sum 
94ced73440dea8c7b9645ee738c5a172  BigEarthNet-S1-v1.0.tar.gz
$ cat BigEarthNet-S2-v1.0.tar.gz.md5sum 
5a64e9ce38deb036a435a7b59494924c  BigEarthNet-S2-v1.0.tar.gz
```