### PR TITLE
Labeler: new label for root scripts

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -17,6 +17,8 @@ transforms:
 # Other
 documentation:
 - docs/**
+scripts:
+- *.py
 testing:
 - tests/**
 - .github/workflows/**


### PR DESCRIPTION
If a PR modifies one of the root `*.py` scripts, we should add a label that notes this.