### PR TITLE
Add Modis dataset

### DIFF
--- a/docs/api/datasets.rst
+++ b/docs/api/datasets.rst
@@ -108,6 +108,11 @@ Landsat
 .. autoclass:: Landsat2
 .. autoclass:: Landsat1
 
+Modis
+^^^^^
+
+.. autoclass:: Modis
+
 NAIP
 ^^^^
 

--- a/docs/api/geo_datasets.csv
+++ b/docs/api/geo_datasets.csv
@@ -13,6 +13,7 @@ Dataset,Type,Source,Size (px),Resolution (m)
 `GlobBiomass`_,Masks,Landsat,"45,000x45,000",100
 `iNaturalist`_,Points,Citizen Scientists,-,-
 `Landsat`_,Imagery,Landsat,"8,900x8,900",30
+`Modis`_,Imagery,"Terra or Aqua",-,250
 `NAIP`_,Imagery,Aerial,"6,100x7,600",1
 `Open Buildings`_,Geometries,"Maxar, CNES/Airbus",-,-
 `Sentinel`_,Imagery,Sentinel,"10,000x10,000",10

--- a/tests/data/modis/data.py
+++ b/tests/data/modis/data.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+"""Create test data for modis dataset."""
+
+import numpy as np
+import rioxarray  # noqa: F401
+import xarray as xa
+from rasterio.crs import CRS
+
+SIZE = 32
+
+filenames = [
+    "MOD09GA.A2022182.h12v04.006.2022184031828.hdf",
+    "MOD09GA.A2022182.h12v05.006.2022184031828.hdf",
+]
+
+
+def create_file(path: str, dtype: str, num_channels: int) -> None:
+    """Create .hdf file."""
+    xa_dataset = xa.Dataset(attrs={"count": num_channels})
+
+    # add spatial_ref
+    for i in range(num_channels):
+
+        band = xa.DataArray(
+            np.random.randint(0, 100, (1, SIZE, SIZE), dtype=dtype),
+            dims=("band", "y", "x"),
+            coords={"band": [1], "y": np.arange(0, SIZE), "x": np.arange(0, SIZE)},
+        )
+
+        band.rio.write_crs(
+            CRS.from_wkt(
+                'PROJCS["unnamed",GEOGCS["Unknown datum based upon the custom,'
+                'spheroid", DATUM["Not specified (based on custom spheroid)",'
+                'SPHEROID["Custom spheroid",6371007.181,0]]'
+                ',PRIMEM["Greenwich",0],'
+                'UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]]]'
+                ',PROJECTION["Sinusoidal"]'
+                ',PARAMETER["longitude_of_center",0]'
+                ',PARAMETER["false_easting",0]'
+                ',PARAMETER["false_northing",0]'
+                ',UNIT["Meter",1],AXIS["Easting",EAST],AXIS["Northing",NORTH]]'
+            ),
+            inplace=True,
+        )
+
+        xa_dataset[f"sur_refl_b{i+1:02d}_1"] = band
+
+    xa_dataset.rio.to_raster(
+        path
+    )  # rioxarray.exceptions.TooManyDimensions: Only 2D and 3D data arrays supported.
+
+
+if __name__ == "__main__":
+    for filename in filenames:
+        create_file(filename, "int16", 7)

