### PR TITLE
pyupgrade: test with Python 3.10

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -82,7 +82,7 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: '3.10'
     - name: Install pip dependencies
       run: |
         pip install -r requirements.txt


### PR DESCRIPTION
I think this test was added at the same time as the PR to switch to Python 3.10, so this section never got updated.