### PR TITLE
Remove "labels" folder from verify for xView2

### DIFF
--- a/torchgeo/datasets/xview.py
+++ b/torchgeo/datasets/xview.py
@@ -188,7 +188,7 @@ class XView2(NonGeoDataset):
         # Check if the files already exist
         exists = []
         for split_info in self.metadata.values():
-            for directory in ["images", "labels", "targets"]:
+            for directory in ["images", "targets"]:
                 exists.append(
                     os.path.exists(
                         os.path.join(self.root, split_info["directory"], directory)


### PR DESCRIPTION
The `labels` folder exists for the `tier3` imagery that was released after the `tier1` imagery for xView2. It should really be called `targets` but we messed up. When you're merging `tier1` with `tier3`, simply copy all the files from `tier3/labels` to `tier1/targets`.