### PR TITLE
.gitignore: ignore lightning_logs directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # TorchGeo
 /data/
-/logs/
+/*logs/
 /output/
 *.pdf
 


### PR DESCRIPTION
The default log directory of PyTorch Lightning is `lightning_logs`. We should ignore it.