### PR TITLE
Fix for warning raised if model outputs no box predictions

### DIFF
--- a/torchgeo/datasets/nasa_marine_debris.py
+++ b/torchgeo/datasets/nasa_marine_debris.py
@@ -236,7 +236,7 @@ class NASAMarineDebris(NonGeoDataset):
         image = draw_bounding_boxes(image=sample["image"], boxes=sample["boxes"])
         image = image.permute((1, 2, 0)).numpy()
 
-        if "prediction_boxes" in sample:
+        if "prediction_boxes" in sample and len(sample["prediction_boxes"]):
             ncols += 1
             preds = draw_bounding_boxes(
                 image=sample["image"], boxes=sample["prediction_boxes"]

--- a/torchgeo/datasets/nasa_marine_debris.py
+++ b/torchgeo/datasets/nasa_marine_debris.py
@@ -233,7 +233,9 @@ class NASAMarineDebris(NonGeoDataset):
         """
         ncols = 1
 
-        image = draw_bounding_boxes(image=sample["image"], boxes=sample["boxes"])
+        image = sample["image"]
+        if "boxes" in sample and len(sample["boxes"]):
+            image = draw_bounding_boxes(image=sample["image"], boxes=sample["boxes"])
         image = image.permute((1, 2, 0)).numpy()
 
         if "prediction_boxes" in sample and len(sample["prediction_boxes"]):


### PR DESCRIPTION
`draw_bounding_boxes` raises a warning if no boxes are passed. PR fixes this by calling the function only if `sample["prediction_boxes"]` has non zero elements.