### PR TITLE
Docs: fix broken build

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,5 +1,5 @@
 # docs
-ipython
+ipython==8.6.0
 ipywidgets==8.0.2
 nbsphinx==0.8.10
 sphinx==5.3.0

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,4 +1,5 @@
 # docs
+ipython
 ipywidgets==8.0.2
 nbsphinx==0.8.10
 sphinx==5.3.0


### PR DESCRIPTION
Documentation is failing to build on recent PRs:
```
WARNING: Pygments lexer name 'ipython3' is not known
```
I have no idea what changed since we lock down all direct dependencies. We'll see if this fixes the issue.

Related to https://github.com/spatialaudio/nbsphinx/issues/24.