### PR TITLE
Datasets: consistent capitalization of band names

### DIFF
--- a/tests/datasets/test_benin_cashews.py
+++ b/tests/datasets/test_benin_cashews.py
@@ -41,7 +41,7 @@ class TestBeninSmallHolderCashews:
         monkeypatch.setattr(BeninSmallHolderCashews, "dates", ("2019_11_05",))
         root = str(tmp_path)
         transforms = nn.Identity()
-        bands = BeninSmallHolderCashews.ALL_BANDS
+        bands = BeninSmallHolderCashews.all_bands
 
         return BeninSmallHolderCashews(
             root,

--- a/tests/datasets/test_seco.py
+++ b/tests/datasets/test_seco.py
@@ -23,7 +23,7 @@ def download_url(url: str, root: str, *args: str, **kwargs: str) -> None:
 
 
 class TestSeasonalContrastS2:
-    @pytest.fixture(params=zip(["100k", "1m"], [["B1"], SeasonalContrastS2.ALL_BANDS]))
+    @pytest.fixture(params=zip(["100k", "1m"], [["B1"], SeasonalContrastS2.all_bands]))
     def dataset(
         self, monkeypatch: MonkeyPatch, tmp_path: Path, request: SubRequest
     ) -> SeasonalContrastS2:
@@ -87,7 +87,7 @@ class TestSeasonalContrastS2:
             SeasonalContrastS2(str(tmp_path))
 
     def test_plot(self, dataset: SeasonalContrastS2) -> None:
-        if not all(band in dataset.bands for band in dataset.RGB_BANDS):
+        if not all(band in dataset.bands for band in dataset.rgb_bands):
             with pytest.raises(ValueError, match="Dataset doesn't contain"):
                 x = dataset[0].copy()
                 dataset.plot(x, suptitle="Test")

--- a/torchgeo/datasets/benin_cashews.py
+++ b/torchgeo/datasets/benin_cashews.py
@@ -137,7 +137,7 @@ class BeninSmallHolderCashews(NonGeoDataset):
         "2020_10_30",
     )
 
