### PR TITLE
Docs: don't override __module__

### DIFF
--- a/tests/models/test_changestar.py
+++ b/tests/models/test_changestar.py
@@ -10,10 +10,6 @@ from torch.nn.modules import Module
 
 from torchgeo.models import ChangeMixin, ChangeStar, ChangeStarFarSeg
 
-# https://github.com/pytorch/pytorch/issues/60979
-# https://github.com/pytorch/pytorch/pull/61045
-Module.__module__ = "torch.nn"
-
 BACKBONE = ["resnet18", "resnet34", "resnet50", "resnet101"]
 IN_CHANNELS = [64, 128]
 INNNR_CHANNELS = [16, 32, 64]

--- a/tests/models/test_changestar.py
+++ b/tests/models/test_changestar.py
@@ -6,7 +6,6 @@ import itertools
 import pytest
 import torch
 import torch.nn as nn
-from torch.nn.modules import Module
 
 from torchgeo.models import ChangeMixin, ChangeStar, ChangeStarFarSeg
 

--- a/torchgeo/datamodules/__init__.py
+++ b/torchgeo/datamodules/__init__.py
@@ -50,7 +50,3 @@ __all__ = (
     "Vaihingen2DDataModule",
     "XView2DataModule",
 )
-
-# https://stackoverflow.com/questions/40018681
-for module in __all__:
-    globals()[module].__module__ = "torchgeo.datamodules"

--- a/torchgeo/datamodules/bigearthnet.py
+++ b/torchgeo/datamodules/bigearthnet.py
@@ -13,10 +13,6 @@ from torchvision.transforms import Compose
 
 from ..datasets import BigEarthNet
 
-# https://github.com/pytorch/pytorch/issues/60979
-# https://github.com/pytorch/pytorch/pull/61045
-DataLoader.__module__ = "torch.utils.data"
-
 
 class BigEarthNetDataModule(pl.LightningDataModule):
     """LightningDataModule implementation for the BigEarthNet dataset.

--- a/torchgeo/datamodules/chesapeake.py
+++ b/torchgeo/datamodules/chesapeake.py
@@ -16,10 +16,6 @@ from ..datasets import ChesapeakeCVPR, stack_samples
 from ..samplers.batch import RandomBatchGeoSampler
 from ..samplers.single import GridGeoSampler
 
-# https://github.com/pytorch/pytorch/issues/60979
-# https://github.com/pytorch/pytorch/pull/61045
-DataLoader.__module__ = "torch.utils.data"
-
 
 class ChesapeakeCVPRDataModule(LightningDataModule):
     """LightningDataModule implementation for the Chesapeake CVPR Land Cover dataset.

--- a/torchgeo/datamodules/cowc.py
+++ b/torchgeo/datamodules/cowc.py
@@ -12,10 +12,6 @@ from torch.utils.data import DataLoader, random_split
 
 from ..datasets import COWCCounting
 
-# https://github.com/pytorch/pytorch/issues/60979
-# https://github.com/pytorch/pytorch/pull/61045
-DataLoader.__module__ = "torch.utils.data"
-
 
 class COWCCountingDataModule(pl.LightningDataModule):
     """LightningDataModule implementation for the COWC Counting dataset."""

--- a/torchgeo/datamodules/cyclone.py
+++ b/torchgeo/datamodules/cyclone.py
@@ -12,10 +12,6 @@ from torch.utils.data import DataLoader, Subset
 
 from ..datasets import TropicalCycloneWindEstimation
 
-# https://github.com/pytorch/pytorch/issues/60979
-# https://github.com/pytorch/pytorch/pull/61045
-DataLoader.__module__ = "torch.utils.data"
-
 
 class CycloneDataModule(pl.LightningDataModule):
     """LightningDataModule implementation for the NASA Cyclone dataset.

--- a/torchgeo/datamodules/fair1m.py
+++ b/torchgeo/datamodules/fair1m.py
@@ -14,10 +14,6 @@ from torchvision.transforms import Compose
 from ..datasets import FAIR1M
 from .utils import dataset_split
 
-# https://github.com/pytorch/pytorch/issues/60979
-# https://github.com/pytorch/pytorch/pull/61045
-DataLoader.__module__ = "torch.utils.data"
-
 
 def collate_fn(batch: List[Dict[str, Tensor]]) -> Dict[str, Any]:
     """Custom object detection collate fn to handle variable number of boxes.

--- a/torchgeo/datamodules/landcoverai.py
+++ b/torchgeo/datamodules/landcoverai.py
@@ -12,10 +12,6 @@ from torch.utils.data import DataLoader
 
 from ..datasets import LandCoverAI
 
