### PR TITLE
Add note about Windows installation

### DIFF
--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -56,6 +56,7 @@ Now, you can install the latest stable release using:
 
    $ conda install torchgeo
 
+.. note:: The installation of torchgeo in this manner is not supported on Windows since pytorch from the conda-forge channel currently does not support Windows. Users are recommended to create a custom conda environment and install torchgeo as shown below.
 
 Conda does not directly support installing development versions, but you can use conda to install our dependencies, then use pip to install TorchGeo itself.
 
@@ -66,8 +67,6 @@ Conda does not directly support installing development versions, but you can use
    $ conda env create --file environment.yml
    $ conda activate torchgeo
    $ pip install .
-
-.. note:: The above method will not work on Windows. Windows users are recommended to create a conda environment and install dependencies via pip.
 
 Conda does not directly support optional dependencies. If you install from conda-forge, only required dependencies will be installed by default. Optional dependencies can be installed afterwards using pip. If you install using the ``environment.yml`` file, all optional dependencies are installed by default.
 


### PR DESCRIPTION
Added a note clarifying installation procedure for Windows users.

As @adamjstewart  mentioned in #561, due to conda-forge feedstocks not allowing channels outside of `conda-forge and defaults`  (as mentioned [here](https://github.com/conda-forge/deepforest-feedstock/pull/26#discussion_r786278832)) and [conda-forge/pytorch](https://anaconda.org/conda-forge/pytorch) not supporting Windows, users will not be able to install `conda install -c conda-forge torchgeo` directly.