### PR TITLE
Labeler: use comments to avoid aliases

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,24 +1,24 @@
 # TorchGeo modules
 datamodules:
-- torchgeo/datamodules/**
+- "torchgeo/datamodules/**"
 datasets:
-- torchgeo/datasets/**
+- "torchgeo/datasets/**"
 losses:
-- torchgeo/losses/**
+- "torchgeo/losses/**"
 models:
-- torchgeo/models/**
+- "torchgeo/models/**"
 samplers:
-- torchgeo/samplers/**
+- "torchgeo/samplers/**"
 trainers:
-- torchgeo/trainers/**
+- "torchgeo/trainers/**"
 transforms:
-- torchgeo/transforms/**
+- "torchgeo/transforms/**"
 
 # Other
 documentation:
-- docs/**
+- "docs/**"
 scripts:
-- *.py
+- "*.py"
 testing:
-- tests/**
-- .github/workflows/**
+- "tests/**"
+- ".github/workflows/**"


### PR DESCRIPTION
Apparently things starting with an asterisk are aliases in YAML. Explicitly encode as strings to avoid this.