### PR TITLE
Fix mistakes caught by pydocstyle convention PR

### DIFF
--- a/torchgeo/datamodules/deepglobelandcover.py
+++ b/torchgeo/datamodules/deepglobelandcover.py
@@ -42,6 +42,10 @@ class DeepGlobeLandCoverDataModule(pl.LightningDataModule):
         During training, the effective batch size is equal to
         ``num_tiles_per_batch`` x ``num_patches_per_tile``.
 
+        .. versionchanged:: 0.4
+           *batch_size* was replaced by *num_tile_per_batch*, *num_patches_per_tile*,
+           and *patch_size*.
+
         Args:
             num_tiles_per_batch: The number of image tiles to sample from during
                 training
@@ -53,10 +57,6 @@ class DeepGlobeLandCoverDataModule(pl.LightningDataModule):
             num_workers: The number of workers to use for parallel data loading
             **kwargs: Additional keyword arguments passed to
                 :class:`~torchgeo.datasets.DeepGlobeLandCover`
-
-        .. versionchanged:: 0.4
-           *batch_size* was replaced by *num_tile_per_batch*, *num_patches_per_tile*,
-           and *patch_size*.
         """
         super().__init__()
 

--- a/torchgeo/datamodules/potsdam.py
+++ b/torchgeo/datamodules/potsdam.py
@@ -44,6 +44,10 @@ class Potsdam2DDataModule(pl.LightningDataModule):
         During training, the effective batch size is equal to
         ``num_tiles_per_batch`` x ``num_patches_per_tile``.
 
+        .. versionchanged:: 0.4
+           *batch_size* was replaced by *num_tile_per_batch*, *num_patches_per_tile*,
+           and *patch_size*.
+
         Args:
             num_tiles_per_batch: The number of image tiles to sample from during
                 training
@@ -55,10 +59,6 @@ class Potsdam2DDataModule(pl.LightningDataModule):
             num_workers: The number of workers to use for parallel data loading
             **kwargs: Additional keyword arguments passed to
                 :class:`~torchgeo.datasets.Potsdam2D`
-
-        .. versionchanged:: 0.4
-           *batch_size* was replaced by *num_tile_per_batch*, *num_patches_per_tile*,
-           and *patch_size*.
         """
         super().__init__()
 

--- a/torchgeo/datamodules/vaihingen.py
+++ b/torchgeo/datamodules/vaihingen.py
@@ -44,6 +44,10 @@ class Vaihingen2DDataModule(pl.LightningDataModule):
         During training, the effective batch size is equal to
         ``num_tiles_per_batch`` x ``num_patches_per_tile``.
 
+        .. versionchanged:: 0.4
+           *batch_size* was replaced by *num_tile_per_batch*, *num_patches_per_tile*,
+           and *patch_size*.
+
         Args:
             num_tiles_per_batch: The number of image tiles to sample from during
                 training
@@ -55,10 +59,6 @@ class Vaihingen2DDataModule(pl.LightningDataModule):
             num_workers: The number of workers to use for parallel data loading
             **kwargs: Additional keyword arguments passed to
                 :class:`~torchgeo.datasets.Vaihingen2D`
-
-        .. versionchanged:: 0.4
-           *batch_size* was replaced by *num_tile_per_batch*, *num_patches_per_tile*,
-           and *patch_size*.
         """
         super().__init__()
 

--- a/torchgeo/datasets/cyclone.py
+++ b/torchgeo/datasets/cyclone.py
@@ -230,7 +230,7 @@ class TropicalCyclone(NonGeoDataset):
             show_titles: flag indicating whether to show titles above each panel
             suptitle: optional suptitle to use for figure
 
-        Returns;
+        Returns:
             a matplotlib Figure with the rendered sample
 
         .. versionadded:: 0.2

--- a/torchgeo/datasets/gid15.py
+++ b/torchgeo/datasets/gid15.py
@@ -250,7 +250,7 @@ class GID15(NonGeoDataset):
             sample: a sample return by :meth:`__getitem__`
             suptitle: optional suptitle to use for figure
 
-        Returns;
+        Returns:
             a matplotlib Figure with the rendered sample
 
         .. versionadded:: 0.2

--- a/torchgeo/models/rcf.py
+++ b/torchgeo/models/rcf.py
@@ -38,15 +38,15 @@ class RCF(Module):
         This is a static model that serves to extract fixed length feature vectors from
         input patches.
 
+        .. versionadded:: 0.2
+           The *seed* parameter.
+
         Args:
             in_channels: number of input channels
             features: number of features to compute, must be divisible by 2
             kernel_size: size of the kernel used to compute the RCFs
             bias: bias of the convolutional layer
             seed: random seed used to initialize the convolutional layer
-
-        .. versionadded:: 0.2
-           The *seed* parameter.
         """
         super().__init__()
 

