### PR TITLE
Some images in the SeCo dataset are not square

### DIFF
--- a/torchgeo/datasets/seco.py
+++ b/torchgeo/datasets/seco.py
@@ -172,8 +172,7 @@ class SeasonalContrastS2(VisionDataset):
             with rasterio.open(fn) as f:
                 band_data = f.read(1)
                 height, width = band_data.shape
-                assert height == width
-                size = height
+                size = min(height, width)
                 if size < 264:
                     # TODO: PIL resize is much slower than cv2, we should check to see
                     # what could be sped up throughout later. There is also a potential


### PR DESCRIPTION
Some images in SeCo 100k (at least) are not squares (e.g. I found one that is 264x263).