### PR TITLE
add predict_step to BYOLTask

### DIFF
--- a/tests/trainers/test_byol.py
+++ b/tests/trainers/test_byol.py
@@ -61,6 +61,7 @@ class TestBYOLTask:
         trainer = Trainer(fast_dev_run=True, log_every_n_steps=1, max_epochs=1)
         trainer.fit(model=model, datamodule=datamodule)
         trainer.test(model=model, datamodule=datamodule)
+        trainer.predict(model=model, dataloaders=datamodule.val_dataloader())
 
     def test_invalid_encoder(self) -> None:
         kwargs = {

--- a/torchgeo/trainers/byol.py
+++ b/torchgeo/trainers/byol.py
@@ -458,10 +458,11 @@ class BYOLTask(pl.LightningModule):
 
         Args:
             batch: the output of your DataLoader
+
         Returns:
             image embeddings
         """
         batch = args[0]
         x = batch["image"]
-        _ = self(x)
+        self(x)
         return self.model.encoder._embedding

--- a/torchgeo/trainers/byol.py
+++ b/torchgeo/trainers/byol.py
@@ -211,6 +211,9 @@ class EncoderWrapper(Module):
         # time this is called
         self._encoded = self.projector(output)
 
+        # Store the image embeddings
+        self._embedding = output
+
     def _register_hook(self) -> None:
         """Register a hook for layer that we will extract features from."""
         layer = list(self.model.children())[self.layer]
@@ -449,3 +452,16 @@ class BYOLTask(pl.LightningModule):
 
     def test_step(self, *args: Any, **kwargs: Any) -> Any:
         """No-op, does nothing."""
+
+    def predict_step(self, *args: Any, **kwargs: Any) -> Tensor:
+        """Compute and return the output embeddings of the image encoder.
+
+        Args:
+            batch: the output of your DataLoader
+        Returns:
+            image embeddings
+        """
+        batch = args[0]
+        x = batch["image"]
+        _ = self(x)
+        return self.model.encoder._embedding


### PR DESCRIPTION
Related to #813. This PR adds a `predict_step` method to `BYOLTask` so that users can utilize PyTorch Lightning's `trainer.predict()` function which will automatically loop and predict over a PyTorch DataLoader e.g.:

```python
preds = trainer.predict(model=task, dataloaders=datamodule.test_dataloader())

# Or if your datamodule has a `predict_dataloader` method defined
preds = trainer.predict(model=task, datamodule=datamodule)
```

Note the way the EncoderWrapper is setup is that calling `self(x)` on a batch of images will return the projector output embeddings. However, we only need this during training. For linear evaluation or other downstream tasks we want the output of the image encoder (the output of the avg pool layer of the ResNet). To work around this I had to add another hook to store the embeddings on a forward pass in the `self._embeddings` attribute.