### PR TITLE
setuptools: setup_requires is deprecated

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,9 +24,6 @@ classifiers =
 keywords = pytorch, deep learning, machine learning, remote sensing, satellite imagery, geospatial
 
 [options]
-setup_requires =
-    # setuptools 42+ required for metadata.license_files support in setup.cfg
-    setuptools>=42
 install_requires =
     einops
     # fiona 1.5+ required for fiona.transform module


### PR DESCRIPTION
Apparently `setup_requires` is deprecated in favor of `pyproject.toml`. Also, setuptools is working on adding `pyproject.toml` support. 

https://setuptools.pypa.io/en/latest/userguide/dependency_management.html