### PR TITLE
Fix a bug for ETCI2021 loader

### DIFF
--- a/torchgeo/datasets/etci2021.py
+++ b/torchgeo/datasets/etci2021.py
@@ -171,17 +171,15 @@ class ETCI2021(NonGeoDataset):
         folders = [os.path.join(folder, "tiles") for folder in folders]
         for folder in folders:
             vvs = sorted(glob.glob(os.path.join(folder, "vv", "*.png")))
-            vhs = [
-                vv.replace("/vv/", "/vh/").replace("_vv.png", "_vh.png") for vv in vvs
-            ]
+            vhs = [vv.replace("vv", "vh") for vv in vvs]
             water_masks = [
-                vv.replace("/vv/", "/water_body_label/").replace("_vv.png", ".png")
+                vv.replace("_vv.png", ".png").replace("vv", "water_body_label")
                 for vv in vvs
             ]
 
             if split != "test":
                 flood_masks = [
-                    vv.replace("/vv/", "/flood_label/").replace("_vv.png", ".png")
+                    vv.replace("_vv.png", ".png").replace("vv", "flood_label")
                     for vv in vvs
                 ]
 

--- a/torchgeo/datasets/etci2021.py
+++ b/torchgeo/datasets/etci2021.py
@@ -171,25 +171,40 @@ class ETCI2021(NonGeoDataset):
         folders = [os.path.join(folder, "tiles") for folder in folders]
         for folder in folders:
             vvs = sorted(glob.glob(os.path.join(folder, "vv", "*.png")))
-            vhs = sorted(glob.glob(os.path.join(folder, "vh", "*.png")))
-            water_masks = sorted(
-                glob.glob(os.path.join(folder, "water_body_label", "*.png"))
-            )
+            vhs = [vv.replace('/vv/', '/vh/').replace('_vv.png', '_vh.png')
+                   for vv in vvs]
+            water_masks = [
+                vv.replace('/vv/',
+                           '/water_body_label/').replace('_vv.png', '.png')
+                for vv in vvs]
 
             if split != "test":
-                flood_masks = sorted(
-                    glob.glob(os.path.join(folder, "flood_label", "*.png"))
-                )
+                flood_masks = [
+                    vv.replace('/vv/',
+                               '/flood_label/').replace('_vv.png', '.png')
+                    for vv in vvs]
 
                 for vv, vh, flood_mask, water_mask in zip(
-                    vvs, vhs, flood_masks, water_masks
+                        vvs, vhs, flood_masks, water_masks
                 ):
-                    files.append(
-                        dict(vv=vv, vh=vh, flood_mask=flood_mask, water_mask=water_mask)
-                    )
+                    if os.path.exists(vh) and os.path.exists(water_mask) \
+                            and os.path.exists(flood_mask):
+                        files.append(
+                            dict(vv=vv, vh=vh, flood_mask=flood_mask,
+                                 water_mask=water_mask)
+                        )
+                    else:
+                        print('Not found: %s' %
+                              (vh if not os.path.exists(vh) else
+                               water_mask if not os.path.exists(water_mask)
+                               else flood_mask))
             else:
                 for vv, vh, water_mask in zip(vvs, vhs, water_masks):
-                    files.append(dict(vv=vv, vh=vh, water_mask=water_mask))
+                    if os.path.exists(vh) and os.path.exists(water_mask):
+                        files.append(dict(vv=vv, vh=vh, water_mask=water_mask))
+                    else:
+                        print('Not found: %s' %
+                              (vh if not os.path.exists(vh) else water_mask))
 
         return files
 

--- a/torchgeo/datasets/etci2021.py
+++ b/torchgeo/datasets/etci2021.py
@@ -186,39 +186,12 @@ class ETCI2021(NonGeoDataset):
                 for vv, vh, flood_mask, water_mask in zip(
                     vvs, vhs, flood_masks, water_masks
                 ):
