### PR TITLE
iNaturalist: fix ref in datasets table

### DIFF
--- a/torchgeo/datasets/inaturalist.py
+++ b/torchgeo/datasets/inaturalist.py
@@ -17,7 +17,7 @@ from .utils import BoundingBox, disambiguate_timestamp
 class INaturalist(GeoDataset):
     """Dataset for iNaturalist.
 
-    `iNaturalist <https://www.inaturalist.org/>`_ is a joint initiative of the
+    `iNaturalist <https://www.inaturalist.org/>`__ is a joint initiative of the
     California Academy of Sciences and the National Geographic Society. It allows
     citizen scientists to upload observations of organisms that can be downloaded by
     scientists and researchers.


### PR DESCRIPTION
Link in https://torchgeo.readthedocs.io/en/stable/api/datasets.html#geospatial-datasets table was pointing to https://www.inaturalist.org/ instead of https://torchgeo.readthedocs.io/en/stable/api/datasets.html#inaturalist