### PR TITLE
Codecov: use repository upload token

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -72,6 +72,8 @@ jobs:
       if: ${{ runner.os == 'Windows' }}
     - name: Report coverage
       uses: codecov/codecov-action@v3.1.1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
   minimum:
     name: minimum
     runs-on: ubuntu-latest
@@ -96,3 +98,5 @@ jobs:
       run: pytest --cov=torchgeo --cov-report=xml --durations=10
     - name: Report coverage
       uses: codecov/codecov-action@v3.1.1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
See https://github.com/codecov/codecov-action/issues/903. I'm hoping this fixes our intermittent codecov issues.

Still need to add the secret to our repo, need to get access first.