### PR TITLE
Landsat: add plot method

### DIFF
--- a/docs/api/geo_datasets.csv
+++ b/docs/api/geo_datasets.csv
@@ -12,7 +12,7 @@ Dataset,Type,Source,Size (px),Resolution (m)
 `GBIF`_,Points,Citizen Scientists,-,-
 `GlobBiomass`_,Masks,Landsat,"45,000x45,000",100
 `iNaturalist`_,Points,Citizen Scientists,-,-
-`Landsat`_,Imagery,Landsat,-,30
+`Landsat`_,Imagery,Landsat,"8,900x8,900",30
 `NAIP`_,Imagery,Aerial,"6,100x7,600",1
 `Open Buildings`_,Geometries,"Maxar, CNES/Airbus",-,-
 `Sentinel`_,Imagery,Sentinel,"10,000x10,000",10

--- a/tests/datasets/test_landsat.py
+++ b/tests/datasets/test_landsat.py
@@ -4,6 +4,7 @@
 import os
 from pathlib import Path
 
+import matplotlib.pyplot as plt
 import pytest
 import torch
 import torch.nn as nn
@@ -37,6 +38,20 @@ class TestLandsat8:
     def test_or(self, dataset: Landsat8) -> None:
         ds = dataset | dataset
         assert isinstance(ds, UnionDataset)
+
+    def test_plot(self, dataset: Landsat8) -> None:
+        x = dataset[dataset.bounds]
+        dataset.plot(x, suptitle="Test")
+        plt.close()
+
+    def test_plot_wrong_bands(self, dataset: Landsat8) -> None:
+        bands = ("SR_B1",)
+        ds = Landsat8(root=dataset.root, bands=bands)
+        x = dataset[dataset.bounds]
+        with pytest.raises(
+            ValueError, match="Dataset doesn't contain some of the RGB bands"
+        ):
+            ds.plot(x)
 
     def test_no_data(self, tmp_path: Path) -> None:
         with pytest.raises(FileNotFoundError, match="No Landsat8 data was found in "):

--- a/torchgeo/datasets/cdl.py
+++ b/torchgeo/datasets/cdl.py
@@ -413,6 +413,10 @@ class CDL(RasterDataset):
 
         Returns:
             a matplotlib Figure with the rendered sample
+
+        .. versionchanged:: 0.3
+           Method now takes a sample dict, not a Tensor. Additionally, possible to
+           show subplot titles and/or use a custom suptitle.
         """
         mask = sample["mask"].squeeze().numpy()
         ncols = 1

--- a/torchgeo/datasets/chesapeake.py
+++ b/torchgeo/datasets/chesapeake.py
@@ -19,7 +19,6 @@ import shapely.ops
 import torch
 from matplotlib.colors import ListedColormap
 from rasterio.crs import CRS
-from torch import Tensor
 
 from .geo import GeoDataset, RasterDataset
 from .utils import BoundingBox, download_url, extract_archive
@@ -178,7 +177,7 @@ class Chesapeake(RasterDataset, abc.ABC):
 
     def plot(
         self,
-        sample: Dict[str, Tensor],
+        sample: Dict[str, Any],
         show_titles: bool = True,
         suptitle: Optional[str] = None,
     ) -> plt.Figure:
@@ -192,7 +191,9 @@ class Chesapeake(RasterDataset, abc.ABC):
         Returns:
             a matplotlib Figure with the rendered sample
 
-        .. versionadded:: 0.3
+        .. versionchanged:: 0.3
+           Method now takes a sample dict, not a Tensor. Additionally, possible to
+           show subplot titles and/or use a custom suptitle.
         """
         mask = sample["mask"].squeeze(0)
         ncols = 1

--- a/torchgeo/datasets/landsat.py
+++ b/torchgeo/datasets/landsat.py
@@ -111,11 +111,8 @@ class Landsat(RasterDataset, abc.ABC):
 
         image = sample["image"][rgb_indices].permute(1, 2, 0).float()
 
-        # Stretch to the range of 2nd to 98th percentile
-        per02 = image.quantile(0.02)
-        per98 = image.quantile(0.98)
-        image = (image - per02) / (per98 - per02)
-        image = image.clamp(min=0, max=1)
+        # Stretch to the full range
+        image = (image - image.min()) / (image.max() - image.min())
 
         fig, ax = plt.subplots(1, 1, figsize=(4, 4))
 

--- a/torchgeo/datasets/landsat.py
+++ b/torchgeo/datasets/landsat.py
@@ -109,7 +109,7 @@ class Landsat(RasterDataset, abc.ABC):
             else:
                 raise ValueError("Dataset doesn't contain some of the RGB bands")
 
