### PR TITLE
Fix ViT weight names in docs

### DIFF
--- a/docs/api/vit_pretrained_weights.csv
+++ b/docs/api/vit_pretrained_weights.csv
@@ -1,3 +1,3 @@
 Weight,Channels,Source,Citation,BigEarthNet,EuroSAT,So2Sat,OSCD
-VITSmall16_Weights.SENTINEL2_ALL_MOCO,13,`link <https://github.com/zhu-xlab/SSL4EO-S12>`__,`link <https://arxiv.org/abs/2211.07044>`__,89.9,98.6,61.6,
-VITSmall16_Weights.SENTINEL2_ALL_DINO,13,`link <https://github.com/zhu-xlab/SSL4EO-S12>`__,`link <https://arxiv.org/abs/2211.07044>`__,90.5,99.0,62.2,
+ViTSmall16_Weights.SENTINEL2_ALL_MOCO,13,`link <https://github.com/zhu-xlab/SSL4EO-S12>`__,`link <https://arxiv.org/abs/2211.07044>`__,89.9,98.6,61.6,
+ViTSmall16_Weights.SENTINEL2_ALL_DINO,13,`link <https://github.com/zhu-xlab/SSL4EO-S12>`__,`link <https://arxiv.org/abs/2211.07044>`__,90.5,99.0,62.2,


### PR DESCRIPTION
Wish there was a way to link to the enum itself so we can enforce that they are named correctly, but it doesn't seem to show up in the docs.