### PR TITLE
DataModules: pass kwargs directly to datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ All TorchGeo datasets are compatible with PyTorch data loaders, making them easy
 In order to facilitate direct comparisons between results published in the literature and further reduce the boilerplate code needed to run experiments with datasets in TorchGeo, we have created PyTorch Lightning [*datamodules*](https://torchgeo.readthedocs.io/en/stable/api/datamodules.html) with well-defined train-val-test splits and [*trainers*](https://torchgeo.readthedocs.io/en/stable/api/trainers.html) for various tasks like classification, regression, and semantic segmentation. These datamodules show how to incorporate augmentations from the kornia library, include preprocessing transforms (with pre-calculated channel statistics), and let users easily experiment with hyperparameters related to the data itself (as opposed to the modeling process). Training a semantic segmentation model on the [Inria Aerial Image Labeling](https://project.inria.fr/aerialimagelabeling/) dataset is as easy as a few imports and four lines of code.
 
 ```python
-datamodule = InriaAerialImageLabelingDataModule(root_dir="...", batch_size=64, num_workers=6)
+datamodule = InriaAerialImageLabelingDataModule(root="...", batch_size=64, num_workers=6)
 task = SemanticSegmentationTask(segmentation_model="unet", encoder_weights="imagenet", learning_rate=0.1)
 trainer = Trainer(gpus=1, default_root_dir="...")
 

--- a/conf/bigearthnet.yaml
+++ b/conf/bigearthnet.yaml
@@ -14,7 +14,7 @@ experiment:
     in_channels: 14
     num_classes: 19
   datamodule:
-    root_dir: "data/bigearthnet"
+    root: "data/bigearthnet"
     bands: "all"
     num_classes: ${experiment.module.num_classes}
     batch_size: 128

--- a/conf/byol.yaml
+++ b/conf/byol.yaml
@@ -14,7 +14,7 @@ experiment:
     learning_rate: 1e-3
     learning_rate_schedule_patience: 6
   datamodule:
-    root_dir: "data/chesapeake/cvpr"
+    root: "data/chesapeake/cvpr"
     train_splits:
       - "de-train"
     val_splits:

--- a/conf/chesapeake_cvpr.yaml
+++ b/conf/chesapeake_cvpr.yaml
@@ -20,7 +20,7 @@ experiment:
     ignore_index: null
     imagenet_pretraining: True
   datamodule:
-    root_dir: "data/chesapeake/cvpr"
+    root: "data/chesapeake/cvpr"
     train_splits:
       - "de-train"
     val_splits:

--- a/conf/cowc_counting.yaml
+++ b/conf/cowc_counting.yaml
@@ -10,7 +10,7 @@ experiment:
     learning_rate_schedule_patience: 2
     pretrained: True
   datamodule:
-    root_dir: "data/cowc_counting"
+    root: "data/cowc_counting"
     seed: 0
     batch_size: 64
     num_workers: 4

--- a/conf/cyclone.yaml
+++ b/conf/cyclone.yaml
@@ -10,7 +10,7 @@ experiment:
     learning_rate_schedule_patience: 2
     pretrained: True
   datamodule:
-    root_dir: "data/cyclone"
+    root: "data/cyclone"
     seed: 0
     batch_size: 32
     num_workers: 4

--- a/conf/etci2021.yaml
+++ b/conf/etci2021.yaml
@@ -11,6 +11,6 @@ experiment:
     num_classes: 2
     ignore_index: 0
   datamodule:
-    root_dir: "data/etci2021"
+    root: "data/etci2021"
     batch_size: 32
     num_workers: 4

--- a/conf/eurosat.yaml
+++ b/conf/eurosat.yaml
@@ -9,6 +9,6 @@ experiment:
     in_channels: 13
     num_classes: 10
   datamodule:
-    root_dir: "data/eurosat"
+    root: "data/eurosat"
     batch_size: 128
     num_workers: 4

--- a/conf/inria.yaml
+++ b/conf/inria.yaml
@@ -23,7 +23,7 @@ experiment:
     num_classes: 2
     ignore_index: null
   datamodule:
-      root_dir: "data/inria"
+      root: "data/inria"
       batch_size: 2
       num_workers: 32
       patch_size: 512

--- a/conf/landcoverai.yaml
+++ b/conf/landcoverai.yaml
@@ -17,6 +17,6 @@ experiment:
     num_filters: 256
     ignore_index: null
   datamodule:
-    root_dir: "data/landcoverai"
+    root: "data/landcoverai"
     batch_size: 32
     num_workers: 4

--- a/conf/naipchesapeake.yaml
+++ b/conf/naipchesapeake.yaml
@@ -18,8 +18,8 @@ experiment:
     num_filters: 64
     ignore_index: null
   datamodule:
-    naip_root_dir: "data/naip"
-    chesapeake_root_dir: "data/chesapeake/BAYWIDE"
+    naip_root: "data/naip"
+    chesapeake_root: "data/chesapeake/BAYWIDE"
     batch_size: 32
     num_workers: 4
     patch_size: 32

--- a/conf/oscd.yaml
+++ b/conf/oscd.yaml
@@ -19,7 +19,7 @@ experiment:
     ignore_index: 0
   datamodule:
     root: "data/oscd"
-    batch_size: 32
+    train_batch_size: 32
     num_workers: 4
     val_split_pct: 0.1
     bands: "all"

--- a/conf/oscd.yaml
+++ b/conf/oscd.yaml
@@ -18,7 +18,7 @@ experiment:
     num_filters: 256
     ignore_index: 0
   datamodule:
-    root_dir: "data/oscd"
+    root: "data/oscd"
     batch_size: 32
     num_workers: 4
     val_split_pct: 0.1

--- a/conf/resisc45.yaml
+++ b/conf/resisc45.yaml
@@ -14,6 +14,6 @@ experiment:
     in_channels: 3
     num_classes: 45
   datamodule:
-    root_dir: "data/resisc45"
+    root: "data/resisc45"
     batch_size: 128
     num_workers: 4

--- a/conf/sen12ms.yaml
+++ b/conf/sen12ms.yaml
@@ -17,7 +17,7 @@ experiment:
     num_classes: 11
     ignore_index: null
   datamodule:
-    root_dir: "data/sen12ms"
+    root: "data/sen12ms"
     band_set: "all"
     batch_size: 32
     num_workers: 4

--- a/conf/so2sat.yaml
+++ b/conf/so2sat.yaml
@@ -14,7 +14,7 @@ experiment:
     in_channels: 3
     num_classes: 17
   datamodule:
-    root_dir: "data/so2sat"
+    root: "data/so2sat"
     batch_size: 128
     num_workers: 4
     bands: "rgb"

--- a/conf/so2sat.yaml
+++ b/conf/so2sat.yaml
@@ -17,5 +17,5 @@ experiment:
     root: "data/so2sat"
     batch_size: 128
     num_workers: 4
-    bands: "rgb"
+    band_set: "rgb"
     unsupervised_mode: False

--- a/conf/ucmerced.yaml
+++ b/conf/ucmerced.yaml
@@ -9,6 +9,6 @@ experiment:
     in_channels: 3
     num_classes: 21
   datamodule:
-    root_dir: "data/ucmerced"
+    root: "data/ucmerced"
     batch_size: 128
     num_workers: 4

--- a/docs/tutorials/trainers.ipynb
+++ b/docs/tutorials/trainers.ipynb
@@ -132,7 +132,7 @@
     "data_dir = os.path.join(tempfile.gettempdir(), \"cyclone_data\")\n",
     "\n",
     "datamodule = CycloneDataModule(\n",
-    "    root_dir=data_dir, seed=1337, batch_size=64, num_workers=6, api_key=MLHUB_API_KEY\n",
+    "    root=data_dir, seed=1337, batch_size=64, num_workers=6, api_key=MLHUB_API_KEY\n",
     ")"
    ]
   },

--- a/evaluate.py
+++ b/evaluate.py
@@ -44,7 +44,7 @@ def set_up_parser() -> argparse.ArgumentParser:
         "--gpu", default=0, type=int, help="GPU ID to use", metavar="ID"
     )
     parser.add_argument(
-        "--root-dir",
+        "--root",
         required=True,
         type=str,
         help="root directory of the dataset for the accompanying task",
@@ -123,7 +123,7 @@ def main(args: argparse.Namespace) -> None:
         args: command-line arguments
     """
     assert os.path.exists(args.input_checkpoint)
-    assert os.path.exists(args.root_dir)
+    assert os.path.exists(args.root)
     TASK = TASK_TO_MODULES_MAPPING[args.task][0]
     DATAMODULE = TASK_TO_MODULES_MAPPING[args.task][1]
 
@@ -135,7 +135,7 @@ def main(args: argparse.Namespace) -> None:
 
     dm = DATAMODULE(  # type: ignore[call-arg]
         seed=args.seed,
-        root_dir=args.root_dir,
+        root=args.root,
         num_workers=args.num_workers,
         batch_size=args.batch_size,
     )

--- a/experiments/test_chesapeakecvpr_models.py
+++ b/experiments/test_chesapeakecvpr_models.py
@@ -138,7 +138,7 @@ def main(args: argparse.Namespace) -> None:
         for test_splits in ALL_TEST_SPLITS:
 
             dm = ChesapeakeCVPRDataModule(
-                args.chesapeakecvpr_root,
+                root=args.chesapeakecvpr_root,
                 train_splits=["de-train"],
                 val_splits=["de-val"],
                 test_splits=test_splits,

--- a/tests/conf/bigearthnet_all.yaml
+++ b/tests/conf/bigearthnet_all.yaml
@@ -9,7 +9,7 @@ experiment:
     in_channels: 14
     num_classes: 19
   datamodule:
-    root_dir: "tests/data/bigearthnet"
+    root: "tests/data/bigearthnet"
     bands: "all"
     num_classes: ${experiment.module.num_classes}
     batch_size: 1

--- a/tests/conf/bigearthnet_s1.yaml
+++ b/tests/conf/bigearthnet_s1.yaml
@@ -9,7 +9,7 @@ experiment:
     in_channels: 2
     num_classes: 19
   datamodule:
-    root_dir: "tests/data/bigearthnet"
+    root: "tests/data/bigearthnet"
     bands: "s1"
     num_classes: ${experiment.module.num_classes}
     batch_size: 1

--- a/tests/conf/bigearthnet_s2.yaml
+++ b/tests/conf/bigearthnet_s2.yaml
@@ -9,7 +9,7 @@ experiment:
     in_channels: 12
     num_classes: 19
   datamodule:
-    root_dir: "tests/data/bigearthnet"
+    root: "tests/data/bigearthnet"
     bands: "s2"
     num_classes: ${experiment.module.num_classes}
     batch_size: 1

--- a/tests/conf/byol.yaml
+++ b/tests/conf/byol.yaml
@@ -9,7 +9,7 @@ experiment:
     learning_rate: 1e-3
     learning_rate_schedule_patience: 6
   datamodule:
-    root_dir: "tests/data/chesapeake/cvpr"
+    root: "tests/data/chesapeake/cvpr"
     train_splits:
       - "de-test"
     val_splits:

--- a/tests/conf/chesapeake_cvpr_5.yaml
+++ b/tests/conf/chesapeake_cvpr_5.yaml
@@ -14,7 +14,7 @@ experiment:
     ignore_index: null
     imagenet_pretraining: False
   datamodule:
-    root_dir: "tests/data/chesapeake/cvpr"
+    root: "tests/data/chesapeake/cvpr"
     train_splits:
     - "de-test"
     val_splits:

--- a/tests/conf/chesapeake_cvpr_7.yaml
+++ b/tests/conf/chesapeake_cvpr_7.yaml
@@ -14,7 +14,7 @@ experiment:
     ignore_index: null
     imagenet_pretraining: True
   datamodule:
-    root_dir: "tests/data/chesapeake/cvpr"
+    root: "tests/data/chesapeake/cvpr"
     train_splits:
     - "de-test"
     val_splits:

--- a/tests/conf/chesapeake_cvpr_prior.yaml
+++ b/tests/conf/chesapeake_cvpr_prior.yaml
@@ -14,7 +14,7 @@ experiment:
     ignore_index: null
     imagenet_pretraining: False
   datamodule:
-    root_dir: "tests/data/chesapeake/cvpr"
+    root: "tests/data/chesapeake/cvpr"
     train_splits:
     - "de-test"
     val_splits:

--- a/tests/conf/cowc_counting.yaml
+++ b/tests/conf/cowc_counting.yaml
@@ -6,7 +6,7 @@ experiment:
     learning_rate_schedule_patience: 2
     pretrained: True
   datamodule:
-    root_dir: "tests/data/cowc_counting"
+    root: "tests/data/cowc_counting"
     seed: 0
     batch_size: 1
     num_workers: 0

--- a/tests/conf/cyclone.yaml
+++ b/tests/conf/cyclone.yaml
@@ -6,7 +6,7 @@ experiment:
     learning_rate_schedule_patience: 2
     pretrained: False
   datamodule:
-    root_dir: "tests/data/cyclone"
+    root: "tests/data/cyclone"
     seed: 0
     batch_size: 1
     num_workers: 0

--- a/tests/conf/deepglobelandcover_0.yaml
+++ b/tests/conf/deepglobelandcover_0.yaml
@@ -13,7 +13,7 @@ experiment:
     num_filters: 1
     ignore_index: null
   datamodule:
-    root_dir: "tests/data/deepglobelandcover"
+    root: "tests/data/deepglobelandcover"
     val_split_pct: 0.0
     batch_size: 1
     num_workers: 0

--- a/tests/conf/deepglobelandcover_5.yaml
+++ b/tests/conf/deepglobelandcover_5.yaml
@@ -13,7 +13,7 @@ experiment:
     num_filters: 1
     ignore_index: null
   datamodule:
-    root_dir: "tests/data/deepglobelandcover"
+    root: "tests/data/deepglobelandcover"
     val_split_pct: 0.5
     batch_size: 1
     num_workers: 0

--- a/tests/conf/etci2021.yaml
+++ b/tests/conf/etci2021.yaml
@@ -11,6 +11,6 @@ experiment:
     num_classes: 2
     ignore_index: 0
   datamodule:
-    root_dir: "tests/data/etci2021"
+    root: "tests/data/etci2021"
     batch_size: 1
     num_workers: 0

--- a/tests/conf/eurosat.yaml
+++ b/tests/conf/eurosat.yaml
@@ -9,6 +9,6 @@ experiment:
     in_channels: 13
     num_classes: 2
   datamodule:
-    root_dir: "tests/data/eurosat"
+    root: "tests/data/eurosat"
     batch_size: 1
     num_workers: 0

--- a/tests/conf/inria.yaml
+++ b/tests/conf/inria.yaml
@@ -11,7 +11,7 @@ experiment:
     num_classes: 2
     ignore_index: null
   datamodule:
-      root_dir: "tests/data/inria"
+      root: "tests/data/inria"
       batch_size: 1
       num_workers: 0
       val_split_pct: 0.2

--- a/tests/conf/landcoverai.yaml
+++ b/tests/conf/landcoverai.yaml
@@ -13,6 +13,6 @@ experiment:
     num_filters: 1
     ignore_index: null
   datamodule:
-    root_dir: "tests/data/landcoverai"
+    root: "tests/data/landcoverai"
     batch_size: 1
     num_workers: 0

--- a/tests/conf/naipchesapeake.yaml
+++ b/tests/conf/naipchesapeake.yaml
@@ -13,8 +13,8 @@ experiment:
     num_filters: 1
     ignore_index: null
   datamodule:
-    naip_root_dir: "tests/data/naip"
-    chesapeake_root_dir: "tests/data/chesapeake/BAYWIDE"
+    naip_root: "tests/data/naip"
+    chesapeake_root: "tests/data/chesapeake/BAYWIDE"
     batch_size: 2
     num_workers: 0
     patch_size: 32

--- a/tests/conf/oscd_all.yaml
+++ b/tests/conf/oscd_all.yaml
@@ -14,7 +14,7 @@ experiment:
     ignore_index: null
   datamodule:
     root: "tests/data/oscd"
-    batch_size: 1
+    train_batch_size: 1
     num_workers: 0
     val_split_pct: 0.5
     bands: "all"

--- a/tests/conf/oscd_all.yaml
+++ b/tests/conf/oscd_all.yaml
@@ -13,7 +13,7 @@ experiment:
     num_filters: 1
     ignore_index: null
   datamodule:
-    root_dir: "tests/data/oscd"
+    root: "tests/data/oscd"
     batch_size: 1
     num_workers: 0
     val_split_pct: 0.5

--- a/tests/conf/oscd_rgb.yaml
+++ b/tests/conf/oscd_rgb.yaml
@@ -14,7 +14,7 @@ experiment:
     ignore_index: null
   datamodule:
     root: "tests/data/oscd"
-    batch_size: 1
+    train_batch_size: 1
     num_workers: 0
     val_split_pct: 0.5
     bands: "rgb"

--- a/tests/conf/oscd_rgb.yaml
+++ b/tests/conf/oscd_rgb.yaml
@@ -13,7 +13,7 @@ experiment:
     num_filters: 1
     ignore_index: null
   datamodule:
-    root_dir: "tests/data/oscd"
+    root: "tests/data/oscd"
     batch_size: 1
     num_workers: 0
     val_split_pct: 0.5

--- a/tests/conf/resisc45.yaml
+++ b/tests/conf/resisc45.yaml
@@ -9,6 +9,6 @@ experiment:
     in_channels: 3
     num_classes: 3
   datamodule:
-    root_dir: "tests/data/resisc45"
+    root: "tests/data/resisc45"
     batch_size: 1
     num_workers: 0

--- a/tests/conf/sen12ms_all.yaml
+++ b/tests/conf/sen12ms_all.yaml
@@ -12,7 +12,7 @@ experiment:
     num_classes: 11
     ignore_index: null
   datamodule:
-    root_dir: "tests/data/sen12ms"
+    root: "tests/data/sen12ms"
     band_set: "all"
     batch_size: 1
     num_workers: 0

--- a/tests/conf/sen12ms_s1.yaml
+++ b/tests/conf/sen12ms_s1.yaml
@@ -13,7 +13,7 @@ experiment:
     num_classes: 11
     ignore_index: null
   datamodule:
-    root_dir: "tests/data/sen12ms"
+    root: "tests/data/sen12ms"
     band_set: "s1"
     batch_size: 1
     num_workers: 0

--- a/tests/conf/sen12ms_s2_all.yaml
+++ b/tests/conf/sen12ms_s2_all.yaml
@@ -12,7 +12,7 @@ experiment:
     num_classes: 11
     ignore_index: null
   datamodule:
-    root_dir: "tests/data/sen12ms"
+    root: "tests/data/sen12ms"
     band_set: "s2-all"
     batch_size: 1
     num_workers: 0

--- a/tests/conf/sen12ms_s2_reduced.yaml
+++ b/tests/conf/sen12ms_s2_reduced.yaml
@@ -12,7 +12,7 @@ experiment:
     num_classes: 11
     ignore_index: null
   datamodule:
-    root_dir: "tests/data/sen12ms"
+    root: "tests/data/sen12ms"
     band_set: "s2-reduced"
     batch_size: 1
     num_workers: 0

--- a/tests/conf/so2sat_supervised.yaml
+++ b/tests/conf/so2sat_supervised.yaml
@@ -12,5 +12,5 @@ experiment:
     root: "tests/data/so2sat"
     batch_size: 1
     num_workers: 0
-    bands: "rgb"
+    band_set: "rgb"
     unsupervised_mode: False

--- a/tests/conf/so2sat_supervised.yaml
+++ b/tests/conf/so2sat_supervised.yaml
@@ -9,7 +9,7 @@ experiment:
     in_channels: 3
     num_classes: 17
   datamodule:
-    root_dir: "tests/data/so2sat"
+    root: "tests/data/so2sat"
     batch_size: 1
     num_workers: 0
     bands: "rgb"

--- a/tests/conf/so2sat_unsupervised.yaml
+++ b/tests/conf/so2sat_unsupervised.yaml
@@ -12,5 +12,5 @@ experiment:
     root: "tests/data/so2sat"
     batch_size: 1
     num_workers: 0
-    bands: "rgb"
+    band_set: "rgb"
     unsupervised_mode: True

--- a/tests/conf/so2sat_unsupervised.yaml
+++ b/tests/conf/so2sat_unsupervised.yaml
@@ -9,7 +9,7 @@ experiment:
     in_channels: 3
     num_classes: 17
   datamodule:
-    root_dir: "tests/data/so2sat"
+    root: "tests/data/so2sat"
     batch_size: 1
     num_workers: 0
     bands: "rgb"

--- a/tests/conf/ucmerced.yaml
+++ b/tests/conf/ucmerced.yaml
@@ -9,6 +9,6 @@ experiment:
     in_channels: 3
     num_classes: 2
   datamodule:
-    root_dir: "tests/data/ucmerced"
+    root: "tests/data/ucmerced"
     batch_size: 1
     num_workers: 0

--- a/tests/datamodules/test_chesapeake.py
+++ b/tests/datamodules/test_chesapeake.py
@@ -33,10 +33,10 @@ class TestChesapeakeCVPRDataModule:
     def test_invalid_param_config(self) -> None:
         with pytest.raises(ValueError, match="The pre-generated prior labels"):
             ChesapeakeCVPRDataModule(
-                os.path.join("tests", "data", "chesapeake", "cvpr"),
-                ["de-test"],
-                ["de-test"],
-                ["de-test"],
+                root=os.path.join("tests", "data", "chesapeake", "cvpr"),
+                train_splits=["de-test"],
+                val_splits=["de-test"],
+                test_splits=["de-test"],
                 patch_size=32,
                 patches_per_tile=2,
                 batch_size=2,

--- a/tests/datamodules/test_fair1m.py
+++ b/tests/datamodules/test_fair1m.py
@@ -15,7 +15,11 @@ class TestFAIR1MDataModule:
         batch_size = 2
         num_workers = 0
         dm = FAIR1MDataModule(
-            root, batch_size, num_workers, val_split_pct=0.33, test_split_pct=0.33
+            root=root,
+            batch_size=batch_size,
+            num_workers=num_workers,
+            val_split_pct=0.33,
+            test_split_pct=0.33,
         )
         dm.setup()
         return dm

--- a/tests/datamodules/test_inria.py
+++ b/tests/datamodules/test_inria.py
@@ -13,24 +13,23 @@ TEST_DATA_DIR = os.path.join("tests", "data", "inria")
 
 class TestInriaAerialImageLabelingDataModule:
     @pytest.fixture(
-        params=zip([0.2, 0.2, 0.0], [0.2, 0.0, 0.0], ["test", "test", "test"])
+        params=zip([0.2, 0.2, 0.0], [0.2, 0.0, 0.0])
     )
     def datamodule(self, request: SubRequest) -> InriaAerialImageLabelingDataModule:
-        val_split_pct, test_split_pct, predict_on = request.param
+        val_split_pct, test_split_pct = request.param
         patch_size = 2  # (2,2)
         num_patches_per_tile = 2
         root = TEST_DATA_DIR
         batch_size = 1
         num_workers = 0
         dm = InriaAerialImageLabelingDataModule(
-            root,
-            batch_size,
-            num_workers,
-            val_split_pct,
-            test_split_pct,
-            patch_size,
-            num_patches_per_tile,
-            predict_on=predict_on,
+            root=root,
+            batch_size=batch_size,
+            num_workers=num_workers,
+            val_split_pct=val_split_pct,
+            test_split_pct=test_split_pct,
+            patch_size=patch_size,
+            num_patches_per_tile=num_patches_per_tile,
         )
         dm.prepare_data()
         dm.setup()

--- a/tests/datamodules/test_inria.py
+++ b/tests/datamodules/test_inria.py
@@ -12,9 +12,7 @@ TEST_DATA_DIR = os.path.join("tests", "data", "inria")
 
 
 class TestInriaAerialImageLabelingDataModule:
-    @pytest.fixture(
-        params=zip([0.2, 0.2, 0.0], [0.2, 0.0, 0.0])
-    )
+    @pytest.fixture(params=zip([0.2, 0.2, 0.0], [0.2, 0.0, 0.0]))
     def datamodule(self, request: SubRequest) -> InriaAerialImageLabelingDataModule:
         val_split_pct, test_split_pct = request.param
         patch_size = 2  # (2,2)

--- a/tests/datamodules/test_loveda.py
+++ b/tests/datamodules/test_loveda.py
@@ -17,7 +17,7 @@ class TestLoveDADataModule:
         scene = ["rural", "urban"]
 
         dm = LoveDADataModule(
-            root_dir=root, scene=scene, batch_size=batch_size, num_workers=num_workers
+            root=root, scene=scene, batch_size=batch_size, num_workers=num_workers
         )
 
         dm.prepare_data()

--- a/tests/datamodules/test_nasa_marine_debris.py
+++ b/tests/datamodules/test_nasa_marine_debris.py
@@ -17,7 +17,11 @@ class TestNASAMarineDebrisDataModule:
         val_split_pct = 0.3
         test_split_pct = 0.3
         dm = NASAMarineDebrisDataModule(
-            root, batch_size, num_workers, val_split_pct, test_split_pct
+            root=root,
+            batch_size=batch_size,
+            num_workers=num_workers,
+            val_split_pct=val_split_pct,
+            test_split_pct=test_split_pct,
         )
         dm.prepare_data()
         dm.setup()

--- a/tests/datamodules/test_oscd.py
+++ b/tests/datamodules/test_oscd.py
@@ -19,13 +19,13 @@ class TestOSCDDataModule:
         batch_size = 1
         num_workers = 0
         dm = OSCDDataModule(
-            root,
-            bands,
-            batch_size,
-            num_workers,
-            val_split_pct,
-            patch_size,
-            num_patches_per_tile,
+            root=root,
+            bands=bands,
+            train_batch_size=batch_size,
+            num_workers=num_workers,
+            val_split_pct=val_split_pct,
+            patch_size=patch_size,
+            num_patches_per_tile=num_patches_per_tile,
         )
         dm.prepare_data()
         dm.setup()
@@ -35,7 +35,7 @@ class TestOSCDDataModule:
         sample = next(iter(datamodule.train_dataloader()))
         assert sample["image"].shape[-2:] == sample["mask"].shape[-2:] == (2, 2)
         assert sample["image"].shape[0] == sample["mask"].shape[0] == 2
-        if datamodule.bands == "all":
+        if datamodule.test_dataset.bands == "all":
             assert sample["image"].shape[1] == 26
         else:
             assert sample["image"].shape[1] == 6
@@ -47,7 +47,7 @@ class TestOSCDDataModule:
                 sample["image"].shape[-2:] == sample["mask"].shape[-2:] == (1280, 1280)
             )
             assert sample["image"].shape[0] == sample["mask"].shape[0] == 1
-            if datamodule.bands == "all":
+            if datamodule.test_dataset.bands == "all":
                 assert sample["image"].shape[1] == 26
             else:
                 assert sample["image"].shape[1] == 6
@@ -56,7 +56,7 @@ class TestOSCDDataModule:
         sample = next(iter(datamodule.test_dataloader()))
         assert sample["image"].shape[-2:] == sample["mask"].shape[-2:] == (1280, 1280)
         assert sample["image"].shape[0] == sample["mask"].shape[0] == 1
-        if datamodule.bands == "all":
+        if datamodule.test_dataset.bands == "all":
             assert sample["image"].shape[1] == 26
         else:
             assert sample["image"].shape[1] == 6

--- a/tests/datamodules/test_potsdam.py
+++ b/tests/datamodules/test_potsdam.py
@@ -17,7 +17,10 @@ class TestPotsdam2DDataModule:
         num_workers = 0
         val_split_size = request.param
         dm = Potsdam2DDataModule(
-            root, batch_size, num_workers, val_split_pct=val_split_size
+            root=root,
+            batch_size=batch_size,
+            num_workers=num_workers,
+            val_split_pct=val_split_size,
         )
         dm.prepare_data()
         dm.setup()

--- a/tests/datamodules/test_usavars.py
+++ b/tests/datamodules/test_usavars.py
@@ -17,7 +17,9 @@ class TestUSAVarsDataModule:
         batch_size = 1
         num_workers = 0
 
-        dm = USAVarsDataModule(root, batch_size=batch_size, num_workers=num_workers)
+        dm = USAVarsDataModule(
+            root=root, batch_size=batch_size, num_workers=num_workers
+        )
         dm.prepare_data()
         dm.setup()
         return dm

--- a/tests/datamodules/test_vaihingen.py
+++ b/tests/datamodules/test_vaihingen.py
@@ -17,7 +17,10 @@ class TestVaihingen2DDataModule:
         num_workers = 0
         val_split_size = request.param
         dm = Vaihingen2DDataModule(
-            root, batch_size, num_workers, val_split_pct=val_split_size
+            root=root,
+            batch_size=batch_size,
+            num_workers=num_workers,
+            val_split_pct=val_split_size,
         )
         dm.prepare_data()
         dm.setup()

--- a/tests/datamodules/test_xview2.py
+++ b/tests/datamodules/test_xview2.py
@@ -17,7 +17,10 @@ class TestXView2DataModule:
         num_workers = 0
         val_split_size = request.param
         dm = XView2DataModule(
-            root, batch_size, num_workers, val_split_pct=val_split_size
+            root=root,
+            batch_size=batch_size,
+            num_workers=num_workers,
+            val_split_pct=val_split_size,
         )
         dm.prepare_data()
         dm.setup()

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -69,7 +69,7 @@ def test_overwrite_experiment_dir(tmp_path: Path) -> None:
         "program.data_dir=" + data_dir,
         "program.log_dir=" + str(log_dir),
         "experiment.task=cyclone",
-        "experiment.datamodule.root_dir=" + data_dir,
+        "experiment.datamodule.root=" + data_dir,
         "program.overwrite=True",
         "trainer.fast_dev_run=1",
         "trainer.gpus=0",
@@ -126,7 +126,7 @@ experiment:
   name: test
   task: cyclone
   datamodule:
-    root_dir: {data_dir}
+    root: {data_dir}
 trainer:
   fast_dev_run: true
   gpus: 0

--- a/torchgeo/datamodules/bigearthnet.py
+++ b/torchgeo/datamodules/bigearthnet.py
@@ -80,6 +80,8 @@ class BigEarthNetDataModule(pl.LightningDataModule):
         Args:
             batch_size: The batch size to use in all created DataLoaders
             num_workers: The number of workers to use in all created DataLoaders
+            **kwargs: Additional keyword arguments passed to
+                :class:`~torchgeo.datasets.BigEarthNet`
         """
         super().__init__()
         self.batch_size = batch_size

--- a/torchgeo/datamodules/bigearthnet.py
+++ b/torchgeo/datamodules/bigearthnet.py
@@ -73,30 +73,21 @@ class BigEarthNetDataModule(pl.LightningDataModule):
     )
 
     def __init__(
-        self,
-        root_dir: str,
-        bands: str = "all",
-        num_classes: int = 19,
-        batch_size: int = 64,
-        num_workers: int = 0,
-        **kwargs: Any,
+        self, batch_size: int = 64, num_workers: int = 0, **kwargs: Any
     ) -> None:
         """Initialize a LightningDataModule for BigEarthNet based DataLoaders.
 
         Args:
-            root_dir: The ``root`` arugment to pass to the BigEarthNet Dataset classes
-            bands: load Sentinel-1 bands, Sentinel-2, or both. one of {s1, s2, all}
-            num_classes: number of classes to load in target. one of {19, 43}
             batch_size: The batch size to use in all created DataLoaders
             num_workers: The number of workers to use in all created DataLoaders
         """
         super().__init__()
-        self.root_dir = root_dir
-        self.bands = bands
-        self.num_classes = num_classes
+
         self.batch_size = batch_size
         self.num_workers = num_workers
+        self.kwargs = kwargs
 
+        bands = kwargs.get("bands", "all")
         if bands == "all":
             self.mins = self.band_mins[:, None, None]
             self.maxs = self.band_maxs[:, None, None]
@@ -119,7 +110,7 @@ class BigEarthNetDataModule(pl.LightningDataModule):
 
         This method is only called once per run.
         """
-        BigEarthNet(self.root_dir, split="train", bands=self.bands, checksum=False)
+        BigEarthNet(split="train", **self.kwargs)
 
     def setup(self, stage: Optional[str] = None) -> None:
         """Initialize the main ``Dataset`` objects.
@@ -128,25 +119,13 @@ class BigEarthNetDataModule(pl.LightningDataModule):
         """
         transforms = Compose([self.preprocess])
         self.train_dataset = BigEarthNet(
-            self.root_dir,
-            split="train",
-            bands=self.bands,
-            num_classes=self.num_classes,
-            transforms=transforms,
+            split="train", transforms=transforms, **self.kwargs
         )
         self.val_dataset = BigEarthNet(
-            self.root_dir,
-            split="val",
-            bands=self.bands,
-            num_classes=self.num_classes,
-            transforms=transforms,
+            split="val", transforms=transforms, **self.kwargs
         )
         self.test_dataset = BigEarthNet(
-            self.root_dir,
-            split="test",
-            bands=self.bands,
-            num_classes=self.num_classes,
-            transforms=transforms,
+            split="test", transforms=transforms, **self.kwargs
         )
 
     def train_dataloader(self) -> DataLoader[Any]:

--- a/torchgeo/datamodules/bigearthnet.py
+++ b/torchgeo/datamodules/bigearthnet.py
@@ -82,7 +82,6 @@ class BigEarthNetDataModule(pl.LightningDataModule):
             num_workers: The number of workers to use in all created DataLoaders
         """
         super().__init__()
-
         self.batch_size = batch_size
         self.num_workers = num_workers
         self.kwargs = kwargs

--- a/torchgeo/datamodules/chesapeake.py
+++ b/torchgeo/datamodules/chesapeake.py
@@ -57,6 +57,8 @@ class ChesapeakeCVPRDataModule(LightningDataModule):
             use_prior_labels: Flag for using a prior over high-resolution classes
                 instead of the high-resolution labels themselves
             prior_smoothing_constant: additive smoothing to add when using prior labels
+            **kwargs: Additional keyword arguments passed to
+                :class:`~torchgeo.datasets.ChesapeakeCVPR`
 
         Raises:
             ValueError: if ``use_prior_labels`` is used with ``class_set==7``

--- a/torchgeo/datamodules/chesapeake.py
+++ b/torchgeo/datamodules/chesapeake.py
@@ -30,7 +30,6 @@ class ChesapeakeCVPRDataModule(LightningDataModule):
 
     def __init__(
         self,
-        root_dir: str,
         train_splits: List[str],
         val_splits: List[str],
         test_splits: List[str],
@@ -46,8 +45,6 @@ class ChesapeakeCVPRDataModule(LightningDataModule):
         """Initialize a LightningDataModule for Chesapeake CVPR based DataLoaders.
 
         Args:
-            root_dir: The ``root`` arugment to pass to the ChesapeakeCVPR Dataset
-                classes
             train_splits: The splits used to train the model, e.g. ["ny-train"]
             val_splits: The splits used to validate the model, e.g. ["ny-val"]
             test_splits: The splits used to test the model, e.g. ["ny-test"]
@@ -74,7 +71,6 @@ class ChesapeakeCVPRDataModule(LightningDataModule):
                 + " class set of labels"
             )
 
-        self.root_dir = root_dir
         self.train_splits = train_splits
         self.val_splits = val_splits
         self.test_splits = test_splits
@@ -88,6 +84,7 @@ class ChesapeakeCVPRDataModule(LightningDataModule):
         self.class_set = class_set
         self.use_prior_labels = use_prior_labels
         self.prior_smoothing_constant = prior_smoothing_constant
+        self.kwargs = kwargs
 
         if self.use_prior_labels:
             self.layers = [
@@ -227,14 +224,7 @@ class ChesapeakeCVPRDataModule(LightningDataModule):
 
         This method is called once per node, while :func:`setup` is called once per GPU.
         """
-        ChesapeakeCVPR(
-            self.root_dir,
-            splits=self.train_splits,
-            layers=self.layers,
-            transforms=None,
-            download=False,
-            checksum=False,
-        )
+        ChesapeakeCVPR(splits=self.train_splits, layers=self.layers, **self.kwargs)
 
     def setup(self, stage: Optional[str] = None) -> None:
         """Create the train/val/test splits based on the original Dataset objects.
@@ -270,28 +260,22 @@ class ChesapeakeCVPRDataModule(LightningDataModule):
         )
 
         self.train_dataset = ChesapeakeCVPR(
-            self.root_dir,
             splits=self.train_splits,
             layers=self.layers,
             transforms=train_transforms,
-            download=False,
-            checksum=False,
+            **self.kwargs,
         )
         self.val_dataset = ChesapeakeCVPR(
-            self.root_dir,
             splits=self.val_splits,
             layers=self.layers,
             transforms=val_transforms,
-            download=False,
-            checksum=False,
+            **self.kwargs,
         )
         self.test_dataset = ChesapeakeCVPR(
-            self.root_dir,
             splits=self.test_splits,
             layers=self.layers,
             transforms=test_transforms,
-            download=False,
-            checksum=False,
+            **self.kwargs,
         )
 
     def train_dataloader(self) -> DataLoader[Any]:

--- a/torchgeo/datamodules/cowc.py
+++ b/torchgeo/datamodules/cowc.py
@@ -21,26 +21,20 @@ class COWCCountingDataModule(pl.LightningDataModule):
     """LightningDataModule implementation for the COWC Counting dataset."""
 
     def __init__(
-        self,
-        root_dir: str,
-        seed: int,
-        batch_size: int = 64,
-        num_workers: int = 0,
-        **kwargs: Any,
+        self, seed: int, batch_size: int = 64, num_workers: int = 0, **kwargs: Any
     ) -> None:
         """Initialize a LightningDataModule for COWC Counting based DataLoaders.
 
         Args:
-            root_dir: The ``root`` arugment to pass to the COWCCounting Dataset class
             seed: The seed value to use when doing the dataset random_split
             batch_size: The batch size to use in all created DataLoaders
             num_workers: The number of workers to use in all created DataLoaders
         """
         super().__init__()
-        self.root_dir = root_dir
         self.seed = seed
         self.batch_size = batch_size
         self.num_workers = num_workers
+        self.kwargs = kwargs
 
     def preprocess(self, sample: Dict[str, Any]) -> Dict[str, Any]:
         """Transform a single sample from the Dataset.
@@ -63,7 +57,7 @@ class COWCCountingDataModule(pl.LightningDataModule):
         This includes optionally downloading the dataset. This is done once per node,
         while :func:`setup` is done once per GPU.
         """
-        COWCCounting(self.root_dir, download=False)
+        COWCCounting(**self.kwargs)
 
     def setup(self, stage: Optional[str] = None) -> None:
         """Create the train/val/test splits based on the original Dataset objects.
@@ -75,10 +69,10 @@ class COWCCountingDataModule(pl.LightningDataModule):
             stage: stage to set up
         """
         train_val_dataset = COWCCounting(
-            self.root_dir, split="train", transforms=self.preprocess
+            split="train", transforms=self.preprocess, **self.kwargs
         )
         self.test_dataset = COWCCounting(
-            self.root_dir, split="test", transforms=self.preprocess
+            split="test", transforms=self.preprocess, **self.kwargs
         )
         self.train_dataset, self.val_dataset = random_split(
             train_val_dataset,

--- a/torchgeo/datamodules/cowc.py
+++ b/torchgeo/datamodules/cowc.py
@@ -29,6 +29,8 @@ class COWCCountingDataModule(pl.LightningDataModule):
             seed: The seed value to use when doing the dataset random_split
             batch_size: The batch size to use in all created DataLoaders
             num_workers: The number of workers to use in all created DataLoaders
+            **kwargs: Additional keyword arguments passed to
+                :class:`~torchgeo.datasets.COWCCounting`
         """
         super().__init__()
         self.seed = seed

--- a/torchgeo/datamodules/cyclone.py
+++ b/torchgeo/datamodules/cyclone.py
@@ -33,6 +33,8 @@ class CycloneDataModule(pl.LightningDataModule):
             seed: The seed value to use when doing the sklearn based GroupShuffleSplit
             batch_size: The batch size to use in all created DataLoaders
             num_workers: The number of workers to use in all created DataLoaders
+            **kwargs: Additional keyword arguments passed to
+                :class:`~torchgeo.datasets.TropicalCycloneWindEstimation`
         """
         super().__init__()
         self.seed = seed

--- a/torchgeo/datamodules/cyclone.py
+++ b/torchgeo/datamodules/cyclone.py
@@ -25,31 +25,20 @@ class CycloneDataModule(pl.LightningDataModule):
     """
 
     def __init__(
-        self,
-        root_dir: str,
-        seed: int,
-        batch_size: int = 64,
-        num_workers: int = 0,
-        api_key: Optional[str] = None,
-        **kwargs: Any,
+        self, seed: int, batch_size: int = 64, num_workers: int = 0, **kwargs: Any
     ) -> None:
         """Initialize a LightningDataModule for NASA Cyclone based DataLoaders.
 
         Args:
-            root_dir: The ``root`` arugment to pass to the
-                TropicalCycloneWindEstimation Datasets classes
             seed: The seed value to use when doing the sklearn based GroupShuffleSplit
             batch_size: The batch size to use in all created DataLoaders
             num_workers: The number of workers to use in all created DataLoaders
-            api_key: The RadiantEarth MLHub API key to use if the dataset needs to be
-                downloaded
         """
         super().__init__()
-        self.root_dir = root_dir
         self.seed = seed
         self.batch_size = batch_size
         self.num_workers = num_workers
-        self.api_key = api_key
+        self.kwargs = kwargs
 
     def preprocess(self, sample: Dict[str, Any]) -> Dict[str, Any]:
         """Transform a single sample from the Dataset.
@@ -76,12 +65,7 @@ class CycloneDataModule(pl.LightningDataModule):
         This includes optionally downloading the dataset. This is done once per node,
         while :func:`setup` is done once per GPU.
         """
-        TropicalCycloneWindEstimation(
-            self.root_dir,
-            split="train",
-            download=self.api_key is not None,
-            api_key=self.api_key,
-        )
+        TropicalCycloneWindEstimation(split="train", **self.kwargs)
 
     def setup(self, stage: Optional[str] = None) -> None:
         """Create the train/val/test splits based on the original Dataset objects.
@@ -100,11 +84,11 @@ class CycloneDataModule(pl.LightningDataModule):
             stage: stage to set up
         """
         self.all_train_dataset = TropicalCycloneWindEstimation(
-            self.root_dir, split="train", transforms=self.preprocess, download=False
+            split="train", transforms=self.preprocess, **self.kwargs
         )
 
         self.all_test_dataset = TropicalCycloneWindEstimation(
-            self.root_dir, split="test", transforms=self.preprocess, download=False
+            split="test", transforms=self.preprocess, **self.kwargs
         )
 
         storm_ids = []

--- a/torchgeo/datamodules/deepglobelandcover.py
+++ b/torchgeo/datamodules/deepglobelandcover.py
@@ -63,7 +63,9 @@ class DeepGlobeLandCoverDataModule(pl.LightningDataModule):
         """
         transforms = Compose([self.preprocess])
 
-        dataset = DeepGlobeLandCover("train", transforms=transforms, **self.kwargs)
+        dataset = DeepGlobeLandCover(
+            split="train", transforms=transforms, **self.kwargs
+        )
 
         self.train_dataset: Dataset[Any]
         self.val_dataset: Dataset[Any]
@@ -77,7 +79,7 @@ class DeepGlobeLandCoverDataModule(pl.LightningDataModule):
             self.val_dataset = dataset
 
         self.test_dataset = DeepGlobeLandCover(
-            "test", transforms=transforms, **self.kwargs
+            split="test", transforms=transforms, **self.kwargs
         )
 
     def train_dataloader(self) -> DataLoader[Dict[str, Any]]:

--- a/torchgeo/datamodules/deepglobelandcover.py
+++ b/torchgeo/datamodules/deepglobelandcover.py
@@ -22,7 +22,6 @@ class DeepGlobeLandCoverDataModule(pl.LightningDataModule):
 
     def __init__(
         self,
-        root_dir: str,
         batch_size: int = 64,
         num_workers: int = 0,
         val_split_pct: float = 0.2,
@@ -31,16 +30,15 @@ class DeepGlobeLandCoverDataModule(pl.LightningDataModule):
         """Initialize a LightningDataModule for DeepGlobe Land Cover based DataLoaders.
 
         Args:
-            root_dir: The ``root`` argument to pass to the DeepGlobe Dataset classes
             batch_size: The batch size to use in all created DataLoaders
             num_workers: The number of workers to use in all created DataLoaders
             val_split_pct: What percentage of the dataset to use as a validation set
         """
         super().__init__()
-        self.root_dir = root_dir
         self.batch_size = batch_size
         self.num_workers = num_workers
         self.val_split_pct = val_split_pct
+        self.kwargs = kwargs
 
     def preprocess(self, sample: Dict[str, Any]) -> Dict[str, Any]:
         """Transform a single sample from the Dataset.
@@ -65,7 +63,7 @@ class DeepGlobeLandCoverDataModule(pl.LightningDataModule):
         """
         transforms = Compose([self.preprocess])
 
-        dataset = DeepGlobeLandCover(self.root_dir, "train", transforms=transforms)
+        dataset = DeepGlobeLandCover("train", transforms=transforms, **self.kwargs)
 
         self.train_dataset: Dataset[Any]
         self.val_dataset: Dataset[Any]
@@ -79,7 +77,7 @@ class DeepGlobeLandCoverDataModule(pl.LightningDataModule):
             self.val_dataset = dataset
 
         self.test_dataset = DeepGlobeLandCover(
-            self.root_dir, "test", transforms=transforms
+            "test", transforms=transforms, **self.kwargs
         )
 
     def train_dataloader(self) -> DataLoader[Dict[str, Any]]:

--- a/torchgeo/datamodules/deepglobelandcover.py
+++ b/torchgeo/datamodules/deepglobelandcover.py
@@ -33,6 +33,8 @@ class DeepGlobeLandCoverDataModule(pl.LightningDataModule):
             batch_size: The batch size to use in all created DataLoaders
             num_workers: The number of workers to use in all created DataLoaders
             val_split_pct: What percentage of the dataset to use as a validation set
+            **kwargs: Additional keyword arguments passed to
+                :class:`~torchgeo.datasets.DeepGlobeLandCover`
         """
         super().__init__()
         self.batch_size = batch_size

--- a/torchgeo/datamodules/etci2021.py
+++ b/torchgeo/datamodules/etci2021.py
@@ -33,26 +33,20 @@ class ETCI2021DataModule(pl.LightningDataModule):
     )
 
     def __init__(
-        self,
-        root_dir: str,
-        seed: int = 0,
-        batch_size: int = 64,
-        num_workers: int = 0,
-        **kwargs: Any,
+        self, seed: int = 0, batch_size: int = 64, num_workers: int = 0, **kwargs: Any
     ) -> None:
         """Initialize a LightningDataModule for ETCI2021 based DataLoaders.
 
         Args:
-            root_dir: The ``root`` arugment to pass to the ETCI2021 Dataset classes
             seed: The seed value to use when doing the dataset random_split
             batch_size: The batch size to use in all created DataLoaders
             num_workers: The number of workers to use in all created DataLoaders
         """
         super().__init__()
-        self.root_dir = root_dir
         self.seed = seed
         self.batch_size = batch_size
         self.num_workers = num_workers
+        self.kwargs = kwargs
 
         self.norm = Normalize(self.band_means, self.band_stds)
 
@@ -83,7 +77,7 @@ class ETCI2021DataModule(pl.LightningDataModule):
 
         This method is only called once per run.
         """
-        ETCI2021(self.root_dir, checksum=False)
+        ETCI2021(**self.kwargs)
 
     def setup(self, stage: Optional[str] = None) -> None:
         """Initialize the main ``Dataset`` objects.
@@ -94,10 +88,10 @@ class ETCI2021DataModule(pl.LightningDataModule):
             stage: stage to set up
         """
         train_val_dataset = ETCI2021(
-            self.root_dir, split="train", transforms=self.preprocess
+            split="train", transforms=self.preprocess, **self.kwargs
         )
         self.test_dataset = ETCI2021(
-            self.root_dir, split="val", transforms=self.preprocess
+            split="val", transforms=self.preprocess, **self.kwargs
         )
 
         size_train_val = len(train_val_dataset)

--- a/torchgeo/datamodules/etci2021.py
+++ b/torchgeo/datamodules/etci2021.py
@@ -41,6 +41,8 @@ class ETCI2021DataModule(pl.LightningDataModule):
             seed: The seed value to use when doing the dataset random_split
             batch_size: The batch size to use in all created DataLoaders
             num_workers: The number of workers to use in all created DataLoaders
+            **kwargs: Additional keyword arguments passed to
+                :class:`~torchgeo.datasets.ETCI2021`
         """
         super().__init__()
         self.seed = seed

--- a/torchgeo/datamodules/eurosat.py
+++ b/torchgeo/datamodules/eurosat.py
@@ -66,6 +66,8 @@ class EuroSATDataModule(pl.LightningDataModule):
         Args:
             batch_size: The batch size to use in all created DataLoaders
             num_workers: The number of workers to use in all created DataLoaders
+            **kwargs: Additional keyword arguments passed to
+                :class:`~torchgeo.datasets.EuroSAT`
         """
         super().__init__()
         self.batch_size = batch_size

--- a/torchgeo/datamodules/eurosat.py
+++ b/torchgeo/datamodules/eurosat.py
@@ -59,19 +59,18 @@ class EuroSATDataModule(pl.LightningDataModule):
     )
 
     def __init__(
-        self, root_dir: str, batch_size: int = 64, num_workers: int = 0, **kwargs: Any
+        self, batch_size: int = 64, num_workers: int = 0, **kwargs: Any
     ) -> None:
         """Initialize a LightningDataModule for EuroSAT based DataLoaders.
 
         Args:
-            root_dir: The ``root`` arugment to pass to the EuroSAT Dataset classes
             batch_size: The batch size to use in all created DataLoaders
             num_workers: The number of workers to use in all created DataLoaders
         """
         super().__init__()
-        self.root_dir = root_dir
         self.batch_size = batch_size
         self.num_workers = num_workers
+        self.kwargs = kwargs
 
         self.norm = Normalize(self.band_means, self.band_stds)
 
@@ -93,7 +92,7 @@ class EuroSATDataModule(pl.LightningDataModule):
 
         This method is only called once per run.
         """
-        EuroSAT(self.root_dir)
+        EuroSAT(**self.kwargs)
 
     def setup(self, stage: Optional[str] = None) -> None:
         """Initialize the main ``Dataset`` objects.
@@ -105,9 +104,11 @@ class EuroSATDataModule(pl.LightningDataModule):
         """
         transforms = Compose([self.preprocess])
 
-        self.train_dataset = EuroSAT(self.root_dir, "train", transforms=transforms)
-        self.val_dataset = EuroSAT(self.root_dir, "val", transforms=transforms)
-        self.test_dataset = EuroSAT(self.root_dir, "test", transforms=transforms)
+        self.train_dataset = EuroSAT(
+            split="train", transforms=transforms, **self.kwargs
+        )
+        self.val_dataset = EuroSAT(split="val", transforms=transforms, **self.kwargs)
+        self.test_dataset = EuroSAT(split="test", transforms=transforms, **self.kwargs)
 
     def train_dataloader(self) -> DataLoader[Any]:
         """Return a DataLoader for training.

--- a/torchgeo/datamodules/fair1m.py
+++ b/torchgeo/datamodules/fair1m.py
@@ -40,7 +40,6 @@ class FAIR1MDataModule(pl.LightningDataModule):
 
     def __init__(
         self,
-        root_dir: str,
         batch_size: int = 64,
         num_workers: int = 0,
         val_split_pct: float = 0.2,
@@ -50,18 +49,17 @@ class FAIR1MDataModule(pl.LightningDataModule):
         """Initialize a LightningDataModule for FAIR1M based DataLoaders.
 
         Args:
-            root_dir: The ``root`` arugment to pass to the FAIR1M Dataset classes
             batch_size: The batch size to use in all created DataLoaders
             num_workers: The number of workers to use in all created DataLoaders
             val_split_pct: What percentage of the dataset to use as a validation set
             test_split_pct: What percentage of the dataset to use as a test set
         """
         super().__init__()
-        self.root_dir = root_dir
         self.batch_size = batch_size
         self.num_workers = num_workers
         self.val_split_pct = val_split_pct
         self.test_split_pct = test_split_pct
+        self.kwargs
 
     def preprocess(self, sample: Dict[str, Any]) -> Dict[str, Any]:
         """Transform a single sample from the Dataset.
@@ -84,7 +82,7 @@ class FAIR1MDataModule(pl.LightningDataModule):
         Args:
             stage: stage to set up
         """
-        dataset = FAIR1M(self.root_dir, transforms=self.preprocess)
+        dataset = FAIR1M(transforms=self.preprocess, **self.kwargs)
         self.train_dataset, self.val_dataset, self.test_dataset = dataset_split(
             dataset, val_pct=self.val_split_pct, test_pct=self.test_split_pct
         )

--- a/torchgeo/datamodules/fair1m.py
+++ b/torchgeo/datamodules/fair1m.py
@@ -59,7 +59,7 @@ class FAIR1MDataModule(pl.LightningDataModule):
         self.num_workers = num_workers
         self.val_split_pct = val_split_pct
         self.test_split_pct = test_split_pct
-        self.kwargs
+        self.kwargs = kwargs
 
     def preprocess(self, sample: Dict[str, Any]) -> Dict[str, Any]:
         """Transform a single sample from the Dataset.

--- a/torchgeo/datamodules/fair1m.py
+++ b/torchgeo/datamodules/fair1m.py
@@ -53,6 +53,8 @@ class FAIR1MDataModule(pl.LightningDataModule):
             num_workers: The number of workers to use in all created DataLoaders
             val_split_pct: What percentage of the dataset to use as a validation set
             test_split_pct: What percentage of the dataset to use as a test set
+            **kwargs: Additional keyword arguments passed to
+                :class:`~torchgeo.datasets.FAIR1M`
         """
         super().__init__()
         self.batch_size = batch_size

--- a/torchgeo/datamodules/inria.py
+++ b/torchgeo/datamodules/inria.py
@@ -61,6 +61,8 @@ class InriaAerialImageLabelingDataModule(pl.LightningDataModule):
             test_split_pct: What percentage of the dataset to use as a test set
             patch_size: Size of random patch from image and mask (height, width)
             num_patches_per_tile: Number of random patches per sample
+            **kwargs: Additional keyword arguments passed to
+                :class:`~torchgeo.datasets.InriaAerialImageLabeling`
         """
         super().__init__()
         self.batch_size = batch_size

--- a/torchgeo/datamodules/inria.py
+++ b/torchgeo/datamodules/inria.py
@@ -165,7 +165,7 @@ class InriaAerialImageLabelingDataModule(pl.LightningDataModule):
             self.test_dataset = self.dataset
 
         self.predict_dataset = InriaAerialImageLabeling(
-            transforms=test_transforms, **self.kwargs
+            split="test", transforms=test_transforms, **self.kwargs
         )
 
     def train_dataloader(self) -> DataLoader[Any]:

--- a/torchgeo/datamodules/landcoverai.py
+++ b/torchgeo/datamodules/landcoverai.py
@@ -24,19 +24,18 @@ class LandCoverAIDataModule(pl.LightningDataModule):
     """
 
     def __init__(
-        self, root_dir: str, batch_size: int = 64, num_workers: int = 0, **kwargs: Any
+        self, batch_size: int = 64, num_workers: int = 0, **kwargs: Any
     ) -> None:
         """Initialize a LightningDataModule for LandCover.ai based DataLoaders.
 
         Args:
-            root_dir: The ``root`` arugment to pass to the Landcover.AI Dataset classes
             batch_size: The batch size to use in all created DataLoaders
             num_workers: The number of workers to use in all created DataLoaders
         """
         super().__init__()
-        self.root_dir = root_dir
         self.batch_size = batch_size
         self.num_workers = num_workers
+        self.kwargs = kwargs
 
     def on_after_batch_transfer(
         self, batch: Dict[str, Any], batch_idx: int
@@ -105,7 +104,7 @@ class LandCoverAIDataModule(pl.LightningDataModule):
 
         This method is only called once per run.
         """
-        LandCoverAI(self.root_dir, download=False, checksum=False)
+        LandCoverAI(**self.kwargs)
 
     def setup(self, stage: Optional[str] = None) -> None:
         """Initialize the main ``Dataset`` objects.
@@ -119,15 +118,15 @@ class LandCoverAIDataModule(pl.LightningDataModule):
         val_test_transforms = self.preprocess
 
         self.train_dataset = LandCoverAI(
-            self.root_dir, split="train", transforms=train_transforms
+            split="train", transforms=train_transforms, **self.kwargs
         )
 
         self.val_dataset = LandCoverAI(
-            self.root_dir, split="val", transforms=val_test_transforms
+            split="val", transforms=val_test_transforms, **self.kwargs
         )
 
         self.test_dataset = LandCoverAI(
-            self.root_dir, split="test", transforms=val_test_transforms
+            split="test", transforms=val_test_transforms, **self.kwargs
         )
 
     def train_dataloader(self) -> DataLoader[Any]:

--- a/torchgeo/datamodules/landcoverai.py
+++ b/torchgeo/datamodules/landcoverai.py
@@ -31,6 +31,8 @@ class LandCoverAIDataModule(pl.LightningDataModule):
         Args:
             batch_size: The batch size to use in all created DataLoaders
             num_workers: The number of workers to use in all created DataLoaders
+            **kwargs: Additional keyword arguments passed to
+                :class:`~torchgeo.datasets.LandCoverAI`
         """
         super().__init__()
         self.batch_size = batch_size

--- a/torchgeo/datamodules/loveda.py
+++ b/torchgeo/datamodules/loveda.py
@@ -3,7 +3,7 @@
 
 """LoveDA datamodule."""
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 import pytorch_lightning as pl
 from torch.utils.data import DataLoader
@@ -24,26 +24,18 @@ class LoveDADataModule(pl.LightningDataModule):
     """
 
     def __init__(
-        self,
-        root_dir: str,
-        scene: List[str],
-        batch_size: int = 32,
-        num_workers: int = 0,
-        **kwargs: Any,
+        self, batch_size: int = 32, num_workers: int = 0, **kwargs: Any
     ) -> None:
         """Initialize a LightningDataModule for LoveDA based DataLoaders.
 
         Args:
-            root_dir: The ``root`` argument to pass to LoveDA Dataset classes
-            scene: specify whether to load only 'urban', only 'rural' or both
             batch_size: The batch size to use in all created DataLoaders
             num_workers: The number of workers to use in all created DataLoaders
         """
         super().__init__()
-        self.root_dir = root_dir
-        self.scene = scene
         self.batch_size = batch_size
         self.num_workers = num_workers
+        self.kwargs = kwargs
 
     def preprocess(self, sample: Dict[str, Any]) -> Dict[str, Any]:
         """Transform a single sample from the Dataset.
@@ -64,7 +56,7 @@ class LoveDADataModule(pl.LightningDataModule):
 
         This method is only called once per run.
         """
-        _ = LoveDA(self.root_dir, scene=self.scene, download=False, checksum=False)
+        LoveDA(**self.kwargs)
 
     def setup(self, stage: Optional[str] = None) -> None:
         """Initialize the main ``Dataset`` objects.
@@ -78,18 +70,15 @@ class LoveDADataModule(pl.LightningDataModule):
         val_test_transforms = self.preprocess
 
         self.train_dataset = LoveDA(
-            self.root_dir, split="train", scene=self.scene, transforms=train_transforms
+            split="train", transforms=train_transforms, **self.kwargs
         )
 
         self.val_dataset = LoveDA(
-            self.root_dir, split="val", scene=self.scene, transforms=val_test_transforms
+            split="val", transforms=val_test_transforms, **self.kwargs
         )
 
         self.test_dataset = LoveDA(
-            self.root_dir,
-            split="test",
-            scene=self.scene,
-            transforms=val_test_transforms,
+            split="test", transforms=val_test_transforms, **self.kwargs
         )
 
     def train_dataloader(self) -> DataLoader[Any]:

--- a/torchgeo/datamodules/loveda.py
+++ b/torchgeo/datamodules/loveda.py
@@ -31,6 +31,8 @@ class LoveDADataModule(pl.LightningDataModule):
         Args:
             batch_size: The batch size to use in all created DataLoaders
             num_workers: The number of workers to use in all created DataLoaders
+            **kwargs: Additional keyword arguments passed to
+                :class:`~torchgeo.datasets.LoveDA`
         """
         super().__init__()
         self.batch_size = batch_size

--- a/torchgeo/datamodules/naip.py
+++ b/torchgeo/datamodules/naip.py
@@ -45,6 +45,9 @@ class NAIPChesapeakeDataModule(pl.LightningDataModule):
             batch_size: The batch size to use in all created DataLoaders
             num_workers: The number of workers to use in all created DataLoaders
             patch_size: size of patches to sample
+            **kwargs: Additional keyword arguments passed to
+                :class:`~torchgeo.datasets.NAIP` and
+                :class:`~torchgeo.datasets.Chesapeake13`
         """
         super().__init__()
         self.naip_root = naip_root

--- a/torchgeo/datamodules/naip.py
+++ b/torchgeo/datamodules/naip.py
@@ -30,8 +30,8 @@ class NAIPChesapeakeDataModule(pl.LightningDataModule):
 
     def __init__(
         self,
-        naip_root_dir: str,
-        chesapeake_root_dir: str,
+        naip_root: str,
+        chesapeake_root: str,
         batch_size: int = 64,
         num_workers: int = 0,
         patch_size: int = 256,
@@ -40,18 +40,19 @@ class NAIPChesapeakeDataModule(pl.LightningDataModule):
         """Initialize a LightningDataModule for NAIP and Chesapeake based DataLoaders.
 
         Args:
-            naip_root_dir: directory containing NAIP data
-            chesapeake_root_dir: directory containing Chesapeake data
+            naip_root: directory containing NAIP data
+            chesapeake_root: directory containing Chesapeake data
             batch_size: The batch size to use in all created DataLoaders
             num_workers: The number of workers to use in all created DataLoaders
             patch_size: size of patches to sample
         """
         super().__init__()
-        self.naip_root_dir = naip_root_dir
-        self.chesapeake_root_dir = chesapeake_root_dir
+        self.naip_root = naip_root
+        self.chesapeake_root = chesapeake_root
         self.batch_size = batch_size
         self.num_workers = num_workers
         self.patch_size = patch_size
+        self.kwargs = kwargs
 
     def preprocess(self, sample: Dict[str, Any]) -> Dict[str, Any]:
         """Transform a single sample from the NAIP Dataset.
@@ -97,7 +98,7 @@ class NAIPChesapeakeDataModule(pl.LightningDataModule):
 
         This method is only called once per run.
         """
-        Chesapeake13(self.chesapeake_root_dir, download=False, checksum=False)
+        Chesapeake13(self.chesapeake_root, **self.kwargs)
 
     def setup(self, stage: Optional[str] = None) -> None:
         """Initialize the main ``Dataset`` objects.
@@ -114,13 +115,14 @@ class NAIPChesapeakeDataModule(pl.LightningDataModule):
         chesapeak_transforms = Compose([self.chesapeake_transform, self.remove_bbox])
 
         chesapeake = Chesapeake13(
-            self.chesapeake_root_dir, transforms=chesapeak_transforms
+            self.chesapeake_root, transforms=chesapeak_transforms, **self.kwargs
         )
         naip = NAIP(
-            self.naip_root_dir,
+            self.naip_root,
             chesapeake.crs,
             chesapeake.res,
             transforms=naip_transforms,
+            **self.kwargs,
         )
         self.dataset = chesapeake & naip
 

--- a/torchgeo/datamodules/nasa_marine_debris.py
+++ b/torchgeo/datamodules/nasa_marine_debris.py
@@ -41,7 +41,6 @@ class NASAMarineDebrisDataModule(pl.LightningDataModule):
 
     def __init__(
         self,
-        root_dir: str,
         batch_size: int = 64,
         num_workers: int = 0,
         val_split_pct: float = 0.2,
@@ -51,18 +50,17 @@ class NASAMarineDebrisDataModule(pl.LightningDataModule):
         """Initialize a LightningDataModule for NASA Marine Debris based DataLoaders.
 
         Args:
-            root_dir: The ``root`` argument to pass to the Dataset class
             batch_size: The batch size to use in all created DataLoaders
             num_workers: The number of workers to use in all created DataLoaders
             val_split_pct: What percentage of the dataset to use as a validation set
             test_split_pct: What percentage of the dataset to use as a test set
         """
         super().__init__()
-        self.root_dir = root_dir
         self.batch_size = batch_size
         self.num_workers = num_workers
         self.val_split_pct = val_split_pct
         self.test_split_pct = test_split_pct
+        self.kwargs = kwargs
 
     def preprocess(self, sample: Dict[str, Any]) -> Dict[str, Any]:
         """Transform a single sample from the Dataset.
@@ -82,7 +80,7 @@ class NASAMarineDebrisDataModule(pl.LightningDataModule):
 
         This method is only called once per run.
         """
-        NASAMarineDebris(self.root_dir, checksum=False)
+        NASAMarineDebris(**self.kwargs)
 
     def setup(self, stage: Optional[str] = None) -> None:
         """Initialize the main ``Dataset`` objects.
@@ -92,7 +90,7 @@ class NASAMarineDebrisDataModule(pl.LightningDataModule):
         Args:
             stage: stage to set up
         """
-        dataset = NASAMarineDebris(self.root_dir, transforms=self.preprocess)
+        dataset = NASAMarineDebris(transforms=self.preprocess, **self.kwargs)
         self.train_dataset, self.val_dataset, self.test_dataset = dataset_split(
             dataset, val_pct=self.val_split_pct, test_pct=self.test_split_pct
         )

--- a/torchgeo/datamodules/nasa_marine_debris.py
+++ b/torchgeo/datamodules/nasa_marine_debris.py
@@ -54,6 +54,8 @@ class NASAMarineDebrisDataModule(pl.LightningDataModule):
             num_workers: The number of workers to use in all created DataLoaders
             val_split_pct: What percentage of the dataset to use as a validation set
             test_split_pct: What percentage of the dataset to use as a test set
+            **kwargs: Additional keyword arguments passed to
+                :class:`~torchgeo.datasets.NASAMarineDebris`
         """
         super().__init__()
         self.batch_size = batch_size

--- a/torchgeo/datamodules/oscd.py
+++ b/torchgeo/datamodules/oscd.py
@@ -64,8 +64,6 @@ class OSCDDataModule(pl.LightningDataModule):
 
     def __init__(
         self,
-        root_dir: str,
-        bands: str = "all",
         train_batch_size: int = 32,
         num_workers: int = 0,
         val_split_pct: float = 0.2,
@@ -77,8 +75,6 @@ class OSCDDataModule(pl.LightningDataModule):
         """Initialize a LightningDataModule for OSCD based DataLoaders.
 
         Args:
-            root_dir: The ``root`` arugment to pass to the OSCD Dataset classes
-            bands: "rgb" or "all"
             train_batch_size: The batch size used in the train DataLoader
                 (val_batch_size == test_batch_size == 1)
             num_workers: The number of workers to use in all created DataLoaders
@@ -88,14 +84,14 @@ class OSCDDataModule(pl.LightningDataModule):
             pad_size: size to pad images to during val/test steps
         """
         super().__init__()
-        self.root_dir = root_dir
-        self.bands = bands
         self.train_batch_size = train_batch_size
         self.num_workers = num_workers
         self.val_split_pct = val_split_pct
         self.patch_size = patch_size
         self.num_patches_per_tile = num_patches_per_tile
+        self.kwargs = kwargs
 
+        bands = kwargs.get("bands", "all")
         if bands == "rgb":
             self.band_means = self.band_means[[3, 2, 1]]
             self.band_stds = self.band_stds[[3, 2, 1]]
@@ -119,7 +115,7 @@ class OSCDDataModule(pl.LightningDataModule):
 
         This method is only called once per run.
         """
-        OSCD(self.root_dir, split="train", bands=self.bands, checksum=False)
+        OSCD(split="train", **self.kwargs)
 
     def setup(self, stage: Optional[str] = None) -> None:
         """Initialize the main ``Dataset`` objects.
@@ -149,20 +145,13 @@ class OSCDDataModule(pl.LightningDataModule):
         # with the upsampling paths in encoder-decoder architectures
         test_transforms = Compose([self.preprocess, pad_to])
 
-        train_dataset = OSCD(
-            self.root_dir, split="train", bands=self.bands, transforms=train_transforms
-        )
+        train_dataset = OSCD(split="train", transforms=train_transforms, **self.kwargs)
 
         self.train_dataset: Dataset[Any]
         self.val_dataset: Dataset[Any]
 
         if self.val_split_pct > 0.0:
-            val_dataset = OSCD(
-                self.root_dir,
-                split="train",
-                bands=self.bands,
-                transforms=test_transforms,
-            )
+            val_dataset = OSCD(split="train", transforms=test_transforms, **self.kwargs)
             self.train_dataset, self.val_dataset, _ = dataset_split(
                 train_dataset, val_pct=self.val_split_pct, test_pct=0.0
             )
@@ -172,7 +161,7 @@ class OSCDDataModule(pl.LightningDataModule):
             self.val_dataset = train_dataset
 
         self.test_dataset = OSCD(
-            self.root_dir, split="test", bands=self.bands, transforms=test_transforms
+            split="test", transforms=test_transforms, **self.kwargs
         )
 
     def train_dataloader(self) -> DataLoader[Any]:

--- a/torchgeo/datamodules/oscd.py
+++ b/torchgeo/datamodules/oscd.py
@@ -82,6 +82,8 @@ class OSCDDataModule(pl.LightningDataModule):
             patch_size: Size of random patch from image and mask (height, width)
             num_patches_per_tile: number of random patches per sample
             pad_size: size to pad images to during val/test steps
+            **kwargs: Additional keyword arguments passed to
+                :class:`~torchgeo.datasets.OSCD`
         """
         super().__init__()
         self.train_batch_size = train_batch_size

--- a/torchgeo/datamodules/potsdam.py
+++ b/torchgeo/datamodules/potsdam.py
@@ -34,6 +34,8 @@ class Potsdam2DDataModule(pl.LightningDataModule):
             batch_size: The batch size to use in all created DataLoaders
             num_workers: The number of workers to use in all created DataLoaders
             val_split_pct: What percentage of the dataset to use as a validation set
+            **kwargs: Additional keyword arguments passed to
+                :class:`~torchgeo.datasets.Potsdam2D`
         """
         super().__init__()
         self.batch_size = batch_size

--- a/torchgeo/datamodules/potsdam.py
+++ b/torchgeo/datamodules/potsdam.py
@@ -23,7 +23,6 @@ class Potsdam2DDataModule(pl.LightningDataModule):
 
     def __init__(
         self,
-        root_dir: str,
         batch_size: int = 64,
         num_workers: int = 0,
         val_split_pct: float = 0.2,
@@ -32,16 +31,15 @@ class Potsdam2DDataModule(pl.LightningDataModule):
         """Initialize a LightningDataModule for Potsdam2D based DataLoaders.
 
         Args:
-            root_dir: The ``root`` argument to pass to the Potsdam2D Dataset classes
             batch_size: The batch size to use in all created DataLoaders
             num_workers: The number of workers to use in all created DataLoaders
             val_split_pct: What percentage of the dataset to use as a validation set
         """
         super().__init__()
-        self.root_dir = root_dir
         self.batch_size = batch_size
         self.num_workers = num_workers
         self.val_split_pct = val_split_pct
+        self.kwargs = kwargs
 
     def preprocess(self, sample: Dict[str, Any]) -> Dict[str, Any]:
         """Transform a single sample from the Dataset.
@@ -66,7 +64,7 @@ class Potsdam2DDataModule(pl.LightningDataModule):
         """
         transforms = Compose([self.preprocess])
 
-        dataset = Potsdam2D(self.root_dir, "train", transforms=transforms)
+        dataset = Potsdam2D(split="train", transforms=transforms, **self.kwargs)
 
         self.train_dataset: Dataset[Any]
         self.val_dataset: Dataset[Any]
@@ -79,7 +77,9 @@ class Potsdam2DDataModule(pl.LightningDataModule):
             self.train_dataset = dataset
             self.val_dataset = dataset
 
-        self.test_dataset = Potsdam2D(self.root_dir, "test", transforms=transforms)
+        self.test_dataset = Potsdam2D(
+            split="test", transforms=transforms, **self.kwargs
+        )
 
     def train_dataloader(self) -> DataLoader[Any]:
         """Return a DataLoader for training.

--- a/torchgeo/datamodules/resisc45.py
+++ b/torchgeo/datamodules/resisc45.py
@@ -36,6 +36,8 @@ class RESISC45DataModule(pl.LightningDataModule):
         Args:
             batch_size: The batch size to use in all created DataLoaders
             num_workers: The number of workers to use in all created DataLoaders
+            **kwargs: Additional keyword arguments passed to
+                :class:`~torchgeo.datasets.RESISC45`
         """
         super().__init__()
         self.batch_size = batch_size

--- a/torchgeo/datamodules/resisc45.py
+++ b/torchgeo/datamodules/resisc45.py
@@ -29,19 +29,18 @@ class RESISC45DataModule(pl.LightningDataModule):
     band_stds = torch.tensor([0.20339924, 0.18524736, 0.18455448])
 
     def __init__(
-        self, root_dir: str, batch_size: int = 64, num_workers: int = 0, **kwargs: Any
+        self, batch_size: int = 64, num_workers: int = 0, **kwargs: Any
     ) -> None:
         """Initialize a LightningDataModule for RESISC45 based DataLoaders.
 
         Args:
-            root_dir: The ``root`` arugment to pass to the RESISC45 Dataset classes
             batch_size: The batch size to use in all created DataLoaders
             num_workers: The number of workers to use in all created DataLoaders
         """
         super().__init__()
-        self.root_dir = root_dir
         self.batch_size = batch_size
         self.num_workers = num_workers
+        self.kwargs = kwargs
 
         self.norm = Normalize(self.band_means, self.band_stds)
 
@@ -106,7 +105,7 @@ class RESISC45DataModule(pl.LightningDataModule):
 
         This method is only called once per run.
         """
-        RESISC45(self.root_dir, checksum=False)
+        RESISC45(**self.kwargs)
 
     def setup(self, stage: Optional[str] = None) -> None:
         """Initialize the main ``Dataset`` objects.
@@ -118,9 +117,11 @@ class RESISC45DataModule(pl.LightningDataModule):
         """
         transforms = Compose([self.preprocess])
 
-        self.train_dataset = RESISC45(self.root_dir, "train", transforms=transforms)
-        self.val_dataset = RESISC45(self.root_dir, "val", transforms=transforms)
-        self.test_dataset = RESISC45(self.root_dir, "test", transforms=transforms)
+        self.train_dataset = RESISC45(
+            split="train", transforms=transforms, **self.kwargs
+        )
+        self.val_dataset = RESISC45(split="val", transforms=transforms, **self.kwargs)
+        self.test_dataset = RESISC45(split="test", transforms=transforms, **self.kwargs)
 
     def train_dataloader(self) -> DataLoader[Any]:
         """Return a DataLoader for training.

--- a/torchgeo/datamodules/sen12ms.py
+++ b/torchgeo/datamodules/sen12ms.py
@@ -53,18 +53,29 @@ class SEN12MSDataModule(pl.LightningDataModule):
     )
 
     def __init__(
-        self, seed: int, batch_size: int = 64, num_workers: int = 0, **kwargs: Any
+        self,
+        seed: int,
+        band_set: str = "all",
+        batch_size: int = 64,
+        num_workers: int = 0,
+        **kwargs: Any,
     ) -> None:
         """Initialize a LightningDataModule for SEN12MS based DataLoaders.
 
         Args:
             seed: The seed value to use when doing the sklearn based ShuffleSplit
+            band_set: The subset of S1/S2 bands to use. Options are: "all",
+                "s1", "s2-all", and "s2-reduced" where the "s2-reduced" set includes:
+                B2, B3, B4, B8, B11, and B12.
             batch_size: The batch size to use in all created DataLoaders
             num_workers: The number of workers to use in all created DataLoaders
         """
         super().__init__()
+        assert band_set in SEN12MS.BAND_SETS.keys()
 
         self.seed = seed
+        self.band_set = band_set
+        self.bands = SEN12MS.BAND_SETS[band_set]
         self.batch_size = batch_size
         self.num_workers = num_workers
         self.kwargs = kwargs
@@ -109,11 +120,11 @@ class SEN12MSDataModule(pl.LightningDataModule):
         season_to_int = {"winter": 0, "spring": 1000, "summer": 2000, "fall": 3000}
 
         self.all_train_dataset = SEN12MS(
-            split="train", transforms=self.preprocess, **self.kwargs
+            split="train", bands=self.bands, transforms=self.preprocess, **self.kwargs
         )
 
         self.all_test_dataset = SEN12MS(
-            split="test", transforms=self.preprocess, **self.kwargs
+            split="test", bands=self.bands, transforms=self.preprocess, **self.kwargs
         )
 
         # A patch is a filename like: "ROIs{num}_{season}_s2_{scene_id}_p{patch_id}.tif"

--- a/torchgeo/datamodules/sen12ms.py
+++ b/torchgeo/datamodules/sen12ms.py
@@ -53,34 +53,21 @@ class SEN12MSDataModule(pl.LightningDataModule):
     )
 
     def __init__(
-        self,
-        root_dir: str,
-        seed: int,
-        band_set: str = "all",
-        batch_size: int = 64,
-        num_workers: int = 0,
-        **kwargs: Any,
+        self, seed: int, batch_size: int = 64, num_workers: int = 0, **kwargs: Any
     ) -> None:
         """Initialize a LightningDataModule for SEN12MS based DataLoaders.
 
         Args:
-            root_dir: The ``root`` arugment to pass to the SEN12MS Dataset classes
             seed: The seed value to use when doing the sklearn based ShuffleSplit
-            band_set: The subset of S1/S2 bands to use. Options are: "all",
-                "s1", "s2-all", and "s2-reduced" where the "s2-reduced" set includes:
-                B2, B3, B4, B8, B11, and B12.
             batch_size: The batch size to use in all created DataLoaders
             num_workers: The number of workers to use in all created DataLoaders
         """
         super().__init__()
-        assert band_set in SEN12MS.BAND_SETS.keys()
 
-        self.root_dir = root_dir
         self.seed = seed
-        self.band_set = band_set
-        self.band_indices = SEN12MS.BAND_SETS[band_set]
         self.batch_size = batch_size
         self.num_workers = num_workers
+        self.kwargs = kwargs
 
     def preprocess(self, sample: Dict[str, Any]) -> Dict[str, Any]:
         """Transform a single sample from the Dataset.
@@ -122,19 +109,11 @@ class SEN12MSDataModule(pl.LightningDataModule):
         season_to_int = {"winter": 0, "spring": 1000, "summer": 2000, "fall": 3000}
 
         self.all_train_dataset = SEN12MS(
-            self.root_dir,
-            split="train",
-            bands=self.band_indices,
-            transforms=self.preprocess,
-            checksum=False,
+            split="train", transforms=self.preprocess, **self.kwargs
         )
 
         self.all_test_dataset = SEN12MS(
-            self.root_dir,
-            split="test",
-            bands=self.band_indices,
-            transforms=self.preprocess,
-            checksum=False,
+            split="test", transforms=self.preprocess, **self.kwargs
         )
 
         # A patch is a filename like: "ROIs{num}_{season}_s2_{scene_id}_p{patch_id}.tif"

--- a/torchgeo/datamodules/sen12ms.py
+++ b/torchgeo/datamodules/sen12ms.py
@@ -69,6 +69,8 @@ class SEN12MSDataModule(pl.LightningDataModule):
                 B2, B3, B4, B8, B11, and B12.
             batch_size: The batch size to use in all created DataLoaders
             num_workers: The number of workers to use in all created DataLoaders
+            **kwargs: Additional keyword arguments passed to
+                :class:`~torchgeo.datasets.SEN12MS`
         """
         super().__init__()
         assert band_set in SEN12MS.BAND_SETS.keys()

--- a/torchgeo/datamodules/so2sat.py
+++ b/torchgeo/datamodules/so2sat.py
@@ -72,6 +72,8 @@ class So2SatDataModule(pl.LightningDataModule):
             band_set: Collection of So2Sat bands to use
             unsupervised_mode: Makes the train dataloader return imagery from the train,
                 val, and test sets
+            **kwargs: Additional keyword arguments passed to
+                :class:`~torchgeo.datasets.So2Sat`
         """
         super().__init__()
         self.batch_size = batch_size

--- a/torchgeo/datamodules/ucmerced.py
+++ b/torchgeo/datamodules/ucmerced.py
@@ -25,19 +25,18 @@ class UCMercedDataModule(pl.LightningDataModule):
     """
 
     def __init__(
-        self, root_dir: str, batch_size: int = 64, num_workers: int = 0, **kwargs: Any
+        self, batch_size: int = 64, num_workers: int = 0, **kwargs: Any
     ) -> None:
         """Initialize a LightningDataModule for UCMerced based DataLoaders.
 
         Args:
-            root_dir: The ``root`` arugment to pass to the UCMerced Dataset classes
             batch_size: The batch size to use in all created DataLoaders
             num_workers: The number of workers to use in all created DataLoaders
         """
         super().__init__()
-        self.root_dir = root_dir
         self.batch_size = batch_size
         self.num_workers = num_workers
+        self.kwargs = kwargs
 
     def preprocess(self, sample: Dict[str, Any]) -> Dict[str, Any]:
         """Transform a single sample from the Dataset.
@@ -62,7 +61,7 @@ class UCMercedDataModule(pl.LightningDataModule):
 
         This method is only called once per run.
         """
-        UCMerced(self.root_dir, download=False, checksum=False)
+        UCMerced(**self.kwargs)
 
     def setup(self, stage: Optional[str] = None) -> None:
         """Initialize the main ``Dataset`` objects.
@@ -74,9 +73,9 @@ class UCMercedDataModule(pl.LightningDataModule):
         """
         transforms = Compose([self.preprocess])
 
-        self.train_dataset = UCMerced(self.root_dir, "train", transforms=transforms)
-        self.val_dataset = UCMerced(self.root_dir, "val", transforms=transforms)
-        self.test_dataset = UCMerced(self.root_dir, "test", transforms=transforms)
+        self.train_dataset = UCMerced("train", transforms=transforms, **self.kwargs)
+        self.val_dataset = UCMerced("val", transforms=transforms, **self.kwargs)
+        self.test_dataset = UCMerced("test", transforms=transforms, **self.kwargs)
 
     def train_dataloader(self) -> DataLoader[Any]:
         """Return a DataLoader for training.

--- a/torchgeo/datamodules/ucmerced.py
+++ b/torchgeo/datamodules/ucmerced.py
@@ -32,6 +32,8 @@ class UCMercedDataModule(pl.LightningDataModule):
         Args:
             batch_size: The batch size to use in all created DataLoaders
             num_workers: The number of workers to use in all created DataLoaders
+            **kwargs: Additional keyword arguments passed to
+                :class:`~torchgeo.datasets.UCMerced`
         """
         super().__init__()
         self.batch_size = batch_size

--- a/torchgeo/datamodules/ucmerced.py
+++ b/torchgeo/datamodules/ucmerced.py
@@ -73,9 +73,11 @@ class UCMercedDataModule(pl.LightningDataModule):
         """
         transforms = Compose([self.preprocess])
 
-        self.train_dataset = UCMerced("train", transforms=transforms, **self.kwargs)
-        self.val_dataset = UCMerced("val", transforms=transforms, **self.kwargs)
-        self.test_dataset = UCMerced("test", transforms=transforms, **self.kwargs)
+        self.train_dataset = UCMerced(
+            split="train", transforms=transforms, **self.kwargs
+        )
+        self.val_dataset = UCMerced(split="val", transforms=transforms, **self.kwargs)
+        self.test_dataset = UCMerced(split="test", transforms=transforms, **self.kwargs)
 
     def train_dataloader(self) -> DataLoader[Any]:
         """Return a DataLoader for training.

--- a/torchgeo/datamodules/usavars.py
+++ b/torchgeo/datamodules/usavars.py
@@ -3,7 +3,7 @@
 
 """USAVars datamodule."""
 
-from typing import Any, Dict, Optional, Sequence
+from typing import Any, Dict, Optional
 
 import pytorch_lightning as pl
 from torch.utils.data import DataLoader
@@ -20,25 +20,18 @@ class USAVarsDataModule(pl.LightningModule):
     """
 
     def __init__(
-        self,
-        root_dir: str,
-        labels: Sequence[str] = USAVars.ALL_LABELS,
-        batch_size: int = 64,
-        num_workers: int = 0,
+        self, batch_size: int = 64, num_workers: int = 0, **kwargs: Any
     ) -> None:
         """Initialize a LightningDataModule for USAVars based DataLoaders.
 
         Args:
-            root_dir: The root argument passed to the USAVars Dataset classes
-            labels: The labels argument passed to the USAVars Dataset classes
             batch_size: The batch size to use in all created DataLoaders
             num_workers: The number of workers to use in all created DataLoaders
         """
         super().__init__()
-        self.root_dir = root_dir
-        self.labels = labels
         self.batch_size = batch_size
         self.num_workers = num_workers
+        self.kwargs = kwargs
 
     def preprocess(self, sample: Dict[str, Any]) -> Dict[str, Any]:
         """Transform a single sample from the Dataset.
@@ -58,7 +51,7 @@ class USAVarsDataModule(pl.LightningModule):
 
         This method is only called once per run.
         """
-        USAVars(self.root_dir, labels=self.labels, checksum=False)
+        USAVars(**self.kwargs)
 
     def setup(self, stage: Optional[str] = None) -> None:
         """Initialize the main Dataset objects.
@@ -66,13 +59,13 @@ class USAVarsDataModule(pl.LightningModule):
         This method is called once per GPU per run.
         """
         self.train_dataset = USAVars(
-            self.root_dir, "train", self.labels, transforms=self.preprocess
+            split="train", transforms=self.preprocess, **self.kwargs
         )
         self.val_dataset = USAVars(
-            self.root_dir, "val", self.labels, transforms=self.preprocess
+            split="val", transforms=self.preprocess, **self.kwargs
         )
         self.test_dataset = USAVars(
-            self.root_dir, "test", self.labels, transforms=self.preprocess
+            split="test", transforms=self.preprocess, **self.kwargs
         )
 
     def train_dataloader(self) -> DataLoader[Any]:

--- a/torchgeo/datamodules/usavars.py
+++ b/torchgeo/datamodules/usavars.py
@@ -27,6 +27,8 @@ class USAVarsDataModule(pl.LightningModule):
         Args:
             batch_size: The batch size to use in all created DataLoaders
             num_workers: The number of workers to use in all created DataLoaders
+            **kwargs: Additional keyword arguments passed to
+                :class:`~torchgeo.datasets.USAVars`
         """
         super().__init__()
         self.batch_size = batch_size

--- a/torchgeo/datamodules/vaihingen.py
+++ b/torchgeo/datamodules/vaihingen.py
@@ -23,7 +23,6 @@ class Vaihingen2DDataModule(pl.LightningDataModule):
 
     def __init__(
         self,
-        root_dir: str,
         batch_size: int = 64,
         num_workers: int = 0,
         val_split_pct: float = 0.2,
@@ -32,16 +31,15 @@ class Vaihingen2DDataModule(pl.LightningDataModule):
         """Initialize a LightningDataModule for Vaihingen2D based DataLoaders.
 
         Args:
-            root_dir: The ``root`` argument to pass to the Vaihingen Dataset classes
             batch_size: The batch size to use in all created DataLoaders
             num_workers: The number of workers to use in all created DataLoaders
             val_split_pct: What percentage of the dataset to use as a validation set
         """
         super().__init__()
-        self.root_dir = root_dir
         self.batch_size = batch_size
         self.num_workers = num_workers
         self.val_split_pct = val_split_pct
+        self.kwargs = kwargs
 
     def preprocess(self, sample: Dict[str, Any]) -> Dict[str, Any]:
         """Transform a single sample from the Dataset.
@@ -66,7 +64,7 @@ class Vaihingen2DDataModule(pl.LightningDataModule):
         """
         transforms = Compose([self.preprocess])
 
-        dataset = Vaihingen2D(self.root_dir, "train", transforms=transforms)
+        dataset = Vaihingen2D(split="train", transforms=transforms, **self.kwargs)
 
         self.train_dataset: Dataset[Any]
         self.val_dataset: Dataset[Any]
@@ -79,7 +77,9 @@ class Vaihingen2DDataModule(pl.LightningDataModule):
             self.train_dataset = dataset
             self.val_dataset = dataset
 
-        self.test_dataset = Vaihingen2D(self.root_dir, "test", transforms=transforms)
+        self.test_dataset = Vaihingen2D(
+            split="test", transforms=transforms, **self.kwargs
+        )
 
     def train_dataloader(self) -> DataLoader[Any]:
         """Return a DataLoader for training.

--- a/torchgeo/datamodules/vaihingen.py
+++ b/torchgeo/datamodules/vaihingen.py
@@ -34,6 +34,8 @@ class Vaihingen2DDataModule(pl.LightningDataModule):
             batch_size: The batch size to use in all created DataLoaders
             num_workers: The number of workers to use in all created DataLoaders
             val_split_pct: What percentage of the dataset to use as a validation set
+            **kwargs: Additional keyword arguments passed to
+                :class:`~torchgeo.datasets.Vaihingen2D`
         """
         super().__init__()
         self.batch_size = batch_size

--- a/torchgeo/datamodules/xview.py
+++ b/torchgeo/datamodules/xview.py
@@ -34,6 +34,8 @@ class XView2DataModule(pl.LightningDataModule):
             batch_size: The batch size to use in all created DataLoaders
             num_workers: The number of workers to use in all created DataLoaders
             val_split_pct: What percentage of the dataset to use as a validation set
+            **kwargs: Additional keyword arguments passed to
+                :class:`~torchgeo.datasets.XView2`
         """
         super().__init__()
         self.batch_size = batch_size

--- a/torchgeo/datamodules/xview.py
+++ b/torchgeo/datamodules/xview.py
@@ -23,7 +23,6 @@ class XView2DataModule(pl.LightningDataModule):
 
     def __init__(
         self,
-        root_dir: str,
         batch_size: int = 64,
         num_workers: int = 0,
         val_split_pct: float = 0.2,
@@ -32,16 +31,15 @@ class XView2DataModule(pl.LightningDataModule):
         """Initialize a LightningDataModule for xView2 based DataLoaders.
 
         Args:
-            root_dir: The ``root`` arugment to pass to the xView2 Dataset classes
             batch_size: The batch size to use in all created DataLoaders
             num_workers: The number of workers to use in all created DataLoaders
             val_split_pct: What percentage of the dataset to use as a validation set
         """
         super().__init__()
-        self.root_dir = root_dir
         self.batch_size = batch_size
         self.num_workers = num_workers
         self.val_split_pct = val_split_pct
+        self.kwargs = kwargs
 
     def preprocess(self, sample: Dict[str, Any]) -> Dict[str, Any]:
         """Transform a single sample from the Dataset.
@@ -66,7 +64,7 @@ class XView2DataModule(pl.LightningDataModule):
         """
         transforms = Compose([self.preprocess])
 
-        dataset = XView2(self.root_dir, "train", transforms=transforms)
+        dataset = XView2(split="train", transforms=transforms, **self.kwargs)
 
         self.train_dataset: Dataset[Any]
         self.val_dataset: Dataset[Any]
@@ -79,7 +77,7 @@ class XView2DataModule(pl.LightningDataModule):
             self.train_dataset = dataset
             self.val_dataset = dataset
 
-        self.test_dataset = XView2(self.root_dir, "test", transforms=transforms)
+        self.test_dataset = XView2(split="test", transforms=transforms, **self.kwargs)
 
     def train_dataloader(self) -> DataLoader[Any]:
         """Return a DataLoader for training.


### PR DESCRIPTION
Closes #666

### Pros

* Consistency: every datamodule now has the same kwargs as its corresponding dataset
* New features: this means that every datamodule now supports automatic downloads if its corresponding dataset does too
* No unused kwargs: previously, a typo in an argument or non-existent argument would go unnoticed, now it will raise an error
* Reduced code duplication: -140 lines of code

### Cons

* Backwards incompatibility, `root_dir` has been renamed to `root` for consistency
* Can no longer pass `root_dir` as the first positional arg, must be a keyword arg

To elaborate, the following are no longer valid:
```python
BigEarthNetDataModule('data/bigearthnet')
BigEarthNetDataModule(root_dir='data/bigearthnet')
```
Instead, users will need to use:
```python
BigEarthNetDataModule(root='data/bigearthnet')
```