-# https://github.com/pytorch/pytorch/issues/60979
-# https://github.com/pytorch/pytorch/pull/61045
-DataLoader.__module__ = "torch.utils.data"
-
 
 class LandCoverAIDataModule(pl.LightningDataModule):
     """LightningDataModule implementation for the LandCover.ai dataset.

--- a/torchgeo/datamodules/loveda.py
+++ b/torchgeo/datamodules/loveda.py
@@ -10,10 +10,6 @@ from torch.utils.data import DataLoader
 
 from ..datasets import LoveDA
 
-# https://github.com/pytorch/pytorch/issues/60979
-# https://github.com/pytorch/pytorch/pull/61045
-DataLoader.__module__ = "torch.utils.data"
-
 
 class LoveDADataModule(pl.LightningDataModule):
     """LightningDataModule implementation for the LoveDA dataset.

--- a/torchgeo/datamodules/naip.py
+++ b/torchgeo/datamodules/naip.py
@@ -12,10 +12,6 @@ from ..datasets import NAIP, BoundingBox, Chesapeake13, stack_samples
 from ..samplers.batch import RandomBatchGeoSampler
 from ..samplers.single import GridGeoSampler
 
-# https://github.com/pytorch/pytorch/issues/60979
-# https://github.com/pytorch/pytorch/pull/61045
-DataLoader.__module__ = "torch.utils.data"
-
 
 class NAIPChesapeakeDataModule(pl.LightningDataModule):
     """LightningDataModule implementation for the NAIP and Chesapeake datasets.

--- a/torchgeo/datamodules/nasa_marine_debris.py
+++ b/torchgeo/datamodules/nasa_marine_debris.py
@@ -14,10 +14,6 @@ from torchvision.transforms import Compose
 from ..datasets import NASAMarineDebris
 from .utils import dataset_split
 
-# https://github.com/pytorch/pytorch/issues/60979
-# https://github.com/pytorch/pytorch/pull/61045
-DataLoader.__module__ = "torch.utils.data"
-
 
 def collate_fn(batch: List[Dict[str, Tensor]]) -> Dict[str, Any]:
     """Custom object detection collate fn to handle variable boxes.

--- a/torchgeo/datamodules/resisc45.py
+++ b/torchgeo/datamodules/resisc45.py
@@ -14,10 +14,6 @@ from torchvision.transforms import Compose, Normalize
 
 from ..datasets import RESISC45
 
-# https://github.com/pytorch/pytorch/issues/60979
-# https://github.com/pytorch/pytorch/pull/61045
-DataLoader.__module__ = "torch.utils.data"
-
 
 class RESISC45DataModule(pl.LightningDataModule):
     """LightningDataModule implementation for the RESISC45 dataset.

--- a/torchgeo/datamodules/sen12ms.py
+++ b/torchgeo/datamodules/sen12ms.py
@@ -12,10 +12,6 @@ from torch.utils.data import DataLoader, Subset
 
 from ..datasets import SEN12MS
 
-# https://github.com/pytorch/pytorch/issues/60979
-# https://github.com/pytorch/pytorch/pull/61045
-DataLoader.__module__ = "torch.utils.data"
-
 
 class SEN12MSDataModule(pl.LightningDataModule):
     """LightningDataModule implementation for the SEN12MS dataset.

--- a/torchgeo/datamodules/so2sat.py
+++ b/torchgeo/datamodules/so2sat.py
@@ -12,10 +12,6 @@ from torchvision.transforms import Compose
 
 from ..datasets import So2Sat
 
-# https://github.com/pytorch/pytorch/issues/60979
-# https://github.com/pytorch/pytorch/pull/61045
-DataLoader.__module__ = "torch.utils.data"
-
 
 class So2SatDataModule(pl.LightningDataModule):
     """LightningDataModule implementation for the So2Sat dataset.

--- a/torchgeo/datamodules/ucmerced.py
+++ b/torchgeo/datamodules/ucmerced.py
@@ -14,10 +14,6 @@ from torchvision.transforms import Compose, Normalize
 
 from ..datasets import UCMerced
 
-# https://github.com/pytorch/pytorch/issues/60979
-# https://github.com/pytorch/pytorch/pull/61045
-DataLoader.__module__ = "torch.utils.data"
-
 
 class UCMercedDataModule(pl.LightningDataModule):
     """LightningDataModule implementation for the UC Merced dataset.

