### PR TITLE
Datasets: download from HTTPS

### DIFF
--- a/torchgeo/datasets/bigearthnet.py
+++ b/torchgeo/datasets/bigearthnet.py
@@ -22,7 +22,7 @@ from .utils import download_url, extract_archive, sort_sentinel2_bands
 class BigEarthNet(VisionDataset):
     """BigEarthNet dataset.
 
-    The `BigEarthNet <http://bigearth.net/>`_
+    The `BigEarthNet <https://bigearth.net/>`_
     dataset is a dataset for multilabel remote sensing image scene classification.
 
     Dataset features:
@@ -244,13 +244,13 @@ class BigEarthNet(VisionDataset):
     }
     metadata = {
         "s1": {
-            "url": "http://bigearth.net/downloads/BigEarthNet-S1-v1.0.tar.gz",
+            "url": "https://bigearth.net/downloads/BigEarthNet-S1-v1.0.tar.gz",
             "md5": "5a64e9ce38deb036a435a7b59494924c",
             "filename": "BigEarthNet-S1-v1.0.tar.gz",
             "directory": "BigEarthNet-S1-v1.0",
         },
         "s2": {
-            "url": "http://bigearth.net/downloads/BigEarthNet-S2-v1.0.tar.gz",
+            "url": "https://bigearth.net/downloads/BigEarthNet-S2-v1.0.tar.gz",
             "md5": "5a64e9ce38deb036a435a7b59494924c",
             "filename": "BigEarthNet-S2-v1.0.tar.gz",
             "directory": "BigEarthNet-v1.0",

--- a/torchgeo/datasets/cyclone.py
+++ b/torchgeo/datasets/cyclone.py
@@ -30,7 +30,7 @@ class TropicalCycloneWindEstimation(VisionDataset):
 
     If you use this dataset in your research, please cite the following paper:
 
-    * http://doi.org/10.1109/JSTARS.2020.3011907
+    * https://doi.org/10.1109/JSTARS.2020.3011907
 
     .. note::
 

--- a/torchgeo/datasets/eddmaps.py
+++ b/torchgeo/datasets/eddmaps.py
@@ -32,7 +32,7 @@ class EDDMapS(GeoDataset):
 
     * EDDMapS. *YEAR*. Early Detection & Distribution Mapping System. The University of
       Georgia - Center for Invasive Species and Ecosystem Health. Available online at
-      http://www.eddmaps.org/; last accessed *DATE*.
+      https://www.eddmaps.org/; last accessed *DATE*.
 
     .. note::
        This dataset requires the following additional library to be installed:

--- a/torchgeo/datasets/eurosat.py
+++ b/torchgeo/datasets/eurosat.py
@@ -51,7 +51,7 @@ class EuroSAT(VisionClassificationDataset):
     * https://ieeexplore.ieee.org/document/8519248
     """
 
-    url = "http://madm.dfki.de/files/sentinel/EuroSATallBands.zip"  # 2.0 GB download
+    url = "https://madm.dfki.de/files/sentinel/EuroSATallBands.zip"  # 2.0 GB download
     filename = "EuroSATallBands.zip"
     md5 = "5ac12b3b2557aa56e1826e981e8e200e"
 


### PR DESCRIPTION
We should always use HTTPS when available. UC Merced doesn't support HTTPS unfortunately.