### PR TITLE
IDTReeS - Clip boxes outside of image bounds

### DIFF
--- a/torchgeo/datasets/idtrees.py
+++ b/torchgeo/datasets/idtrees.py
@@ -289,10 +289,10 @@ class IDTReeS(NonGeoDataset):
         with rasterio.open(path) as f:
             for geom in geoms:
                 coords = [f.index(x, y) for x, y in geom]
-                xmin = min(coord[0] for coord in coords)
-                xmax = max(coord[0] for coord in coords)
-                ymin = min(coord[1] for coord in coords)
-                ymax = max(coord[1] for coord in coords)
+                xmin = min(coord[1] for coord in coords)
+                xmax = max(coord[1] for coord in coords)
+                ymin = min(coord[0] for coord in coords)
+                ymax = max(coord[0] for coord in coords)
                 boxes.append([xmin, ymin, xmax, ymax])
 
         tensor = torch.tensor(boxes)

--- a/torchgeo/datasets/idtrees.py
+++ b/torchgeo/datasets/idtrees.py
@@ -284,11 +284,15 @@ class IDTReeS(NonGeoDataset):
         geometries = cast(Dict[int, Dict[str, Any]], self.geometries)
 
         # Find object ids and geometries
+        # The train set geometry->image mapping is contained
+        # in the train/Field/itc_rsFile.csv file
         if self.split == "train":
             indices = self.labels["rsFile"] == base_path
             ids = self.labels[indices]["id"].tolist()
             geoms = [geometries[i]["geometry"]["coordinates"][0][:4] for i in ids]