--- a/torchgeo/datasets/__init__.py
+++ b/torchgeo/datasets/__init__.py
@@ -197,7 +197,3 @@ __all__ = (
     "stack_samples",
     "unbind_samples",
 )
-
-# https://stackoverflow.com/questions/40018681
-for module in __all__:
-    globals()[module].__module__ = "torchgeo.datasets"

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -31,11 +31,6 @@ from torchvision.datasets.folder import default_loader as pil_loader
 
 from .utils import BoundingBox, concat_samples, disambiguate_timestamp, merge_samples
 
-# https://github.com/pytorch/pytorch/issues/60979
-# https://github.com/pytorch/pytorch/pull/61045
-Dataset.__module__ = "torch.utils.data"
-ImageFolder.__module__ = "torchvision.datasets"
-
 
 class GeoDataset(Dataset[Dict[str, Any]], abc.ABC):
     """Abstract base class for datasets containing geospatial information.

--- a/torchgeo/losses/__init__.py
+++ b/torchgeo/losses/__init__.py
@@ -6,7 +6,3 @@
 from .qr import QRLoss, RQLoss
 
 __all__ = ("QRLoss", "RQLoss")
-
-# https://stackoverflow.com/questions/40018681
-for module in __all__:
-    globals()[module].__module__ = "torchgeo.losses"

--- a/torchgeo/losses/qr.py
+++ b/torchgeo/losses/qr.py
@@ -6,10 +6,6 @@ import torch
 import torch.nn.functional as F
 from torch.nn.modules import Module
 
-# https://github.com/pytorch/pytorch/issues/60979
-# https://github.com/pytorch/pytorch/pull/61045
-Module.__module__ = "torch.nn"
-
 
 class QRLoss(Module):
     """The QR (forward) loss between class probabilities and predictions.

--- a/torchgeo/models/__init__.py
+++ b/torchgeo/models/__init__.py
@@ -21,7 +21,3 @@ __all__ = (
     "RCF",
     "resnet50",
 )
-
-# https://stackoverflow.com/questions/40018681
-for module in __all__:
-    globals()[module].__module__ = "torchgeo.models"

--- a/torchgeo/models/changestar.py
+++ b/torchgeo/models/changestar.py
@@ -13,10 +13,6 @@ from torch.nn.modules import Module
 
 from .farseg import FarSeg
 
-# https://github.com/pytorch/pytorch/issues/60979
-# https://github.com/pytorch/pytorch/pull/61045
-Module.__module__ = "torch.nn"
-
 
 class ChangeMixin(Module):
     """This module enables any segmentation model to detect binary change.

--- a/torchgeo/models/farseg.py
+++ b/torchgeo/models/farseg.py
@@ -23,18 +23,6 @@ from torch.nn.modules import (
 from torchvision.models import resnet
 from torchvision.ops import FeaturePyramidNetwork as FPN
 
-# https://github.com/pytorch/pytorch/issues/60979
-# https://github.com/pytorch/pytorch/pull/61045
-Module.__module__ = "torch.nn"
-ModuleList.__module__ = "nn.ModuleList"
-Sequential.__module__ = "nn.Sequential"
-Conv2d.__module__ = "nn.Conv2d"
-BatchNorm2d.__module__ = "nn.BatchNorm2d"
-ReLU.__module__ = "nn.ReLU"
-UpsamplingBilinear2d.__module__ = "nn.UpsamplingBilinear2d"
-Sigmoid.__module__ = "nn.Sigmoid"
-Identity.__module__ = "nn.Identity"
-
 
 class FarSeg(Module):
     """Foreground-Aware Relation Network (FarSeg).

--- a/torchgeo/models/fcn.py
+++ b/torchgeo/models/fcn.py
@@ -7,10 +7,6 @@ import torch.nn as nn
 from torch import Tensor
 from torch.nn.modules import Module
 
-# https://github.com/pytorch/pytorch/issues/60979
-# https://github.com/pytorch/pytorch/pull/61045
-Module.__module__ = "torch.nn"
-
 
 class FCN(Module):
     """A simple 5 layer FCN with leaky relus and 'same' padding."""

--- a/torchgeo/models/fcsiam.py
+++ b/torchgeo/models/fcsiam.py
@@ -11,8 +11,6 @@ from segmentation_models_pytorch.base.model import SegmentationModel
 from segmentation_models_pytorch.unet.model import Unet
 from torch import Tensor
 
