### PR TITLE
Labeler: add labels to dependency files

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -15,6 +15,10 @@ transforms:
 - "torchgeo/transforms/**"
 
 # Other
+dependencies:
+- "environment.yml"
+- "setup.cfg"
+- "requirements/**"
 documentation:
 - "docs/**"
 scripts:


### PR DESCRIPTION
Dependabot adds this label when it creates a PR, but we should also use it when one of these files is manually updated.