--- a/torchgeo/samplers/batch.py
+++ b/torchgeo/samplers/batch.py
@@ -80,6 +80,12 @@ class RandomBatchGeoSampler(BatchGeoSampler):
         * a ``tuple`` of two floats - in which case, the first *float* is used for the
           height dimension, and the second *float* for the width dimension
 
+        .. versionchanged:: 0.3
+           Added ``units`` parameter, changed default to pixel units
+
+        .. versionchanged:: 0.4
+           ``length`` parameter is now optional, a reasonable default will be used
+
         Args:
             dataset: dataset to index from
             size: dimensions of each :term:`patch`
@@ -91,12 +97,6 @@ class RandomBatchGeoSampler(BatchGeoSampler):
             roi: region of interest to sample from (minx, maxx, miny, maxy, mint, maxt)
                 (defaults to the bounds of ``dataset.index``)
             units: defines if ``size`` is in pixel or CRS units
-
-        .. versionchanged:: 0.3
-           Added ``units`` parameter, changed default to pixel units
-
-        .. versionchanged:: 0.4
-           ``length`` parameter is now optional, a reasonable default will be used
         """
         super().__init__(dataset, roi)
         self.size = _to_tuple(size)

--- a/torchgeo/samplers/single.py
+++ b/torchgeo/samplers/single.py
@@ -82,6 +82,12 @@ class RandomGeoSampler(GeoSampler):
         * a ``tuple`` of two floats - in which case, the first *float* is used for the
           height dimension, and the second *float* for the width dimension
 
+        .. versionchanged:: 0.3
+           Added ``units`` parameter, changed default to pixel units
+
+        .. versionchanged:: 0.4
+           ``length`` parameter is now optional, a reasonable default will be used
+
         Args:
             dataset: dataset to index from
             size: dimensions of each :term:`patch`
@@ -92,12 +98,6 @@ class RandomGeoSampler(GeoSampler):
             roi: region of interest to sample from (minx, maxx, miny, maxy, mint, maxt)
                 (defaults to the bounds of ``dataset.index``)
             units: defines if ``size`` is in pixel or CRS units
-
-        .. versionchanged:: 0.3
-           Added ``units`` parameter, changed default to pixel units
-
-        .. versionchanged:: 0.4
-           ``length`` parameter is now optional, a reasonable default will be used
         """
         super().__init__(dataset, roi)
         self.size = _to_tuple(size)
@@ -190,6 +190,9 @@ class GridGeoSampler(GeoSampler):
         * a ``tuple`` of two floats - in which case, the first *float* is used for the
           height dimension, and the second *float* for the width dimension
 
+        .. versionchanged:: 0.3
+           Added ``units`` parameter, changed default to pixel units
+
         Args:
             dataset: dataset to index from
             size: dimensions of each :term:`patch`
@@ -197,9 +200,6 @@ class GridGeoSampler(GeoSampler):
             roi: region of interest to sample from (minx, maxx, miny, maxy, mint, maxt)
                 (defaults to the bounds of ``dataset.index``)
             units: defines if ``size`` and ``stride`` are in pixel or CRS units
-
-        .. versionchanged:: 0.3
-           Added ``units`` parameter, changed default to pixel units
         """
         super().__init__(dataset, roi)
         self.size = _to_tuple(size)
@@ -286,13 +286,13 @@ class PreChippedGeoSampler(GeoSampler):
     ) -> None:
         """Initialize a new Sampler instance.
 
+        .. versionadded:: 0.3
+
         Args:
             dataset: dataset to index from
             roi: region of interest to sample from (minx, maxx, miny, maxy, mint, maxt)
                 (defaults to the bounds of ``dataset.index``)
             shuffle: if True, reshuffle data at every epoch
-
-        .. versionadded:: 0.3
         """
         super().__init__(dataset, roi)
         self.shuffle = shuffle


### PR DESCRIPTION
pydocstyle's support for Google-style docstring checking has been broken for a long time: https://github.com/PyCQA/pydocstyle/issues/459. I tested out https://github.com/PyCQA/pydocstyle/pull/589 which fixes this issue and discovered the following mistakes in our docstrings. I'm not sure if Google's style guide actually requires Args/Returns to come last, but the `Returns;` mistakes are real and [affected our docs](https://torchgeo.readthedocs.io/en/stable/api/datasets.html#torchgeo.datasets.GID15.plot).