-        image = sample["image"][rgb_indices].permute(1, 2, 0)
+        image = sample["image"][rgb_indices].permute(1, 2, 0).float()
 
         # Stretch to the range of 2nd to 98th percentile
         per02 = image.quantile(0.02)

--- a/torchgeo/datasets/landsat.py
+++ b/torchgeo/datasets/landsat.py
@@ -6,6 +6,7 @@
 import abc
 from typing import Any, Callable, Dict, Optional, Sequence
 
+import matplotlib.pyplot as plt
 from rasterio.crs import CRS
 
 from .geo import RasterDataset
@@ -77,6 +78,57 @@ class Landsat(RasterDataset, abc.ABC):
         self.filename_glob = self.filename_glob.format(self.bands[0])
 
         super().__init__(root, crs, res, transforms, cache)
+
+    def plot(
+        self,
+        sample: Dict[str, Any],
+        show_titles: bool = True,
+        suptitle: Optional[str] = None,
+    ) -> plt.Figure:
+        """Plot a sample from the dataset.
+
+        Args:
+            sample: a sample returned by :meth:`RasterDataset.__getitem__`
+            show_titles: flag indicating whether to show titles above each panel
+            suptitle: optional string to use as a suptitle
+
+        Returns:
+            a matplotlib Figure with the rendered sample
+
+        Raises:
+            ValueError: if the RGB bands are not included in ``self.bands``
+
+        .. versionchanged:: 0.3
+           Method now takes a sample dict, not a Tensor. Additionally, possible to
+           show subplot titles and/or use a custom suptitle.
+        """
+        rgb_indices = []
+        for band in self.rgb_bands:
+            if band in self.bands:
+                rgb_indices.append(self.bands.index(band))
+            else:
+                raise ValueError("Dataset doesn't contain some of the RGB bands")
+
+        image = sample["image"][rgb_indices].permute(1, 2, 0)
+
+        # Stretch to the range of 2nd to 98th percentile
+        per02 = image.quantile(0.02)
+        per98 = image.quantile(0.98)
+        image = (image - per02) / (per98 - per02)
+        image = image.clamp(min=0, max=1)
+
+        fig, ax = plt.subplots(1, 1, figsize=(4, 4))
+
+        ax.imshow(image)
+        ax.axis("off")
+
+        if show_titles:
+            ax.set_title("Image")
+
+        if suptitle is not None:
+            plt.suptitle(suptitle)
+
+        return fig
 
 
 class Landsat1(Landsat):

--- a/torchgeo/datasets/naip.py
+++ b/torchgeo/datasets/naip.py
@@ -64,8 +64,8 @@ class NAIP(RasterDataset):
             a matplotlib Figure with the rendered sample
 
         .. versionchanged:: 0.3
-            Method now takes a sample dict, not a Tensor. Additionally, possible to
-            show subplot titles and/or use a custom suptitle.
+           Method now takes a sample dict, not a Tensor. Additionally, possible to
+           show subplot titles and/or use a custom suptitle.
         """
         image = sample["image"][0:3, :, :].permute(1, 2, 0)
 

--- a/torchgeo/datasets/sentinel.py
+++ b/torchgeo/datasets/sentinel.py
@@ -8,7 +8,6 @@ from typing import Any, Callable, Dict, Optional, Sequence
 import matplotlib.pyplot as plt
 import torch
 from rasterio.crs import CRS
-from torch import Tensor
 
 from .geo import RasterDataset
 
@@ -104,7 +103,7 @@ class Sentinel2(Sentinel):
 
     def plot(
         self,
-        sample: Dict[str, Tensor],
+        sample: Dict[str, Any],
         show_titles: bool = True,
         suptitle: Optional[str] = None,
     ) -> plt.Figure:
@@ -121,7 +120,9 @@ class Sentinel2(Sentinel):
         Raises:
             ValueError: if the RGB bands are not included in ``self.bands``
 
-        .. versionadded:: 0.3
+        .. versionchanged:: 0.3
+           Method now takes a sample dict, not a Tensor. Additionally, possible to
+           show subplot titles and/or use a custom suptitle.
         """
         rgb_indices = []
         for band in self.RGB_BANDS:


### PR DESCRIPTION
We removed the `RasterDataset.plot` method in #476. Landsat was the only remaining `RasterDataset` that didn't have a replacement `plot` method. Added it so we don't have to explain why Landsat used to have a `plot` method but no longer does.

Also cleaned up some typing and documentation mistakes. `RasterDataset.__getitem__` returns `Dict[str, Any]`, not `Dict[str, Tensor]`. Plot methods weren't _added_ in 0.3 since they existed (albeit in the base class) in 0.2. They were _changed_ because they now have completely different inputs.

Example image from Novaya Zemlya, Russia:
![landsat](https://user-images.githubusercontent.com/12021217/178127701-5992d3e3-be23-4174-8137-ac875ab45af4.png)
