### PR TITLE
Fixes VectorDataset rounding bug causing sample mask size mismatch

### DIFF
--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -223,7 +223,7 @@ class TestVectorDataset:
     def test_empty_shapes(self, dataset: CustomVectorDataset) -> None:
         query = BoundingBox(1.1, 1.9, 1.1, 1.9, 0, 0)
         x = dataset[query]
-        assert torch.equal(x["mask"], torch.zeros(7, 7, dtype=torch.uint8))
+        assert torch.equal(x["mask"], torch.zeros(8, 8, dtype=torch.uint8))
 
     def test_invalid_query(self, dataset: CustomVectorDataset) -> None:
         query = BoundingBox(3, 3, 3, 3, 0, 0)

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -611,12 +611,12 @@ class VectorDataset(GeoDataset):
         )
         if shapes:
             masks = rasterio.features.rasterize(
-                shapes, out_shape=(int(height), int(width)), transform=transform
+                shapes, out_shape=(int(round(height)), int(round(width))), transform=transform
             )
         else:
             # If no features are found in this query, return an empty mask
             # with the default fill value and dtype used by rasterize
-            masks = np.zeros((int(height), int(width)), dtype=np.uint8)
+            masks = np.zeros((int(round(height)), int(round(width))), dtype=np.uint8)
 
         sample = {"mask": torch.tensor(masks), "crs": self.crs, "bbox": query}
 

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -611,12 +611,12 @@ class VectorDataset(GeoDataset):
         )
         if shapes:
             masks = rasterio.features.rasterize(
-                shapes, out_shape=(int(round(height)), int(round(width))), transform=transform
+                shapes, out_shape=(round(height), round(width)), transform=transform
             )
         else:
             # If no features are found in this query, return an empty mask
             # with the default fill value and dtype used by rasterize
-            masks = np.zeros((int(round(height)), int(round(width))), dtype=np.uint8)
+            masks = np.zeros((round(height), round(width)), dtype=np.uint8)
 
         sample = {"mask": torch.tensor(masks), "crs": self.crs, "bbox": query}
 


### PR DESCRIPTION
I've had to adjust the test to also account for the extra pixel generated, which seems right to me (`1.9-1.1 = 0.8` which would be 8 pixels with a `res=0.1`).

Fixes #674