### PR TITLE
Weights: add sha256 suffix

### DIFF
--- a/docs/api/resnet_pretrained_weights.csv
+++ b/docs/api/resnet_pretrained_weights.csv
@@ -3,7 +3,7 @@ ResNet18_Weights.SENTINEL2_ALL_MOCO,13,`link <https://github.com/zhu-xlab/SSL4EO
 ResNet18_Weights.SENTINEL2_RGB_MOCO, 3,`link <https://github.com/zhu-xlab/SSL4EO-S12>`__,`link <https://arxiv.org/abs/2211.07044>`__,,,,
 ResNet18_Weights.SENTINEL2_RGB_SECO, 3,`link <https://github.com/ServiceNow/seasonal-contrast>`__,`link <https://arxiv.org/abs/2103.16607>`__,87.27,93.14,,46.94
 ResNet50_Weights.SENTINEL1_ALL_MOCO, 2,`link <https://github.com/zhu-xlab/SSL4EO-S12>`__,`link <https://arxiv.org/abs/2211.07044>`__,,,,
+ResNet50_Weights.SENTINEL2_ALL_DINO,13,`link <https://github.com/zhu-xlab/SSL4EO-S12>`__,`link <https://arxiv.org/abs/2211.07044>`__,90.7,99.1,63.6,
 ResNet50_Weights.SENTINEL2_ALL_MOCO,13,`link <https://github.com/zhu-xlab/SSL4EO-S12>`__,`link <https://arxiv.org/abs/2211.07044>`__,91.8,99.1,60.9,
 ResNet50_Weights.SENTINEL2_RGB_MOCO, 3,`link <https://github.com/zhu-xlab/SSL4EO-S12>`__,`link <https://arxiv.org/abs/2211.07044>`__,,,,
-ResNet50_Weights.SENTINEL2_ALL_DINO,13,`link <https://github.com/zhu-xlab/SSL4EO-S12>`__,`link <https://arxiv.org/abs/2211.07044>`__,90.7,99.1,63.6,
 ResNet50_Weights.SENTINEL2_RGB_SECO, 3,`link <https://github.com/ServiceNow/seasonal-contrast>`__,`link <https://arxiv.org/abs/2103.16607>`__,87.81,,,

--- a/docs/api/vit_pretrained_weights.csv
+++ b/docs/api/vit_pretrained_weights.csv
@@ -1,3 +1,3 @@
 Weight,Channels,Source,Citation,BigEarthNet,EuroSAT,So2Sat,OSCD
-ViTSmall16_Weights.SENTINEL2_ALL_MOCO,13,`link <https://github.com/zhu-xlab/SSL4EO-S12>`__,`link <https://arxiv.org/abs/2211.07044>`__,89.9,98.6,61.6,
 ViTSmall16_Weights.SENTINEL2_ALL_DINO,13,`link <https://github.com/zhu-xlab/SSL4EO-S12>`__,`link <https://arxiv.org/abs/2211.07044>`__,90.5,99.0,62.2,
