### PR TITLE
Dependabot: manage GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,9 @@
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
   - package-ecosystem: "pip"
     directory: "/requirements"
     schedule:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,7 +6,7 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v3
+    - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         sync-labels: true

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,7 +6,7 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v4
+    - uses: actions/labeler@v4.0.1
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         sync-labels: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Clone repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v3.0.2
     - name: Set up python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v4.2.0
       with:
         python-version: '3.10'
     - name: Install pip dependencies
@@ -28,9 +28,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Clone repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v3.0.2
     - name: Set up python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v4.2.0
       with:
         python-version: '3.10'
     - name: Install pip dependencies
@@ -44,9 +44,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Clone repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v3.0.2
     - name: Set up python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v4.2.0
       with:
         python-version: '3.10'
     - name: Install pip dependencies

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Clone repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.10'
     - name: Install pip dependencies
@@ -28,9 +28,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Clone repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.10'
     - name: Install pip dependencies
@@ -44,9 +44,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Clone repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.10'
     - name: Install pip dependencies

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Clone repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v3.0.2
     - name: Set up python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v4.2.0
       with:
         python-version: '3.10'
     - name: Install pip dependencies
@@ -30,9 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Clone repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v3.0.2
     - name: Set up python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v4.2.0
       with:
         python-version: '3.10'
     - name: Install pip dependencies
@@ -46,9 +46,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Clone repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v3.0.2
     - name: Set up python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v4.2.0
       with:
         python-version: '3.10'
     - name: Install pip dependencies
@@ -62,9 +62,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Clone repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v3.0.2
     - name: Set up python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v4.2.0
       with:
         python-version: '3.10'
     - name: Install pip dependencies
@@ -78,9 +78,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Clone repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v3.0.2
     - name: Set up python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v4.2.0
       with:
         python-version: '3.10'
     - name: Install pip dependencies

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Clone repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.10'
     - name: Install pip dependencies
@@ -30,9 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Clone repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.10'
     - name: Install pip dependencies
@@ -46,9 +46,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Clone repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.10'
     - name: Install pip dependencies
@@ -62,9 +62,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Clone repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.10'
     - name: Install pip dependencies
@@ -78,9 +78,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Clone repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.10'
     - name: Install pip dependencies

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Clone repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v3.0.2
     - name: Set up python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v4.2.0
       with:
         python-version: '3.10'
     - name: Install pip dependencies
@@ -39,9 +39,9 @@ jobs:
           python-version: '3.7'
     steps:
     - name: Clone repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v3.0.2
     - name: Set up python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v4.2.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install apt dependencies (Linux)
@@ -76,7 +76,7 @@ jobs:
         pytest --cov=torchgeo --cov-report=xml
       if: ${{ runner.os == 'Windows' }}
     - name: Report coverage
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v3.1.1
   minimum:
     name: minimum
     runs-on: ubuntu-latest
@@ -84,9 +84,9 @@ jobs:
       MPLBACKEND: Agg
     steps:
     - name: Clone repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v3.0.2
     - name: Set up python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v4.2.0
       with:
         python-version: '3.7'
     - name: Install apt dependencies (Linux)
@@ -99,4 +99,4 @@ jobs:
     - name: Run pytest checks
       run: pytest --cov=torchgeo --cov-report=xml
     - name: Report coverage
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v3.1.1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Clone repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.10'
     - name: Install pip dependencies
@@ -39,9 +39,9 @@ jobs:
           python-version: '3.7'
     steps:
     - name: Clone repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install apt dependencies (Linux)
@@ -76,7 +76,7 @@ jobs:
         pytest --cov=torchgeo --cov-report=xml
       if: ${{ runner.os == 'Windows' }}
     - name: Report coverage
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
   minimum:
     name: minimum
     runs-on: ubuntu-latest
@@ -84,9 +84,9 @@ jobs:
       MPLBACKEND: Agg
     steps:
     - name: Clone repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.7'
     - name: Install apt dependencies (Linux)
@@ -99,4 +99,4 @@ jobs:
     - name: Run pytest checks
       run: pytest --cov=torchgeo --cov-report=xml
     - name: Report coverage
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3


### PR DESCRIPTION
We've been seeing a lot of codecov issues. Apparently the bash uploader is deprecated and there's a new version that works completely differently. Hoping this fixes our issues.

Also updated other actions. We could drop the version requirement, but this helps with stability. If only dependabot could handle these files for us too.