-Unet.__module__ = "segmentation_models_pytorch"
-
 
 class FCSiamConc(SegmentationModel):  # type: ignore[misc]
     """Fully-convolutional Siamese Concatenation (FC-Siam-conc).

--- a/torchgeo/models/rcf.py
+++ b/torchgeo/models/rcf.py
@@ -10,9 +10,6 @@ import torch.nn.functional as F
 from torch import Tensor
 from torch.nn.modules import Conv2d, Module
 
-Module.__module__ = "torch.nn"
-Conv2d.__module__ = "torch.nn"
-
 
 class RCF(Module):
     """This model extracts random convolutional features (RCFs) from its input.

--- a/torchgeo/models/rcf.py
+++ b/torchgeo/models/rcf.py
@@ -8,7 +8,7 @@ from typing import Optional
 import torch
 import torch.nn.functional as F
 from torch import Tensor
-from torch.nn.modules import Conv2d, Module
+from torch.nn.modules import Module
 
 
 class RCF(Module):

--- a/torchgeo/samplers/__init__.py
+++ b/torchgeo/samplers/__init__.py
@@ -20,7 +20,3 @@ __all__ = (
     # Constants
     "Units",
 )
-
-# https://stackoverflow.com/questions/40018681
-for module in __all__:
-    globals()[module].__module__ = "torchgeo.samplers"

--- a/torchgeo/samplers/batch.py
+++ b/torchgeo/samplers/batch.py
@@ -14,10 +14,6 @@ from ..datasets import BoundingBox, GeoDataset
 from .constants import Units
 from .utils import _to_tuple, get_random_bounding_box
 
-# https://github.com/pytorch/pytorch/issues/60979
-# https://github.com/pytorch/pytorch/pull/61045
-Sampler.__module__ = "torch.utils.data"
-
 
 class BatchGeoSampler(Sampler[List[BoundingBox]], abc.ABC):
     """Abstract base class for sampling from :class:`~torchgeo.datasets.GeoDataset`.

--- a/torchgeo/samplers/single.py
+++ b/torchgeo/samplers/single.py
@@ -14,10 +14,6 @@ from ..datasets import BoundingBox, GeoDataset
 from .constants import Units
 from .utils import _to_tuple, get_random_bounding_box
 
-# https://github.com/pytorch/pytorch/issues/60979
-# https://github.com/pytorch/pytorch/pull/61045
-Sampler.__module__ = "torch.utils.data"
-
 
 class GeoSampler(Sampler[BoundingBox], abc.ABC):
     """Abstract base class for sampling from :class:`~torchgeo.datasets.GeoDataset`.

--- a/torchgeo/trainers/__init__.py
+++ b/torchgeo/trainers/__init__.py
@@ -15,7 +15,3 @@ __all__ = (
     "RegressionTask",
     "SemanticSegmentationTask",
 )
-
-# https://stackoverflow.com/questions/40018681
-for module in __all__:
-    globals()[module].__module__ = "torchgeo.trainers"

--- a/torchgeo/trainers/byol.py
+++ b/torchgeo/trainers/byol.py
@@ -19,10 +19,6 @@ from torch.optim.lr_scheduler import ReduceLROnPlateau
 from torchvision.models import resnet18
 from torchvision.models.resnet import resnet50
 
