### PR TITLE
EuroSAT100: add new dataset/datamodule

### DIFF
--- a/tests/datasets/test_eurosat.py
+++ b/tests/datasets/test_eurosat.py
@@ -27,7 +27,8 @@ class TestEuroSAT:
     def dataset(
         self, monkeypatch: MonkeyPatch, tmp_path: Path, request: SubRequest
     ) -> EuroSAT:
-        base_class, split = request.param
+        base_class: EuroSAT = request.param[0]
+        split: str = request.param[1]
         monkeypatch.setattr(torchgeo.datasets.eurosat, "download_url", download_url)
         md5 = "aa051207b0547daba0ac6af57808d68e"
         monkeypatch.setattr(base_class, "md5", md5)

--- a/tests/datasets/test_eurosat.py
+++ b/tests/datasets/test_eurosat.py
@@ -5,6 +5,7 @@ import os
 import shutil
 from itertools import product
 from pathlib import Path
+from typing import Type
 
 import matplotlib.pyplot as plt
 import pytest
@@ -27,7 +28,7 @@ class TestEuroSAT:
     def dataset(
         self, monkeypatch: MonkeyPatch, tmp_path: Path, request: SubRequest
     ) -> EuroSAT:
-        base_class: EuroSAT = request.param[0]
+        base_class: Type[EuroSAT] = request.param[0]
         split: str = request.param[1]
         monkeypatch.setattr(torchgeo.datasets.eurosat, "download_url", download_url)
         md5 = "aa051207b0547daba0ac6af57808d68e"

--- a/tests/datasets/test_eurosat.py
+++ b/tests/datasets/test_eurosat.py
@@ -3,6 +3,7 @@
 
 import os
 import shutil
+from itertools import product
 from pathlib import Path
 
 import matplotlib.pyplot as plt
@@ -14,7 +15,7 @@ from _pytest.monkeypatch import MonkeyPatch
 from torch.utils.data import ConcatDataset
 
 import torchgeo.datasets.utils
-from torchgeo.datasets import EuroSAT
+from torchgeo.datasets import EuroSAT, EuroSAT100
 
 
 def download_url(url: str, root: str, *args: str, **kwargs: str) -> None:
@@ -22,17 +23,19 @@ def download_url(url: str, root: str, *args: str, **kwargs: str) -> None:
 
 
 class TestEuroSAT:
-    @pytest.fixture(params=["train", "val", "test"])
+    @pytest.fixture(params=product([EuroSAT, EuroSAT100], ["train", "val", "test"]))
     def dataset(
         self, monkeypatch: MonkeyPatch, tmp_path: Path, request: SubRequest
     ) -> EuroSAT:
+        base_class, split = request.param
         monkeypatch.setattr(torchgeo.datasets.eurosat, "download_url", download_url)
         md5 = "aa051207b0547daba0ac6af57808d68e"
-        monkeypatch.setattr(EuroSAT, "md5", md5)
+        monkeypatch.setattr(base_class, "md5", md5)
         url = os.path.join("tests", "data", "eurosat", "EuroSATallBands.zip")
-        monkeypatch.setattr(EuroSAT, "url", url)
+        monkeypatch.setattr(base_class, "url", url)
+        monkeypatch.setattr(base_class, "filename", "EuroSATallBands.zip")
         monkeypatch.setattr(
-            EuroSAT,
+            base_class,
             "split_urls",
             {
                 "train": os.path.join("tests", "data", "eurosat", "eurosat-train.txt"),
@@ -41,7 +44,7 @@ class TestEuroSAT:
             },
         )
         monkeypatch.setattr(
-            EuroSAT,
+            base_class,
             "split_md5s",
             {
                 "train": "4af60a00fdfdf8500572ae5360694b71",
@@ -50,9 +53,8 @@ class TestEuroSAT:
             },
         )
         root = str(tmp_path)
-        split = request.param
         transforms = nn.Identity()
