### PR TITLE
Datasets: add default 'root' argument

### DIFF
--- a/tests/datasets/test_spacenet.py
+++ b/tests/datasets/test_spacenet.py
@@ -40,7 +40,7 @@ def fetch_collection(collection_id: str, **kwargs: str) -> Collection:
 
 
 class TestSpaceNet1:
-    @pytest.fixture(params=["rgb", "8band", ""])
+    @pytest.fixture(params=["rgb", "8band"])
     def dataset(
         self, request: SubRequest, monkeypatch: MonkeyPatch, tmp_path: Path
     ) -> SpaceNet1:

--- a/tests/datasets/test_spacenet.py
+++ b/tests/datasets/test_spacenet.py
@@ -40,7 +40,7 @@ def fetch_collection(collection_id: str, **kwargs: str) -> Collection:
 
 
 class TestSpaceNet1:
-    @pytest.fixture(params=["rgb", "8band"])
+    @pytest.fixture(params=["rgb", "8band", ""])
     def dataset(
         self, request: SubRequest, monkeypatch: MonkeyPatch, tmp_path: Path
     ) -> SpaceNet1:

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -306,7 +306,7 @@ class RasterDataset(GeoDataset):
 
     def __init__(
         self,
-        root: str,
+        root: str = "data",
         crs: Optional[CRS] = None,
         res: Optional[float] = None,
         bands: Optional[Sequence[str]] = None,
@@ -712,7 +712,7 @@ class NonGeoClassificationDataset(NonGeoDataset, ImageFolder):  # type: ignore[m
 
     def __init__(
         self,
-        root: str,
+        root: str = "data",
         transforms: Optional[Callable[[Dict[str, Tensor]], Dict[str, Tensor]]] = None,
         loader: Optional[Callable[[str], Any]] = pil_loader,
         is_valid_file: Optional[Callable[[str], bool]] = None,

--- a/torchgeo/datasets/inria.py
+++ b/torchgeo/datasets/inria.py
@@ -53,7 +53,7 @@ class InriaAerialImageLabeling(NonGeoDataset):
 
     def __init__(
         self,
-        root: str,
+        root: str = "data",
         split: str = "train",
         transforms: Optional[Callable[[Dict[str, Any]], Dict[str, Any]]] = None,
         checksum: bool = False,

--- a/torchgeo/datasets/spacenet.py
+++ b/torchgeo/datasets/spacenet.py
@@ -69,8 +69,8 @@ class SpaceNet(NonGeoDataset, abc.ABC):
 
     def __init__(
         self,
-        root: str = "data",
-        image: str = "",
+        root: str,
+        image: str,
         collections: List[str] = [],
         transforms: Optional[Callable[[Dict[str, Any]], Dict[str, Any]]] = None,
         download: bool = False,
@@ -93,10 +93,7 @@ class SpaceNet(NonGeoDataset, abc.ABC):
             RuntimeError: if ``download=False`` but dataset is missing
         """
         self.root = root
-        if image:
-            self.image = image
-        else:
-            self.image = list(self.imagery.keys())[0]
+        self.image = image  # For testing
 
         if collections:
             for collection in collections:

--- a/torchgeo/datasets/spacenet.py
+++ b/torchgeo/datasets/spacenet.py
@@ -69,7 +69,7 @@ class SpaceNet(NonGeoDataset, abc.ABC):
 
     def __init__(
         self,
-        root: str,
+        root: str = "data",
         image: str,
         collections: List[str] = [],
         transforms: Optional[Callable[[Dict[str, Any]], Dict[str, Any]]] = None,
@@ -401,7 +401,7 @@ class SpaceNet1(SpaceNet):
 
     def __init__(
         self,
-        root: str,
+        root: str = "data",
         image: str = "rgb",
         transforms: Optional[Callable[[Dict[str, Any]], Dict[str, Any]]] = None,
         download: bool = False,
@@ -523,7 +523,7 @@ class SpaceNet2(SpaceNet):
 
     def __init__(
         self,
-        root: str,
+        root: str = "data",
         image: str = "PS-RGB",
         collections: List[str] = [],
         transforms: Optional[Callable[[Dict[str, Any]], Dict[str, Any]]] = None,
@@ -650,7 +650,7 @@ class SpaceNet3(SpaceNet):
 
     def __init__(
         self,
-        root: str,
+        root: str = "data",
         image: str = "PS-RGB",
         speed_mask: Optional[bool] = False,
         collections: List[str] = [],
@@ -907,7 +907,7 @@ class SpaceNet4(SpaceNet):
 
     def __init__(
         self,
-        root: str,
+        root: str = "data",
         image: str = "PS-RGBNIR",
         angles: List[str] = [],
         transforms: Optional[Callable[[Dict[str, Any]], Dict[str, Any]]] = None,
@@ -1082,7 +1082,7 @@ class SpaceNet5(SpaceNet3):
 
     def __init__(
         self,
-        root: str,
+        root: str = "data",
         image: str = "PS-RGB",
         speed_mask: Optional[bool] = False,
         collections: List[str] = [],
@@ -1179,7 +1179,7 @@ class SpaceNet7(SpaceNet):
 
     def __init__(
         self,
-        root: str,
+        root: str = "data",
         split: str = "train",
         transforms: Optional[Callable[[Dict[str, Any]], Dict[str, Any]]] = None,
         download: bool = False,

--- a/torchgeo/datasets/spacenet.py
+++ b/torchgeo/datasets/spacenet.py
@@ -70,7 +70,7 @@ class SpaceNet(NonGeoDataset, abc.ABC):
     def __init__(
         self,
         root: str = "data",
-        image: str,
+        image: str = "",
         collections: List[str] = [],
         transforms: Optional[Callable[[Dict[str, Any]], Dict[str, Any]]] = None,
         download: bool = False,
@@ -93,7 +93,10 @@ class SpaceNet(NonGeoDataset, abc.ABC):
             RuntimeError: if ``download=False`` but dataset is missing
         """
         self.root = root
-        self.image = image  # For testing
+        if image:
+            self.image = image
+        else:
+            self.image = list(self.imagery.keys())[0]
 
         if collections:
             for collection in collections:


### PR DESCRIPTION
Apparently not all of our datasets have a default `root` argument.