### PR TITLE
Tutorials: clean up file names, execution codes, and output

### DIFF
--- a/docs/tutorials/benchmarking.ipynb
+++ b/docs/tutorials/benchmarking.ipynb
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,7 +58,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {
     "gather": {
      "logged": 1629238744113
@@ -90,7 +90,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -118,7 +118,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -143,7 +143,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {
     "gather": {
      "logged": 1629238744228
@@ -183,7 +183,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {
     "gather": {
      "logged": 1629248963725
@@ -236,7 +236,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {
     "gather": {
      "logged": 1629239313388
@@ -289,7 +289,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {
     "gather": {
      "logged": 1629249843438

--- a/docs/tutorials/custom_raster_dataset.ipynb
+++ b/docs/tutorials/custom_raster_dataset.ipynb
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -43,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -75,7 +75,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -106,7 +106,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -120,7 +120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {

--- a/docs/tutorials/getting_started.ipynb
+++ b/docs/tutorials/getting_started.ipynb
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "019092f0",
    "metadata": {},
    "outputs": [],
@@ -60,7 +60,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 2,
    "id": "3d92b0f1",
    "metadata": {
     "id": "entire-albania"
@@ -91,7 +91,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "4a39af46",
    "metadata": {
     "colab": {
@@ -263,7 +263,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 4,
    "id": "689bb2b0",
    "metadata": {
     "colab": {
@@ -299,7 +299,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 5,
    "id": "daefbc4d",
    "metadata": {
     "id": "WXxy8F8l2-aC"
@@ -323,7 +323,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 6,
    "id": "b8a0d99c",
    "metadata": {
     "id": "RLczuU293itT"
@@ -347,7 +347,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 7,
    "id": "96faa142",
    "metadata": {
     "id": "jfx-9ZmU8ZTc"
@@ -371,7 +371,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 8,
    "id": "8a2b44f8",
    "metadata": {
     "id": "7sGmNvBy8uIg"

--- a/docs/tutorials/indices.ipynb
+++ b/docs/tutorials/indices.ipynb
@@ -54,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "id": "wOwsb8KT_uXR",
     "outputId": "db729cf8-74eb-41ea-a605-bd0913b3e0e2",
@@ -62,90 +62,7 @@
      "base_uri": "https://localhost:8080/"
     }
    },
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Requirement already satisfied: torchgeo in /usr/local/lib/python3.7/dist-packages (0.2.1)\n",
-      "Requirement already satisfied: fiona>=1.5 in /usr/local/lib/python3.7/dist-packages (from torchgeo) (1.8.21)\n",
-      "Requirement already satisfied: numpy in /usr/local/lib/python3.7/dist-packages (from torchgeo) (1.21.5)\n",
-      "Requirement already satisfied: pytorch-lightning>=1.3 in /usr/local/lib/python3.7/dist-packages (from torchgeo) (1.6.0)\n",
-      "Requirement already satisfied: torch>=1.7 in /usr/local/lib/python3.7/dist-packages (from torchgeo) (1.10.0+cu111)\n",
-      "Requirement already satisfied: torchvision>=0.10 in /usr/local/lib/python3.7/dist-packages (from torchgeo) (0.11.1+cu111)\n",
-      "Requirement already satisfied: segmentation-models-pytorch>=0.2 in /usr/local/lib/python3.7/dist-packages (from torchgeo) (0.2.1)\n",
-      "Requirement already satisfied: scikit-learn>=0.18 in /usr/local/lib/python3.7/dist-packages (from torchgeo) (1.0.2)\n",
-      "Requirement already satisfied: pyproj>=2.2 in /usr/local/lib/python3.7/dist-packages (from torchgeo) (3.2.1)\n",
-      "Requirement already satisfied: rasterio>=1.0.16 in /usr/local/lib/python3.7/dist-packages (from torchgeo) (1.2.10)\n",
-      "Requirement already satisfied: omegaconf>=2.1 in /usr/local/lib/python3.7/dist-packages (from torchgeo) (2.1.1)\n",
-      "Requirement already satisfied: rtree>=0.9.4 in /usr/local/lib/python3.7/dist-packages (from torchgeo) (0.9.7)\n",
-      "Requirement already satisfied: timm>=0.2.1 in /usr/local/lib/python3.7/dist-packages (from torchgeo) (0.4.12)\n",
-      "Requirement already satisfied: torchmetrics>=0.7 in /usr/local/lib/python3.7/dist-packages (from torchgeo) (0.7.3)\n",
-      "Requirement already satisfied: einops in /usr/local/lib/python3.7/dist-packages (from torchgeo) (0.4.1)\n",
-      "Requirement already satisfied: matplotlib in /usr/local/lib/python3.7/dist-packages (from torchgeo) (3.2.2)\n",
-      "Requirement already satisfied: shapely>=1.3 in /usr/local/lib/python3.7/dist-packages (from torchgeo) (1.8.1.post1)\n",
-      "Requirement already satisfied: pillow>=2.9 in /usr/local/lib/python3.7/dist-packages (from torchgeo) (7.1.2)\n",
-      "Requirement already satisfied: kornia>=0.5.11 in /usr/local/lib/python3.7/dist-packages (from torchgeo) (0.6.4)\n",
-      "Requirement already satisfied: certifi in /usr/local/lib/python3.7/dist-packages (from fiona>=1.5->torchgeo) (2021.10.8)\n",
-      "Requirement already satisfied: cligj>=0.5 in /usr/local/lib/python3.7/dist-packages (from fiona>=1.5->torchgeo) (0.7.2)\n",
-      "Requirement already satisfied: attrs>=17 in /usr/local/lib/python3.7/dist-packages (from fiona>=1.5->torchgeo) (21.4.0)\n",
-      "Requirement already satisfied: munch in /usr/local/lib/python3.7/dist-packages (from fiona>=1.5->torchgeo) (2.5.0)\n",
-      "Requirement already satisfied: setuptools in /usr/local/lib/python3.7/dist-packages (from fiona>=1.5->torchgeo) (57.4.0)\n",
-      "Requirement already satisfied: click-plugins>=1.0 in /usr/local/lib/python3.7/dist-packages (from fiona>=1.5->torchgeo) (1.1.1)\n",
-      "Requirement already satisfied: six>=1.7 in /usr/local/lib/python3.7/dist-packages (from fiona>=1.5->torchgeo) (1.15.0)\n",
-      "Requirement already satisfied: click>=4.0 in /usr/local/lib/python3.7/dist-packages (from fiona>=1.5->torchgeo) (7.1.2)\n",
-      "Requirement already satisfied: packaging in /usr/local/lib/python3.7/dist-packages (from kornia>=0.5.11->torchgeo) (21.3)\n",
-      "Requirement already satisfied: antlr4-python3-runtime==4.8 in /usr/local/lib/python3.7/dist-packages (from omegaconf>=2.1->torchgeo) (4.8)\n",
-      "Requirement already satisfied: PyYAML>=5.1.0 in /usr/local/lib/python3.7/dist-packages (from omegaconf>=2.1->torchgeo) (6.0)\n",
-      "Requirement already satisfied: tensorboard>=2.2.0 in /usr/local/lib/python3.7/dist-packages (from pytorch-lightning>=1.3->torchgeo) (2.8.0)\n",
-      "Requirement already satisfied: pyDeprecate<0.4.0,>=0.3.1 in /usr/local/lib/python3.7/dist-packages (from pytorch-lightning>=1.3->torchgeo) (0.3.2)\n",
-      "Requirement already satisfied: typing-extensions>=4.0.0 in /usr/local/lib/python3.7/dist-packages (from pytorch-lightning>=1.3->torchgeo) (4.1.1)\n",
-      "Requirement already satisfied: fsspec[http]!=2021.06.0,>=2021.05.0 in /usr/local/lib/python3.7/dist-packages (from pytorch-lightning>=1.3->torchgeo) (2022.3.0)\n",
-      "Requirement already satisfied: tqdm>=4.41.0 in /usr/local/lib/python3.7/dist-packages (from pytorch-lightning>=1.3->torchgeo) (4.63.0)\n",
-      "Requirement already satisfied: requests in /usr/local/lib/python3.7/dist-packages (from fsspec[http]!=2021.06.0,>=2021.05.0->pytorch-lightning>=1.3->torchgeo) (2.23.0)\n",
-      "Requirement already satisfied: aiohttp in /usr/local/lib/python3.7/dist-packages (from fsspec[http]!=2021.06.0,>=2021.05.0->pytorch-lightning>=1.3->torchgeo) (3.8.1)\n",
-      "Requirement already satisfied: pyparsing!=3.0.5,>=2.0.2 in /usr/local/lib/python3.7/dist-packages (from packaging->kornia>=0.5.11->torchgeo) (3.0.7)\n",
-      "Requirement already satisfied: affine in /usr/local/lib/python3.7/dist-packages (from rasterio>=1.0.16->torchgeo) (2.3.1)\n",
-      "Requirement already satisfied: snuggs>=1.4.1 in /usr/local/lib/python3.7/dist-packages (from rasterio>=1.0.16->torchgeo) (1.4.7)\n",
-      "Requirement already satisfied: scipy>=1.1.0 in /usr/local/lib/python3.7/dist-packages (from scikit-learn>=0.18->torchgeo) (1.4.1)\n",
-      "Requirement already satisfied: joblib>=0.11 in /usr/local/lib/python3.7/dist-packages (from scikit-learn>=0.18->torchgeo) (1.1.0)\n",
-      "Requirement already satisfied: threadpoolctl>=2.0.0 in /usr/local/lib/python3.7/dist-packages (from scikit-learn>=0.18->torchgeo) (3.1.0)\n",
-      "Requirement already satisfied: pretrainedmodels==0.7.4 in /usr/local/lib/python3.7/dist-packages (from segmentation-models-pytorch>=0.2->torchgeo) (0.7.4)\n",
-      "Requirement already satisfied: efficientnet-pytorch==0.6.3 in /usr/local/lib/python3.7/dist-packages (from segmentation-models-pytorch>=0.2->torchgeo) (0.6.3)\n",
-      "Requirement already satisfied: werkzeug>=0.11.15 in /usr/local/lib/python3.7/dist-packages (from tensorboard>=2.2.0->pytorch-lightning>=1.3->torchgeo) (1.0.1)\n",
-      "Requirement already satisfied: protobuf>=3.6.0 in /usr/local/lib/python3.7/dist-packages (from tensorboard>=2.2.0->pytorch-lightning>=1.3->torchgeo) (3.17.3)\n",
-      "Requirement already satisfied: google-auth-oauthlib<0.5,>=0.4.1 in /usr/local/lib/python3.7/dist-packages (from tensorboard>=2.2.0->pytorch-lightning>=1.3->torchgeo) (0.4.6)\n",
-      "Requirement already satisfied: grpcio>=1.24.3 in /usr/local/lib/python3.7/dist-packages (from tensorboard>=2.2.0->pytorch-lightning>=1.3->torchgeo) (1.44.0)\n",
-      "Requirement already satisfied: markdown>=2.6.8 in /usr/local/lib/python3.7/dist-packages (from tensorboard>=2.2.0->pytorch-lightning>=1.3->torchgeo) (3.3.6)\n",
-      "Requirement already satisfied: tensorboard-plugin-wit>=1.6.0 in /usr/local/lib/python3.7/dist-packages (from tensorboard>=2.2.0->pytorch-lightning>=1.3->torchgeo) (1.8.1)\n",
-      "Requirement already satisfied: absl-py>=0.4 in /usr/local/lib/python3.7/dist-packages (from tensorboard>=2.2.0->pytorch-lightning>=1.3->torchgeo) (1.0.0)\n",
-      "Requirement already satisfied: tensorboard-data-server<0.7.0,>=0.6.0 in /usr/local/lib/python3.7/dist-packages (from tensorboard>=2.2.0->pytorch-lightning>=1.3->torchgeo) (0.6.1)\n",
-      "Requirement already satisfied: wheel>=0.26 in /usr/local/lib/python3.7/dist-packages (from tensorboard>=2.2.0->pytorch-lightning>=1.3->torchgeo) (0.37.1)\n",
-      "Requirement already satisfied: google-auth<3,>=1.6.3 in /usr/local/lib/python3.7/dist-packages (from tensorboard>=2.2.0->pytorch-lightning>=1.3->torchgeo) (1.35.0)\n",
-      "Requirement already satisfied: rsa<5,>=3.1.4 in /usr/local/lib/python3.7/dist-packages (from google-auth<3,>=1.6.3->tensorboard>=2.2.0->pytorch-lightning>=1.3->torchgeo) (4.8)\n",
-      "Requirement already satisfied: pyasn1-modules>=0.2.1 in /usr/local/lib/python3.7/dist-packages (from google-auth<3,>=1.6.3->tensorboard>=2.2.0->pytorch-lightning>=1.3->torchgeo) (0.2.8)\n",
-      "Requirement already satisfied: cachetools<5.0,>=2.0.0 in /usr/local/lib/python3.7/dist-packages (from google-auth<3,>=1.6.3->tensorboard>=2.2.0->pytorch-lightning>=1.3->torchgeo) (4.2.4)\n",
-      "Requirement already satisfied: requests-oauthlib>=0.7.0 in /usr/local/lib/python3.7/dist-packages (from google-auth-oauthlib<0.5,>=0.4.1->tensorboard>=2.2.0->pytorch-lightning>=1.3->torchgeo) (1.3.1)\n",
-      "Requirement already satisfied: importlib-metadata>=4.4 in /usr/local/lib/python3.7/dist-packages (from markdown>=2.6.8->tensorboard>=2.2.0->pytorch-lightning>=1.3->torchgeo) (4.11.3)\n",
-      "Requirement already satisfied: zipp>=0.5 in /usr/local/lib/python3.7/dist-packages (from importlib-metadata>=4.4->markdown>=2.6.8->tensorboard>=2.2.0->pytorch-lightning>=1.3->torchgeo) (3.7.0)\n",
-      "Requirement already satisfied: pyasn1<0.5.0,>=0.4.6 in /usr/local/lib/python3.7/dist-packages (from pyasn1-modules>=0.2.1->google-auth<3,>=1.6.3->tensorboard>=2.2.0->pytorch-lightning>=1.3->torchgeo) (0.4.8)\n",
-      "Requirement already satisfied: chardet<4,>=3.0.2 in /usr/local/lib/python3.7/dist-packages (from requests->fsspec[http]!=2021.06.0,>=2021.05.0->pytorch-lightning>=1.3->torchgeo) (3.0.4)\n",
-      "Requirement already satisfied: idna<3,>=2.5 in /usr/local/lib/python3.7/dist-packages (from requests->fsspec[http]!=2021.06.0,>=2021.05.0->pytorch-lightning>=1.3->torchgeo) (2.10)\n",
-      "Requirement already satisfied: urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 in /usr/local/lib/python3.7/dist-packages (from requests->fsspec[http]!=2021.06.0,>=2021.05.0->pytorch-lightning>=1.3->torchgeo) (1.24.3)\n",
-      "Requirement already satisfied: oauthlib>=3.0.0 in /usr/local/lib/python3.7/dist-packages (from requests-oauthlib>=0.7.0->google-auth-oauthlib<0.5,>=0.4.1->tensorboard>=2.2.0->pytorch-lightning>=1.3->torchgeo) (3.2.0)\n",
-      "Requirement already satisfied: asynctest==0.13.0 in /usr/local/lib/python3.7/dist-packages (from aiohttp->fsspec[http]!=2021.06.0,>=2021.05.0->pytorch-lightning>=1.3->torchgeo) (0.13.0)\n",
-      "Requirement already satisfied: aiosignal>=1.1.2 in /usr/local/lib/python3.7/dist-packages (from aiohttp->fsspec[http]!=2021.06.0,>=2021.05.0->pytorch-lightning>=1.3->torchgeo) (1.2.0)\n",
-      "Requirement already satisfied: yarl<2.0,>=1.0 in /usr/local/lib/python3.7/dist-packages (from aiohttp->fsspec[http]!=2021.06.0,>=2021.05.0->pytorch-lightning>=1.3->torchgeo) (1.7.2)\n",
-      "Requirement already satisfied: frozenlist>=1.1.1 in /usr/local/lib/python3.7/dist-packages (from aiohttp->fsspec[http]!=2021.06.0,>=2021.05.0->pytorch-lightning>=1.3->torchgeo) (1.3.0)\n",
-      "Requirement already satisfied: charset-normalizer<3.0,>=2.0 in /usr/local/lib/python3.7/dist-packages (from aiohttp->fsspec[http]!=2021.06.0,>=2021.05.0->pytorch-lightning>=1.3->torchgeo) (2.0.12)\n",
-      "Requirement already satisfied: async-timeout<5.0,>=4.0.0a3 in /usr/local/lib/python3.7/dist-packages (from aiohttp->fsspec[http]!=2021.06.0,>=2021.05.0->pytorch-lightning>=1.3->torchgeo) (4.0.2)\n",
-      "Requirement already satisfied: multidict<7.0,>=4.5 in /usr/local/lib/python3.7/dist-packages (from aiohttp->fsspec[http]!=2021.06.0,>=2021.05.0->pytorch-lightning>=1.3->torchgeo) (6.0.2)\n",
-      "Requirement already satisfied: cycler>=0.10 in /usr/local/lib/python3.7/dist-packages (from matplotlib->torchgeo) (0.11.0)\n",
-      "Requirement already satisfied: kiwisolver>=1.0.1 in /usr/local/lib/python3.7/dist-packages (from matplotlib->torchgeo) (1.4.0)\n",
-      "Requirement already satisfied: python-dateutil>=2.1 in /usr/local/lib/python3.7/dist-packages (from matplotlib->torchgeo) (2.8.2)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%pip install torchgeo"
    ]
@@ -161,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
     "id": "cvPMr76K_9uk"
    },
@@ -209,7 +126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {
     "id": "_seqhOz-Cw9c"
    },
@@ -301,7 +218,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {
     "id": "ppyTj0-oFY6d"
    },
@@ -339,7 +256,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {
     "id": "Yq5iUrwJQCQe",
     "outputId": "ac4d7337-b368-4700-f269-13c3b8cd313a",
@@ -361,7 +278,7 @@
       ]
      },
      "metadata": {},
-     "execution_count": 5
+     "execution_count": 6
     }
    ],
    "source": [
@@ -388,7 +305,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -446,7 +363,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {
     "id": "iqNZFeMi-A-9"
    },
@@ -478,7 +395,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {
     "id": "tymUtqGAQCQl",
     "outputId": "a1f7233a-b83e-4964-c1f3-4a85d9bc01ce",
@@ -536,7 +453,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {
     "id": "e9Aob95YQCQn",
     "outputId": "c4c211ca-5649-492b-8c8a-4b8d79e723d8",
@@ -603,7 +520,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {
     "id": "H8CPnPD9QCQp",
     "outputId": "c9826f37-e8ff-465d-cc69-d766c61e4d65",
@@ -670,7 +587,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {
     "id": "F607CaDoQCQq",
     "outputId": "2082f16c-42e6-4c89-9d65-927cc040bdc0",
@@ -718,7 +635,7 @@
  ],
  "metadata": {
   "colab": {
-   "name": "Copy of indices.ipynb",
+   "name": "indices.ipynb",
    "provenance": []
   },
   "kernelspec": {

--- a/docs/tutorials/trainers.ipynb
+++ b/docs/tutorials/trainers.ipynb
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "3f0d31a8",
    "metadata": {},
    "outputs": [],
@@ -84,7 +84,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "e8bc0d83",
    "metadata": {},
    "outputs": [],
@@ -113,7 +113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "4b9c9591",
    "metadata": {},
    "outputs": [],
@@ -124,7 +124,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "0f2a04c7",
    "metadata": {},
    "outputs": [],
@@ -148,7 +148,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "ba5c5442",
    "metadata": {
     "colab": {
@@ -181,7 +181,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "ffe26e5c",
    "metadata": {
     "id": "RLczuU293itT"
@@ -209,7 +209,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "225a6d36",
    "metadata": {},
    "outputs": [
@@ -244,7 +244,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "00e08790",
    "metadata": {},
    "outputs": [
@@ -463,7 +463,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 10,
    "id": "c38033e0",
    "metadata": {},
    "outputs": [],
@@ -494,7 +494,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 11,
    "id": "1ba23407",
    "metadata": {},
    "outputs": [
@@ -574,7 +574,7 @@
        "[{'test_loss': 227.86709594726562, 'test_rmse': 13.240558624267578}]"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -587,7 +587,7 @@
  "metadata": {
   "colab": {
    "collapsed_sections": [],
-   "name": "getting_started.ipynb",
+   "name": "trainers.ipynb",
    "provenance": []
   },
   "execution": {

--- a/docs/tutorials/transforms.ipynb
+++ b/docs/tutorials/transforms.ipynb
@@ -51,7 +51,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "id": "wOwsb8KT_uXR"
    },
@@ -687,7 +687,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 16,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -711,7 +711,7 @@
        "<PIL.Image.Image image mode=RGB size=256x256 at 0x7F009BE81F10>"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -733,7 +733,7 @@
  "metadata": {
   "accelerator": "GPU",
   "colab": {
-   "name": "indices.ipynb",
+   "name": "transforms.ipynb",
    "provenance": []
   },
   "interpreter": {


### PR DESCRIPTION
This PR fixes a few things to make our tutorials more consistent:

- [x] Correct tab names when opening files in Colab
- [x] No output from `pip install` cell
- [x] All cells have a sequential numeric execution count

The last one should convert cells that look like:
```
[
]:
```
to the much more visually appealing:
```
[1]:
```