### PR TITLE
Test using best checkpoint

### DIFF
--- a/train.py
+++ b/train.py
@@ -199,7 +199,7 @@ def main(conf: DictConfig) -> None:
     # Run experiment
     ######################################
     trainer.fit(model=task, datamodule=datamodule)
-    trainer.test(model=task, datamodule=datamodule)
+    trainer.test(ckpt_path="best", datamodule=datamodule)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
According to the [docs](https://pytorch-lightning.readthedocs.io/en/stable/common/evaluation_intermediate.html), calling `trainer.test(model=model)` will test using the current latest weights of a model. Changing this to `trainer.test(ckpt_path="best")` will use the previous best weights of the model used in the `trainer.fit()` call.