### PR TITLE
Change BigEarthNet class mapping order to match original code

### DIFF
--- a/torchgeo/datasets/bigearthnet.py
+++ b/torchgeo/datasets/bigearthnet.py
@@ -45,50 +45,50 @@ class BigEarthNet(NonGeoDataset):
 
     Dataset classes (43):
 
-    0. Agro-forestry areas
-    1. Airports
-    2. Annual crops associated with permanent crops
-    3. Bare rock
-    4. Beaches, dunes, sands
-    5. Broad-leaved forest
-    6. Burnt areas
-    7. Coastal lagoons
-    8. Complex cultivation patterns
-    9. Coniferous forest
-    10. Construction sites
-    11. Continuous urban fabric
-    12. Discontinuous urban fabric
-    13. Dump sites
-    14. Estuaries
-    15. Fruit trees and berry plantations
-    16. Green urban areas
-    17. Industrial or commercial units
-    18. Inland marshes
-    19. Intertidal flats
-    20. Land principally occupied by agriculture, with significant
+    0: Continuous urban fabric
+    1: Discontinuous urban fabric
+    2: Industrial or commercial units
+    3: Road and rail networks and associated land
+    4: Port areas
+    5: Airports
+    6: Mineral extraction sites
+    7: Dump sites
+    8: Construction sites
+    9: Green urban areas
+    10: Sport and leisure facilities
+    11: Non-irrigated arable land
+    12: Permanently irrigated land
+    13: Rice fields
+    14: Vineyards
+    15: Fruit trees and berry plantations
+    16: Olive groves
+    17: Pastures
+    18: Annual crops associated with permanent crops
+    19: Complex cultivation patterns
+    20: Land principally occupied by agriculture, with significant
         areas of natural vegetation
-    21. Mineral extraction sites
-    22. Mixed forest
-    23. Moors and heathland
-    24. Natural grassland
-    25. Non-irrigated arable land
-    26. Olive groves
-    27. Pastures
-    28. Peatbogs
-    29. Permanently irrigated land
-    30. Port areas
-    31. Rice fields
-    32. Road and rail networks and associated land
-    33. Salines
-    34. Salt marshes
-    35. Sclerophyllous vegetation
-    36. Sea and ocean
-    37. Sparsely vegetated areas
-    38. Sport and leisure facilities
-    39. Transitional woodland/shrub
-    40. Vineyards
-    41. Water bodies
-    42. Water courses
+    21: Agro-forestry areas
+    22: Broad-leaved forest
+    23: Coniferous forest
+    24: Mixed forest
+    25: Natural grassland
+    26: Moors and heathland
+    27: Sclerophyllous vegetation
+    28: Transitional woodland/shrub
+    29: Beaches, dunes, sands
+    30: Bare rock
+    31: Sparsely vegetated areas
+    32: Burnt areas
+    33: Inland marshes
+    34: Peatbogs
+    35: Salt marshes
+    36: Salines
+    37: Intertidal flats
+    38: Water courses
+    39: Water bodies
+    40: Coastal lagoons
+    41: Estuaries
+    42: Sea and ocean
 
     Dataset classes (19):
 