--- a/tests/datasets/test_modis.py
+++ b/tests/datasets/test_modis.py
@@ -1,0 +1,60 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+"""Tests for Modis Dataset."""
+
+import os
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import pytest
+import torch
+from rasterio.crs import CRS
+
+from torchgeo.datasets import BoundingBox, IntersectionDataset, Modis, UnionDataset
+
+
+class TestModis:
+    @pytest.fixture
+    def dataset(self) -> Modis:
+        root = os.path.join("tests", "data", "modis")
+        return Modis(root)
+
+    def test_getitem(self, dataset: Modis) -> None:
+        x = dataset[dataset.bounds]
+        assert isinstance(x, dict)
+        assert isinstance(x["crs"], CRS)
+        assert isinstance(x["image"], torch.Tensor)
+
+    def test_and(self, dataset: Modis) -> None:
+        ds = dataset & dataset
+        assert isinstance(ds, IntersectionDataset)
+
+    def test_or(self, dataset: Modis) -> None:
+        ds = dataset | dataset
+        assert isinstance(ds, UnionDataset)
+
+    def test_no_data(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError, match="No Modis data was found in "):
+            Modis(str(tmp_path))
+
+    def test_plot(self, dataset: Modis) -> None:
+        x = dataset[dataset.bounds]
+        dataset.plot(x, suptitle="Test")
+        plt.close()
+
+    def test_plot_wrong_bands(self, dataset: Modis) -> None:
+        bands = ["B02"]
+        ds = Modis(root=dataset.root, res=dataset.res, bands=bands)
+        x = dataset[dataset.bounds]
+        with pytest.raises(
+            ValueError, match="Dataset doesn't contain some of the RGB bands"
+        ):
+            ds.plot(x)
+
+    def test_invalid_query(self, dataset: Modis) -> None:
+        query = BoundingBox(0, 0, 0, 0, 0, 0)
+        with pytest.raises(
+            IndexError, match="query: .* not found in index with bounds:"
+        ):
+            dataset[query]

