### PR TITLE
Evaluation -> Elevation

### DIFF
--- a/torchgeo/datasets/astergdem.py
+++ b/torchgeo/datasets/astergdem.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-"""Aster Global Digital Evaluation Model dataset."""
+"""Aster Global Digital Elevation Model dataset."""
 
 import glob
 import os
@@ -14,9 +14,9 @@ from .geo import RasterDataset
 
 
 class AsterGDEM(RasterDataset):
-    """Aster Global Digital Evaluation Model Dataset.
+    """Aster Global Digital Elevation Model Dataset.
 
-    The `Aster Global Digital Evaluation Model
+    The `Aster Global Digital Elevation Model
     <https://lpdaac.usgs.gov/products/astgtmv003/>`_
     dataset is a Digital Elevation Model (DEM) on a global scale.
     The dataset can be downloaded from the


### PR DESCRIPTION
The "Aster Global Digital Elevation Model Dataset" is wrongly named "Aster Global Digital Evaluation Model Dataset". 

This PR fixes the name in the datasets' docstring. 