### PR TITLE
add predict_step to RegressionTask and tests

### DIFF
--- a/tests/trainers/test_regression.py
+++ b/tests/trainers/test_regression.py
@@ -38,6 +38,7 @@ class TestRegressionTask:
         trainer = Trainer(fast_dev_run=True, log_every_n_steps=1, max_epochs=1)
         trainer.fit(model=model, datamodule=datamodule)
         trainer.test(model=model, datamodule=datamodule)
+        trainer.predict(model=model, dataloaders=datamodule.val_dataloader())
 
     def test_no_logger(self) -> None:
         conf = OmegaConf.load(os.path.join("tests", "conf", "cyclone.yaml"))

--- a/torchgeo/trainers/regression.py
+++ b/torchgeo/trainers/regression.py
@@ -176,6 +176,19 @@ class RegressionTask(pl.LightningModule):
         self.log_dict(self.test_metrics.compute())
         self.test_metrics.reset()
 
+    def predict_step(self, *args: Any, **kwargs: Any) -> Tensor:
+        """Compute and return the predictions.
+
+        Args:
+            batch: the output of your DataLoader
+        Returns:
+            predicted values
+        """
+        batch = args[0]
+        x = batch["image"]
+        y_hat: Tensor = self(x)
+        return y_hat
+
     def configure_optimizers(self) -> Dict[str, Any]:
         """Initialize the optimizer and learning rate scheduler.
 


### PR DESCRIPTION
Related to #813. This PR adds a `predict_step` method to `RegressionTask` so that users can utilize PyTorch Lightning's `trainer.predict()` function which will automatically loop and predict over a PyTorch DataLoader e.g.:

```python
preds = trainer.predict(model=task, dataloaders=datamodule.test_dataloader())

# Or if your datamodule has a `predict_dataloader` method defined
preds = trainer.predict(model=task, datamodule=datamodule)