-                    if (
-                        os.path.exists(vh)
-                        and os.path.exists(water_mask)
-                        and os.path.exists(flood_mask)
-                    ):
-                        files.append(
-                            dict(
-                                vv=vv,
-                                vh=vh,
-                                flood_mask=flood_mask,
-                                water_mask=water_mask,
-                            )
-                        )
-                    else:
-                        print(
-                            "Not found: %s"
-                            % (
-                                vh
-                                if not os.path.exists(vh)
-                                else water_mask
-                                if not os.path.exists(water_mask)
-                                else flood_mask
-                            )
-                        )
+                    files.append(
+                        dict(vv=vv, vh=vh, flood_mask=flood_mask, water_mask=water_mask)
+                    )
             else:
                 for vv, vh, water_mask in zip(vvs, vhs, water_masks):
-                    if os.path.exists(vh) and os.path.exists(water_mask):
-                        files.append(dict(vv=vv, vh=vh, water_mask=water_mask))
-                    else:
-                        print(
-                            "Not found: %s"
-                            % (vh if not os.path.exists(vh) else water_mask)
-                        )
+                    files.append(dict(vv=vv, vh=vh, water_mask=water_mask))
 
         return files
 

--- a/torchgeo/datasets/etci2021.py
+++ b/torchgeo/datasets/etci2021.py
@@ -171,40 +171,56 @@ class ETCI2021(NonGeoDataset):
         folders = [os.path.join(folder, "tiles") for folder in folders]
         for folder in folders:
             vvs = sorted(glob.glob(os.path.join(folder, "vv", "*.png")))
-            vhs = [vv.replace('/vv/', '/vh/').replace('_vv.png', '_vh.png')
-                   for vv in vvs]
+            vhs = [
+                vv.replace("/vv/", "/vh/").replace("_vv.png", "_vh.png") for vv in vvs
+            ]
             water_masks = [
-                vv.replace('/vv/',
-                           '/water_body_label/').replace('_vv.png', '.png')
-                for vv in vvs]
+                vv.replace("/vv/", "/water_body_label/").replace("_vv.png", ".png")
+                for vv in vvs
+            ]
 
             if split != "test":
                 flood_masks = [
-                    vv.replace('/vv/',
-                               '/flood_label/').replace('_vv.png', '.png')
-                    for vv in vvs]
+                    vv.replace("/vv/", "/flood_label/").replace("_vv.png", ".png")
+                    for vv in vvs
+                ]
 
                 for vv, vh, flood_mask, water_mask in zip(
-                        vvs, vhs, flood_masks, water_masks
+                    vvs, vhs, flood_masks, water_masks
                 ):
-                    if os.path.exists(vh) and os.path.exists(water_mask) \
-                            and os.path.exists(flood_mask):
+                    if (
+                        os.path.exists(vh)
+                        and os.path.exists(water_mask)
+                        and os.path.exists(flood_mask)
+                    ):
                         files.append(
-                            dict(vv=vv, vh=vh, flood_mask=flood_mask,
-                                 water_mask=water_mask)
+                            dict(
+                                vv=vv,
+                                vh=vh,
+                                flood_mask=flood_mask,
+                                water_mask=water_mask,
+                            )
                         )
                     else:
-                        print('Not found: %s' %
-                              (vh if not os.path.exists(vh) else
-                               water_mask if not os.path.exists(water_mask)
-                               else flood_mask))
+                        print(
+                            "Not found: %s"
+                            % (
+                                vh
+                                if not os.path.exists(vh)
+                                else water_mask
+                                if not os.path.exists(water_mask)
+                                else flood_mask
+                            )
+                        )
             else:
                 for vv, vh, water_mask in zip(vvs, vhs, water_masks):
                     if os.path.exists(vh) and os.path.exists(water_mask):
                         files.append(dict(vv=vv, vh=vh, water_mask=water_mask))
                     else:
-                        print('Not found: %s' %
-                              (vh if not os.path.exists(vh) else water_mask))
+                        print(
+                            "Not found: %s"
+                            % (vh if not os.path.exists(vh) else water_mask)
+                        )
 
         return files
 


### PR DESCRIPTION
### Summary

Fix the ETCI 2021 Data loader by removing glob for each folder

### Details

I tried ETCI2021DataModule (on Mac), then found a bug for loading the images.
The loaded images are sometimes not correct by each sorted glob

You can find the image file paths are not same (of vv and water_mask) in attached result.
![Screen Shot 2022-10-20 at 18 16 52](https://user-images.githubusercontent.com/4539228/196911037-b4c8ced6-9284-4e75-b198-7e632408a193.png)

This PR changes the loader will do sorted glob once in vv folder, and then use it for others.