### PR TITLE
Random GeoSamplers: add default length

### DIFF
--- a/docs/api/samplers.rst
+++ b/docs/api/samplers.rst
@@ -76,6 +76,12 @@ Batch Geo Sampler
 
 .. autoclass:: BatchGeoSampler
 
+Utilities
+---------
+
+.. autofunction:: get_random_bounding_box
+.. autofunction:: tile_to_chips
+
 Units
 -----
 

--- a/tests/samplers/test_single.py
+++ b/tests/samplers/test_single.py
@@ -18,6 +18,7 @@ from torchgeo.samplers import (
     RandomGeoSampler,
     Units,
 )
+from torchgeo.samplers.utils import tile_to_chips
 
 
 class CustomGeoSampler(GeoSampler):
@@ -182,8 +183,7 @@ class TestGridGeoSampler:
             )
 
     def test_len(self, sampler: GridGeoSampler) -> None:
-        rows = math.ceil((100 - sampler.size[0]) / sampler.stride[0]) + 1
-        cols = math.ceil((100 - sampler.size[1]) / sampler.stride[1]) + 1
+        rows, cols = tile_to_chips(sampler.roi, sampler.size, sampler.stride)
         length = rows * cols * 2  # two items in dataset
         assert len(sampler) == length
 

--- a/tests/samplers/test_single.py
+++ b/tests/samplers/test_single.py
@@ -17,8 +17,8 @@ from torchgeo.samplers import (
     PreChippedGeoSampler,
     RandomGeoSampler,
     Units,
+    tile_to_chips,
 )
-from torchgeo.samplers import tile_to_chips
 
 
 class CustomGeoSampler(GeoSampler):

--- a/tests/samplers/test_single.py
+++ b/tests/samplers/test_single.py
@@ -18,7 +18,7 @@ from torchgeo.samplers import (
     RandomGeoSampler,
     Units,
 )
-from torchgeo.samplers.utils import tile_to_chips
+from torchgeo.samplers import tile_to_chips
 
 
 class CustomGeoSampler(GeoSampler):

--- a/tests/samplers/test_utils.py
+++ b/tests/samplers/test_utils.py
@@ -33,7 +33,7 @@ MAYBE_TUPLE = Union[float, Tuple[float, float]]
 )
 def test_tile_to_chips(
     size: MAYBE_TUPLE, stride: Optional[MAYBE_TUPLE], expected: MAYBE_TUPLE
-) -> Tuple[float, float]:
+) -> None:
     bounds = BoundingBox(0, 10, 20, 30, 40, 50)
     size = _to_tuple(size)
     if stride is not None:

--- a/tests/samplers/test_utils.py
+++ b/tests/samplers/test_utils.py
@@ -1,0 +1,44 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import math
+from typing import Optional, Tuple, Union
+
+import pytest
+
+from torchgeo.datasets import BoundingBox
+from torchgeo.samplers.utils import _to_tuple, tile_to_chips
+
+MAYBE_TUPLE = Union[float, Tuple[float, float]]
+
+
+@pytest.mark.parametrize(
+    "size,stride,expected",
+    [
+        # size == bounds
+        (10, 1, 1),
+        (10, None, 1),
+        # stride < size
+        (8, 1, 3),
+        (6, 2, 3),
+        (4, 3, 3),
+        ((8, 6), (1, 2), (3, 3)),
+        ((6, 4), (2, 3), (3, 3)),
+        # stride == size
+        (3, 3, 4),
+        (3, None, 4),
+        # stride > size
+        (2.5, 3, 4),
+    ],
+)
+def test_tile_to_chips(
+    size: MAYBE_TUPLE, stride: Optional[MAYBE_TUPLE], expected: MAYBE_TUPLE
+) -> Tuple[float, float]:
+    bounds = BoundingBox(0, 10, 20, 30, 40, 50)
+    size = _to_tuple(size)
+    if stride is not None:
+        stride = _to_tuple(stride)
+    expected = _to_tuple(expected)
+    rows, cols = tile_to_chips(bounds, size, stride)
+    assert math.isclose(rows, expected[0])
+    assert math.isclose(cols, expected[1])

--- a/tests/samplers/test_utils.py
+++ b/tests/samplers/test_utils.py
@@ -7,7 +7,8 @@ from typing import Optional, Tuple, Union
 import pytest
 
 from torchgeo.datasets import BoundingBox
-from torchgeo.samplers.utils import _to_tuple, tile_to_chips
+from torchgeo.samplers import tile_to_chips
+from torchgeo.samplers.utils import _to_tuple
 
 MAYBE_TUPLE = Union[float, Tuple[float, float]]
 