@@ -143,50 +143,50 @@ class BigEarthNet(NonGeoDataset):
             "Marine waters",
         ],
         43: [
-            "Agro-forestry areas",
-            "Airports",
-            "Annual crops associated with permanent crops",
-            "Bare rock",
-            "Beaches, dunes, sands",
-            "Broad-leaved forest",
-            "Burnt areas",
-            "Coastal lagoons",
-            "Complex cultivation patterns",
-            "Coniferous forest",
-            "Construction sites",
             "Continuous urban fabric",
             "Discontinuous urban fabric",
-            "Dump sites",
-            "Estuaries",
-            "Fruit trees and berry plantations",
-            "Green urban areas",
             "Industrial or commercial units",
-            "Inland marshes",
-            "Intertidal flats",
-            "Land principally occupied by agriculture, with significant areas of"
-            " natural vegetation",
+            "Road and rail networks and associated land",
+            "Port areas",
+            "Airports",
             "Mineral extraction sites",
-            "Mixed forest",
-            "Moors and heathland",
-            "Natural grassland",
+            "Dump sites",
+            "Construction sites",
+            "Green urban areas",
+            "Sport and leisure facilities",
             "Non-irrigated arable land",
+            "Permanently irrigated land",
+            "Rice fields",
+            "Vineyards",
+            "Fruit trees and berry plantations",
             "Olive groves",
             "Pastures",
-            "Peatbogs",
-            "Permanently irrigated land",
-            "Port areas",
-            "Rice fields",
-            "Road and rail networks and associated land",
-            "Salines",
-            "Salt marshes",
+            "Annual crops associated with permanent crops",
+            "Complex cultivation patterns",
+            "Land principally occupied by agriculture, with significant areas of"
+            " natural vegetation",
+            "Agro-forestry areas",
+            "Broad-leaved forest",
+            "Coniferous forest",
+            "Mixed forest",
+            "Natural grassland",
+            "Moors and heathland",
             "Sclerophyllous vegetation",
-            "Sea and ocean",
-            "Sparsely vegetated areas",
-            "Sport and leisure facilities",
             "Transitional woodland/shrub",
-            "Vineyards",
-            "Water bodies",
+            "Beaches, dunes, sands",
+            "Bare rock",
+            "Sparsely vegetated areas",
+            "Burnt areas",
+            "Inland marshes",
+            "Peatbogs",
+            "Salt marshes",
+            "Salines",
+            "Intertidal flats",
             "Water courses",
+            "Water bodies",
+            "Coastal lagoons",
+            "Estuaries",
+            "Sea and ocean",
         ],
     }
 

--- a/torchgeo/datasets/bigearthnet.py
+++ b/torchgeo/datasets/bigearthnet.py
@@ -45,50 +45,50 @@ class BigEarthNet(NonGeoDataset):
 
     Dataset classes (43):
 
-    0: Continuous urban fabric
-    1: Discontinuous urban fabric
-    2: Industrial or commercial units
-    3: Road and rail networks and associated land
-    4: Port areas
-    5: Airports
-    6: Mineral extraction sites
-    7: Dump sites
-    8: Construction sites
-    9: Green urban areas
-    10: Sport and leisure facilities
-    11: Non-irrigated arable land
-    12: Permanently irrigated land
-    13: Rice fields
-    14: Vineyards
-    15: Fruit trees and berry plantations
-    16: Olive groves
-    17: Pastures
-    18: Annual crops associated with permanent crops
-    19: Complex cultivation patterns
-    20: Land principally occupied by agriculture, with significant
+    0. Continuous urban fabric
+    1. Discontinuous urban fabric
+    2. Industrial or commercial units
+    3. Road and rail networks and associated land
+    4. Port areas
+    5. Airports
+    6. Mineral extraction sites
+    7. Dump sites
+    8. Construction sites
+    9. Green urban areas
+    10. Sport and leisure facilities
+    11. Non-irrigated arable land
+    12. Permanently irrigated land
+    13. Rice fields
+    14. Vineyards
+    15. Fruit trees and berry plantations
+    16. Olive groves
+    17. Pastures
+    18. Annual crops associated with permanent crops
+    19. Complex cultivation patterns
+    20. Land principally occupied by agriculture, with significant
         areas of natural vegetation
-    21: Agro-forestry areas
-    22: Broad-leaved forest
-    23: Coniferous forest
-    24: Mixed forest
-    25: Natural grassland
-    26: Moors and heathland
-    27: Sclerophyllous vegetation
-    28: Transitional woodland/shrub
-    29: Beaches, dunes, sands
-    30: Bare rock
-    31: Sparsely vegetated areas
-    32: Burnt areas
-    33: Inland marshes
-    34: Peatbogs
-    35: Salt marshes
-    36: Salines
-    37: Intertidal flats
-    38: Water courses
-    39: Water bodies
-    40: Coastal lagoons
-    41: Estuaries
-    42: Sea and ocean
+    21. Agro-forestry areas
+    22. Broad-leaved forest
+    23. Coniferous forest
+    24. Mixed forest
+    25. Natural grassland
+    26. Moors and heathland
+    27. Sclerophyllous vegetation
+    28. Transitional woodland/shrub
+    29. Beaches, dunes, sands
+    30. Bare rock
+    31. Sparsely vegetated areas
+    32. Burnt areas
+    33. Inland marshes
+    34. Peatbogs
+    35. Salt marshes
+    36. Salines
+    37. Intertidal flats
+    38. Water courses
+    39. Water bodies
+    40. Coastal lagoons
+    41. Estuaries
+    42. Sea and ocean
 
     Dataset classes (19):
 