+ViTSmall16_Weights.SENTINEL2_ALL_MOCO,13,`link <https://github.com/zhu-xlab/SSL4EO-S12>`__,`link <https://arxiv.org/abs/2211.07044>`__,89.9,98.6,61.6,

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -136,7 +136,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
     )
 
     SENTINEL2_RGB_SECO = Weights(
-        url="https://huggingface.co/torchgeo/resnet50_sentinel2_rgb_seco/blob/main/resnet50_sentinel2_rgb_seco-584035db.pth",  # noqa: E501
+        url="https://huggingface.co/torchgeo/resnet50_sentinel2_rgb_seco/resolve/main/resnet50_sentinel2_rgb_seco-584035db.pth",  # noqa: E501
         transforms=nn.Identity(),
         meta={
             "dataset": "SeCo Dataset",

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -35,10 +35,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
     """
 
     SENTINEL2_ALL_MOCO = Weights(
-        url=(
-            "https://huggingface.co/torchgeo/resnet18_sentinel2_all_moco/"
-            "resolve/main/resnet18_sentinel2_all_moco.pth"
-        ),
+        url="https://huggingface.co/torchgeo/resnet18_sentinel2_all_moco/resolve/main/resnet18_sentinel2_all_moco-59bfdff9.pth",  # noqa: E501
         transforms=_zhu_xlab_transforms,
         meta={
             "dataset": "SSL4EO-S12",
@@ -51,10 +48,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
     )
 
     SENTINEL2_RGB_MOCO = Weights(
-        url=(
-            "https://huggingface.co/torchgeo/resnet18_sentinel2_rgb_moco/"
-            "resolve/main/resnet18_sentinel2_rgb_moco.pth"
-        ),
+        url="https://huggingface.co/torchgeo/resnet18_sentinel2_rgb_moco/resolve/main/resnet18_sentinel2_rgb_moco-e3a335e3.pth",  # noqa: E501
         transforms=_zhu_xlab_transforms,
         meta={
             "dataset": "SSL4EO-S12",
@@ -67,10 +61,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
     )
 
     SENTINEL2_RGB_SECO = Weights(
-        url=(
-            "https://huggingface.co/torchgeo/resnet18_sentinel2_rgb_seco/"
-            "resolve/main/resnet18_sentinel2_rgb_seco.ckpt"
-        ),
+        url="https://huggingface.co/torchgeo/resnet18_sentinel2_rgb_seco/resolve/main/resnet18_sentinel2_rgb_seco-9976a9cb.pth",  # noqa: E501
         transforms=nn.Identity(),
         meta={
             "dataset": "SeCo Dataset",
@@ -93,10 +84,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
     """
 
     SENTINEL1_ALL_MOCO = Weights(
-        url=(
-            "https://huggingface.co/torchgeo/resnet50_sentinel1_all_moco/"
-            "resolve/main/resnet50_sentinel1_all_moco.pth"
-        ),
+        url="https://huggingface.co/torchgeo/resnet50_sentinel1_all_moco/resolve/main/resnet50_sentinel1_all_moco-906e4356.pth",  # noqa: E501
         transforms=_zhu_xlab_transforms,
         meta={
             "dataset": "SSL4EO-S12",
@@ -108,11 +96,21 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
         },
     )
 
+    SENTINEL2_ALL_DINO = Weights(
+        url="https://huggingface.co/torchgeo/resnet50_sentinel2_all_dino/resolve/main/resnet50_sentinel2_all_dino-d6c330e9.pth",  # noqa: E501
+        transforms=_zhu_xlab_transforms,
+        meta={
+            "dataset": "SSL4EO-S12",
+            "in_chans": 13,
+            "model": "resnet50",
+            "publication": "https://arxiv.org/abs/2211.07044",
+            "repo": "https://github.com/zhu-xlab/SSL4EO-S12",
+            "ssl_method": "dino",
+        },
+    )
+
     SENTINEL2_ALL_MOCO = Weights(
-        url=(
-            "https://huggingface.co/torchgeo/resnet50_sentinel2_all_moco/"
-            "resolve/main/resnet50_sentinel2_all_moco.pth"
-        ),
+        url="https://huggingface.co/torchgeo/resnet50_sentinel2_all_moco/resolve/main/resnet50_sentinel2_all_moco-df8b932e.pth",  # noqa: E501
         transforms=_zhu_xlab_transforms,
         meta={
             "dataset": "SSL4EO-S12",
@@ -125,10 +123,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
     )
 
     SENTINEL2_RGB_MOCO = Weights(
-        url=(
-            "https://huggingface.co/torchgeo/resnet50_sentinel2_rgb_moco/"
-            "resolve/main/resnet50_sentinel2_rgb_moco.pth"
-        ),
+        url="https://huggingface.co/torchgeo/resnet50_sentinel2_rgb_moco/resolve/main/resnet50_sentinel2_rgb_moco-2b57ba8b.pth",  # noqa: E501
         transforms=_zhu_xlab_transforms,
         meta={
             "dataset": "SSL4EO-S12",
@@ -140,27 +135,8 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
         },
     )
 
-    SENTINEL2_ALL_DINO = Weights(
-        url=(
-            "https://huggingface.co/torchgeo/resnet50_sentinel2_all_dino/"
-            "resolve/main/resnet50_sentinel2_all_dino.pth"
-        ),
-        transforms=_zhu_xlab_transforms,
-        meta={
-            "dataset": "SSL4EO-S12",
-            "in_chans": 13,
-            "model": "resnet50",
-            "publication": "https://arxiv.org/abs/2211.07044",
-            "repo": "https://github.com/zhu-xlab/SSL4EO-S12",
-            "ssl_method": "dino",
-        },
-    )
-
     SENTINEL2_RGB_SECO = Weights(
-        url=(
-            "https://huggingface.co/torchgeo/resnet50_sentinel2_rgb_seco/"
-            "resolve/main/resnet50_sentinel2_rgb_seco.ckpt"
-        ),
+        url="https://huggingface.co/torchgeo/resnet50_sentinel2_rgb_seco/blob/main/resnet50_sentinel2_rgb_seco-584035db.pth",  # noqa: E501
         transforms=nn.Identity(),
         meta={
             "dataset": "SeCo Dataset",

--- a/torchgeo/models/vit.py
+++ b/torchgeo/models/vit.py
@@ -33,27 +33,8 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
     .. versionadded:: 0.4
     """
 
-    SENTINEL2_ALL_MOCO = Weights(
-        url=(
-            "https://huggingface.co/torchgeo/vit_small_patch16_224_sentinel2_all_moco/"
-            "resolve/main/vit_small_patch16_224_sentinel2_all_moco.pth"
-        ),
-        transforms=_zhu_xlab_transforms,
-        meta={
-            "dataset": "SSL4EO-S12",
-            "in_chans": 13,
-            "model": "vit_small_patch16_224",
-            "publication": "https://arxiv.org/abs/2211.07044",
-            "repo": "https://github.com/zhu-xlab/SSL4EO-S12",
-            "ssl_method": "moco",
-        },
-    )
-
     SENTINEL2_ALL_DINO = Weights(
-        url=(
-            "https://huggingface.co/torchgeo/vit_small_patch16_224_sentinel2_all_dino/"
-            "resolve/main/vit_small_patch16_224_sentinel2_all_dino.pth"
-        ),
+        url="https://huggingface.co/torchgeo/vit_small_patch16_224_sentinel2_all_dino/resolve/main/vit_small_patch16_224_sentinel2_all_dino-36bcc127.pth",  # noqa: E501
         transforms=_zhu_xlab_transforms,
         meta={
             "dataset": "SSL4EO-S12",
@@ -62,6 +43,19 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             "publication": "https://arxiv.org/abs/2211.07044",
             "repo": "https://github.com/zhu-xlab/SSL4EO-S12",
             "ssl_method": "dino",
+        },
+    )
+
+    SENTINEL2_ALL_MOCO = Weights(
+        url="https://huggingface.co/torchgeo/vit_small_patch16_224_sentinel2_all_moco/resolve/main/vit_small_patch16_224_sentinel2_all_moco-67c9032d.pth",  # noqa: E501
+        transforms=_zhu_xlab_transforms,
+        meta={
+            "dataset": "SSL4EO-S12",
+            "in_chans": 13,
+            "model": "vit_small_patch16_224",
+            "publication": "https://arxiv.org/abs/2211.07044",
+            "repo": "https://github.com/zhu-xlab/SSL4EO-S12",
+            "ssl_method": "moco",
         },
     )
 


### PR DESCRIPTION
This PR includes the following changes:

- [x] Add the first 8 digits of the sha256 to the filename suffix
- [x] Standardize on .pth file extension
- [x] Sort weights alphabetically
- [x] Keep URLs on a single line

All old weights still exist at the same URLs for backwards compatibility. All new weights should follow this `<name>-<sha256>.pth` format.

References:

* https://github.com/pytorch/vision/issues/7210
* https://github.com/pytorch/vision/pull/7219
* https://pytorch.org/docs/stable/hub.html#torch.hub.load_state_dict_from_url

We won't actually be able to use this checksum until torchvision 0.15.0, but might as well do the heavy lifting now.