--- a/torchgeo/samplers/__init__.py
+++ b/torchgeo/samplers/__init__.py
@@ -6,6 +6,7 @@
 from .batch import BatchGeoSampler, RandomBatchGeoSampler
 from .constants import Units
 from .single import GeoSampler, GridGeoSampler, PreChippedGeoSampler, RandomGeoSampler
+from .utils import get_random_bounding_box, tile_to_chips
 
 __all__ = (
     # Samplers
@@ -17,6 +18,9 @@ __all__ = (
     # Base classes
     "GeoSampler",
     "BatchGeoSampler",
+    # Utilities
+    "get_random_bounding_box",
+    "tile_to_chips",
     # Constants
     "Units",
 )

--- a/torchgeo/samplers/batch.py
+++ b/torchgeo/samplers/batch.py
@@ -114,8 +114,11 @@ class RandomBatchGeoSampler(BatchGeoSampler):
                 bounds.maxx - bounds.minx >= self.size[1]
                 and bounds.maxy - bounds.miny >= self.size[0]
             ):
-                rows, cols = tile_to_chips(bounds, self.size)
-                self.length += rows * cols
+                if bounds.area > 0:
+                    rows, cols = tile_to_chips(bounds, self.size)
+                    self.length += rows * cols
+                else:
+                    self.length += 1
                 self.hits.append(hit)
                 areas.append(bounds.area)
         if length is not None:

--- a/torchgeo/samplers/batch.py
+++ b/torchgeo/samplers/batch.py
@@ -88,6 +88,8 @@ class RandomBatchGeoSampler(BatchGeoSampler):
             size: dimensions of each :term:`patch`
             batch_size: number of samples per batch
             length: number of samples per epoch
+                (defaults to the maximal number of non-overlapping :term:`chips <chip>`
+                of size ``size`` that can be sampled from the dataset)
             roi: region of interest to sample from (minx, maxx, miny, maxy, mint, maxt)
                 (defaults to the bounds of ``dataset.index``)
             units: defines if ``size`` is in pixel or CRS units

--- a/torchgeo/samplers/batch.py
+++ b/torchgeo/samplers/batch.py
@@ -62,7 +62,8 @@ class RandomBatchGeoSampler(BatchGeoSampler):
     """Samples batches of elements from a region of interest randomly.
 
     This is particularly useful during training when you want to maximize the size of
-    the dataset and return as many random :term:`chips <chip>` as possible.
+    the dataset and return as many random :term:`chips <chip>` as possible. Note that
+    randomly sampled chips may overlap.
     """
 
     def __init__(
@@ -88,8 +89,9 @@ class RandomBatchGeoSampler(BatchGeoSampler):
             size: dimensions of each :term:`patch`
             batch_size: number of samples per batch
             length: number of samples per epoch
-                (defaults to the maximal number of non-overlapping :term:`chips <chip>`
-                of size ``size`` that can be sampled from the dataset)
+                (defaults to approximately the maximal number of non-overlapping
+                :term:`chips <chip>` of size ``size`` that could be sampled from
+                the dataset)
             roi: region of interest to sample from (minx, maxx, miny, maxy, mint, maxt)
                 (defaults to the bounds of ``dataset.index``)
             units: defines if ``size`` is in pixel or CRS units

--- a/torchgeo/samplers/single.py
+++ b/torchgeo/samplers/single.py
@@ -114,8 +114,11 @@ class RandomGeoSampler(GeoSampler):
                 bounds.maxx - bounds.minx >= self.size[1]
                 and bounds.maxy - bounds.miny >= self.size[0]
             ):
-                rows, cols = tile_to_chips(bounds, self.size)
-                self.length += rows * cols
+                if bounds.area > 0:
+                    rows, cols = tile_to_chips(bounds, self.size)
+                    self.length += rows * cols
+                else:
+                    self.length += 1
                 self.hits.append(hit)
                 areas.append(bounds.area)
         if length is not None:

--- a/torchgeo/samplers/single.py
+++ b/torchgeo/samplers/single.py
@@ -89,6 +89,8 @@ class RandomGeoSampler(GeoSampler):
             dataset: dataset to index from
             size: dimensions of each :term:`patch`
             length: number of random samples to draw per epoch
+                (defaults to the maximal number of non-overlapping :term:`chips <chip>`
+                of size ``size`` that can be sampled from the dataset)
             roi: region of interest to sample from (minx, maxx, miny, maxy, mint, maxt)
                 (defaults to the bounds of ``dataset.index``)
             units: defines if ``size`` is in pixel or CRS units

