### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,58 @@
+name: 🐛 Bug report
+description: Create a report to help us reproduce and fix a bug
+labels: [bug]
+
+body:
+- type: textarea
+  attributes:
+    label: Description
+    description: >
+      Please provide a clear and concise description of the bug.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Steps to reproduce
+    description: >
+      We can't solve your issue if we can't reproduce it. Please provide a
+      [minimal reproducible example](https://stackoverflow.com/help/minimal-reproducible-example)
+      that shows how to reproduce the bug. If the bug requires any additional files to
+      reproduce, please upload those or provide a download link. Your code should be
+      runnable and include all relevant imports.
+    placeholder: |
+      1. Download any Landsat 8 scene from https://earthexplorer.usgs.gov/
+      2. Run the following code to reproduce the error
+
+      ```python
+      from torchgeo.datasets import Landsat8
+
+      ds = Landsat8("/path/to/downloads/directory")
+      ...
+      ```
+  validations:
+    required: true
+- type: input
+  attributes:
+    label: Version
+    description: |
+      What version of TorchGeo are you using? This can be found using the following code.
+      ```console
+      $ python
+      >>> import torchgeo
+      >>> torchgeo.__version__
+      X.Y.Z
+      ```
+      If you are using a development release (ends with ".dev0") please also include the specific git commit.
+
+      Whenever possible, try to reproduce your issue with the latest commit from `main`. You never know, someone may have already fixed your bug!
+    placeholder: |
+      1.2.3.dev0 (e1285e6cc6b65080e82bdbf7de9dea3f647d8b3b)
+  validations:
+    required: true
+- type: markdown
+  attributes:
+    value: >
+      Thanks for taking the time to report this bug! TorchGeo is an open-source project
+      maintained by its users. If you're Python savvy and want to contribute a pull
+      request to fix this bug, we'll be happy to review it. If not, we'll try to fix it
+      as long as we can reproduce it.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: ❓ Questions
+    url: https://github.com/microsoft/torchgeo/discussions
+    about: Ask questions or discuss ideas with other TorchGeo users

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,25 @@
+name: 📚 Documentation
+description: Issues or suggestions related to documentation
+labels: [documentation]
+
+body:
+- type: textarea
+  attributes:
+    label: Issue
+    description: >
+      A clear and concise description of what is wrong with or missing from the
+      documentation.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Fix
+    description: >
+      Tell us how we could improve the documentation!
+- type: markdown
+  attributes:
+    value: >
+      Thanks for taking the time to improve the documentation! TorchGeo is an
+      open-source project maintained by its users. If you're rST savvy and want
+      to contribute a pull request to improve the docs, we'll be happy to review
+      it. If not, we'll try to fix it when a get a chance.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,38 @@
+name: 🚀 Feature request
+description: Submit a proposal/request for a new TorchGeo feature
+labels: [feature]
+
+body:
+- type: textarea
+  attributes:
+    label: Summary
+    description: >
+      A clear and concise summary of your suggestion.
+- type: textarea
+  attributes:
+    label: Rationale
+    description: >
+      Why is this feature important? Is it related to a problem you are experiencing?
+- type: textarea
+  attributes:
+    label: Implementation
+    description: >
+      If you've thought about how to implement this feature, describe your proposed
+      solution.
+- type: textarea
+  attributes:
+    label: Alternatives
+    description: >
+      Are there any alternatives to the solution you've proposed?
+- type: textarea
+  attributes:
+    label: Additional information
+    description: >
+      Any additional information that might be relevant to the proposed feature.
+- type: markdown
+  attributes:
+    value: >
+      Thanks for suggesting this awesome new feature! TorchGeo is an open-source project
+      maintained by its users. If you're Python savvy and want to contribute a pull
+      request to implement this feature, we'll be happy to review it. If not, we'll try
+      to implement your feature when we get a chance.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -3,6 +3,15 @@ description: Submit a proposal/request for a new TorchGeo feature
 labels: [feature]
 
 body:
+- type: markdown
+  attributes:
+    value: >
+      TorchGeo is a PyTorch domain library for _geospatial_ data. If the feature you
+      are suggesting is not specific to working with geospatial data or multispectral
+      satellite imagery and may be of interest to the broader computer vision
+      community, consider contributing it to
+      [torchvision](https://github.com/pytorch/vision) or
+      [kornia](https://github.com/kornia/kornia) instead.
 - type: textarea
   attributes:
     label: Summary

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -19,4 +19,4 @@ documentation:
 - docs/**
 testing:
 - tests/**
-- .github/**
+- .github/workflows/**


### PR DESCRIPTION
This PR adds issue templates to the repository. They are loosely based on [PyTorch's](https://github.com/pytorch/pytorch/issues/new/choose) and [Spack's](https://github.com/spack/spack/issues/new/choose) issue templates. See the [official docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests) for more details on possible values and syntax.

I don't really know how to view/test these without forking the repo and merging them to main in the fork? I guess we can do all the wordsmithing in this PR and fix any bugs we find after merging.

Closes #584