### PR TITLE
0.3.0 release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,6 @@ jobs:
         python-version: '3.10'
     - name: Install pip dependencies
       run: |
-        pip install --pre 'rasterio>=1.0.16'
         pip install .[tests]
         pip list
     - name: Run pytest checks
@@ -36,7 +35,6 @@ jobs:
         python-version: '3.10'
     - name: Install pip dependencies
       run: |
-        pip install --pre 'rasterio>=1.0.16'
         pip install .[datasets,tests]
         pip list
     - name: Run integration checks
@@ -53,7 +51,6 @@ jobs:
         python-version: '3.10'
     - name: Install pip dependencies
       run: |
-        pip install --pre 'rasterio>=1.0.16'
         pip install .[datasets,docs,tests]
         pip list
     - name: Run notebook checks

--- a/docs/tutorials/trainers.ipynb
+++ b/docs/tutorials/trainers.ipynb
@@ -119,7 +119,7 @@
    "outputs": [],
    "source": [
     "# Set this to your API key (available for free at https://mlhub.earth/)\n",
-    "RADIANT_EARTH_API_KEY = \"\""
+    "MLHUB_API_KEY = os.environ[\"MLHUB_API_KEY\"]"
    ]
   },
   {
@@ -136,7 +136,7 @@
     "    seed=1337,\n",
     "    batch_size=64,\n",
     "    num_workers=6,\n",
-    "    api_key=RADIANT_EARTH_API_KEY,\n",
+    "    api_key=MLHUB_API_KEY,\n",
     ")"
    ]
   },

--- a/docs/tutorials/trainers.ipynb
+++ b/docs/tutorials/trainers.ipynb
@@ -132,11 +132,7 @@
     "data_dir = os.path.join(tempfile.gettempdir(), \"cyclone_data\")\n",
     "\n",
     "datamodule = CycloneDataModule(\n",
