### PR TITLE
MultiLabelClassificationTask predict step

### DIFF
--- a/tests/trainers/test_classification.py
+++ b/tests/trainers/test_classification.py
@@ -153,6 +153,7 @@ class TestMultiLabelClassificationTask:
         trainer = Trainer(fast_dev_run=True, log_every_n_steps=1, max_epochs=1)
         trainer.fit(model=model, datamodule=datamodule)
         trainer.test(model=model, datamodule=datamodule)
+        trainer.predict(model=model, dataloaders=datamodule.val_dataloader())
 
     def test_no_logger(self) -> None:
         conf = OmegaConf.load(os.path.join("tests", "conf", "bigearthnet_s1.yaml"))

--- a/torchgeo/trainers/classification.py
+++ b/torchgeo/trainers/classification.py
@@ -388,3 +388,15 @@ class MultiLabelClassificationTask(ClassificationTask):
         # by default, the test and validation steps only log per *epoch*
         self.log("test_loss", loss, on_step=False, on_epoch=True)
         self.test_metrics(y_hat_hard, y)
+
+    def predict_step(self, *args: Any, **kwargs: Any) -> Tensor:
+        """Compute and return the predictions.
+        Args:
+            batch: the output of your DataLoader
+        Returns:
+            predicted sigmoid probabilities
+        """
+        batch = args[0]
+        x = batch["image"]
+        y_hat = torch.sigmoid(self(x))
+        return y_hat

--- a/torchgeo/trainers/classification.py
+++ b/torchgeo/trainers/classification.py
@@ -391,6 +391,7 @@ class MultiLabelClassificationTask(ClassificationTask):
 
     def predict_step(self, *args: Any, **kwargs: Any) -> Tensor:
         """Compute and return the predictions.
+
         Args:
             batch: the output of your DataLoader
         Returns:


### PR DESCRIPTION
This PR is similar to #790 and adds a `predict_step` method to `MultiLabelClassificationTask` so that users can utilize PyTorch Lightning's `trainer.predict()` function which will automatically loop and predict over a PyTorch DataLoader e.g.:

```python
preds = trainer.predict(model=task, dataloaders=datamodule.test_dataloader())

# Or if your datamodule has a `predict_dataloader` method defined
preds = trainer.predict(model=task, datamodule=datamodule)