### PR TITLE
add predict_step to SemanticSegmentationTask

### DIFF
--- a/tests/trainers/test_segmentation.py
+++ b/tests/trainers/test_segmentation.py
@@ -78,6 +78,7 @@ class TestSemanticSegmentationTask:
         trainer = Trainer(fast_dev_run=True, log_every_n_steps=1, max_epochs=1)
         trainer.fit(model=model, datamodule=datamodule)
         trainer.test(model=model, datamodule=datamodule)
+        trainer.predict(model=model, dataloaders=datamodule.val_dataloader())
 
     def test_no_logger(self) -> None:
         conf = OmegaConf.load(os.path.join("tests", "conf", "landcoverai.yaml"))

--- a/torchgeo/trainers/segmentation.py
+++ b/torchgeo/trainers/segmentation.py
@@ -251,6 +251,11 @@ class SemanticSegmentationTask(pl.LightningModule):
     def predict_step(self, *args: Any, **kwargs: Any) -> Tensor:
         """Compute and return the predictions.
 
+        By default, this will loop over images in a dataloader and aggregate
+        predictions into a list. This may not be desirable if you have many images
+        or large images which could cause out of memory errors. In this case
+        it's recommended to override this with a custom predict_step.
+
         Args:
             batch: the output of your DataLoader
 

--- a/torchgeo/trainers/segmentation.py
+++ b/torchgeo/trainers/segmentation.py
@@ -248,6 +248,20 @@ class SemanticSegmentationTask(pl.LightningModule):
         self.log_dict(self.test_metrics.compute())
         self.test_metrics.reset()
 
+    def predict_step(self, *args: Any, **kwargs: Any) -> Tensor:
+        """Compute and return the predictions.
+
+        Args:
+            batch: the output of your DataLoader
+
+        Returns:
+            predicted softmax probabilities
+        """
+        batch = args[0]
+        x = batch["image"]
+        y_hat: Tensor = self(x).softmax(dim=1)
+        return y_hat
+
     def configure_optimizers(self) -> Dict[str, Any]:
         """Initialize the optimizer and learning rate scheduler.
 


### PR DESCRIPTION
Closes #813. This PR adds a `predict_step` method to `SemanticSegmentationTask` so that users can utilize PyTorch Lightning's `trainer.predict()` function which will automatically loop and predict over a PyTorch DataLoader e.g.:

Added a note to the docstring for users to override this if they have many images or the images are large.

```python
preds = trainer.predict(model=task, dataloaders=datamodule.test_dataloader())

# Or if your datamodule has a `predict_dataloader` method defined
preds = trainer.predict(model=task, datamodule=datamodule)