### PR TITLE
Fix NDVI and SWI calculation

### DIFF
--- a/docs/tutorials/indices.ipynb
+++ b/docs/tutorials/indices.ipynb
@@ -531,7 +531,7 @@
    "source": [
     "Below we use TorchGeo's `indices.AppendNDVI` to compute the [Normalized Difference Vegetation Index (NDVI)](https://gisgeography.com/ndvi-normalized-difference-vegetation-index/) from [\"Red and photographic infrared linear combinations for monitoring vegetation\", Tucker et al. (1979)](https://doi.org/10.1016/0034-4257(79)90013-0). NDVI is useful for measuring the presence of vegetation and vegetation health. It can be calculated using the Near Infrared (NIR) and Red bands using the formula below, resulting in a value between [-1, 1] where low NDVI values represents no or unhealthy vegetation and high NDVI values represents healthy vegetation. Here we use a diverging red, yellow, green colormap representing -1, 0, and 1, respectively.\n",
     "\n",
-    "$$\text{NDVI} = \frac{\text{NIR} - \text{R}}{\text{NIR} + \text{R}}$$"
+    "$$\\text{NDVI} = \\frac{\\text{NIR} - \\text{R}}{\\text{NIR} + \\text{R}}$$"
    ]
   },
   {
@@ -598,7 +598,7 @@
    "source": [
     "Below we use TorchGeo's `indices.AppendNDWI` to compute the [Normalized Difference Water Index (NDWI)](https://custom-scripts.sentinel-hub.com/custom-scripts/sentinel-2/ndwi/) from [\"The use of the Normalized Difference Water Index (NDWI) in the delineation of open water features\", McFeeters et al. (1995)](https://doi.org/10.1080/01431169608948714). NDWI is useful for measuring the presence of water content in water bodies. It can be calculated using the Green and Near Infrared (NIR) bands using the formula below, resulting in a value between [-1, 1] where low NDWI values represents no water and high NDWI values represents water bodies. Here we use a diverging brown, white, blue-green colormap representing -1, 0, and 1, respectively.\n",
     "\n",
-    "$$\text{NDWI} = \frac{\text{G} - \text{NIR}}{\text{G} + \text{NIR}}$$"
+    "$$\\text{NDWI} = \\frac{\\text{G} - \\text{NIR}}{\\text{G} + \\text{NIR}}$$"
    ]
   },
   {
@@ -665,7 +665,7 @@
    "source": [
     "Below we use TorchGeo's `indices.AppendNDBI` to compute the [Normalized Difference Built-up Index (NDBI)](https://www.linkedin.com/pulse/ndvi-ndbi-ndwi-calculation-using-landsat-7-8-tek-bahadur-kshetri/) from [\"Use of normalized difference built-up index in automatically mapping urban areas from TM imagery\", Zha et al. (2010)](https://doi.org/10.1080/01431160304987). NDBI is useful for measuring the presence of urban buildings. It can be calculated using the Short-wave Infrared (SWIR)  and Near Infrared (NIR) bands using the formula below, resulting in a value between [-1, 1] where low NDBI values represents no urban land and high NDBI values represents urban land. Here we use a terrain colormap with blue, green-yellow, and brown representing -1, 0, and 1, respectively.\n",
     "\n",
-    "$$\text{NDBI} = \frac{\text{SWIR} - \text{NIR}}{\text{SWIR} + \text{NIR}}$$"
+    "$$\\text{NDBI} = \\frac{\\text{SWIR} - \\text{NIR}}{\\text{SWIR} + \\text{NIR}}$$"
    ]
   },
   {

--- a/docs/tutorials/indices.ipynb
+++ b/docs/tutorials/indices.ipynb
@@ -529,9 +529,9 @@
     "id": "yGTZzk6_QH1a"
    },
    "source": [
-    "Below we use TorchGeo's `indices.AppendNDVI` to compute the [Normalized Difference Vegetation Index (NDVI)](https://gisgeography.com/ndvi-normalized-difference-vegetation-index/) from [\"Red and photographic infrared linear combinations for monitoring vegetation\", Tucker et al. (1979)](https://doi.org/10.1016/0034-4257(79)90013-0). NDVI is useful for measuring the presence of vegetation and vegetation health. It can be calculated using the Red and Near Infrared (NIR) bands using the formula below, resulting in a value between [-1, 1] where low NDVI values represents no or unhealthy vegetation and high NDVI values represents healthy vegetation. Here we use a diverging red, yellow, green colormap representing -1, 0, and 1, respectively.\n",
+    "Below we use TorchGeo's `indices.AppendNDVI` to compute the [Normalized Difference Vegetation Index (NDVI)](https://gisgeography.com/ndvi-normalized-difference-vegetation-index/) from [\"Red and photographic infrared linear combinations for monitoring vegetation\", Tucker et al. (1979)](https://doi.org/10.1016/0034-4257(79)90013-0). NDVI is useful for measuring the presence of vegetation and vegetation health. It can be calculated using the Near Infrared (NIR) and Red bands using the formula below, resulting in a value between [-1, 1] where low NDVI values represents no or unhealthy vegetation and high NDVI values represents healthy vegetation. Here we use a diverging red, yellow, green colormap representing -1, 0, and 1, respectively.\n",
     "\n",
-    "`NDVI = (Red - NIR) / (Red + NIR)`"
+    "$$\text{NDVI} = \frac{\text{NIR} - \text{R}}{\text{NIR} + \text{R}}$$"
    ]
   },
   {
@@ -561,7 +561,7 @@
    ],
    "source": [
     "# NDVI is appended to channel dimension (dim=0)\n",
-    "index = indices.AppendNDVI(index_red=0, index_nir=3)\n",
+    "index = indices.AppendNDVI(index_nir=3, index_red=0)\n",
     "sample1 = index(sample1)\n",
     "sample2 = index(sample2)\n",
     "\n",
@@ -570,10 +570,10 @@
     "sample2[\"image\"][-1] = (sample2[\"image\"][-1] + 1) / 2\n",
     "\n",
     "fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 6))\n",
-    "ax1.imshow(sample1[\"image\"][-1], cmap=\"RdYlGn_r\")\n",
+    "ax1.imshow(sample1[\"image\"][-1], cmap=\"RdYlGn\")\n",
     "ax1.set_axis_off()\n",
     "ax1.set_title(\"11/16/2018\", fontsize=20)\n",
-    "ax2.imshow(sample2[\"image\"][-1], cmap=\"RdYlGn_r\")\n",
+    "ax2.imshow(sample2[\"image\"][-1], cmap=\"RdYlGn\")\n",
     "ax2.set_axis_off()\n",
     "ax2.set_title(\"09/11/2021\", fontsize=20)\n",
     "plt.tight_layout()\n",
@@ -598,7 +598,7 @@
    "source": [
     "Below we use TorchGeo's `indices.AppendNDWI` to compute the [Normalized Difference Water Index (NDWI)](https://custom-scripts.sentinel-hub.com/custom-scripts/sentinel-2/ndwi/) from [\"The use of the Normalized Difference Water Index (NDWI) in the delineation of open water features\", McFeeters et al. (1995)](https://doi.org/10.1080/01431169608948714). NDWI is useful for measuring the presence of water content in water bodies. It can be calculated using the Green and Near Infrared (NIR) bands using the formula below, resulting in a value between [-1, 1] where low NDWI values represents no water and high NDWI values represents water bodies. Here we use a diverging brown, white, blue-green colormap representing -1, 0, and 1, respectively.\n",
     "\n",
-    "`NDWI = (Green - NIR) / (Green + NIR)`"
+    "$$\text{NDWI} = \frac{\text{G} - \text{NIR}}{\text{G} + \text{NIR}}$$"
    ]
   },
   {
@@ -665,7 +665,7 @@
    "source": [
     "Below we use TorchGeo's `indices.AppendNDBI` to compute the [Normalized Difference Built-up Index (NDBI)](https://www.linkedin.com/pulse/ndvi-ndbi-ndwi-calculation-using-landsat-7-8-tek-bahadur-kshetri/) from [\"Use of normalized difference built-up index in automatically mapping urban areas from TM imagery\", Zha et al. (2010)](https://doi.org/10.1080/01431160304987). NDBI is useful for measuring the presence of urban buildings. It can be calculated using the Short-wave Infrared (SWIR)  and Near Infrared (NIR) bands using the formula below, resulting in a value between [-1, 1] where low NDBI values represents no urban land and high NDBI values represents urban land. Here we use a terrain colormap with blue, green-yellow, and brown representing -1, 0, and 1, respectively.\n",
     "\n",
-    "`NDBI = (SWIR - NIR) / (SWIR + NIR)`"
+    "$$\text{NDBI} = \frac{\text{SWIR} - \text{NIR}}{\text{SWIR} + \text{NIR}}$$"
    ]
   },
   {

--- a/torchgeo/transforms/indices.py
+++ b/torchgeo/transforms/indices.py
@@ -160,21 +160,21 @@ class AppendNDVI(AppendNormalizedDifferenceIndex):
 
     .. math::
 
-       \text{NDVI} = \frac{\text{R} - \text{NIR}}{\text{R} + \text{NIR}}
+       \text{NDVI} = \frac{\text{NIR} - \text{R}}{\text{NIR} + \text{R}}
 
     If you use this index in your research, please cite the following paper:
 
     * https://doi.org/10.1016/0034-4257(79)90013-0
     """
 
-    def __init__(self, index_red: int, index_nir: int) -> None:
+    def __init__(self, index_nir: int, index_red: int) -> None:
         """Initialize a new transform instance.
 
         Args:
-            index_red: index of the Red band in the image
             index_nir: index of the Near Infrared (NIR) band in the image
+            index_red: index of the Red band in the image
         """
-        super().__init__(index_a=index_red, index_b=index_nir)
+        super().__init__(index_a=index_nir, index_b=index_red)
 
 
 class AppendNDWI(AppendNormalizedDifferenceIndex):
@@ -208,7 +208,7 @@ class AppendSWI(AppendNormalizedDifferenceIndex):
 
     .. math::
 
-       \text{SWI} = \frac{\text{R} - \text{SWIR}}{\text{R} + \text{SWIR}}
+       \text{SWI} = \frac{\text{VRE1} - \text{SWIR2}}{\text{VRE1} + \text{SWIR2}}
 
     If you use this index in your research, please cite the following paper:
 
@@ -217,14 +217,14 @@ class AppendSWI(AppendNormalizedDifferenceIndex):
     .. versionadded:: 0.3
     """
 
-    def __init__(self, index_red: int, index_swir: int) -> None:
+    def __init__(self, index_vre1: int, index_swir2: int) -> None:
         """Initialize a new transform instance.
 
         Args:
-            index_red: index of the VRE1 band, e.g. B5 in Sentinel 2 imagery
-            index_swir: index of the SWIR2 band, e.g. B11 in Sentinel 2 imagery
+            index_vre1: index of the VRE1 band, e.g. B5 in Sentinel 2 imagery
+            index_swir2: index of the SWIR2 band, e.g. B11 in Sentinel 2 imagery
         """
-        super().__init__(index_a=index_red, index_b=index_swir)
+        super().__init__(index_a=index_vre1, index_b=index_swir2)
 
 
 class AppendGNDVI(AppendNormalizedDifferenceIndex):


### PR DESCRIPTION
Fixes #713 

We were calculating NDVI incorrectly, using (Red - NIR) instead of (NIR - Red). The only reason our plots looked correct is that we were inverting the color scales.

We used the incorrect band names for SWI. This PR fixes those as well.

I double checked all other indices and things look correct, but I would appreciate it if someone else could triple check.

I'll see if I can get our [blog](https://pytorch.org/blog/geospatial-deep-learning-with-torchgeo/) fixed as well.

@cagsen @isaaccorley @MATRIX4284 