### PR TITLE
Add upper bounds to dep versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
-    "setuptools>=42",
-    "wheel",
+    "setuptools>=42,<63",
+    "wheel<0.38",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,6 +45,11 @@ scipy==1.8.1;python_version>='3.8'
 scipy==1.7.3;python_version=='3.7'
 zipfile-deflate64==0.2.0
 
+# docs
+ipywidgets==7.7.0
+nbsphinx==0.8.9
+sphinx==5.0.1
+
 # style
 black[jupyter]==22.3.0
 flake8==4.0.1;python_version=='3.10'
@@ -57,8 +62,3 @@ mypy==0.960
 nbmake==1.3.0
 pytest==7.1.2
 pytest-cov==3.0.0
-
-# docs
-ipywidgets==7.7.0
-nbsphinx==0.8.9
-sphinx==5.0.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,40 +25,40 @@ keywords = pytorch, deep learning, machine learning, remote sensing, satellite i
 
 [options]
 install_requires =
-    einops
+    einops<0.5
     # fiona 1.5+ required for fiona.transform module
-    fiona>=1.5
+    fiona~=1.5
     # kornia 0.6.4+ required for kornia.contrib.compute_padding
-    kornia>=0.6.4
-    matplotlib
-    numpy
+    kornia>=0.6.4,<0.7
+    matplotlib<4
+    numpy<2
     # omegaconf 2.1+ required for to_object method
-    omegaconf>=2.1
+    omegaconf~=2.1
     # pillow 2.9+ required for height attribute
-    pillow>=2.9
+    pillow>=2.9,<10
     # pyproj 2.2+ required for CRS object
-    pyproj>=2.2
+    pyproj>=2.2,<4
     # pytorch-lightning 1.3+ required for gradient_clip_algorithm argument to Trainer
-    pytorch-lightning>=1.3
+    pytorch-lightning~=1.3
     # rasterio 1.0.16+ required for CRS support
-    rasterio>=1.0.16
+    rasterio>=1.0.16,<2
     # rtree 0.9.4+ required for Index.get_size
-    rtree>=0.9.4
+    rtree>=0.9.4,<2
     # scikit-learn 0.18+ required for sklearn.model_selection module
-    scikit-learn>=0.18
+    scikit-learn>=0.18,<2
     # segmentation-models-pytorch 0.2+ required for smp.losses module
-    segmentation-models-pytorch>=0.2
+    segmentation-models-pytorch>=0.2,<0.3
     # shapely 1.3+ required for Python 3 support
-    shapely>=1.3
+    shapely~=1.3
     # timm 0.2.1+ required for `features_only` option in create_model
-    timm>=0.2.1
+    timm>=0.2.1,<0.5
     # torch 1.7+ required for typing
-    torch>=1.7
+    torch~=1.7
     # torchmetrics 0.7+ required for JaccardIndex
-    torchmetrics>=0.7
+    torchmetrics>=0.7,<0.10
     # torchvision 0.10+ required for torchvision.utils.draw_segmentation_masks
-    torchvision>=0.10
-python_requires = >= 3.7
+    torchvision>=0.10,<0.13
+python_requires = ~= 3.7
 packages = find:
 
 [options.package_data]
@@ -69,56 +69,56 @@ include = torchgeo*
 
 [options.extras_require]
 datasets =
-    h5py!=3.7.0
+    h5py!=3.7.0,<4
     # laspy 2+ required for Python 3.7+ support
-    laspy>=2
+    laspy~=2.0
     # open3d 0.11.2+ required to avoid GLFW error:
     # https://github.com/isl-org/Open3D/issues/1550
-    open3d>=0.11.2;python_version<'3.10'
-    opencv-python
+    open3d>=0.11.2,<0.15;python_version<'3.10'
+    opencv-python<5
     # pandas 0.23.2+ required for python 3.7 support
-    pandas>=0.23.2
-    pycocotools
+    pandas>=0.23.2,<2
+    pycocotools<3
     # radiant-mlhub 0.2.1+ required for api_key bugfix:
     # https://github.com/radiantearth/radiant-mlhub/pull/48
-    radiant-mlhub>=0.2.1
+    radiant-mlhub>=0.2.1,<0.6
     # rarfile 3+ required for correct Rar file detection
-    rarfile>=3
+    rarfile>=3,<5
     # scipy 0.9+ required for scipy.io.wavfile.read
-    scipy>=0.9
+    scipy>=0.9,<2
     # zipfile-deflate64 0.2+ required for extraction bugfix:
     # https://github.com/brianhelba/zipfile-deflate64/issues/19
-    zipfile-deflate64>=0.2
+    zipfile-deflate64>=0.2,<0.3
 docs =
     # ipywidgets 7+ required for nbsphinx
-    ipywidgets>=7
+    ipywidgets~=7.0
     # nbsphinx 0.8.5 fixes bug with nbformat attributes
-    nbsphinx>=0.8.5
+    nbsphinx~=0.8.5
     # release versions missing files, must install from master
     pytorch-sphinx-theme
     # sphinx 4+ required for autodoc_typehints_description_target = documented
-    sphinx>=4
+    sphinx>=4,<6
 style =
     # black 21.8+ required for Jupyter support
-    black[jupyter]>=21.8
+    black[jupyter]>=21.8,<23
     # flake8 3.8+ depends on pyflakes 2.2+, which fixes a bug with mypy error code ignores:
     # https://github.com/PyCQA/pyflakes/pull/455
-    flake8>=3.8
+    flake8>=3.8,<5
     # isort 5.8+ required for extend_skip option
-    isort[colors]>=5.8
+    isort[colors]~=5.8
     # pydocstyle 6.1+ required for pyproject.toml support
-    pydocstyle[toml]>=6.1
+    pydocstyle[toml]~=6.1
     # pyupgrade 1.24+ required for --py37-plus flag
-    pyupgrade>=1.24
+    pyupgrade>=1.24,<3
 tests =
     # mypy 0.900+ required for pyproject.toml support
-    mypy>=0.900
+    mypy>=0.900,<=0.960
     # nbmake 0.1+ required to fix path_source bug
-    nbmake>=0.1
+    nbmake>=0.1,<2
     # pytest 6+ required for pyproject.toml support
-    pytest>=6
+    pytest>=6,<8
     # pytest-cov 2.4+ required for pytest --cov flags
-    pytest-cov>=2.4
+    pytest-cov>=2.4,<4
 
 [flake8]
 max-line-length = 88


### PR DESCRIPTION
Another attempt to make TorchGeo more stable. Assuming that our dependencies follow [semver](https://semver.org/), this PR assures that each TorchGeo release will continue to build for the indefinite future. 

For a concrete example of why this PR is necessary, our 0.2.1 release currently doesn't work with the latest version of torchmetrics since 0.9 introduced a backwards-incompatible change (fixed in #555). Our 0.2.0 and older releases also doesn't work with torchmetrics 0.8 due to another backwards-incompatible change (fixed in #361, #382). Since neither release specified an upper bound on the torchmetrics dependency, the simple `pip install torchgeo` no longer works, you have to manually specify a compatible version of torchmetrics too. In Spack and Conda, we can specify this restriction after the fact, but this isn't possible with pip without a new release.

Caveats:

* This PR assumes our dependencies know about and care enough to follow semver properly. It remains to be seen how closely our dependencies follow semver. Luckily, none of our dependencies use non-semver versioning schemes like dates.
* These upper bounds need to be updated any time a new major release (or minor release for 0.X versions) comes out. We'll see how this interacts with dependabot. For now, I'm following the GitHub release announcements for all of our dependencies, so that should be sufficient to catch these kinds of things.

Closes #544