### PR TITLE
Fix failing minimum tests

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -32,7 +32,7 @@ dependencies:
     - opencv-python>=3.4.2.17
     - packaging>=17
     - pandas>=1.0
-    - pillow>=6.2
+    - pillow>=8.2
     - pydocstyle[toml]>=6.1
     - pytest>=6.1.2
     - pytest-cov>=2.4

--- a/environment.yml
+++ b/environment.yml
@@ -21,7 +21,7 @@ dependencies:
   - pip:
     - black[jupyter]>=21.8
     - flake8>=3.8
-    - ipywidgets>=7
+    - ipywidgets>=7.6
     - isort[colors]>=5.8
     - kornia>=0.6.4
     - laspy>=2

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - einops>=0.3
   - fiona>=1.8
   - h5py>=2.6
-  - numpy>=1.17.2
+  - numpy>=1.18
   - open3d>=0.13.0
   - pip
   - pycocotools>=2

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - fiona>=1.8
   - h5py>=2.6
   - numpy>=1.17.2
-  - open3d>=0.11.2
+  - open3d>=0.13.0
   - pip
   - pycocotools>=2
   - pyproj>=2.2

--- a/environment.yml
+++ b/environment.yml
@@ -31,7 +31,7 @@ dependencies:
     - omegaconf>=2.1
     - opencv-python>=3.4.2.17
     - packaging>=17
