### PR TITLE
Fix landcoverai datamodule

### DIFF
--- a/conf/landcoverai.yaml
+++ b/conf/landcoverai.yaml
@@ -13,7 +13,7 @@ experiment:
     learning_rate: 1e-3
     learning_rate_schedule_patience: 6
     in_channels: 3
-    num_classes: 6
+    num_classes: 5
     num_filters: 256
     ignore_index: null
   datamodule:

--- a/torchgeo/datamodules/landcoverai.py
+++ b/torchgeo/datamodules/landcoverai.py
@@ -97,7 +97,7 @@ class LandCoverAIDataModule(pl.LightningDataModule):
         sample["image"] /= 255.0
 
         if "mask" in sample:
-            sample["mask"] = sample["mask"].long() + 1
+            sample["mask"] = sample["mask"].long()
 
         return sample
 


### PR DESCRIPTION
Currently we add 1 to the LandCover.AI class indices. This causes several problems:
- We don't ignore the resulting 0 class index in training so the default train configuration doesn't work
- torchmetrics doesn't compute mIoU correctly because it thinks we have 6 classes (but we only have 5)
- Plotting doesn't work in the validation step of training

I don't see any upside to adding 1, so I removed it!