-    ALL_BANDS = (
+    all_bands = (
         "B01",
         "B02",
         "B03",
@@ -152,7 +152,7 @@ class BeninSmallHolderCashews(NonGeoDataset):
         "B12",
         "CLD",
     )
-    RGB_BANDS = ("B04", "B03", "B02")
+    rgb_bands = ("B04", "B03", "B02")
 
     classes = [
         "No data",
@@ -173,7 +173,7 @@ class BeninSmallHolderCashews(NonGeoDataset):
         root: str = "data",
         chip_size: int = 256,
         stride: int = 128,
-        bands: Tuple[str, ...] = ALL_BANDS,
+        bands: Tuple[str, ...] = all_bands,
         transforms: Optional[Callable[[Dict[str, Tensor]], Dict[str, Tensor]]] = None,
         download: bool = False,
         api_key: Optional[str] = None,
@@ -278,12 +278,12 @@ class BeninSmallHolderCashews(NonGeoDataset):
         """
         assert isinstance(bands, tuple), "The list of bands must be a tuple"
         for band in bands:
-            if band not in self.ALL_BANDS:
+            if band not in self.all_bands:
                 raise ValueError(f"'{band}' is an invalid band name.")
 
     @lru_cache(maxsize=128)
     def _load_all_imagery(
-        self, bands: Tuple[str, ...] = ALL_BANDS
+        self, bands: Tuple[str, ...] = all_bands
     ) -> Tuple[Tensor, rasterio.Affine, CRS]:
         """Load all the imagery (across time) for the dataset.
 
@@ -447,7 +447,7 @@ class BeninSmallHolderCashews(NonGeoDataset):
         .. versionadded:: 0.2
         """
         rgb_indices = []
-        for band in self.RGB_BANDS:
+        for band in self.rgb_bands:
             if band in self.bands:
                 rgb_indices.append(self.bands.index(band))
             else:

--- a/torchgeo/datasets/cloud_cover.py
+++ b/torchgeo/datasets/cloud_cover.py
@@ -91,7 +91,7 @@ class CloudCoverDetection(NonGeoDataset):
 
     band_names = ["B02", "B03", "B04", "B08"]
 
-    RGB_BANDS = ["B04", "B03", "B02"]
+    rgb_bands = ["B04", "B03", "B02"]
 
     def __init__(
         self,
@@ -364,7 +364,7 @@ class CloudCoverDetection(NonGeoDataset):
             ValueError: if dataset does not contain an RGB band
         """
         rgb_indices = []
-        for band in self.RGB_BANDS:
+        for band in self.rgb_bands:
             if band in self.bands:
                 rgb_indices.append(self.bands.index(band))
             else:

--- a/torchgeo/datasets/cv4a_kenya_crop_type.py
+++ b/torchgeo/datasets/cv4a_kenya_crop_type.py
@@ -103,7 +103,7 @@ class CV4AKenyaCropType(NonGeoDataset):
         "CLD",
     )
 
-    RGB_BANDS = ["B04", "B03", "B02"]
+    rgb_bands = ["B04", "B03", "B02"]
 
     # Same for all tiles
     tile_height = 3035
@@ -422,7 +422,7 @@ class CV4AKenyaCropType(NonGeoDataset):
         .. versionadded:: 0.2
         """
         rgb_indices = []
-        for band in self.RGB_BANDS:
+        for band in self.rgb_bands:
             if band in self.bands:
                 rgb_indices.append(self.bands.index(band))
             else:

--- a/torchgeo/datasets/eurosat.py
+++ b/torchgeo/datasets/eurosat.py
@@ -100,9 +100,9 @@ class EuroSAT(NonGeoClassificationDataset):
         "B12",
     )
 
-    RGB_BANDS = ("B04", "B03", "B02")
+    rgb_bands = ("B04", "B03", "B02")
 
-    BAND_SETS = {"all": all_band_names, "rgb": RGB_BANDS}
+    BAND_SETS = {"all": all_band_names, "rgb": rgb_bands}
 
     def __init__(
         self,
@@ -277,7 +277,7 @@ class EuroSAT(NonGeoClassificationDataset):
         .. versionadded:: 0.2
         """
         rgb_indices = []
-        for band in self.RGB_BANDS:
+        for band in self.rgb_bands:
             if band in self.bands:
                 rgb_indices.append(self.bands.index(band))
             else:

--- a/torchgeo/datasets/seco.py
+++ b/torchgeo/datasets/seco.py
@@ -35,7 +35,7 @@ class SeasonalContrastS2(NonGeoDataset):
     * https://arxiv.org/pdf/2103.16607.pdf
     """
 
-    ALL_BANDS = [
+    all_bands = [
         "B1",
         "B2",
         "B3",
@@ -49,7 +49,7 @@ class SeasonalContrastS2(NonGeoDataset):
         "B11",
         "B12",
     ]
-    RGB_BANDS = ["B4", "B3", "B2"]
+    rgb_bands = ["B4", "B3", "B2"]
 
     urls = {
         # 7.3 GB
@@ -68,7 +68,7 @@ class SeasonalContrastS2(NonGeoDataset):
         self,
         root: str = "data",
         version: str = "100k",
-        bands: List[str] = RGB_BANDS,
+        bands: List[str] = rgb_bands,
         transforms: Optional[Callable[[Dict[str, Tensor]], Dict[str, Tensor]]] = None,
         download: bool = False,
         checksum: bool = False,
@@ -90,7 +90,7 @@ class SeasonalContrastS2(NonGeoDataset):
         """
         assert version in ["100k", "1m"]
         for band in bands:
-            assert band in self.ALL_BANDS
+            assert band in self.all_bands
 
         self.root = root
         self.bands = bands
@@ -259,7 +259,7 @@ class SeasonalContrastS2(NonGeoDataset):
             raise ValueError("This dataset doesn't support plotting predictions")
 
         rgb_indices = []
-        for band in self.RGB_BANDS:
+        for band in self.rgb_bands:
             if band in self.bands:
                 rgb_indices.append(self.bands.index(band))
             else:

--- a/torchgeo/datasets/sen12ms.py
+++ b/torchgeo/datasets/sen12ms.py
@@ -118,7 +118,7 @@ class SEN12MS(NonGeoDataset):
         "B12",
     )
 
