### PR TITLE
Trainers: refactor tests

### DIFF
--- a/tests/trainers/test_byol.py
+++ b/tests/trainers/test_byol.py
@@ -24,7 +24,7 @@ from torchgeo.samplers import GridGeoSampler
 from torchgeo.trainers import BYOLTask
 from torchgeo.trainers.byol import BYOL, SimCLRAugmentation
 
-from .test_utils import SegmentationTestModel
+from .test_segmentation import SegmentationTestModel
 
 
 def load(url: str, *args: Any, **kwargs: Any) -> Dict[str, Any]:

--- a/tests/trainers/test_classification.py
+++ b/tests/trainers/test_classification.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Type, cast
 import pytest
 import timm
 import torch
+import torch.nn as nn
 import torchvision
 from _pytest.fixtures import SubRequest
 from _pytest.monkeypatch import MonkeyPatch
@@ -28,7 +29,22 @@ from torchgeo.datasets import BigEarthNet, EuroSAT
 from torchgeo.models import get_model_weights, list_models
 from torchgeo.trainers import ClassificationTask, MultiLabelClassificationTask
 
-from .test_utils import ClassificationTestModel
+
+class ClassificationTestModel(Module):
+    def __init__(
+        self, in_chans: int = 3, num_classes: int = 1000, **kwargs: Any
+    ) -> None:
+        super().__init__()
+        self.conv1 = nn.Conv2d(in_channels=in_chans, out_channels=1, kernel_size=1)
+        self.pool = nn.AdaptiveAvgPool2d((1, 1))
+        self.fc = nn.Linear(1, num_classes)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.conv1(x)
+        x = self.pool(x)
+        x = torch.flatten(x, 1)
+        x = self.fc(x)
+        return x
 
 
 class PredictClassificationDataModule(EuroSATDataModule):

--- a/tests/trainers/test_regression.py
+++ b/tests/trainers/test_regression.py
@@ -24,17 +24,22 @@ from torchgeo.datasets import TropicalCyclone
 from torchgeo.models import get_model_weights, list_models
 from torchgeo.trainers import RegressionTask
 
-from .test_utils import RegressionTestModel
+from .test_classification import ClassificationTestModel
 
 
-def load(url: str, *args: Any, **kwargs: Any) -> Dict[str, Any]:
-    state_dict: Dict[str, Any] = torch.load(url)
-    return state_dict
+class RegressionTestModel(ClassificationTestModel):
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(in_chans=3, num_classes=1)
 
 
 class PredictRegressionDataModule(TropicalCycloneDataModule):
     def setup(self, stage: str) -> None:
         self.predict_dataset = TropicalCyclone(split="test", **self.kwargs)
+
+
+def load(url: str, *args: Any, **kwargs: Any) -> Dict[str, Any]:
+    state_dict: Dict[str, Any] = torch.load(url)
+    return state_dict
 
 
 def plot(*args: Any, **kwargs: Any) -> None:

--- a/tests/trainers/test_segmentation.py
+++ b/tests/trainers/test_segmentation.py
@@ -6,6 +6,8 @@ from typing import Any, Dict, Type, cast
 
 import pytest
 import segmentation_models_pytorch as smp
+import torch
+import torch.nn as nn
 from _pytest.monkeypatch import MonkeyPatch
 from omegaconf import OmegaConf
 from pytorch_lightning import LightningDataModule, Trainer
@@ -29,7 +31,18 @@ from torchgeo.datamodules import (
 from torchgeo.datasets import LandCoverAI
 from torchgeo.trainers import SemanticSegmentationTask
 
-from .test_utils import SegmentationTestModel
+
+class SegmentationTestModel(Module):
+    def __init__(
+        self, in_channels: int = 3, classes: int = 1000, **kwargs: Any
+    ) -> None:
+        super().__init__()
+        self.conv1 = nn.Conv2d(
+            in_channels=in_channels, out_channels=classes, kernel_size=1, padding=0
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return cast(torch.Tensor, self.conv1(x))
 
 
 def create_model(**kwargs: Any) -> Module:

--- a/tests/trainers/test_utils.py
+++ b/tests/trainers/test_utils.py
@@ -3,7 +3,7 @@
 
 import os
 from pathlib import Path
-from typing import Any, cast
+from typing import cast
 
 import pytest
 import timm
@@ -19,39 +19,8 @@ from torchgeo.trainers.utils import (
 )
 
 
-class ClassificationTestModel(Module):
-    def __init__(
-        self, in_chans: int = 3, num_classes: int = 1000, **kwargs: Any
-    ) -> None:
-        super().__init__()
-        self.conv1 = nn.Conv2d(in_channels=in_chans, out_channels=1, kernel_size=1)
-        self.pool = nn.AdaptiveAvgPool2d((1, 1))
-        self.fc = nn.Linear(1, num_classes)
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        x = self.conv1(x)
-        x = self.pool(x)
-        x = torch.flatten(x, 1)
-        x = self.fc(x)
-        return x
-
-
-class RegressionTestModel(ClassificationTestModel):
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(in_chans=3, num_classes=1)
-
-
-class SegmentationTestModel(Module):
-    def __init__(
-        self, in_channels: int = 3, classes: int = 1000, **kwargs: Any
-    ) -> None:
-        super().__init__()
-        self.conv1 = nn.Conv2d(
-            in_channels=in_channels, out_channels=classes, kernel_size=1, padding=0
-        )
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return cast(torch.Tensor, self.conv1(x))
+def test_extract_backbone(checkpoint: str) -> None:
+    extract_backbone(checkpoint)
 
 
 def test_extract_backbone_unsupported_model(tmp_path: Path) -> None:
@@ -63,8 +32,11 @@ def test_extract_backbone_unsupported_model(tmp_path: Path) -> None:
         extract_backbone(path)
 
 
-def test_extract_backbone(checkpoint: str) -> None:
-    extract_backbone(checkpoint)
+def test_get_input_layer_name_and_module() -> None:
+    key, module = _get_input_layer_name_and_module(timm.create_model("resnet18"))
+    assert key == "conv1"
+    assert isinstance(module, nn.Conv2d)
+    assert module.in_channels == 3
 
 
 def test_load_state_dict(checkpoint: str, model: Module) -> None:
@@ -117,10 +89,3 @@ def test_reinit_initial_conv_layer() -> None:
     assert in_channels == 4
     assert k1 == 3 and k2 == 3
     assert new_conv_layer.stride[0] == 2
-
-
-def test_get_input_layer_name_and_module() -> None:
-    key, module = _get_input_layer_name_and_module(timm.create_model("resnet18"))
-    assert key == "conv1"
-    assert isinstance(module, nn.Conv2d)
-    assert module.in_channels == 3


### PR DESCRIPTION
These fake models have nothing to do with testing `torchgeo/trainers/utils.py` and should either be in the files where they are used or in `conftest.py`.