### PR TITLE
Ignore pytorch-sphinx-theme installation

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -88,4 +88,4 @@ jobs:
         pip install -r requirements/style.txt
         pip list
     - name: Run pyupgrade checks
-      run: pyupgrade --py37-plus $(find . -name "*.py")
+      run: pyupgrade --py37-plus $(find . -path ./docs/src -prune -o -name "*.py" -print)

--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/src/
 
 # PyBuilder
 target/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ color_output = true
 [tool.mypy]
 ignore_missing_imports = true
 show_error_codes = true
-exclude = "(build|data|dist|logo|logs|output)/"
+exclude = "(build|data|dist|docs/src|logo|logs|output)/"
 
 # Strict
 warn_unused_configs = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -138,6 +138,9 @@ exclude =
     logs/,
     output/,
 
+    # Docs
+    docs/src/,
+
     # Spack
     .spack-env/,
 


### PR DESCRIPTION
In order to build the docs locally, pytorch-sphinx-theme _must_ be installed in editable mode in `docs/src`: https://github.com/pytorch/pytorch_sphinx_theme/issues/143

This PR tells git and our linters to ignore this installation.