### PR TITLE
Install only the needed lint tool in style checks CI

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -21,8 +21,7 @@ jobs:
         python-version: '3.10'
     - name: Install pip dependencies
       run: |
-        pip install --pre 'rasterio>=1.0.16'
-        pip install .[style]
+        pip install black
         pip list
     - name: Run black checks
       run: black . --check --diff
@@ -38,8 +37,7 @@ jobs:
         python-version: '3.10'
     - name: Install pip dependencies
       run: |
-        pip install --pre 'rasterio>=1.0.16'
-        pip install .[style]
+        pip install flake8
         pip list
     - name: Run flake8 checks
       run: flake8
@@ -55,8 +53,7 @@ jobs:
         python-version: '3.10'
     - name: Install pip dependencies
       run: |
-        pip install --pre 'rasterio>=1.0.16'
-        pip install .[style]
+        pip install isort
         pip list
     - name: Run isort checks
       run: isort . --check --diff
@@ -72,8 +69,7 @@ jobs:
         python-version: '3.10'
     - name: Install pip dependencies
       run: |
-        pip install --pre 'rasterio>=1.0.16'
-        pip install .[style]
+        pip install pydocstyle
         pip list
     - name: Run pydocstyle checks
       run: pydocstyle
@@ -89,8 +85,7 @@ jobs:
         python-version: 3.9
     - name: Install pip dependencies
       run: |
-        pip install --pre 'rasterio>=1.0.16'
-        pip install .[style]
+        pip install pyupgrade
         pip list
     - name: Run pyupgrade checks
       run: pyupgrade --py37-plus $(find . -name "*.py")


### PR DESCRIPTION
Instead of installing all of  `torchgeo`'s required dependencies, just install the lint tool (`black`/`flake8`/`isort`/`pydocstyle`/`pyupgrade`) directly. Should make for a faster style checks CI.

As per https://github.com/microsoft/torchgeo/pull/552#discussion_r889339370