### PR TITLE
One extra to rule them all

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -128,6 +128,8 @@ tests =
     pytest>=6.1.2,<8
     # pytest-cov 2.4+ required for pytest --cov flags
     pytest-cov>=2.4,<5
+all =
+    torchgeo[datasets,docs,style,tests]
 
 [flake8]
 max-line-length = 88


### PR DESCRIPTION
This adds an "all" extra that allows you to install all optional dependencies. The following:
```console
$ pip install torchgeo[all]
```
is now equivalent to:
```console
$ pip install torchgeo[datasets,docs,style,tests]
```
Note that this requires pip 21.2+. Users on older versions of pip can still install torchgeo normally, but won't be able to install `torchgeo[all]`.

See https://hynek.me/articles/python-recursive-optional-dependencies/.