### PR TITLE
Resolve DeprecationWarnings

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -41,7 +41,7 @@ dependencies:
     - pytorch-lightning>=1.3
     - git+https://github.com/pytorch/pytorch_sphinx_theme
     - radiant-mlhub>=0.2.1
-    - rtree>=0.5
+    - rtree>=1
     - scikit-learn>=0.18
     - scipy>=0.9
     - segmentation-models-pytorch>=0.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,9 +58,6 @@ filterwarnings = [
     "error",
 
     # Warnings raised by dependencies of dependencies, out of our control
-    # https://github.com/tensorflow/tensorboard/pull/5138
-    #"ignore:.*is a deprecated alias for the builtin:DeprecationWarning",
-    #"ignore:.*Create unlinked descriptors is going to go away:DeprecationWarning",
     # https://github.com/pytorch/vision/pull/5898
     # https://github.com/rwightman/pytorch-image-models/pull/1256
     "ignore:.*is deprecated and will be removed in Pillow 10:DeprecationWarning",
@@ -69,21 +66,6 @@ filterwarnings = [
     "ignore:distutils Version classes are deprecated. Use packaging.version instead.:DeprecationWarning",
     # https://github.com/PyTorchLightning/pytorch-lightning/issues/13256
     "ignore:torch.distributed._sharded_tensor will be deprecated, use torch.distributed._shard.sharded_tensor instead:DeprecationWarning",
-
-    # Expected warnings
-    # Kornia fixed a bug in bbox handling, but there's no way to suppress the warning
-    #"ignore:Previous behaviour produces incorrect box coordinates:UserWarning",
-    # pytorch-lightning warns us about using num_workers=0, but it's faster on macOS
-    #"ignore:The dataloader, .*, does not have many workers which may be a bottleneck:UserWarning",
-    # pytorch-lightning warns us if a GPU is available but isn't being used
-    #"ignore:GPU available but not used:UserWarning",
-
-    # Unexpected warnings, worth investigating
-    # pytorch-lightning warns us not to use shuffle=True with val/test dataloader, but we aren't...
-    # Warning only raised for GeoSamplers, need to investigate
-    #"ignore:Your `.*_dataloader` has `shuffle=True`:UserWarning",
-    # pytorch-lightning is having trouble inferring the batch size for CycloneDataModule for some reason
-    #"ignore:Trying to infer the `batch_size` from an ambiguous collection:UserWarning",
 ]
 markers = [
     "slow: marks tests as slow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,29 +59,31 @@ filterwarnings = [
 
     # Warnings raised by dependencies of dependencies, out of our control
     # https://github.com/tensorflow/tensorboard/pull/5138
-    "ignore:.*is a deprecated alias for the builtin:DeprecationWarning",
-    "ignore:.*Create unlinked descriptors is going to go away:DeprecationWarning",
+    #"ignore:.*is a deprecated alias for the builtin:DeprecationWarning",
+    #"ignore:.*Create unlinked descriptors is going to go away:DeprecationWarning",
     # https://github.com/pytorch/vision/pull/5898
     # https://github.com/rwightman/pytorch-image-models/pull/1256
     "ignore:.*is deprecated and will be removed in Pillow 10:DeprecationWarning",
     # https://github.com/pytorch/pytorch/issues/72906
     # https://github.com/pytorch/pytorch/pull/69823
     "ignore:distutils Version classes are deprecated. Use packaging.version instead.:DeprecationWarning",
+    # https://github.com/PyTorchLightning/pytorch-lightning/issues/13256
+    "ignore:torch.distributed._sharded_tensor will be deprecated, use torch.distributed._shard.sharded_tensor instead:DeprecationWarning",
 
     # Expected warnings
     # Kornia fixed a bug in bbox handling, but there's no way to suppress the warning
-    "ignore:Previous behaviour produces incorrect box coordinates:UserWarning",
+    #"ignore:Previous behaviour produces incorrect box coordinates:UserWarning",
     # pytorch-lightning warns us about using num_workers=0, but it's faster on macOS
-    "ignore:The dataloader, .*, does not have many workers which may be a bottleneck:UserWarning",
+    #"ignore:The dataloader, .*, does not have many workers which may be a bottleneck:UserWarning",
     # pytorch-lightning warns us if a GPU is available but isn't being used
-    "ignore:GPU available but not used:UserWarning",
+    #"ignore:GPU available but not used:UserWarning",
 
     # Unexpected warnings, worth investigating
     # pytorch-lightning warns us not to use shuffle=True with val/test dataloader, but we aren't...
     # Warning only raised for GeoSamplers, need to investigate
-    "ignore:Your `.*_dataloader` has `shuffle=True`:UserWarning",
+    #"ignore:Your `.*_dataloader` has `shuffle=True`:UserWarning",
     # pytorch-lightning is having trouble inferring the batch size for CycloneDataModule for some reason
-    "ignore:Trying to infer the `batch_size` from an ambiguous collection:UserWarning",
+    #"ignore:Trying to infer the `batch_size` from an ambiguous collection:UserWarning",
 ]
 markers = [
     "slow: marks tests as slow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,10 @@ filterwarnings = [
     # https://github.com/PyTorchLightning/pytorch-lightning/issues/13256
     "ignore:torch.distributed._sharded_tensor will be deprecated, use torch.distributed._shard.sharded_tensor instead:DeprecationWarning",
 
+    # Expected warnings
+    # pytorch-lightning warns us about using num_workers=0, but it's faster on macOS
+    "ignore:The dataloader, .*, does not have many workers which may be a bottleneck:UserWarning",
+
     # Unexpected warnings, worth investigating
     # pytorch-lightning is having trouble inferring the batch size for ChesapeakeCVPRDataModule and CycloneDataModule for some reason
     "ignore:Trying to infer the `batch_size` from an ambiguous collection:UserWarning",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,10 +54,19 @@ match_dir = "(datamodules|datasets|losses|models|samplers|torchgeo|trainers|tran
 addopts = "-m 'not slow'"
 # https://docs.pytest.org/en/latest/how-to/capture-warnings.html
 filterwarnings = [
+    # Treat all warnings as errors
+    "error",
+
     # Warnings raised by dependencies of dependencies, out of our control
     # https://github.com/tensorflow/tensorboard/pull/5138
     "ignore:.*is a deprecated alias for the builtin:DeprecationWarning",
     "ignore:.*Create unlinked descriptors is going to go away:DeprecationWarning",
+    # https://github.com/pytorch/vision/pull/5898
+    # https://github.com/rwightman/pytorch-image-models/pull/1256
+    "ignore:.*is deprecated and will be removed in Pillow 10:DeprecationWarning",
+    # https://github.com/pytorch/pytorch/issues/72906
+    # https://github.com/pytorch/pytorch/pull/69823
+    "ignore:distutils Version classes are deprecated. Use packaging.version instead.:DeprecationWarning",
 
     # Expected warnings
     # Kornia fixed a bug in bbox handling, but there's no way to suppress the warning

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,10 @@ filterwarnings = [
     "ignore:distutils Version classes are deprecated. Use packaging.version instead.:DeprecationWarning",
     # https://github.com/PyTorchLightning/pytorch-lightning/issues/13256
     "ignore:torch.distributed._sharded_tensor will be deprecated, use torch.distributed._shard.sharded_tensor instead:DeprecationWarning",
+
+    # Unexpected warnings, worth investigating
+    # pytorch-lightning is having trouble inferring the batch size for ChesapeakeCVPRDataModule and CycloneDataModule for some reason
+    "ignore:Trying to infer the `batch_size` from an ambiguous collection:UserWarning",
 ]
 markers = [
     "slow: marks tests as slow",

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,8 +44,8 @@ install_requires =
     pytorch-lightning~=1.3
     # rasterio 1.0.16+ required for CRS support
     rasterio>=1.0.16,<2
-    # rtree 0.9.4+ required for Index.get_size
-    rtree>=0.9.4,<2
+    # rtree 1+ required for len(Index)
+    rtree>=1
     # scikit-learn 0.18+ required for sklearn.model_selection module
     scikit-learn>=0.18,<2
     # segmentation-models-pytorch 0.2+ required for smp.losses module

--- a/tests/trainers/test_byol.py
+++ b/tests/trainers/test_byol.py
@@ -58,7 +58,7 @@ class TestBYOLTask:
         model.encoder = ClassificationTestModel(**model_kwargs)
 
         # Instantiate trainer
-        trainer = Trainer(fast_dev_run=True, log_every_n_steps=1)
+        trainer = Trainer(fast_dev_run=True, log_every_n_steps=1, max_epochs=1)
         trainer.fit(model=model, datamodule=datamodule)
         trainer.test(model=model, datamodule=datamodule)
 

--- a/tests/trainers/test_classification.py
+++ b/tests/trainers/test_classification.py
@@ -58,7 +58,7 @@ class TestClassificationTask:
         model = ClassificationTask(**model_kwargs)
 
         # Instantiate trainer
-        trainer = Trainer(fast_dev_run=True, log_every_n_steps=1)
+        trainer = Trainer(fast_dev_run=True, log_every_n_steps=1, max_epochs=1)
         trainer.fit(model=model, datamodule=datamodule)
         trainer.test(model=model, datamodule=datamodule)
 
@@ -76,7 +76,9 @@ class TestClassificationTask:
         model = ClassificationTask(**model_kwargs)
 
         # Instantiate trainer
-        trainer = Trainer(logger=False, fast_dev_run=True, log_every_n_steps=1)
+        trainer = Trainer(
+            logger=False, fast_dev_run=True, log_every_n_steps=1, max_epochs=1
+        )
         trainer.fit(model=model, datamodule=datamodule)
 
     @pytest.fixture
@@ -148,7 +150,7 @@ class TestMultiLabelClassificationTask:
         model = MultiLabelClassificationTask(**model_kwargs)
 
         # Instantiate trainer
-        trainer = Trainer(fast_dev_run=True, log_every_n_steps=1)
+        trainer = Trainer(fast_dev_run=True, log_every_n_steps=1, max_epochs=1)
         trainer.fit(model=model, datamodule=datamodule)
         trainer.test(model=model, datamodule=datamodule)
 
@@ -166,7 +168,9 @@ class TestMultiLabelClassificationTask:
         model = MultiLabelClassificationTask(**model_kwargs)
 
         # Instantiate trainer
-        trainer = Trainer(logger=False, fast_dev_run=True, log_every_n_steps=1)
+        trainer = Trainer(
+            logger=False, fast_dev_run=True, log_every_n_steps=1, max_epochs=1
+        )
         trainer.fit(model=model, datamodule=datamodule)
 
     @pytest.fixture

--- a/tests/trainers/test_regression.py
+++ b/tests/trainers/test_regression.py
@@ -35,7 +35,7 @@ class TestRegressionTask:
         model.model = RegressionTestModel()
 
         # Instantiate trainer
-        trainer = Trainer(fast_dev_run=True, log_every_n_steps=1)
+        trainer = Trainer(fast_dev_run=True, log_every_n_steps=1, max_epochs=1)
         trainer.fit(model=model, datamodule=datamodule)
         trainer.test(model=model, datamodule=datamodule)
 
@@ -53,7 +53,9 @@ class TestRegressionTask:
         model = RegressionTask(**model_kwargs)
 
         # Instantiate trainer
-        trainer = Trainer(logger=False, fast_dev_run=True, log_every_n_steps=1)
+        trainer = Trainer(
+            logger=False, fast_dev_run=True, log_every_n_steps=1, max_epochs=1
+        )
         trainer.fit(model=model, datamodule=datamodule)
 
     def test_invalid_model(self) -> None:

--- a/tests/trainers/test_segmentation.py
+++ b/tests/trainers/test_segmentation.py
@@ -67,7 +67,7 @@ class TestSemanticSegmentationTask:
         model = SemanticSegmentationTask(**model_kwargs)
 
         # Instantiate trainer
-        trainer = Trainer(fast_dev_run=True, log_every_n_steps=1)
+        trainer = Trainer(fast_dev_run=True, log_every_n_steps=1, max_epochs=1)
         trainer.fit(model=model, datamodule=datamodule)
         trainer.test(model=model, datamodule=datamodule)
 
@@ -85,7 +85,9 @@ class TestSemanticSegmentationTask:
         model = SemanticSegmentationTask(**model_kwargs)
 
         # Instantiate trainer
-        trainer = Trainer(logger=False, fast_dev_run=True, log_every_n_steps=1)
+        trainer = Trainer(
+            logger=False, fast_dev_run=True, log_every_n_steps=1, max_epochs=1
+        )
         trainer.fit(model=model, datamodule=datamodule)
 
     @pytest.fixture

--- a/torchgeo/datamodules/landcoverai.py
+++ b/torchgeo/datamodules/landcoverai.py
@@ -66,7 +66,12 @@ class LandCoverAIDataModule(pl.LightningDataModule):
                 K.RandomVerticalFlip(p=0.5),
                 K.RandomSharpness(p=0.5),
                 K.ColorJitter(
-                    p=0.5, brightness=0.1, contrast=0.1, saturation=0.1, hue=0.1
+                    p=0.5,
+                    brightness=0.1,
+                    contrast=0.1,
+                    saturation=0.1,
+                    hue=0.1,
+                    silence_instantiation_warning=True,
                 ),
                 data_keys=["input", "mask"],
             )

--- a/torchgeo/datamodules/resisc45.py
+++ b/torchgeo/datamodules/resisc45.py
@@ -73,7 +73,12 @@ class RESISC45DataModule(pl.LightningDataModule):
                 K.RandomSharpness(p=0.5),
                 K.RandomErasing(p=0.1),
                 K.ColorJitter(
-                    p=0.5, brightness=0.1, contrast=0.1, saturation=0.1, hue=0.1
+                    p=0.5,
+                    brightness=0.1,
+                    contrast=0.1,
+                    saturation=0.1,
+                    hue=0.1,
+                    silence_instantiation_warning=True,
                 ),
                 data_keys=["input"],
             )

--- a/torchgeo/datasets/cyclone.py
+++ b/torchgeo/datasets/cyclone.py
@@ -146,7 +146,7 @@ class TropicalCycloneWindEstimation(VisionDataset):
             if img.height != self.size or img.width != self.size:
                 if tuple(int(v) for v in PIL.__version__.split(".")) >= (9, 1):
                     resample = Image.Resampling.BILINEAR
-                else:
+                else:  # pragma: no cover
                     resample = Image.BILINEAR
                 img = img.resize(size=(self.size, self.size), resample=resample)
             array: "np.typing.NDArray[np.int_]" = np.array(img)

--- a/torchgeo/datasets/cyclone.py
+++ b/torchgeo/datasets/cyclone.py
@@ -144,9 +144,10 @@ class TropicalCycloneWindEstimation(VisionDataset):
         filename = os.path.join(directory.format("source"), "image.jpg")
         with Image.open(filename) as img:
             if img.height != self.size or img.width != self.size:
-                if tuple(int(v) for v in PIL.__version__.split(".")) >= (9, 1):
+                # Added in PIL 9.1.0
+                try:
                     resample = Image.Resampling.BILINEAR
-                else:  # pragma: no cover
+                except AttributeError:  # pragma: no cover
                     resample = Image.BILINEAR
                 img = img.resize(size=(self.size, self.size), resample=resample)
             array: "np.typing.NDArray[np.int_]" = np.array(img)

--- a/torchgeo/datasets/cyclone.py
+++ b/torchgeo/datasets/cyclone.py
@@ -143,7 +143,11 @@ class TropicalCycloneWindEstimation(VisionDataset):
         filename = os.path.join(directory.format("source"), "image.jpg")
         with Image.open(filename) as img:
             if img.height != self.size or img.width != self.size:
-                img = img.resize(size=(self.size, self.size), resample=Image.BILINEAR)
+                if tuple(int(v) for v in PIL.__version__.split(".")) >= (9, 1):
+                    resample = Image.Resampling.BILINEAR
+                else:
+                    resample = Image.BILINEAR
+                img = img.resize(size=(self.size, self.size), resample=resample)
             array: "np.typing.NDArray[np.int_]" = np.array(img)
             if len(array.shape) == 3:
                 array = array[:, :, 0]

--- a/torchgeo/datasets/cyclone.py
+++ b/torchgeo/datasets/cyclone.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, Dict, Optional, cast
 
 import matplotlib.pyplot as plt
 import numpy as np
+import PIL
 import torch
 from PIL import Image
 from torch import Tensor

--- a/torchgeo/datasets/cyclone.py
+++ b/torchgeo/datasets/cyclone.py
@@ -144,7 +144,7 @@ class TropicalCycloneWindEstimation(VisionDataset):
         filename = os.path.join(directory.format("source"), "image.jpg")
         with Image.open(filename) as img:
             if img.height != self.size or img.width != self.size:
-                # Added in PIL 9.1.0
+                # Moved in PIL 9.1.0
                 try:
                     resample = Image.Resampling.BILINEAR
                 except AttributeError:  # pragma: no cover

--- a/torchgeo/datasets/cyclone.py
+++ b/torchgeo/datasets/cyclone.py
@@ -10,7 +10,6 @@ from typing import Any, Callable, Dict, Optional, cast
 
 import matplotlib.pyplot as plt
 import numpy as np
-import PIL
 import torch
 from PIL import Image
 from torch import Tensor

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -160,8 +160,7 @@ class GeoDataset(Dataset[Dict[str, Any]], abc.ABC):
         Returns:
             length of the dataset
         """
-        count: int = self.index.get_size()
-        return count
+        return len(self.index)
 
     def __str__(self) -> str:
         """Return the informal string representation of the object.

--- a/torchgeo/datasets/seco.py
+++ b/torchgeo/datasets/seco.py
@@ -181,7 +181,7 @@ class SeasonalContrastS2(VisionDataset):
                     # slowdown here from converting to/from a PIL Image just to resize.
                     # https://gist.github.com/calebrob6/748045ac8d844154067b2eefa47de92f
                     pil_image = Image.fromarray(band_data)
-                    # Added in PIL 9.1.0
+                    # Moved in PIL 9.1.0
                     try:
                         resample = Image.Resampling.BILINEAR
                     except AttributeError:  # pragma: no cover

--- a/torchgeo/datasets/seco.py
+++ b/torchgeo/datasets/seco.py
@@ -180,8 +180,12 @@ class SeasonalContrastS2(VisionDataset):
                     # slowdown here from converting to/from a PIL Image just to resize.
                     # https://gist.github.com/calebrob6/748045ac8d844154067b2eefa47de92f
                     pil_image = Image.fromarray(band_data)
+                    if tuple(int(v) for v in PIL.__version__.split(".")) >= (9, 1):
+                        resample = Image.Resampling.BILINEAR
+                    else:
+                        resample = Image.BILINEAR
                     band_data = np.array(
-                        pil_image.resize((264, 264), resample=Image.BILINEAR)
+                        pil_image.resize((264, 264), resample=resample)
                     )
                 all_data.append(band_data)
         image = torch.from_numpy(np.stack(all_data, axis=0))

--- a/torchgeo/datasets/seco.py
+++ b/torchgeo/datasets/seco.py
@@ -183,7 +183,7 @@ class SeasonalContrastS2(VisionDataset):
                     pil_image = Image.fromarray(band_data)
                     if tuple(int(v) for v in PIL.__version__.split(".")) >= (9, 1):
                         resample = Image.Resampling.BILINEAR
-                    else:
+                    else:  # pragma: no cover
                         resample = Image.BILINEAR
                     band_data = np.array(
                         pil_image.resize((264, 264), resample=resample)

--- a/torchgeo/datasets/seco.py
+++ b/torchgeo/datasets/seco.py
@@ -9,6 +9,7 @@ from typing import Callable, Dict, List, Optional
 
 import matplotlib.pyplot as plt
 import numpy as np
+import PIL
 import rasterio
 import torch
 from PIL import Image

--- a/torchgeo/datasets/seco.py
+++ b/torchgeo/datasets/seco.py
@@ -9,7 +9,6 @@ from typing import Callable, Dict, List, Optional
 
 import matplotlib.pyplot as plt
 import numpy as np
-import PIL
 import rasterio
 import torch
 from PIL import Image

--- a/torchgeo/datasets/seco.py
+++ b/torchgeo/datasets/seco.py
@@ -181,9 +181,10 @@ class SeasonalContrastS2(VisionDataset):
                     # slowdown here from converting to/from a PIL Image just to resize.
                     # https://gist.github.com/calebrob6/748045ac8d844154067b2eefa47de92f
                     pil_image = Image.fromarray(band_data)
-                    if tuple(int(v) for v in PIL.__version__.split(".")) >= (9, 1):
+                    # Added in PIL 9.1.0
+                    try:
                         resample = Image.Resampling.BILINEAR
-                    else:  # pragma: no cover
+                    except AttributeError:  # pragma: no cover
                         resample = Image.BILINEAR
                     band_data = np.array(
                         pil_image.resize((264, 264), resample=resample)


### PR DESCRIPTION
This is the third PR in a series of attempts to improve the stability and robustness of TorchGeo's build system (#557, #551).

If you look at the logs for our unit tests, you'll see a slew of warning messages, desperately trying to warn us that TorchGeo is using deprecated features that will be removed in future versions of our dependencies. Up until now, these were ignored until someone noticed/reported an issue. With this PR, these kind of warnings will become fatal. We weren't able to do something this extreme before, but now that we use dependabot, we can restrict these kind of failures to version update PRs, not user PRs.

### Deprecation Fixes

- [x] Rtree 1.0.0 introduced a new `len(index)` method to replace `index.get_size()` (see https://github.com/Toblerity/rtree/pull/207). The latter is now deprecated and may be removed someday.
- [x] Pillow 9.1.0 relocated all resampling methods from `Image.*` to `Image.Resampling.*`. The former is now deprecated and will be removed in Pillow 10

### Considerations

* When a dependency changes its API, should we use the new API and bump the required version of that dependency, or should we maintain compatibility with historic versions? 

I did the former for rtree/torchmetrics/other instances because I didn't see a good reason not to, but I did the latter for pillow because pillow-simd doesn't yet have a 9.1.0 release and normal pillow is much slower. There's also the question of how to maintain coverage of both branches. This may require a test using the minimum supported versions: #32.

* What's the best way to handle warnings in our dependencies, not in our own code?

So far I'm just ignoring these using `filterwarnings`, but that may not be sufficient. What I would really love is an option to only issue warnings for our own code, not for dependencies, but I don't believe that's an option. One potential issue here is if a dep of a dep has a new release that causes the tests to fail, but it isn't managed by dependabot because it's not a direct dep.

* How long should we keep around warning ignores? Even after they no longer exist in newer versions?

Ideally, our tests will pass not only on CI which uses the latest versions of everything, but also locally where users may have any version of these dependencies installed. I'm not sure if it's worth keeping a running list of all possible warning messages for all versions of our dependencies. One option would be to remove `"error"` from `filterwarnings` in `pyproject.toml` and instead use `pytest -Werror` in CI so that warnings are only considered errors in CI, not locally.