-        return EuroSAT(
+        return base_class(
             root=root, split=split, transforms=transforms, download=True, checksum=True
         )
 

--- a/tests/trainers/test_classification.py
+++ b/tests/trainers/test_classification.py
@@ -18,8 +18,8 @@ from torchvision.models._api import WeightsEnum
 
 from torchgeo.datamodules import (
     BigEarthNetDataModule,
-    EuroSATDataModule,
     EuroSAT100DataModule,
+    EuroSATDataModule,
     MisconfigurationException,
     RESISC45DataModule,
     So2SatDataModule,

--- a/tests/trainers/test_classification.py
+++ b/tests/trainers/test_classification.py
@@ -19,6 +19,7 @@ from torchvision.models._api import WeightsEnum
 from torchgeo.datamodules import (
     BigEarthNetDataModule,
     EuroSATDataModule,
+    EuroSAT100DataModule,
     MisconfigurationException,
     RESISC45DataModule,
     So2SatDataModule,
@@ -59,6 +60,7 @@ class TestClassificationTask:
         "name,classname",
         [
             ("eurosat", EuroSATDataModule),
+            ("eurosat", EuroSAT100DataModule),
             ("resisc45", RESISC45DataModule),
             ("so2sat_all", So2SatDataModule),
             ("so2sat_s1", So2SatDataModule),

--- a/torchgeo/datamodules/__init__.py
+++ b/torchgeo/datamodules/__init__.py
@@ -9,7 +9,7 @@ from .cowc import COWCCountingDataModule
 from .cyclone import TropicalCycloneDataModule
 from .deepglobelandcover import DeepGlobeLandCoverDataModule
 from .etci2021 import ETCI2021DataModule
-from .eurosat import EuroSATDataModule
+from .eurosat import EuroSATDataModule, EuroSAT100DataModule
 from .fair1m import FAIR1MDataModule
 from .geo import GeoDataModule, NonGeoDataModule
 from .gid15 import GID15DataModule
@@ -40,6 +40,7 @@ __all__ = (
     "DeepGlobeLandCoverDataModule",
     "ETCI2021DataModule",
     "EuroSATDataModule",
+    "EuroSAT100DataModule",
     "FAIR1MDataModule",
     "GID15DataModule",
     "InriaAerialImageLabelingDataModule",

--- a/torchgeo/datamodules/__init__.py
+++ b/torchgeo/datamodules/__init__.py
@@ -9,7 +9,7 @@ from .cowc import COWCCountingDataModule
 from .cyclone import TropicalCycloneDataModule
 from .deepglobelandcover import DeepGlobeLandCoverDataModule
 from .etci2021 import ETCI2021DataModule
-from .eurosat import EuroSATDataModule, EuroSAT100DataModule
+from .eurosat import EuroSAT100DataModule, EuroSATDataModule
 from .fair1m import FAIR1MDataModule
 from .geo import GeoDataModule, NonGeoDataModule
 from .gid15 import GID15DataModule

--- a/torchgeo/datamodules/eurosat.py
+++ b/torchgeo/datamodules/eurosat.py
@@ -10,6 +10,42 @@ import torch
 from ..datasets import EuroSAT, EuroSAT100
 from .geo import NonGeoDataModule
 
+MEAN = torch.tensor(
+    [
+        1354.40546513,
+        1118.24399958,
+        1042.92983953,
+        947.62620298,
+        1199.47283961,
+        1999.79090914,
+        2369.22292565,
+        2296.82608323,
+        732.08340178,
+        12.11327804,
+        1819.01027855,
+        1118.92391149,
+        2594.14080798,
+    ]
+)
+
+STD = torch.tensor(
+    [
+        245.71762908,
+        333.00778264,
+        395.09249139,
+        593.75055589,
+        566.4170017,
+        861.18399006,
+        1086.63139075,
+        1117.98170791,
+        404.91978886,
+        4.77584468,
+        1002.58768311,
+        761.30323499,
+        1231.58581042,
+    ]
+)
+
 
 class EuroSATDataModule(NonGeoDataModule):
     """LightningDataModule implementation for the EuroSAT dataset.
@@ -19,41 +55,8 @@ class EuroSATDataModule(NonGeoDataModule):
     .. versionadded:: 0.2
     """
 
-    mean = torch.tensor(
-        [
-            1354.40546513,
-            1118.24399958,
-            1042.92983953,
-            947.62620298,
-            1199.47283961,
-            1999.79090914,
-            2369.22292565,
-            2296.82608323,
-            732.08340178,
-            12.11327804,
-            1819.01027855,
-            1118.92391149,
-            2594.14080798,
-        ]
-    )
-
-    std = torch.tensor(
-        [
-            245.71762908,
-            333.00778264,
-            395.09249139,
-            593.75055589,
-            566.4170017,
-            861.18399006,
-            1086.63139075,
-            1117.98170791,
-            404.91978886,
-            4.77584468,
-            1002.58768311,
-            761.30323499,
-            1231.58581042,
-        ]
-    )
+    mean = MEAN
+    std = STD
 
     def __init__(
         self, batch_size: int = 64, num_workers: int = 0, **kwargs: Any
@@ -72,44 +75,13 @@ class EuroSATDataModule(NonGeoDataModule):
 class EuroSAT100DataModule(NonGeoDataModule):
     """LightningDataModule implementation for the EuroSAT100 dataset.
 
+    Intended for tutorials and demonstrations, not for benchmarking.
+
     .. versionadded:: 0.5
     """
 
-    mean = torch.tensor(
-        [
-            1354.40546513,
-            1118.24399958,
-            1042.92983953,
-            947.62620298,
-            1199.47283961,
-            1999.79090914,
-            2369.22292565,
-            2296.82608323,
-            732.08340178,
-            12.11327804,
-            1819.01027855,
-            1118.92391149,
-            2594.14080798,
-        ]
-    )
-
-    std = torch.tensor(
-        [
-            245.71762908,
-            333.00778264,
-            395.09249139,
-            593.75055589,
-            566.4170017,
-            861.18399006,
-            1086.63139075,
-            1117.98170791,
-            404.91978886,
-            4.77584468,
-            1002.58768311,
-            761.30323499,
-            1231.58581042,
-        ]
-    )
+    mean = MEAN
+    std = STD
 
     def __init__(
         self, batch_size: int = 64, num_workers: int = 0, **kwargs: Any

--- a/torchgeo/datamodules/eurosat.py
+++ b/torchgeo/datamodules/eurosat.py
@@ -69,11 +69,47 @@ class EuroSATDataModule(NonGeoDataModule):
         super().__init__(EuroSAT, batch_size, num_workers, **kwargs)
 
 
-class EuroSAT100DataModule(EuroSATDataModule):
+class EuroSAT100DataModule(NonGeoDataModule):
     """LightningDataModule implementation for the EuroSAT100 dataset.
 
     .. versionadded:: 0.5
     """
+
+    mean = torch.tensor(
+        [
+            1354.40546513,
+            1118.24399958,
+            1042.92983953,
+            947.62620298,
+            1199.47283961,
+            1999.79090914,
+            2369.22292565,
+            2296.82608323,
+            732.08340178,
+            12.11327804,
+            1819.01027855,
+            1118.92391149,
+            2594.14080798,
+        ]
+    )
+
+    std = torch.tensor(
+        [
+            245.71762908,
+            333.00778264,
+            395.09249139,
+            593.75055589,
+            566.4170017,
+            861.18399006,
+            1086.63139075,
+            1117.98170791,
+            404.91978886,
+            4.77584468,
+            1002.58768311,
+            761.30323499,
+            1231.58581042,
+        ]
+    )
 
     def __init__(
         self, batch_size: int = 64, num_workers: int = 0, **kwargs: Any

--- a/torchgeo/datamodules/eurosat.py
+++ b/torchgeo/datamodules/eurosat.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import torch
 
-from ..datasets import EuroSAT
+from ..datasets import EuroSAT, EuroSAT100
 from .geo import NonGeoDataModule
 
 
@@ -67,3 +67,23 @@ class EuroSATDataModule(NonGeoDataModule):
                 :class:`~torchgeo.datasets.EuroSAT`.
         """
         super().__init__(EuroSAT, batch_size, num_workers, **kwargs)
+
+
+class EuroSAT100DataModule(EuroSATDataModule):
+    """LightningDataModule implementation for the EuroSAT100 dataset.
+
+    .. versionadded:: 0.5
+    """
+
+    def __init__(
+        self, batch_size: int = 64, num_workers: int = 0, **kwargs: Any
+    ) -> None:
+        """Initialize a new EuroSAT100DataModule instance.
+
+        Args:
+            batch_size: Size of each mini-batch.
+            num_workers: Number of workers for parallel data loading.
+            **kwargs: Additional keyword arguments passed to
+                :class:`~torchgeo.datasets.EuroSAT100`.
+        """
+        super().__init__(EuroSAT100, batch_size, num_workers, **kwargs)

--- a/torchgeo/datasets/__init__.py
+++ b/torchgeo/datasets/__init__.py
@@ -35,7 +35,7 @@ from .enviroatlas import EnviroAtlas
 from .esri2020 import Esri2020
 from .etci2021 import ETCI2021
 from .eudem import EUDEM
-from .eurosat import EuroSAT
+from .eurosat import EuroSAT, EuroSAT100
 from .fair1m import FAIR1M
 from .forestdamage import ForestDamage
 from .gbif import GBIF
@@ -160,6 +160,7 @@ __all__ = (
     "EnviroAtlas",
     "ETCI2021",
     "EuroSAT",
+    "EuroSAT100",
     "FAIR1M",
     "ForestDamage",
     "GID15",

--- a/torchgeo/datasets/eurosat.py
+++ b/torchgeo/datasets/eurosat.py
@@ -307,3 +307,30 @@ class EuroSAT(NonGeoClassificationDataset):
         if suptitle is not None:
             plt.suptitle(suptitle)
         return fig
+
+
+class EuroSAT100(EuroSAT):
+    """Subset of EuroSAT containing only 100 images.
+
+    Intended for tutorials and demonstrations, not for benchmarking.
+
+    Maintains the same file structure, classes, and train-val-test split. Each class has
+    10 images (6 train, 2 val, 2 test), for a total of 100 images.
+
+    .. versionadded:: 0.5
+    """
+
+    url = "https://huggingface.co/datasets/torchgeo/eurosat/resolve/main/EuroSAT100.zip"
+    filename = "EuroSAT100.zip"
+    md5 = "c21c649ba747e86eda813407ef17d596"
+
+    split_urls = {
+        "train": "https://huggingface.co/datasets/torchgeo/eurosat/raw/main/eurosat-train.txt",  # noqa: E501
+        "val": "https://huggingface.co/datasets/torchgeo/eurosat/raw/main/eurosat-val.txt",  # noqa: E501
+        "test": "https://huggingface.co/datasets/torchgeo/eurosat/raw/main/eurosat-test.txt",  # noqa: E501
+    }
+    split_md5s = {
+        "train": "033d0c23e3a75e3fa79618b0e35fe1c7",
+        "val": "3e3f8b3c344182b8d126c4cc88f3f215",
+        "test": "f908f151b950f270ad18e61153579794",
+    }


### PR DESCRIPTION
#### What?

This is a subset of the EuroSAT MS dataset containing only 100 images. Yes, you heard that right, 100 images. This dataset maintains the 60-20-20 train-val-test split from https://arxiv.org/abs/1911.06721. There are 10 images (6 train, 2 val, 2 test) for all 10 classes, for a total of 100 images.

#### But why?

![](https://media.giphy.com/media/s239QJIh56sRW/giphy.gif)

Our tutorials download a lot of data. So much in fact that we crash the meager 14 GB SSD in our [GitHub Actions runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources), causing our notebook tests to fail for the last year or so. Between NAIP, Chesapeake, Sentinel, EuroSAT, and TropicalCyclone, we're talking several minutes of downloads. The TropicalCyclone download doesn't even work unless you sign up for an API key (#1074). A quick comparison:

| Dataset | Compressed | Uncompressed | Download Time |
| --- | --- | --- | --- |
| EuroSAT | 1.9G | 4.7G | 3m 7s |
| EuroSAT100 | 7.4M | 18M | 1s |

Yes, 1 second, down to the millisecond:
```console
$ time wget https://huggingface.co/datasets/torchgeo/eurosat/resolve/main/EuroSAT100.zip
...
real	0m1.000s
user	0m0.055s
sys	0m0.110s
```
Our tutorials should not take several minutes just on data prep, nor should they fill up your hard drive, nor should they require an API key.

#### Why EuroSAT?

EuroSAT was chosen for the following reasons:

* Many of our existing tutorials already use EuroSAT, making them easy to port
* It contains Sentinel-2 images, which our tutorials rely on to show off things like NDVI or pre-trained models
* It is distributed under a [permissive license](https://github.com/phelber/EuroSAT/issues/10#issuecomment-1409891796)
* Images are georeferenced, meaning we could add a GeoDataset version of this someday

#### The milestone says 0.4.1 but versionadded says 0.5...

Technically, new features shouldn't be added in patch releases. But this may fix our chronically failing notebook tests. So I would like to add this to the next patch release for the sake of testing, but we can just pretend that it was actually added in 0.5.

#### Hey, you forgot to update the docs!

I'll open a separate PR to add this to the docs that we can save for the 0.5 release.