-        # Test set - Task 2 has no mapping csv. Mapping is inside of geometry
+        # The test set has no mapping csv. The mapping is inside of the geometry
+        # properties i.e. geom["property"]["plotID"] contains the RGB image filename
+        # Return all geometries with the matching RGB image filename of the sample
         else:
             ids = [
                 k
@@ -397,9 +401,10 @@ class IDTReeS(NonGeoDataset):
         for path in filepaths:
             with fiona.open(path) as src:
                 for feature in src:
+                    # The train set has a unique id for each geometry in the properties
                     if self.split == "train":
                         features[feature["properties"]["id"]] = feature
-                    # Test set task 2 has no id
+                    # The test set has no unique id so create a dummy id
                     else:
                         id = len(features) + 1
                         features[id] = feature

--- a/torchgeo/datasets/idtrees.py
+++ b/torchgeo/datasets/idtrees.py
@@ -396,12 +396,13 @@ class IDTReeS(NonGeoDataset):
         features: Dict[int, Dict[str, Any]] = {}
         for path in filepaths:
             with fiona.open(path) as src:
-                for i, feature in enumerate(src):
+                for feature in src:
                     if self.split == "train":
                         features[feature["properties"]["id"]] = feature
                     # Test set task 2 has no id
                     else:
-                        features[i] = feature
+                        id = len(features) + 1
+                        features[id] = feature
         return features
 
     def _filter_boxes(

--- a/torchgeo/datasets/idtrees.py
+++ b/torchgeo/datasets/idtrees.py
@@ -289,10 +289,10 @@ class IDTReeS(NonGeoDataset):
         with rasterio.open(path) as f:
             for geom in geoms:
                 coords = [f.index(x, y) for x, y in geom]
-                xmin = min(coord[1] for coord in coords)
-                xmax = max(coord[1] for coord in coords)
-                ymin = min(coord[0] for coord in coords)
-                ymax = max(coord[0] for coord in coords)
+                xmin = min(coord[0] for coord in coords)
+                xmax = max(coord[0] for coord in coords)
+                ymin = min(coord[1] for coord in coords)
+                ymax = max(coord[1] for coord in coords)
                 boxes.append([xmin, ymin, xmax, ymax])
 
         tensor = torch.tensor(boxes)

--- a/torchgeo/datasets/idtrees.py
+++ b/torchgeo/datasets/idtrees.py
@@ -397,6 +397,7 @@ class IDTReeS(NonGeoDataset):
         """
         filepaths = glob.glob(os.path.join(directory, "ITC", "*.shp"))
 
+        i = 0
         features: Dict[int, Dict[str, Any]] = {}
         for path in filepaths:
             with fiona.open(path) as src:
@@ -406,8 +407,8 @@ class IDTReeS(NonGeoDataset):
                         features[feature["properties"]["id"]] = feature
                     # The test set has no unique id so create a dummy id
                     else:
-                        id = len(features) + 1
-                        features[id] = feature
+                        features[i] = feature
+                        i += 1
         return features
 
     @overload

--- a/torchgeo/datasets/idtrees.py
+++ b/torchgeo/datasets/idtrees.py
@@ -422,8 +422,6 @@ class IDTReeS(NonGeoDataset):
 
         Returns:
             a tuple of filtered boxes and labels
-
-        .. versionadded:: 0.3.1
         """
         boxes = clip_boxes_to_image(boxes=boxes, size=image_size)
         indices = remove_small_boxes(boxes=boxes, min_size=min_size)

--- a/torchgeo/datasets/idtrees.py
+++ b/torchgeo/datasets/idtrees.py
@@ -217,13 +217,15 @@ class IDTReeS(NonGeoDataset):
                     image_size=(h, w), boxes=sample["boxes"]
                 )
         else:
-            sample["boxes"] = self._load_boxes(path)
-            sample["label"] = self._load_target(path)
+            boxes = self._load_boxes(path)
+            labels = self._load_target(path)
 
             h, w = sample["image"].shape[1:]
-            sample["boxes"], sample["label"] = self._filter_boxes(
-                image_size=(h, w), boxes=sample["boxes"], labels=sample["label"]
+            boxes, labels = self._filter_boxes(  # type: ignore[assignment]
+                image_size=(h, w), boxes=boxes, labels=labels
             )
+            sample["boxes"] = boxes
+            sample["label"] = labels
 
         # Filter boxes
         if self.transforms is not None:

--- a/torchgeo/datasets/idtrees.py
+++ b/torchgeo/datasets/idtrees.py
@@ -296,6 +296,7 @@ class IDTReeS(NonGeoDataset):
                 boxes.append([xmin, ymin, xmax, ymax])
 
         tensor = torch.tensor(boxes)
+        tensor = torch.clamp(tensor, min=0, max=self.image_size[0])
         return tensor
 
     def _load_target(self, path: str) -> Tensor:

--- a/torchgeo/datasets/idtrees.py
+++ b/torchgeo/datasets/idtrees.py
@@ -18,7 +18,7 @@ from torchvision.ops import clip_boxes_to_image, remove_small_boxes
 from torchvision.utils import draw_bounding_boxes
 
 from .geo import NonGeoDataset
-from .utils import download_url, extract_archive, filter_boxes
+from .utils import download_url, extract_archive
 
 
 class IDTReeS(NonGeoDataset):
@@ -409,7 +409,7 @@ class IDTReeS(NonGeoDataset):
         min_size: int = 1,
         labels: Optional[Tensor] = None,
     ) -> Tuple[Tensor, Optional[Tensor]]:
-        """Clip boxes to image size and filter boxes with any side less than ``min_size``.
+        """Clip boxes to image size and filter boxes with sides less than ``min_size``.
 
         Args:
             image_size: tuple of (height, width) of image

--- a/torchgeo/datasets/idtrees.py
+++ b/torchgeo/datasets/idtrees.py
@@ -212,7 +212,7 @@ class IDTReeS(NonGeoDataset):
         if self.split == "test":
             if self.task == "task2":
                 sample["boxes"] = self._load_boxes(path)
-                w, h = sample["image"].shape[1:]
+                h, w = sample["image"].shape[1:]
                 sample["boxes"], _ = self._filter_boxes(
                     image_size=(h, w), boxes=sample["boxes"]
                 )

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -32,7 +32,6 @@ import rasterio
 import torch
 from torch import Tensor
 from torchvision.datasets.utils import check_integrity, download_url
-from torchvision.ops import clip_boxes_to_image, remove_small_boxes
 from torchvision.utils import draw_segmentation_masks
 
 __all__ = (
@@ -52,7 +51,6 @@ __all__ = (
     "draw_semantic_segmentation_masks",
     "rgb_to_mask",
     "percentile_normalization",
-    "filter_boxes",
 )
 
 
@@ -709,32 +707,3 @@ def percentile_normalization(
         (img - lower_percentile) / (upper_percentile - lower_percentile), 0, 1
     )
     return img_normalized
-
-
-def filter_boxes(
-    image_size: Tuple[int, int],
-    boxes: Tensor,
-    min_size: int = 1,
-    labels: Optional[Tensor] = None,
-) -> Tuple[Tensor, Optional[Tensor]]:
-    """Clip boxes to image size and filter boxes with any side less than ``min_size``.
-
-    Args:
-        image_size: tuple of (height, width) of image
-        min_size: filter boxes that have any side less than min_size
-        boxes: [N, 4] shape tensor of xyxy bounding box coordinates
-        labels: (Optional) [N,] shape tensor of bounding box labels
-
-    Returns:
-        a tuple of filtered boxes and labels
-
-    .. versionadded:: 0.3.1
-    """
-    boxes = clip_boxes_to_image(boxes=boxes, size=image_size)
-    indices = remove_small_boxes(boxes=boxes, min_size=min_size)
-
-    boxes = boxes[indices]
-    if labels is not None:
-        labels = labels[indices]
-
-    return boxes, labels

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -32,6 +32,7 @@ import rasterio
 import torch
 from torch import Tensor
 from torchvision.datasets.utils import check_integrity, download_url
+from torchvision.ops import clip_boxes_to_image, remove_small_boxes
 from torchvision.utils import draw_segmentation_masks
 
 __all__ = (
@@ -51,6 +52,7 @@ __all__ = (
     "draw_semantic_segmentation_masks",
     "rgb_to_mask",
     "percentile_normalization",
+    "filter_boxes",
 )
 
 
@@ -707,3 +709,32 @@ def percentile_normalization(
         (img - lower_percentile) / (upper_percentile - lower_percentile), 0, 1
     )
     return img_normalized
+
+
+def filter_boxes(
+    image_size: Tuple[int, int],
+    boxes: Tensor,
+    min_size: int = 1,
+    labels: Optional[Tensor] = None,
+) -> Tuple[Tensor, Optional[Tensor]]:
+    """Clip boxes to image size and filter boxes with any side less than ``min_size``.
+
+    Args:
+        image_size: tuple of (height, width) of image
+        min_size: filter boxes that have any side less than min_size
+        boxes: [N, 4] shape tensor of xyxy bounding box coordinates
+        labels: (Optional) [N,] shape tensor of bounding box labels
+
+    Returns:
+        a tuple of filtered boxes and labels
+
+    .. versionadded:: 0.3.1
+    """
+    boxes = clip_boxes_to_image(boxes=boxes, size=image_size)
+    indices = remove_small_boxes(boxes=boxes, min_size=min_size)
+
+    boxes = boxes[indices]
+    if labels is not None:
+        labels = labels[indices]
+
+    return boxes, labels


### PR DESCRIPTION
This PR
- clips the bounding box coordinates to the image size (essentially clips boxes that go outside of the image bounds) and filters any boxes that have zero area after clipping.
- fixed bug where id of some geometries were being overriden resulting in some images have no objects.


Fixes part of #684

For `MLBS_5` the boxes before

```python
tensor([[107, -57, 165, -10],
        [157, -48, 190, -10],
        [127,  24, 198,  92],
        [149, 122, 199, 174],
        [ 30,  70,  70, 109],
        [ -6, -80,  48, -10],
        [ 47, 121, 114, 197],
        [119,  84, 144, 129],
        [108,  74, 129, 101],
        [ 36,  21,  83,  73],
        [137,  73, 187, 128],
        [ 38, -63,  81, -10],
        [ 19,  93,  62, 152],
        [ 71,  81, 117, 133]])
```

and after filtering

```python
tensor([[127,  24, 198,  92],
        [149, 122, 199, 174],
        [ 30,  70,  70, 109],
        [ 47, 121, 114, 197],
        [119,  84, 144, 129],
        [108,  74, 129, 101],
        [ 36,  21,  83,  73],
        [137,  73, 187, 128],
        [ 19,  93,  62, 152],
        [ 71,  81, 117, 133]])
```

Visual result:
<img width="267" alt="image" src="https://user-images.githubusercontent.com/22203655/188673377-246f3d6e-8d18-4760-9c75-8b52ef111b0e.png">