-    "    root_dir=data_dir,\n",
-    "    seed=1337,\n",
-    "    batch_size=64,\n",
-    "    num_workers=6,\n",
-    "    api_key=MLHUB_API_KEY,\n",
+    "    root_dir=data_dir, seed=1337, batch_size=64, num_workers=6, api_key=MLHUB_API_KEY\n",
     ")"
    ]
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ filterwarnings = [
     # https://github.com/tensorflow/tensorboard/issues/5798
     "ignore:Call to deprecated create function:DeprecationWarning:tensorboard.compat.proto",
     # https://github.com/treebeardtech/nbmake/issues/68
-    'ignore:The \(fspath: py.path.local\) argument to NotebookFile is deprecated:pytest.PytestRemovedIn8Warning:nbmake.pytest_plugin',
+    "ignore:The (fspath. py.path.local) argument to NotebookFile is deprecated:pytest.PytestDeprecationWarning:nbmake.pytest_plugin",
 
     # Expected warnings
     # pytorch-lightning warns us about using num_workers=0, but it's faster on macOS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ filterwarnings = [
     # https://github.com/tensorflow/tensorboard/issues/5798
     "ignore:Call to deprecated create function:DeprecationWarning:tensorboard.compat.proto",
     # https://github.com/treebeardtech/nbmake/issues/68
-    "ignore:The (fspath. py.path.local) argument to NotebookFile is deprecated:pytest.PytestDeprecationWarning:nbmake.pytest_plugin",
+    'ignore:The \(fspath. py.path.local\) argument to NotebookFile is deprecated:pytest.PytestDeprecationWarning:nbmake.pytest_plugin',
 
     # Expected warnings
     # pytorch-lightning warns us about using num_workers=0, but it's faster on macOS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ filterwarnings = [
     # https://github.com/tensorflow/tensorboard/issues/5798
     "ignore:Call to deprecated create function:DeprecationWarning:tensorboard.compat.proto",
     # https://github.com/treebeardtech/nbmake/issues/68
-    "ignore:The (fspath: py.path.local) argument to NotebookFile is deprecated:pytest.PytestRemovedIn8Warning:nbmake.pytest_plugin",
+    "ignore:The \(fspath: py.path.local\) argument to NotebookFile is deprecated:pytest.PytestRemovedIn8Warning:nbmake.pytest_plugin",
 
     # Expected warnings
     # pytorch-lightning warns us about using num_workers=0, but it's faster on macOS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ filterwarnings = [
     # https://github.com/tensorflow/tensorboard/issues/5798
     "ignore:Call to deprecated create function:DeprecationWarning:tensorboard.compat.proto",
     # https://github.com/treebeardtech/nbmake/issues/68
-    "ignore:The \(fspath: py.path.local\) argument to NotebookFile is deprecated:pytest.PytestRemovedIn8Warning:nbmake.pytest_plugin",
+    'ignore:The \(fspath: py.path.local\) argument to NotebookFile is deprecated:pytest.PytestRemovedIn8Warning:nbmake.pytest_plugin',
 
     # Expected warnings
     # pytorch-lightning warns us about using num_workers=0, but it's faster on macOS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ filterwarnings = [
     # https://github.com/pytorch/pytorch/issues/72906
     # https://github.com/pytorch/pytorch/pull/69823
     "ignore:distutils Version classes are deprecated. Use packaging.version instead:DeprecationWarning:torch.utils.tensorboard",
+    "ignore:The distutils package is deprecated and slated for removal in Python 3.12:DeprecationWarning:torch.utils.tensorboard",
     # https://github.com/PyTorchLightning/pytorch-lightning/issues/13256
     # https://github.com/PyTorchLightning/pytorch-lightning/pull/13261
     "ignore:torch.distributed._sharded_tensor will be deprecated:DeprecationWarning:torch.distributed._sharded_tensor",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,8 @@ filterwarnings = [
     "ignore:Named tensors and all their associated APIs are an experimental feature and subject to change:UserWarning:torch.nn.functional",
     # https://github.com/tensorflow/tensorboard/issues/5798
     "ignore:Call to deprecated create function:DeprecationWarning:tensorboard.compat.proto",
+    # https://github.com/treebeardtech/nbmake/issues/68
+    "ignore:The (fspath: py.path.local) argument to NotebookFile is deprecated:pytest.PytestRemovedIn8Warning:nbmake.pytest_plugin",
 
     # Expected warnings
     # pytorch-lightning warns us about using num_workers=0, but it's faster on macOS

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,5 +1,5 @@
 # tests
 mypy==0.961
-nbmake==1.1
+nbmake==1.3.0
 pytest==7.1.2
 pytest-cov==3.0.0

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,5 +1,5 @@
 # tests
 mypy==0.961
-nbmake==1.3.0
+nbmake==1.1
 pytest==7.1.2
 pytest-cov==3.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -120,8 +120,10 @@ style =
     pyupgrade>=1.24,<3
 tests =
     # mypy 0.900+ required for pyproject.toml support
-    mypy>=0.900,<=0.961
+    mypy>=0.900,<0.962
     # nbmake 0.1+ required to fix path_source bug
+    # nbmake 1.2+ is buggy:
+    # https://github.com/treebeardtech/nbmake/issues/71
     nbmake>=0.1,<1.2
     # pytest 6.1.2+ required by nbmake
     pytest>=6.1.2,<8

--- a/setup.cfg
+++ b/setup.cfg
@@ -122,7 +122,7 @@ tests =
     # mypy 0.900+ required for pyproject.toml support
     mypy>=0.900,<=0.961
     # nbmake 0.1+ required to fix path_source bug
-    nbmake>=0.1,<1.3
+    nbmake>=0.1,<1.2
     # pytest 6.1.2+ required by nbmake
     pytest>=6.1.2,<8
     # pytest-cov 2.4+ required for pytest --cov flags

--- a/setup.cfg
+++ b/setup.cfg
@@ -122,7 +122,7 @@ tests =
     # mypy 0.900+ required for pyproject.toml support
     mypy>=0.900,<=0.961
     # nbmake 0.1+ required to fix path_source bug
-    nbmake>=0.1,<2
+    nbmake>=0.1,<1.3
     # pytest 6.1.2+ required by nbmake
     pytest>=6.1.2,<8
     # pytest-cov 2.4+ required for pytest --cov flags

--- a/tests/datamodules/test_usavars.py
+++ b/tests/datamodules/test_usavars.py
@@ -12,6 +12,7 @@ from torchgeo.datamodules import USAVarsDataModule
 class TestUSAVarsDataModule:
     @pytest.fixture()
     def datamodule(self, request: SubRequest) -> USAVarsDataModule:
+        pytest.importorskip("pandas", minversion="0.23.2")
         root = os.path.join("tests", "data", "usavars")
         batch_size = 1
         num_workers = 0

--- a/tests/datasets/test_landcoverai.py
+++ b/tests/datasets/test_landcoverai.py
@@ -26,6 +26,7 @@ class TestLandCoverAI:
     def dataset(
         self, monkeypatch: MonkeyPatch, tmp_path: Path, request: SubRequest
     ) -> LandCoverAI:
+        pytest.importorskip("cv2", minversion="3.4.2.17")
         monkeypatch.setattr(torchgeo.datasets.landcoverai, "download_url", download_url)
         md5 = "ff8998857cc8511f644d3f7d0f3688d0"
         monkeypatch.setattr(LandCoverAI, "md5", md5)

--- a/tests/datasets/test_landcoverai.py
+++ b/tests/datasets/test_landcoverai.py
@@ -57,6 +57,7 @@ class TestLandCoverAI:
         LandCoverAI(root=dataset.root, download=True)
 
     def test_already_downloaded(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+        pytest.importorskip("cv2", minversion="3.4.2.17")
         sha256 = "ecec8e871faf1bbd8ca525ca95ddc1c1f5213f40afb94599884bd85f990ebd6b"
         monkeypatch.setattr(LandCoverAI, "sha256", sha256)
         url = os.path.join("tests", "data", "landcoverai", "landcover.ai.v1.zip")

--- a/tests/datasets/test_openbuildings.py
+++ b/tests/datasets/test_openbuildings.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from typing import Any
 
 import matplotlib.pyplot as plt
-import pandas as pd
 import pytest
 import torch
 import torch.nn as nn
@@ -24,7 +23,7 @@ from torchgeo.datasets import (
     UnionDataset,
 )
 
-pytest.importorskip("pandas", minversion="0.23.2")
+pd = pytest.importorskip("pandas", minversion="0.23.2")
 
 
 class TestOpenBuildings:

--- a/tests/datasets/test_reforestree.py
+++ b/tests/datasets/test_reforestree.py
@@ -24,6 +24,7 @@ def download_url(url: str, root: str, *args: str) -> None:
 class TestReforesTree:
     @pytest.fixture
     def dataset(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> ReforesTree:
+        pytest.importorskip("pandas", minversion="0.23.2")
         monkeypatch.setattr(torchgeo.datasets.utils, "download_url", download_url)
         data_dir = os.path.join("tests", "data", "reforestree")
 

--- a/tests/datasets/test_reforestree.py
+++ b/tests/datasets/test_reforestree.py
@@ -79,6 +79,7 @@ class TestReforesTree:
         assert len(dataset) == 2
 
     def test_not_extracted(self, tmp_path: Path) -> None:
+        pytest.importorskip("pandas", minversion="0.23.2")
         url = os.path.join("tests", "data", "reforestree", "reforesTree.zip")
         shutil.copy(url, tmp_path)
         ReforesTree(root=str(tmp_path))

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -69,8 +69,10 @@ def test_overwrite_experiment_dir(tmp_path: Path) -> None:
         "program.data_dir=" + data_dir,
         "program.log_dir=" + str(log_dir),
         "experiment.task=cyclone",
+        "experiment.datamodule.root_dir=" + data_dir,
         "program.overwrite=True",
         "trainer.fast_dev_run=1",
+        "trainer.gpus=0",
     ]
     ps = subprocess.run(args, capture_output=True, check=True)
     assert re.search(
@@ -123,8 +125,11 @@ program:
 experiment:
   name: test
   task: cyclone
+  datamodule:
+    root_dir: {data_dir}
 trainer:
   fast_dev_run: true
+  gpus: 0
 """
     )
     args = [sys.executable, "train.py", "config_file=" + str(config_file)]

--- a/torchgeo/__init__.py
+++ b/torchgeo/__init__.py
@@ -11,4 +11,4 @@ common image transformations for geospatial data.
 """
 
 __author__ = "Adam J. Stewart"
-__version__ = "0.3.0.dev0"
+__version__ = "0.3.0"

--- a/torchgeo/datasets/eurosat.py
+++ b/torchgeo/datasets/eurosat.py
@@ -129,6 +129,8 @@ class EuroSAT(NonGeoClassificationDataset):
             RuntimeError: if ``download=False`` and data is not found, or checksums
                 don't match
 
+        .. versionadded:: 0.3
+           The *bands* parameter.
         """
         self.root = root
         self.transforms = transforms

--- a/torchgeo/datasets/so2sat.py
+++ b/torchgeo/datasets/so2sat.py
@@ -150,6 +150,9 @@ class So2Sat(NonGeoDataset):
         Raises:
             AssertionError: if ``split`` argument is invalid
             RuntimeError: if data is not found in ``root``, or checksums don't match
+
+        .. versionadded:: 0.3
+           The *bands* parameter.
         """
         try:
             import h5py  # noqa: F401

--- a/torchgeo/trainers/segmentation.py
+++ b/torchgeo/trainers/segmentation.py
@@ -82,6 +82,9 @@ class SemanticSegmentationTask(LightningModule):
 
         Raises:
             ValueError: if kwargs arguments are invalid
+
+        .. versionchanged:: 0.3
+           The *ignore_zeros* parameter was renamed to *ignore_index*.
         """
         super().__init__()
 

--- a/torchgeo/transforms/indices.py
+++ b/torchgeo/transforms/indices.py
@@ -213,6 +213,8 @@ class AppendSWI(AppendNormalizedDifferenceIndex):
     If you use this index in your research, please cite the following paper:
 
     * https://doi.org/10.3390/w13121647
+
+    .. versionadded:: 0.3
     """
 
     def __init__(self, index_red: int, index_swir: int) -> None:
@@ -237,6 +239,8 @@ class AppendGNDVI(AppendNormalizedDifferenceIndex):
     If you use this index in your research, please cite the following paper:
 
     * https://doi.org/10.2134/agronj2001.933583x
+
+    .. versionadded:: 0.3
     """
 
     def __init__(self, index_nir: int, index_green: int) -> None:


### PR DESCRIPTION
# TorchGeo 0.3.0 Release Notes

This release contains a number of new features, and brings increased stability to installations and testing. 

In previous releases, not all dependencies had a minimum supported version listed, causing issues if users had old versions lying around. Old releases would also install the latest version of all dependencies even if they had never been tested before. TorchGeo now lists a minimum and maximum supported version for all dependencies. Moreover, we now test the minimum supported versions of all dependencies. Dependencies are automatically updated using dependabot to prevent unrelated CI failures from sneaking into PRs. We hope this makes it even easier to contribute to TorchGeo, and ensures that old releases will continue to work even if our dependencies make backwards-incompatible changes.

## Backwards-incompatible changes

* VisionDataset and VisionClassificationDataset have been renamed to NonGeoDataset and NonGeoClassificationDataset (#627)
* Sample size now defaults to pixel units, use `units=Units.CRS` for old behavior (#294)
* RasterDataset no longer has a plot method, subclasses have their own plot methods (#476)
* Plot method of RasterDataset subclasses now take sample dicts, not image tensors (#476)
* Removed FCEF model, use segmentation_models_pytorch.Unet instead (#345)
* SemanticSegmentationTrainer: ignore_zeros renamed to ignore_index (#444, #644)

## Dependencies

* Python 3.7+ is now required (#413, #482, #486)
* Add lower version bounds to all dependencies based on testing (#574)
* Add upper version bounds to all dependencies based on semver (#544, #557)
* Fix Conda environment installation (#527, #528, #529, #545)

## Datamodules

New datamodules:

* Inria Aerial Image Labeling (#498)
* USAVars (#441)

Changes to existing datamodules:

* Improved consistency between datamodules (#657)

## Datasets

New datasets:

* Aboveground Live Woody Biomass Density (#425)
* Aster GDEM (#404)
* CMS Global Mangrove Canopy (#391, #427)
* DeepGlobe (#578)
* DFC 2022 (#354)
* EDDMapS (#533)
* EnviroAtlas (#364)
* Esri 2020 Land Cover (#390, #405)
* EU-DEM (#426)
* Forest Damage (#461, #499)
* GBIF (#507)
* GlobBiomass (#395)
* iNaturalist (#532)
* Inria Aerial Image Labeling (#355)
* Million-AID (#455)
* OpenBuildings (#68, #402)
* ReforesTree (#582)
* SpaceNet 3 (#480)
* USAVars (#363)

Changes to existing datasets:

* Benin Small Holder Cashews: return geospatial metadata (#377)
* BigEarthNet: fix checksum (#550)
* CBF: add plot method (#410)
* CDL: add 2021 download (#418)
* CDL: add plot method (#415)
* Chesapeake: add plot method (#417)
* EuroSat: new bands parameter (#396, #397)
* LandCover.ai: update download URL (#559, #579)
* Landsat: add support for all Level-1 and Level-2 products (#492, #504)
* Landsat: add plot method (#661)
* NAIP: add plot method (#407)
* Seasonal Contrast: ensure that all images are square (#658)
* Sentinel: add plot method (#416, #493)
* SEN12MS: avoid casting float to int (#500, #502)
* So2Sat: new bands parameter (#394)

Base classes and utilities:

* VisionDataset and VisionClassificationDataset have been renamed to NonGeoDataset and NonGeoClassificationDataset (#627)
* RasterDataset no longer has a plot method, subclasses have their own plot methods (#476)
* Plot method of RasterDataset subclasses now take sample dicts, not image tensors (#476)
* BoundingBox has new area and volume attributes (#375)
* Don't subtract microsecond from mint (#506)

## Models

* Removed FCEF model, use segmentation_models_pytorch.Unet instead (#345)
* FCSiamConf and FCSiamDiff now inherit from segmentation_models_pytorch.Unet, allowing for easily loading pretrained weights (#345)

## Samplers

New samplers:

* PreChippedGeoSampler (#479)

Changes to existing samplers:

* Allow for point sampling (#477)
* Allow for sampling of entire scene (#477)
* RandomGeoSampler no longer suffers from area bias (#408, #477)
* Sample size now defaults to pixel units, use `units=Units.CRS` for old behavior (#294)

## Trainers

Changes to existing trainers:

* BYOLTask: fix in_channels handling (#522)
* BYOLTask: fix loading of encoder weights (#524)
* SemanticSegmentationTask: ignore_zeros renamed to ignore_index (#444, #644)

## Transforms

New spectral indices:

* BNDVI (#386)
* GBNDVI (#450)
* GNDVI (#371)
* GRNDVI (#450)
* NDRE (#386)
* RBNDVI (#450)
* SWI (#371)

New base classes:

* AppendTriBandNormalizedDifferenceIndex (#414)

## Documentation

* Improved README (#589, #626)
* Add dataset tables (#435, #478, #649)
* Shorter dataset/datamodule/model names (#569, #571)
* Spectral indices now display mathematical equations (#400)
* Fix NAIP download in tutorials (#526, #531)
* Add issue templates on GitHub (#584, #590)
* Clarify Windows conda installation (#581)
* Public type hints (#508)

## Tests

* Test on Python 3.10 (#457)
* Use dependabot to manage dependencies (#488, #551, #647)
* Test minimum version of dependencies (#574)
* Resolve and test for deprecation warnings (#567)
* FCSiam tests no longer require internet access (#495, #497)