### PR TITLE
CI: cancel in-progress jobs when new commit

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,5 +10,5 @@ jobs:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         sync-labels: true
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,6 @@
 name: "labeler"
 on:
 - pull_request_target
-
 jobs:
   label:
     runs-on: ubuntu-latest
@@ -10,3 +9,6 @@ jobs:
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         sync-labels: true
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -78,3 +78,6 @@ jobs:
       env:
         MLHUB_API_KEY: ${{ secrets.MLHUB_API_KEY }}
       run: pytest --nbmake docs/tutorials --durations=10
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -79,5 +79,5 @@ jobs:
         MLHUB_API_KEY: ${{ secrets.MLHUB_API_KEY }}
       run: pytest --nbmake docs/tutorials --durations=10
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -124,3 +124,6 @@ jobs:
         pip list
     - name: Run pyupgrade checks
       run: pyupgrade --py38-plus $(find . -path ./docs/src -prune -o -name "*.py" -print)
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -125,5 +125,5 @@ jobs:
     - name: Run pyupgrade checks
       run: pyupgrade --py38-plus $(find . -path ./docs/src -prune -o -name "*.py" -print)
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -121,3 +121,6 @@ jobs:
       uses: codecov/codecov-action@v3.1.1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -122,5 +122,5 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
See [the docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow).

If a new commit is pushed, there's no reason to finish jobs for old commits. RtD CI already does this.

The name of the concurrency group seems rather finicky. Other users recommend [something else]( https://stackoverflow.com/a/72408109/5828163). Spack uses [yet another option](https://github.com/spack/spack/pull/32361/files#r964394342). It's unclear to me which is required. I suggest starting simple and adding complexity when needed.