### PR TITLE
ClassificationTask predict step

### DIFF
--- a/tests/trainers/test_classification.py
+++ b/tests/trainers/test_classification.py
@@ -61,6 +61,7 @@ class TestClassificationTask:
         trainer = Trainer(fast_dev_run=True, log_every_n_steps=1, max_epochs=1)
         trainer.fit(model=model, datamodule=datamodule)
         trainer.test(model=model, datamodule=datamodule)
+        trainer.predict(model=model, dataloaders=datamodule.val_dataloader())
 
     def test_no_logger(self) -> None:
         conf = OmegaConf.load(os.path.join("tests", "conf", "ucmerced.yaml"))

--- a/torchgeo/trainers/classification.py
+++ b/torchgeo/trainers/classification.py
@@ -249,7 +249,7 @@ class ClassificationTask(pl.LightningModule):
         """
         batch = args[0]
         x = batch["image"]
-        y_hat = self(x).softmax(dim=-1)
+        y_hat: Tensor = self(x).softmax(dim=-1)
         return y_hat
 
     def configure_optimizers(self) -> Dict[str, Any]:

--- a/torchgeo/trainers/classification.py
+++ b/torchgeo/trainers/classification.py
@@ -238,6 +238,20 @@ class ClassificationTask(pl.LightningModule):
         self.log_dict(self.test_metrics.compute())
         self.test_metrics.reset()
 
+    def predict_step(self, *args: Any, **kwargs: Any) -> Tensor:
+        """Compute and return the predictions.
+
+        Args:
+            batch: the output of your DataLoader
+
+        Returns:
+            predicted softmax probabilities
+        """
+        batch = args[0]
+        x = batch["image"]
+        y_hat = self(x).softmax(dim=-1)
+        return y_hat
+
     def configure_optimizers(self) -> Dict[str, Any]:
         """Initialize the optimizer and learning rate scheduler.
 


### PR DESCRIPTION
Running `trainer.predict()` with the `ClassificationTask` fails because the default pytorch_lightning `predict_step` expects a batch tuple and not a dict. This PR overrides `predict_step` to work with our classification datasets.

E.g.

```python
preds = trainer.predict(model=task, dataloaders=datamodule.test_dataloader())

# Or if your datamodule has a `predict_dataloader` method defined
preds = trainer.predict(model=task, datamodule=datamodule)
```