### PR TITLE
pyproject.toml: silence protobuf deprecation warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,9 @@ filterwarnings = [
     "ignore:Call to deprecated create function:DeprecationWarning:tensorboard.compat.proto",
     # https://github.com/treebeardtech/nbmake/issues/68
     'ignore:The \(fspath. py.path.local\) argument to NotebookFile is deprecated:pytest.PytestDeprecationWarning:nbmake.pytest_plugin',
+    # https://github.com/lanpa/tensorboardX/issues/653
+    # https://github.com/lanpa/tensorboardX/pull/654
+    "ignore:Call to deprecated create function:DeprecationWarning:tensorboardX",
 
     # Expected warnings
     # pytorch-lightning warns us about using num_workers=0, but it's faster on macOS


### PR DESCRIPTION
I haven't yet figured out why we don't see this issue in CI, but locally with the exact same versions of tensorboardX and protobuf I see:
```console
$ pytest
...
tests/trainers/test_segmentation.py:11: in <module>
    from pytorch_lightning import LightningDataModule, Trainer
../.spack/.spack-env/view/lib/python3.10/site-packages/pytorch_lightning/__init__.py:35: in <module>
    from pytorch_lightning.callbacks import Callback  # noqa: E402
../.spack/.spack-env/view/lib/python3.10/site-packages/pytorch_lightning/callbacks/__init__.py:28: in <module>
    from pytorch_lightning.callbacks.pruning import ModelPruning
../.spack/.spack-env/view/lib/python3.10/site-packages/pytorch_lightning/callbacks/pruning.py:31: in <module>
    from pytorch_lightning.core.module import LightningModule
../.spack/.spack-env/view/lib/python3.10/site-packages/pytorch_lightning/core/__init__.py:16: in <module>
    from pytorch_lightning.core.module import LightningModule
../.spack/.spack-env/view/lib/python3.10/site-packages/pytorch_lightning/core/module.py:46: in <module>
    from pytorch_lightning.loggers import Logger
../.spack/.spack-env/view/lib/python3.10/site-packages/pytorch_lightning/loggers/__init__.py:23: in <module>
    from pytorch_lightning.loggers.tensorboard import TensorBoardLogger
../.spack/.spack-env/view/lib/python3.10/site-packages/pytorch_lightning/loggers/tensorboard.py:26: in <module>
    from tensorboardX import SummaryWriter
../.spack/.spack-env/view/lib/python3.10/site-packages/tensorboardX/__init__.py:5: in <module>
    from .torchvis import TorchVis
../.spack/.spack-env/view/lib/python3.10/site-packages/tensorboardX/torchvis.py:10: in <module>
    from .writer import SummaryWriter
../.spack/.spack-env/view/lib/python3.10/site-packages/tensorboardX/writer.py:16: in <module>
    from .comet_utils import CometLogger
../.spack/.spack-env/view/lib/python3.10/site-packages/tensorboardX/comet_utils.py:7: in <module>
    from .summary import _clean_tag
../.spack/.spack-env/view/lib/python3.10/site-packages/tensorboardX/summary.py:12: in <module>
    from .proto.summary_pb2 import Summary
../.spack/.spack-env/view/lib/python3.10/site-packages/tensorboardX/proto/summary_pb2.py:16: in <module>
    from tensorboardX.proto import tensor_pb2 as tensorboardX_dot_proto_dot_tensor__pb2
../.spack/.spack-env/view/lib/python3.10/site-packages/tensorboardX/proto/tensor_pb2.py:16: in <module>
    from tensorboardX.proto import resource_handle_pb2 as tensorboardX_dot_proto_dot_resource__handle__pb2
../.spack/.spack-env/view/lib/python3.10/site-packages/tensorboardX/proto/resource_handle_pb2.py:18: in <module>
    DESCRIPTOR = _descriptor.FileDescriptor(
../.spack/.spack-env/view/lib/python3.10/site-packages/google/protobuf/descriptor.py:1034: in __init__
    _Deprecated('FileDescriptor')
../.spack/.spack-env/view/lib/python3.10/site-packages/google/protobuf/descriptor.py:97: in _Deprecated
    warnings.warn(
E   DeprecationWarning: Call to deprecated create function FileDescriptor(). Note: Create unlinked descriptors is going to go away. Please use get/find descriptors from generated code or query the descriptor_pool.
```