### PR TITLE
Update landcover.ai dataset download link

### DIFF
--- a/torchgeo/datasets/landcoverai.py
+++ b/torchgeo/datasets/landcoverai.py
@@ -60,7 +60,7 @@ class LandCoverAI(VisionDataset):
          the train/val/test split
     """
 
-    url = "https://landcover.ai/download/landcover.ai.v1.zip"
+    url = "https://landcover.ai.linuxpolska.com/download/landcover.ai.v1.zip"
     filename = "landcover.ai.v1.zip"
     md5 = "3268c89070e8734b4e91d531c0617e03"
     sha256 = "15ee4ca9e3fd187957addfa8f0d74ac31bc928a966f76926e11b3c33ea76daa1"


### PR DESCRIPTION
Closes #559

I double checked that the checksum of the zip file is the same when downloaded from this new link.