### PR TITLE
Bump nbmake dependency

### DIFF
--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,5 +1,5 @@
 # tests
 mypy==0.961
-nbmake==1.3.0
+nbmake==1.3.2
 pytest==7.1.2
 pytest-cov==3.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -122,9 +122,7 @@ tests =
     # mypy 0.900+ required for pyproject.toml support
     mypy>=0.900,<0.962
     # nbmake 0.1+ required to fix path_source bug
-    # nbmake 1.2+ is buggy:
-    # https://github.com/treebeardtech/nbmake/issues/71
-    nbmake>=0.1,<1.2
+    nbmake>=0.1,<2
     # pytest 6.1.2+ required by nbmake
     pytest>=6.1.2,<8
     # pytest-cov 2.4+ required for pytest --cov flags


### PR DESCRIPTION
nbmake 1.3.1 fixes an issue we found during the release process.

Already backported this to releases/v0.3