### PR TITLE
UnionDataset: fix __getitem__ bug

### DIFF
--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -1005,7 +1005,7 @@ class UnionDataset(GeoDataset):
         # Not all datasets are guaranteed to have a valid query
         samples = []
         for ds in self.datasets:
-            if ds.index.intersection(tuple(query)):
+            if list(ds.index.intersection(tuple(query))):
                 samples.append(ds[query])
 
         return self.collate_fn(samples)


### PR DESCRIPTION
### What was the bug?

TL;DR: `UnionDataset` doesn't work and has never worked.

In `UnionDataset.__getitem__`, we were using the following check:
```python
if ds.index.intersection(tuple(query)):
    samples.append(ds[query])
```
The idea was that we shouldn't be trying to query from a dataset unless the dataset contains files that overlap with the query. 

However, this doesn't work. `rtree.index.Index.intersection` returns a generator, which always evaluates to True. This resulted in bugs like #769.

### What was the fix?

The fix is simple: just convert the generator to a list. The list will evaluate to False if it's empty, and the dataset won't be sampled from because it has no overlap.

### Why didn't the tests catch this?

Our existing tests were basically useless. Our `CustomGeoDatset.__getitem__` just returned the query, so even if the query didn't overlap at all with the dataset, it didn't raise an error. And our `UnionDataset` tests only tested the union of overlapping datasets, they never tested disparate geospatial locations.

I changed the tests to actually check the rtree index for the query, and to test the union of two disjoint datasets. The tests fail without the fix, and pass with the fix. Hopefully the new and improved tests will be more useful.