-    RGB_BANDS = ["B04", "B03", "B02"]
+    rgb_bands = ["B04", "B03", "B02"]
 
     filenames = [
         "ROIs1158_spring_lc.tar.gz",
@@ -330,7 +330,7 @@ class SEN12MS(NonGeoDataset):
         .. versionadded:: 0.2
         """
         rgb_indices = []
-        for band in self.RGB_BANDS:
+        for band in self.rgb_bands:
             if band in self.bands:
                 rgb_indices.append(self.bands.index(band))
             else:

--- a/torchgeo/datasets/sentinel.py
+++ b/torchgeo/datasets/sentinel.py
@@ -66,7 +66,7 @@ class Sentinel2(Sentinel):
         "B11",
         "B12",
     ]
-    RGB_BANDS = ["B04", "B03", "B02"]
+    rgb_bands = ["B04", "B03", "B02"]
 
     separate_files = True
 
@@ -125,7 +125,7 @@ class Sentinel2(Sentinel):
            show subplot titles and/or use a custom suptitle.
         """
         rgb_indices = []
-        for band in self.RGB_BANDS:
+        for band in self.rgb_bands:
             if band in self.bands:
                 rgb_indices.append(self.bands.index(band))
             else:

--- a/torchgeo/datasets/so2sat.py
+++ b/torchgeo/datasets/so2sat.py
@@ -129,7 +129,7 @@ class So2Sat(NonGeoDataset):
     )
     all_band_names = all_s1_band_names + all_s2_band_names
 
-    RGB_BANDS = ["S2_B04", "S2_B03", "S2_B02"]
+    rgb_bands = ["S2_B04", "S2_B03", "S2_B02"]
 
     BAND_SETS = {
         "all": all_band_names,
@@ -299,7 +299,7 @@ class So2Sat(NonGeoDataset):
         .. versionadded:: 0.2
         """
         rgb_indices = []
-        for band in self.RGB_BANDS:
+        for band in self.rgb_bands:
             if band in self.s2_band_names:
                 idx = self.s2_band_names.index(band) + len(self.s1_band_names)
                 rgb_indices.append(idx)

--- a/torchgeo/datasets/zuericrop.py
+++ b/torchgeo/datasets/zuericrop.py
@@ -58,7 +58,7 @@ class ZueriCrop(NonGeoDataset):
     filenames = ["ZueriCrop.hdf5", "labels.csv"]
 
     band_names = ("NIR", "B03", "B02", "B04", "B05", "B06", "B07", "B11", "B12")
-    RGB_BANDS = ["B04", "B03", "B02"]
+    rgb_bands = ["B04", "B03", "B02"]
 
     def __init__(
         self,
@@ -281,7 +281,7 @@ class ZueriCrop(NonGeoDataset):
         .. versionadded:: 0.2
         """
         rgb_indices = []
-        for band in self.RGB_BANDS:
+        for band in self.rgb_bands:
             if band in self.bands:
                 rgb_indices.append(self.bands.index(band))
             else:


### PR DESCRIPTION
There seems to be a 50/50 mix of `RGB_BANDS`/`ALL_BANDS` and `rgb_bands`/`all_bands` in our datasets. The `GeoDataset` base class uses lowercase, so this PR changes all other datasets to match. From what I can tell, [PEP-8](https://peps.python.org/pep-0008/) doesn't seem to distinguish between class attributes and instance attributes, so I'm not sure if these are considered variables or global variables.

@ashnair1 not sure if this affects #687