--- a/torchgeo/samplers/single.py
+++ b/torchgeo/samplers/single.py
@@ -62,7 +62,8 @@ class RandomGeoSampler(GeoSampler):
     """Samples elements from a region of interest randomly.
 
     This is particularly useful during training when you want to maximize the size of
-    the dataset and return as many random :term:`chips <chip>` as possible.
+    the dataset and return as many random :term:`chips <chip>` as possible. Note that
+    randomly sampled chips may overlap.
 
     This sampler is not recommended for use with tile-based datasets. Use
     :class:`RandomBatchGeoSampler` instead.
@@ -89,8 +90,9 @@ class RandomGeoSampler(GeoSampler):
             dataset: dataset to index from
             size: dimensions of each :term:`patch`
             length: number of random samples to draw per epoch
-                (defaults to the maximal number of non-overlapping :term:`chips <chip>`
-                of size ``size`` that can be sampled from the dataset)
+                (defaults to approximately the maximal number of non-overlapping
+                :term:`chips <chip>` of size ``size`` that could be sampled from
+                the dataset)
             roi: region of interest to sample from (minx, maxx, miny, maxy, mint, maxt)
                 (defaults to the bounds of ``dataset.index``)
             units: defines if ``size`` is in pixel or CRS units

--- a/torchgeo/samplers/utils.py
+++ b/torchgeo/samplers/utils.py
@@ -101,9 +101,9 @@ def tile_to_chips(
     """
     if stride is None:
         stride = size
-    else:
-        assert stride[0] > 0
-        assert stride[1] > 0
+
+    assert stride[0] > 0
+    assert stride[1] > 0
 
     rows = math.ceil((bounds.maxy - bounds.miny - size[0]) / stride[0]) + 1
     cols = math.ceil((bounds.maxx - bounds.minx - size[1]) / stride[1]) + 1

--- a/torchgeo/samplers/utils.py
+++ b/torchgeo/samplers/utils.py
@@ -74,7 +74,7 @@ def tile_to_chips(
     size: Tuple[float, float],
     stride: Optional[Tuple[float, float]] = None,
 ) -> Tuple[int, int]:
-    r"""Compute number of :term:`chips <chip` that can be sampled from a :term:`tile`.
+    r"""Compute number of :term:`chips <chip>` that can be sampled from a :term:`tile`.
 
     Let :math:`i` be the size of the input tile. Let :math:`k` be the requested size of
     the output patch. Let :math:`s` be the requested stride. Let :math:`o` be the number

--- a/torchgeo/samplers/utils.py
+++ b/torchgeo/samplers/utils.py
@@ -3,7 +3,8 @@
 
 """Common sampler utilities."""
 
-from typing import Tuple, Union
+import math
+from typing import Optional, Tuple, Union
 
 import torch
 
@@ -66,3 +67,45 @@ def get_random_bounding_box(
 
     query = BoundingBox(minx, maxx, miny, maxy, mint, maxt)
     return query
+
+
+def tile_to_chips(
+    bounds: BoundingBox,
+    size: Tuple[float, float],
+    stride: Optional[Tuple[float, float]] = None,
+) -> Tuple[int, int]:
+    r"""Compute number of :term:`chips <chip` that can be sampled from a :term:`tile`.
+
+    Let :math:`i` be the size of the input tile. Let :math:`k` be the requested size of
+    the output patch. Let :math:`s` be the requested stride. Let :math:`o` be the number
+    of output chips sampled from each tile. :math:`o` can then be computed as:
+
+    .. math::
+
+       o = \left\lceil \frac{i - k}{s} \right\rceil + 1
+
+    This is almost identical to relationship 5 in
+    https://doi.org/10.48550/arXiv.1603.07285. However, we use ceiling instead of floor
+    because we want to include the final remaining chip in each row/column when bounds
+    is not an integer multiple of stride.
+
+    Args:
+        bounds: bounding box of tile
+        size: size of output patch
+        stride: stride with which to sample (defaults to ``size``)
+
+    Returns:
+        the number of rows/columns that can be sampled
+
+    .. versionadded:: 0.4
+    """
+    if stride is None:
+        stride = size
+    else:
+        assert stride[0] > 0
+        assert stride[1] > 0
+
+    rows = math.ceil((bounds.maxy - bounds.miny - size[0]) / stride[0]) + 1
+    cols = math.ceil((bounds.maxx - bounds.minx - size[1]) / stride[1]) + 1
+
+    return rows, cols


### PR DESCRIPTION
Closes #380 @tritolol 

Uses the same logic we use to compute `GridGeoSampler` length, updated by @remtav in #630

Has to wait until the 0.4.0 release since we add a new public function. We could make it private, but I wanted to render the math in the docs 😃 