-# https://github.com/pytorch/pytorch/issues/60979
-# https://github.com/pytorch/pytorch/pull/61045
-Module.__module__ = "torch.nn"
-
 
 def normalized_mse(x: Tensor, y: Tensor) -> Tensor:
     """Computes the normalized mean squared error between x and y.

--- a/torchgeo/trainers/classification.py
+++ b/torchgeo/trainers/classification.py
@@ -19,11 +19,6 @@ from torchmetrics import Accuracy, FBetaScore, JaccardIndex, MetricCollection
 from ..datasets.utils import unbind_samples
 from . import utils
 
-# https://github.com/pytorch/pytorch/issues/60979
-# https://github.com/pytorch/pytorch/pull/61045
-Conv2d.__module__ = "nn.Conv2d"
-Linear.__module__ = "nn.Linear"
-
 
 class ClassificationTask(pl.LightningModule):
     """LightningModule for image classification."""

--- a/torchgeo/trainers/classification.py
+++ b/torchgeo/trainers/classification.py
@@ -12,7 +12,6 @@ import torch
 import torch.nn as nn
 from segmentation_models_pytorch.losses import FocalLoss, JaccardLoss
 from torch import Tensor
-from torch.nn.modules import Conv2d, Linear
 from torch.optim.lr_scheduler import ReduceLROnPlateau
 from torchmetrics import Accuracy, FBetaScore, JaccardIndex, MetricCollection
 

--- a/torchgeo/trainers/regression.py
+++ b/torchgeo/trainers/regression.py
@@ -17,11 +17,6 @@ from torchvision import models
 
 from ..datasets.utils import unbind_samples
 
-# https://github.com/pytorch/pytorch/issues/60979
-# https://github.com/pytorch/pytorch/pull/61045
-Conv2d.__module__ = "nn.Conv2d"
-Linear.__module__ = "nn.Linear"
-
 
 class RegressionTask(pl.LightningModule):
     """LightningModule for training models on regression datasets."""

--- a/torchgeo/trainers/regression.py
+++ b/torchgeo/trainers/regression.py
@@ -10,7 +10,6 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch import Tensor
-from torch.nn.modules import Conv2d, Linear
 from torch.optim.lr_scheduler import ReduceLROnPlateau
 from torchmetrics import MeanAbsoluteError, MeanSquaredError, MetricCollection
 from torchvision import models

--- a/torchgeo/trainers/segmentation.py
+++ b/torchgeo/trainers/segmentation.py
@@ -17,10 +17,6 @@ from torchmetrics import Accuracy, JaccardIndex, MetricCollection
 from ..datasets.utils import unbind_samples
 from ..models import FCN
 
-# https://github.com/pytorch/pytorch/issues/60979
-# https://github.com/pytorch/pytorch/pull/61045
-DataLoader.__module__ = "torch.utils.data"
-
 
 class SemanticSegmentationTask(LightningModule):
     """LightningModule for semantic segmentation of images."""

--- a/torchgeo/trainers/segmentation.py
+++ b/torchgeo/trainers/segmentation.py
@@ -11,7 +11,6 @@ import torch.nn as nn
 from pytorch_lightning.core.lightning import LightningModule
 from torch import Tensor
 from torch.optim.lr_scheduler import ReduceLROnPlateau
-from torch.utils.data import DataLoader
 from torchmetrics import Accuracy, JaccardIndex, MetricCollection
 
 from ..datasets.utils import unbind_samples

--- a/torchgeo/trainers/utils.py
+++ b/torchgeo/trainers/utils.py
@@ -12,11 +12,6 @@ import torch.nn as nn
 from torch import Tensor
 from torch.nn.modules import Conv2d, Module
 
-# https://github.com/pytorch/pytorch/issues/60979
-# https://github.com/pytorch/pytorch/pull/61045
-Module.__module__ = "nn.Module"
-Conv2d.__module__ = "nn.Conv2d"
-
 
 def extract_encoder(path: str) -> Tuple[str, "OrderedDict[str, Tensor]"]:
     """Extracts an encoder from a pytorch lightning checkpoint file.

--- a/torchgeo/transforms/__init__.py
+++ b/torchgeo/transforms/__init__.py
@@ -38,7 +38,3 @@ __all__ = (
     "AppendTriBandNormalizedDifferenceIndex",
     "AugmentationSequential",
 )
-
-# https://stackoverflow.com/questions/40018681
-for module in __all__:
-    globals()[module].__module__ = "torchgeo.transforms"

--- a/torchgeo/transforms/indices.py
+++ b/torchgeo/transforms/indices.py
@@ -14,11 +14,6 @@ import torch
 from torch import Tensor
 from torch.nn.modules import Module
 
-# https://github.com/pytorch/pytorch/issues/60979
-# https://github.com/pytorch/pytorch/pull/61045
-Module.__module__ = "torch.nn"
-
-
 _EPSILON = 1e-10
 
 

--- a/torchgeo/transforms/transforms.py
+++ b/torchgeo/transforms/transforms.py
@@ -10,10 +10,6 @@ import torch
 from torch import Tensor
 from torch.nn.modules import Module
 
-# https://github.com/pytorch/pytorch/issues/60979
-# https://github.com/pytorch/pytorch/pull/61045
-Module.__module__ = "torch.nn"
-
 
 class AugmentationSequential(Module):
     """Wrapper around kornia AugmentationSequential to handle input dicts."""


### PR DESCRIPTION
In Sphinx 3, import aliases would throw off intersphinx:

* https://github.com/pytorch/pytorch/issues/60979
* https://stackoverflow.com/questions/40018681

This was supposedly fixed in Sphinx 4:

* https://github.com/sphinx-doc/sphinx/issues/9395

I was finally able to upgrade PyTorch and torchvision to use Sphinx 5:

* https://github.com/pytorch/pytorch/pull/70309
* https://github.com/pytorch/vision/pull/5121

So in theory, we should no longer need to override `__module__`. Fingers crossed that the doc tests pass and the docs look okay!