### PR TITLE
Adds custom typehinting for size (pixel or CRS) arguments

### DIFF
--- a/torchgeo/samplers/batch.py
+++ b/torchgeo/samplers/batch.py
@@ -12,7 +12,7 @@ from torch.utils.data import Sampler
 
 from ..datasets import BoundingBox, GeoDataset
 from .constants import Units
-from .utils import _to_tuple, get_random_bounding_box
+from .utils import PixelsOrCRS, _to_tuple, get_random_bounding_box
 
 # https://github.com/pytorch/pytorch/issues/60979
 # https://github.com/pytorch/pytorch/pull/61045
@@ -68,7 +68,7 @@ class RandomBatchGeoSampler(BatchGeoSampler):
     def __init__(
         self,
         dataset: GeoDataset,
-        size: Union[Tuple[float, float], float],
+        size: Union[Tuple[PixelsOrCRS, PixelsOrCRS], PixelsOrCRS],
         batch_size: int,
         length: int,
         roi: Optional[BoundingBox] = None,
@@ -78,10 +78,10 @@ class RandomBatchGeoSampler(BatchGeoSampler):
 
         The ``size`` argument can either be:
 
-        * a single ``float`` - in which case the same value is used for the height and
-          width dimension
-        * a ``tuple`` of two floats - in which case, the first *float* is used for the
-          height dimension, and the second *float* for the width dimension
+        * a single ``int`` or ``float`` - in which case the same value is used for
+          the height and width dimension
+        * a ``tuple`` of two ints or floats - in which case, the first value is used
+          for the height dimension, and the second value for the width dimension
 
         Args:
             dataset: dataset to index from

--- a/torchgeo/samplers/single.py
+++ b/torchgeo/samplers/single.py
@@ -12,7 +12,7 @@ from torch.utils.data import Sampler
 
 from ..datasets import BoundingBox, GeoDataset
 from .constants import Units
-from .utils import _to_tuple, get_random_bounding_box
+from .utils import PixelsOrCRS, _to_tuple, get_random_bounding_box
 
 # https://github.com/pytorch/pytorch/issues/60979
 # https://github.com/pytorch/pytorch/pull/61045
@@ -71,7 +71,7 @@ class RandomGeoSampler(GeoSampler):
     def __init__(
         self,
         dataset: GeoDataset,
-        size: Union[Tuple[float, float], float],
+        size: Union[Tuple[PixelsOrCRS, PixelsOrCRS], PixelsOrCRS],
         length: int,
         roi: Optional[BoundingBox] = None,
         units: Units = Units.PIXELS,
@@ -80,10 +80,10 @@ class RandomGeoSampler(GeoSampler):
 
         The ``size`` argument can either be:
 
-        * a single ``float`` - in which case the same value is used for the height and
-          width dimension
-        * a ``tuple`` of two floats - in which case, the first *float* is used for the
-          height dimension, and the second *float* for the width dimension
+        * a single ``int`` or ``float`` - in which case the same value is used for
+          the height and width dimension
+        * a ``tuple`` of two ints or floats - in which case, the first value is used
+          for the height dimension, and the second value for the width dimension
 
         Args:
             dataset: dataset to index from
@@ -163,8 +163,8 @@ class GridGeoSampler(GeoSampler):
     def __init__(
         self,
         dataset: GeoDataset,
-        size: Union[Tuple[float, float], float],
-        stride: Union[Tuple[float, float], float],
+        size: Union[Tuple[PixelsOrCRS, PixelsOrCRS], PixelsOrCRS],
+        stride: Union[Tuple[PixelsOrCRS, PixelsOrCRS], PixelsOrCRS],
         roi: Optional[BoundingBox] = None,
         units: Units = Units.PIXELS,
     ) -> None:
@@ -172,10 +172,10 @@ class GridGeoSampler(GeoSampler):
 
         The ``size`` and ``stride`` arguments can either be:
 
-        * a single ``float`` - in which case the same value is used for the height and
-          width dimension
-        * a ``tuple`` of two floats - in which case, the first *float* is used for the
-          height dimension, and the second *float* for the width dimension
+        * a single ``int`` or ``float`` - in which case the same value is used for
+          the height and width dimension
+        * a ``tuple`` of two ints or floats - in which case, the first value is used
+          for the height dimension, and the second value for the width dimension
 
         Args:
             dataset: dataset to index from

--- a/torchgeo/samplers/utils.py
+++ b/torchgeo/samplers/utils.py
@@ -9,8 +9,12 @@ import torch
 
 from ..datasets import BoundingBox
 
+PixelsOrCRS = Union[int, float]
 
-def _to_tuple(value: Union[Tuple[float, float], float]) -> Tuple[float, float]:
+
+def _to_tuple(
+    value: Union[Tuple[PixelsOrCRS, PixelsOrCRS], PixelsOrCRS]
+) -> Tuple[PixelsOrCRS, PixelsOrCRS]:
     """Convert value to a tuple if it is not already a tuple.
 
     Args:


### PR DESCRIPTION
My IDE was complaining about me using an integer for the `size` parameter, despite that being not only supported, but also the default expected type.

I'm not 100% certain about the naming of the custom type (`PixelsOrCRS`), or if its addition even hinders readability, but explicitly writing `Union[int, float]` would make the type hinting very verbose and difficult to read imo.