@@ -112,6 +112,11 @@ class BigEarthNet(NonGeoDataset):
     16. Coastal wetlands
     17. Inland waters
     18. Marine waters
+
+    The source for the above dataset classes, their respective ordering, and
+    43-to-19-class mappings can be found here:
+
+    * https://git.tu-berlin.de/rsim/BigEarthNet-S2_19-classes_models/-/blob/master/label_indices.json
 
     If you use this dataset in your research, please cite the following paper:
 

--- a/torchgeo/datasets/bigearthnet.py
+++ b/torchgeo/datasets/bigearthnet.py
@@ -122,7 +122,7 @@ class BigEarthNet(NonGeoDataset):
 
     * https://doi.org/10.1109/IGARSS.2019.8900532
 
-    """
+    """ # noqa: E501
 
     class_sets = {
         19: [

--- a/torchgeo/datasets/bigearthnet.py
+++ b/torchgeo/datasets/bigearthnet.py
@@ -122,7 +122,7 @@ class BigEarthNet(NonGeoDataset):
 
     * https://doi.org/10.1109/IGARSS.2019.8900532
 
-    """ # noqa: E501
+    """  # noqa: E501
 
     class_sets = {
         19: [


### PR DESCRIPTION
It seems like the mapping from 43 to 19 classes in the BigEarthNet dataset code is incorrect. 

**Example**
The below image corresponds to the RGB visualization of S2B_MSIL2A_20180502T093039_42_25. The provided textual labels are 'Broad-leaved forest', 'Natural grassland', and 'Transitional woodland/shrub'. Per the mapping provided [here](https://github.com/microsoft/torchgeo/blob/main/torchgeo/datasets/bigearthnet.py#L145-L190) , this corresponds to indices 5, 24, and 39. After converting these from 43 class labels to 19 class labels using the [label converter](https://github.com/microsoft/torchgeo/blob/main/torchgeo/datasets/bigearthnet.py#L193-L226), we end up with 5 being discarded, 24 (Natural grassland) mapping to 10 (Mixed forest) and 39 (Transitional woodland/shrub) mapping to 17 (Inland waters). All three of these are incorrect. 5 (Broad-leaved forest) should be mapped to 8 (Broad-leaved forest), 24 (Natural grassland) should actually map to 11 (Natural grassland and sparsely vegetated areas) and 39 (Transitional woodland/shrub) should map to 13 (Transitional woodland, shrub).

![S2B_MSIL2A_20180502T093039_42_25](https://user-images.githubusercontent.com/22565214/220122458-84304785-f648-40fb-a0f3-e311e1fec6c4.PNG)

**Root Cause and Fix**
The root cause of this issue appears to be an alphabetically sorted list here: https://github.com/microsoft/torchgeo/blob/main/torchgeo/datasets/bigearthnet.py#L145-L190 when it should instead match the order provided by the BigEarthNet code: https://git.tu-berlin.de/rsim/BigEarthNet-S2_19-classes_models/-/blob/master/label_indices.json#L2-46. 

1. Look at the BigEarthNet code for 43 to 19 class mappings provided at https://bigearth.net/. Specifically, this file: https://git.tu-berlin.de/rsim/BigEarthNet-S2_19-classes_models/-/blob/master/label_indices.json#L2-46. Here, the mapping are not sorted in alphabetical order. 

2. Look at the BigEarthNet code for 43 to 19 class mappings in torchgeo: https://github.com/microsoft/torchgeo/blob/main/torchgeo/datasets/bigearthnet.py#L145-L190. These are sorted in alphabetical order. 

3. However, the mappings from 43 to 19 classes remain index based and are the same as the indexes used in: https://github.com/microsoft/torchgeo/blob/main/torchgeo/datasets/bigearthnet.py#L193-L226 and https://git.tu-berlin.de/rsim/BigEarthNet-S2_19-classes_models/-/blob/master/label_indices.json#L47-67. To fix this, either the ordering of the 43 classes or the indexing dictionary must be changed to fix this mismatch.

This commit adjusts the order of the 43 classes to match the original. After testing, I find that the above example now has the correct mapping: 
```
Textual label: ['Broad-leaved forest', 'Natural grassland', 'Transitional woodland/shrub']
43 class: [22, 25, 28]
19 class: [8, 11, 13]
```