-    - pandas>=0.23.2
+    - pandas>=1.0
     - pillow>=6.2
     - pydocstyle[toml]>=6.1
     - pytest>=6.1.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,8 @@ filterwarnings = [
     # https://github.com/rasterio/rasterio/issues/1742
     # https://github.com/rasterio/rasterio/pull/1753
     "ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated:DeprecationWarning:rasterio.crs",
+    # https://github.com/rasterio/rasterio/pull/1764
+    "ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated:DeprecationWarning:rasterio.transform",
     # https://github.com/pytorch/pytorch/issues/60053
     # https://github.com/pytorch/pytorch/pull/60059
     "ignore:Named tensors and all their associated APIs are an experimental feature and subject to change:UserWarning:torch.nn.functional",

--- a/requirements/min.old
+++ b/requirements/min.old
@@ -35,7 +35,7 @@ scipy==1.2.0
 zipfile-deflate64==0.2.0
 
 # docs
-ipywidgets==7.0.0
+ipywidgets==7.6.0
 nbsphinx==0.8.5
 sphinx==4.0.0
 

--- a/requirements/min.old
+++ b/requirements/min.old
@@ -1,5 +1,5 @@
 # setup
-setuptools==47.0.0
+setuptools==46.4.0
 
 # install
 einops==0.3.0

--- a/requirements/min.old
+++ b/requirements/min.old
@@ -36,7 +36,7 @@ zipfile-deflate64==0.2.0
 
 # docs
 ipywidgets==7.6.0
-jupyterlab==3.1.0
+jupyterlab==3.0.18
 nbsphinx==0.8.5
 sphinx==4.0.0
 

--- a/requirements/min.old
+++ b/requirements/min.old
@@ -25,7 +25,7 @@ torchvision==0.10.0
 # datasets
 h5py==2.6.0
 laspy==2.0.0
-open3d==0.11.2
+open3d==0.13.0
 opencv-python==3.4.2.17
 pandas==0.23.2
 pycocotools==2.0.0

--- a/requirements/min.old
+++ b/requirements/min.old
@@ -36,6 +36,7 @@ zipfile-deflate64==0.2.0
 
 # docs
 ipywidgets==7.6.0
+jupyterlab==3.1.0
 nbsphinx==0.8.5
 sphinx==4.0.0
 

--- a/requirements/min.old
+++ b/requirements/min.old
@@ -36,7 +36,7 @@ zipfile-deflate64==0.2.0
 
 # docs
 ipywidgets==7.6.0
-jupyterlab==3.0.18
+jupyter-packaging==0.10.3
 nbsphinx==0.8.5
 sphinx==4.0.0
 

--- a/requirements/min.old
+++ b/requirements/min.old
@@ -12,7 +12,7 @@ packaging==17.0
 pillow==8.2.0
 pyproj==2.2.0
 pytorch-lightning==1.5.1
-rasterio==1.0.20
+rasterio==1.1.0
 rtree==1.0.0
 scikit-learn==0.21.0
 segmentation-models-pytorch==0.2.0

--- a/requirements/min.old
+++ b/requirements/min.old
@@ -1,5 +1,5 @@
 # setup
-setuptools==46.4.0
+setuptools==42.0.0
 
 # install
 einops==0.3.0

--- a/requirements/min.old
+++ b/requirements/min.old
@@ -1,5 +1,5 @@
 # setup
-setuptools==42.0.0
+setuptools==47.0.0
 
 # install
 einops==0.3.0
@@ -37,6 +37,7 @@ zipfile-deflate64==0.2.0
 # docs
 ipywidgets==7.6.0
 nbsphinx==0.8.5
+nbconvert==4.0.0
 sphinx==4.0.0
 
 # style

--- a/requirements/min.old
+++ b/requirements/min.old
@@ -6,7 +6,7 @@ einops==0.3.0
 fiona==1.8.0
 kornia==0.6.4
 matplotlib==3.3.0
-numpy==1.17.2
+numpy==1.18.0
 omegaconf==2.1.0
 packaging==17.0
 pillow==6.2.0

--- a/requirements/min.old
+++ b/requirements/min.old
@@ -12,7 +12,7 @@ packaging==17.0
 pillow==8.2.0
 pyproj==2.2.0
 pytorch-lightning==1.5.1
-rasterio==1.1.0
+rasterio==1.0.20
 rtree==1.0.0
 scikit-learn==0.21.0
 segmentation-models-pytorch==0.2.0

--- a/requirements/min.old
+++ b/requirements/min.old
@@ -27,7 +27,7 @@ h5py==2.6.0
 laspy==2.0.0
 open3d==0.13.0
 opencv-python==3.4.2.17
-pandas==0.23.2
+pandas==1.0.0
 pycocotools==2.0.0
 radiant-mlhub==0.2.1
 rarfile==3.0

--- a/requirements/min.old
+++ b/requirements/min.old
@@ -9,7 +9,7 @@ matplotlib==3.3.0
 numpy==1.18.0
 omegaconf==2.1.0
 packaging==17.0
-pillow==6.2.0
+pillow==8.2.0
 pyproj==2.2.0
 pytorch-lightning==1.5.1
 rasterio==1.0.20

--- a/requirements/min.old
+++ b/requirements/min.old
@@ -1,5 +1,5 @@
 # setup
-setuptools==42.0.0
+setuptools==46.4.0
 
 # install
 einops==0.3.0
@@ -36,7 +36,6 @@ zipfile-deflate64==0.2.0
 
 # docs
 ipywidgets==7.6.0
-jupyter-packaging==0.10.3
 nbsphinx==0.8.5
 sphinx==4.0.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,8 +39,8 @@ install_requires =
     omegaconf>=2.1,<3
     # packaging 17+ required by pytorch-lightning
     packaging>=17,<22
-    # pillow 6.2+ required by matplotlib
-    pillow>=6.2,<10
+    # pillow 8.2+ required by open3d>=0.13
+    pillow>=8.2,<10
     # pyproj 2.2+ required for CRS object
     pyproj>=2.2,<4
     # pytorch-lightning 1.5.1+ required for apply_to_collection bugfix

--- a/setup.cfg
+++ b/setup.cfg
@@ -78,9 +78,8 @@ datasets =
     h5py>=2.6,<4
     # laspy 2+ required for laspy.read
     laspy>=2,<3
-    # open3d 0.11.2+ required to avoid GLFW error:
-    # https://github.com/isl-org/Open3D/issues/1550
-    open3d>=0.11.2,<0.15;python_version<'3.10'
+    # open3d 0.13.0+ required to avoid using deprecated sklearn dependency
+    open3d>=0.13.0,<0.15;python_version<'3.10'
     # opencv-python 3.4.2.17 is oldest buildable version on PyPI
     opencv-python>=3.4.2.17,<5
     # pandas 0.23.2+ required for Python 3.7 wheels

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,8 +33,8 @@ install_requires =
     kornia>=0.6.4,<0.7
     # matplotlib 3.3+ required for (H, W, 1) image support in plt.imshow
     matplotlib>=3.3,<4
-    # numpy 1.17.2+ required by pytorch-lightning
-    numpy>=1.17.2,<2
+    # numpy 1.18+ required by open3d>=0.13
+    numpy>=1.18,<2
     # omegaconf 2.1+ required for to_object method
     omegaconf>=2.1,<3
     # packaging 17+ required by pytorch-lightning

--- a/setup.cfg
+++ b/setup.cfg
@@ -78,8 +78,8 @@ datasets =
     h5py>=2.6,<4
     # laspy 2+ required for laspy.read
     laspy>=2,<3
-    # open3d 0.13.0+ required to avoid using deprecated sklearn dependency
-    open3d>=0.13.0,<0.15;python_version<'3.10'
+    # open3d 0.13+ required to avoid using deprecated sklearn dependency
+    open3d>=0.13,<0.15;python_version<'3.10'
     # opencv-python 3.4.2.17 is oldest buildable version on PyPI
     opencv-python>=3.4.2.17,<5
     # pandas 0.23.2+ required for Python 3.7 wheels

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,8 +45,8 @@ install_requires =
     pyproj>=2.2,<4
     # pytorch-lightning 1.5.1+ required for apply_to_collection bugfix
     pytorch-lightning>=1.5.1,<2
-    # rasterio 1.1+ required for avoiding deprecation warnings from collections module
-    rasterio>=1.1,<2
+    # rasterio 1.0.20+ required for out_dtype parameter of DatasetReaderBase.read
+    rasterio>=1.0.20,<2
     # rtree 1+ required for len(index), index & index, index | index
     rtree>=1,<2
     # scikit-learn 0.21+ required to fix murmurhash3_32 import bug

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,8 +45,8 @@ install_requires =
     pyproj>=2.2,<4
     # pytorch-lightning 1.5.1+ required for apply_to_collection bugfix
     pytorch-lightning>=1.5.1,<2
-    # rasterio 1.0.20+ required for out_dtype parameter of DatasetReaderBase.read
-    rasterio>=1.0.20,<2
+    # rasterio 1.1+ required for avoiding deprecation warnings from collections module
+    rasterio>=1.1,<2
     # rtree 1+ required for len(index), index & index, index | index
     rtree>=1,<2
     # scikit-learn 0.21+ required to fix murmurhash3_32 import bug

--- a/setup.cfg
+++ b/setup.cfg
@@ -99,8 +99,8 @@ datasets =
     # https://github.com/brianhelba/zipfile-deflate64/issues/19
     zipfile-deflate64>=0.2,<0.3
 docs =
-    # ipywidgets 7+ required by nbsphinx
-    ipywidgets>=7,<9
+    # ipywidgets 7.6+ required by open3d>=0.13
+    ipywidgets>=7.6,<9
     # nbsphinx 0.8.5 fixes bug with nbformat attributes
     nbsphinx>=0.8.5,<0.9
     # release versions missing files, must install from master

--- a/setup.cfg
+++ b/setup.cfg
@@ -82,8 +82,8 @@ datasets =
     open3d>=0.13,<0.15;python_version<'3.10'
     # opencv-python 3.4.2.17 is oldest buildable version on PyPI
     opencv-python>=3.4.2.17,<5
-    # pandas 0.23.2+ required for Python 3.7 wheels
-    pandas>=0.23.2,<2
+    # pandas 1.0+ required for open3d>=0.13
+    pandas>=1.0,<2
     # pycocotools 2.0.0 is oldest version on PyPI
     pycocotools>=2,<3
     # radiant-mlhub 0.2.1+ required for api_key bugfix:

--- a/setup.cfg
+++ b/setup.cfg
@@ -82,8 +82,8 @@ datasets =
     open3d>=0.13,<0.15;python_version<'3.10'
     # opencv-python 3.4.2.17 is oldest buildable version on PyPI
     opencv-python>=3.4.2.17,<5
-    # pandas 1.0+ required for open3d>=0.13
-    pandas>=1.0,<2
+    # pandas 1+ required for open3d>=0.13
+    pandas>=1,<2
     # pycocotools 2.0.0 is oldest version on PyPI
     pycocotools>=2,<3
     # radiant-mlhub 0.2.1+ required for api_key bugfix:


### PR DESCRIPTION
This PR fixes the cause for the minimum tests failing in #854 (and presumably any PR created after Dec 1st). 

`scikit-learn` has officially begun deprecating `sklearn` to prevent malicious actors from using it. So any dependency that attempts to install `sklearn` would install the new `sklearn` package which throws an exception  at certain intervals - Refer https://pypi.org/project/sklearn/ for more details.

`open3d=0.11.2` was our problem package. The open3d team had switched from `sklearn` to `scikit-learn` in version `0.13.0`. This PR bumps the minimum version to the same.

It seems there was a PR prepped to replace `open3d` with `pyvista` - #663. If this lands for the `0.4.0` release, this PR can be ignored.
