### PR TITLE
Fix compatibility with torchmetrics 0.9, failing Windows tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -73,7 +73,7 @@ include = torchgeo*
 [options.extras_require]
 # Optional dataset requirements
 datasets =
-    h5py
+    h5py!=3.7.0
     # laspy 2+ required for Python 3.7+ support
     laspy>=2
     # open3d 0.11.2+ required to avoid GLFW error:

--- a/torchgeo/trainers/segmentation.py
+++ b/torchgeo/trainers/segmentation.py
@@ -98,6 +98,7 @@ class SemanticSegmentationTask(LightningModule):
                 Accuracy(
                     num_classes=self.hyperparams["num_classes"],
                     ignore_index=self.ignore_zeros,
+                    mdmc_average="global",
                 ),
                 JaccardIndex(
                     num_classes=self.hyperparams["num_classes"],


### PR DESCRIPTION
Hoping this fixes the failing CI. See https://github.com/microsoft/torchgeo/runs/6733678644?check_suite_focus=true for an example of the error message.

See https://github.com/PyTorchLightning/metrics/pull/1036 for the change that I believe caused the tests to fail. I'm not sure if this setting is right for us, or if there's something else that needs to be done, but this should at least fix CI.