### PR TITLE
dependabot: fewer setuptools updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,12 @@ updates:
     directory: "/requirements"
     schedule:
       interval: "daily"
-    # Allow up to 2 open pull requests at a time
-    open-pull-requests-limit: 2
     ignore:
       # radiant-mlhub 0.5+ changed download behavior:
       # https://github.com/radiantearth/radiant-mlhub/pull/104
       - dependency-name: "radiant-mlhub"
+      # setuptools releases new versions almost daily
+      - dependency-name: "setuptools"
+        update-types: ["version-update:semver-patch"]
       # segmentation-models-pytorch requires older timm, can't update
       - dependency-name: "timm"


### PR DESCRIPTION
Setuptools has a new release almost daily:

* https://github.com/pypa/setuptools/releases
* https://pypi.org/project/setuptools/#history

We don't need to test every single patch release, let's focus on testing major and minor version updates only.