--- a/torchgeo/datasets/__init__.py
+++ b/torchgeo/datasets/__init__.py
@@ -72,6 +72,7 @@ from .landsat import (
 from .levircd import LEVIRCDPlus
 from .loveda import LoveDA
 from .millionaid import MillionAID
+from .modis import Modis
 from .naip import NAIP
 from .nasa_marine_debris import NASAMarineDebris
 from .nwpu import VHR10
@@ -142,6 +143,7 @@ __all__ = (
     "Landsat7",
     "Landsat8",
     "Landsat9",
+    "Modis",
     "NAIP",
     "OpenBuildings",
     "Sentinel",

--- a/torchgeo/datasets/modis.py
+++ b/torchgeo/datasets/modis.py
@@ -1,0 +1,302 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+"""Modis dataset."""
+
+import functools
+import glob
+import os
+import re
+import sys
+from typing import Any, Callable, Dict, List, Optional, Sequence, cast
+
+import matplotlib.pyplot as plt
+import numpy as np
+import rasterio
+import rioxarray as rxr
+import torch
+from rasterio.crs import CRS
+from rioxarray.merge import merge_datasets
+from torch import Tensor
+from xarray import Dataset as xrDataset
+
+from torchgeo.datasets.geo import GeoDataset
+
+from .utils import BoundingBox, disambiguate_timestamp
+
+
+class Modis(GeoDataset):
+    """Modis Dataset.
+
+    Moderate Resolution Imaging Spectroradiometer (`Modis
+    <https://modis.gsfc.nasa.gov/data/>`_) data measures up to 36 spectral
+    bands at different resolution for earth and climate monitoring.
+    Datasets can be downloaded from the `USGS Earth Explorer website
+    <https://earthexplorer.usgs.gov/>`_ after making an account.
+
+    Dataset features:
+
+    * Multispectral data at various resolutions (250m, 500m, and 1km)
+    * data collected from `Terra <https://terra.nasa.gov/about/terra-instruments>`_
+      or `Aqua <https://aqua.nasa.gov/content/instruments>`_ instrument
+
+    Dataset format
+
+    * .hdf files containing data variables and meta data
+
+    Since there are many different Modis data products, you might
+    have to adapt the *filename_glob* and *filename_regex* to build
+    your dataset. This defautl implementation is for the USGS
+    `MOD09GA` product.
+
+    .. note::
+        This dataset requires the following additional installations:
+
+        * `rioxarray <https://corteva.github.io/rioxarray/stable/>`_ to load
+          the modis files
+        * a full GDAL installation from source for rasterio, for information see
+          `rasterio documentation
+          <https://rasterio.readthedocs.io/en/latest/installation.html>`_.
+
+
+    .. versionadded:: 0.4
+    """
+
+    filename_glob = "MOD09GA.*.hdf"
+    filename_regex = r"""^
+        (?P<product_name>[MOD09GA]{7})
+        .(?P<julian_date>[A0-9]{8})
+        .(?P<tile_id>[h0-9v0-9]{6})
+        .(?P<collection_ver>[0-9]{3})
+        .(?P<julian_data_aquisition>[0-9]{13})
+    """
+
+    all_bands = ("B01", "B02", "B03", "B04", "B05", "B06", "B07")
+
+    rgb_bands = ("B01", "B04", "B03")
+
+    date_format = "A%Y%j"
+
+    is_image = True
+
+    def __init__(
+        self,
+        root: str,
+        crs: Optional[CRS] = None,
+        res: Optional[float] = None,
+        bands: Optional[Sequence[str]] = None,
+        transforms: Optional[Callable[[Dict[str, Any]], Dict[str, Any]]] = None,
+        cache: bool = True,
+        checksum: bool = False,
+    ) -> None:
+        """Initialize a new instance of Modis dataset."""
+        super().__init__(transforms=transforms)
+        self.root = root
+        self.checksum = checksum
+        self.cache = cache
+
+        bands = bands or self.all_bands
+        self._validate_bands(bands)
+        self.bands = bands
+
+        # specify band names as they are used in the data product
+        self.modis_band_names = [f"sur_refl_{band.lower()}_1" for band in self.bands]
+
+        # Populate the dataset index
+        i = 0
+        pathname = os.path.join(root, "**", self.filename_glob)
+        filename_regex = re.compile(self.filename_regex, re.VERBOSE)
+        for filepath in glob.iglob(pathname, recursive=True):
+            match = re.match(filename_regex, os.path.basename(filepath))
+
+            if match is not None:
+                try:
+                    with rxr.open_rasterio(
+                        filepath, variable=self.modis_band_names
+                    ) as src:
+                        if crs is None:
+                            crs = src.rio.crs
+
+                        if res is None:
+                            res = src.rio.resolution()[0]
+
+                        warped = src.rio.clip_box(*src.rio.bounds(), crs=crs)
+                        minx, miny, maxx, maxy = warped.rio.bounds()
+
+                # not sure what the right exception to raise is here
+                except rasterio.errors.RasterioIOError:
+                    # Skip files that rasterio is unable to read
+                    continue
+
+                else:
+                    mint: float = 0
+                    maxt: float = sys.maxsize
+                    if "julian_date" in match.groupdict():
+                        date = match.group("julian_date")
+                        mint, maxt = disambiguate_timestamp(date, self.date_format)
+
+                    coords = (minx, maxx, miny, maxy, mint, maxt)
+                    self.index.insert(i, coords, filepath)
+                    i += 1
+
+        if i == 0:
+            raise FileNotFoundError(
+                f"No {self.__class__.__name__} data was found in '{root}'"
+            )
+
+        band_indexes = [self.all_bands.index(i) + 1 for i in bands]
+        assert len(band_indexes) == len(self.bands)
+        self.band_indexes = band_indexes
+
+        # need to specify band indices
+        self._crs = cast(CRS, crs)
+        self.res = cast(float, res)
+
+    def __getitem__(self, query: BoundingBox) -> Dict[str, Any]:
+        """Retrieve image/mask and metadata indexed by query.
+
+        Args:
+            query: (minx, maxx, miny, maxy, mint, maxt) coordinates to index
+
+        Returns:
+            sample of image/mask and metadata at that index
+
+        Raises:
+            IndexError: if query is not found in the index
+        """
+        hits = self.index.intersection(tuple(query), objects=True)
+        filepaths = cast(List[str], [hit.object for hit in hits])
+
+        if not filepaths:
+            raise IndexError(
+                f"query: {query} not found in index with bounds: {self.bounds}"
+            )
+
+        data = self._merge_files(filepaths, query)
+
+        key = "image" if self.is_image else "mask"
+        sample = {key: data, "crs": self.crs, "bbox": query}
+
+        if self.transforms is not None:
+            sample = self.transforms(sample)
+
+        return sample
+
+    def _merge_files(self, filepaths: Sequence[str], query: BoundingBox) -> Tensor:
+        """Load and merge one or more files.
+
+        Args:
+            filepaths: one or more files to load and merge
+            query: (minx, maxx, miny, maxy, mint, maxt) coordinates to index
+
+        Returns:
+            image/mask at that index
+        """
+        if self.cache:
+            rxr_fhs = [self._cached_load_warp_file(fp) for fp in filepaths]
+        else:
+            rxr_fhs = [self._load_warp_file(fp) for fp in filepaths]
+
+        bounds = (query.minx, query.miny, query.maxx, query.maxy)
+        dest = (
+            merge_datasets(rxr_fhs, bounds, res=self.res)
+            .to_array()
+            .to_numpy()
+            .squeeze(1)
+        )
+
+        # fix numpy dtypes which are not supported by pytorch tensors
+        if dest.dtype == np.uint16:
+            dest = dest.astype(np.int32)
+        elif dest.dtype == np.uint32:
+            dest = dest.astype(np.int64)
+
+        tensor = torch.from_numpy(dest)
+        return tensor
+
+    @functools.lru_cache(maxsize=128)
+    def _cached_load_warp_file(self, filepath: str) -> xrDataset:
+        """Cached version of :meth:`_load_warp_file`.
+
+        Args:
+            filepath: file to load and warp
+
+        Returns:
+            file handle of warped VRT
+        """
+        return self._load_warp_file(filepath)
+
+    def _load_warp_file(self, filepath: str) -> xrDataset:
+        """Load and warp a file to the correct CRS and resolution.
+
+        Args:
+            filepath: file to load and warp
+
+        Returns:
+            file handle of warped riox Dataset
+        """
+        src = rxr.open_rasterio(filepath, variable=self.modis_band_names)
+
+        # Only warp if necessary
+        if src.rio.crs != self.crs:
+            rxr_warped = src.rio.clip_box(*src.rio.bounds(), crs=self.crs)
+            return rxr_warped
+        else:
+            return src
+
+    def _validate_bands(self, bands: Sequence[str]) -> None:
+        """Validate list of bands.
+
+        Args:
+            bands: user-provided sequence of bands to load
+
+        Raises:
+            AssertionError: if ``bands`` is not a sequence
+            ValueError: if an invalid band name is provided
+        """
+        assert isinstance(bands, tuple), "'bands' must be a sequence"
+        for band in bands:
+            if band not in self.all_bands:
+                raise ValueError(f"'{band}' is an invalid band name.")
+
+    def plot(
+        self,
+        sample: Dict[str, Any],
+        show_titles: bool = True,
+        suptitle: Optional[str] = None,
+    ) -> plt.Figure:
+        """Plot a sample from the dataset.
+
+        Args:
+            sample: a sample returned by :meth:`RasterDataset.__getitem__`
+            show_titles: flag indicating whether to show titles above each panel
+            suptitle: optional string to use as a suptitle
+
+        Returns:
+            a matplotlib Figure with the rendered sample
+
+        Raises:
+            ValueError: if the RGB bands are not included in ``self.bands``
+        """
+        rgb_indices = []
+        for band in self.rgb_bands:
+            if band in self.bands:
+                rgb_indices.append(self.bands.index(band))
+            else:
+                raise ValueError("Dataset doesn't contain some of the RGB bands")
+
+        image = sample["image"][rgb_indices].permute(1, 2, 0)
+        image = torch.clamp(image / 2000, min=0, max=1)
+
+        fig, ax = plt.subplots(1, 1, figsize=(10, 10))
+
+        ax.imshow(image)
+        ax.axis("off")
+
+        if show_titles:
+            ax.set_title("Image")
+
+        if suptitle is not None:
+            plt.suptitle(suptitle)
+
+        return fig


### PR DESCRIPTION
This PR adds support for the Modis data product from USGS. 

The files are `.hdf` format and I could not figure out a different way than using the rioxarray library with a source installed GDAL version. I have also looked at Planetary Computer data and when you download data from there the bands come as individual `.tif` files, meaning that in a sense torchgeo already has Modis data support when writing a `RasterDataset` class for it.

Issues I am currently having:

- [ ] when running pytest, there occurs `rasterio.errors.NotGeoreferencedWarning: Dataset has no geotransform, gcps, or rpcs. The identity matrix will be returned`  when trying to open the `.hdf`file, when using `ds = Modis(root=test_data_root)` no errors occur
- [ ] generating dummy `.hdf` dummy data is not working yet, and raises `rioxarray.exceptions.TooManyDimensions: Only 2D and 3D data arrays supported` when trying to save the data even though I feel like I only create a 3D array


Plot example:
<img src="https://user-images.githubusercontent.com/35272119/202507312-b4add686-580f-41ba-985f-b4253a043055.png" width="450" height="450">