### PR TITLE
RasterDataset: fix band indexing bug

### DIFF
--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -220,16 +220,13 @@ class TestRasterDataset:
         bands = ["B04", "B03", "B02"]
         transforms = nn.Identity()
         cache = True
-        ds = CustomSentinelDataset(
-            root, bands=bands, transforms=transforms, cache=cache
-        )
-
         msg = (
             "CustomSentinelDataset is missing an `all_bands` attribute,"
             " so `bands` cannot be specified."
         )
+
         with pytest.raises(AssertionError, match=msg):
-            ds[ds.index.bounds]
+            CustomSentinelDataset(root, bands=bands, transforms=transforms, cache=cache)
 
 
 class TestVectorDataset:

--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -52,6 +52,7 @@ class CustomVectorDataset(VectorDataset):
 
 class CustomSentinelDataset(Sentinel2):
     all_bands: List[str] = []
+    separate_files = False
 
 
 class CustomNonGeoDataset(NonGeoDataset):
@@ -214,18 +215,21 @@ class TestRasterDataset:
         with pytest.raises(FileNotFoundError, match="No RasterDataset data was found"):
             RasterDataset(str(tmp_path))
 
-    def test_no_allbands(self) -> None:
+    def test_no_all_bands(self) -> None:
         root = os.path.join("tests", "data", "sentinel2")
         bands = ["B04", "B03", "B02"]
         transforms = nn.Identity()
         cache = True
+        ds = CustomSentinelDataset(
+            root, bands=bands, transforms=transforms, cache=cache
+        )
+
         msg = (
             "CustomSentinelDataset is missing an `all_bands` attribute,"
             " so `bands` cannot be specified."
         )
-
         with pytest.raises(AssertionError, match=msg):
-            CustomSentinelDataset(root, bands=bands, transforms=transforms, cache=cache)
+            ds[ds.index.bounds]
 
 
 class TestVectorDataset:

--- a/tests/datasets/test_landsat.py
+++ b/tests/datasets/test_landsat.py
@@ -8,6 +8,7 @@ import matplotlib.pyplot as plt
 import pytest
 import torch
 import torch.nn as nn
+from _pytest.fixtures import SubRequest
 from _pytest.monkeypatch import MonkeyPatch
 from rasterio.crs import CRS
 
@@ -15,10 +16,15 @@ from torchgeo.datasets import BoundingBox, IntersectionDataset, Landsat8, UnionD
 
 
 class TestLandsat8:
-    @pytest.fixture
-    def dataset(self, monkeypatch: MonkeyPatch) -> Landsat8:
+    @pytest.fixture(
+        params=[
+            ["SR_B1", "SR_B2", "SR_B3", "SR_B4", "SR_B5", "SR_B6", "SR_B7"],
+            ["SR_B4", "SR_B3", "SR_B2", "SR_QA_AEROSOL"],
+        ]
+    )
+    def dataset(self, monkeypatch: MonkeyPatch, request: SubRequest) -> Landsat8:
         root = os.path.join("tests", "data", "landsat8")
-        bands = ["SR_B1", "SR_B2", "SR_B3", "SR_B4", "SR_B5", "SR_B6", "SR_B7"]
+        bands = request.param
         transforms = nn.Identity()
         return Landsat8(root, bands=bands, transforms=transforms)
 

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -369,16 +369,18 @@ class RasterDataset(GeoDataset):
             )
 
         if not self.separate_files:
-            if self.bands and self.all_bands:
-                self.band_indexes = [self.all_bands.index(i) + 1 for i in self.bands]
-            elif self.bands:
-                msg = (
-                    f"{self.__class__.__name__} is missing an `all_bands` attribute,"
-                    " so `bands` cannot be specified."
-                )
-                raise AssertionError(msg)
-            else:
-                self.band_indexes = None
+            self.band_indexes = None
+            if self.bands:
+                if self.all_bands:
+                    self.band_indexes = [
+                        self.all_bands.index(i) + 1 for i in self.bands
+                    ]
+                else:
+                    msg = (
+                        f"{self.__class__.__name__} is missing an `all_bands` "
+                        "attribute, so `bands` cannot be specified."
+                    )
+                    raise AssertionError(msg)
 
         self._crs = cast(CRS, crs)
         self.res = cast(float, res)

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -370,7 +370,7 @@ class RasterDataset(GeoDataset):
 
         if not self.separate_files:
             if self.bands and self.all_bands:
-                band_indexes = [self.all_bands.index(i) + 1 for i in self.bands]
+                self.band_indexes = [self.all_bands.index(i) + 1 for i in self.bands]
             elif self.bands:
                 msg = (
                     f"{self.__class__.__name__} is missing an `all_bands` attribute,"
@@ -378,7 +378,7 @@ class RasterDataset(GeoDataset):
                 )
                 raise AssertionError(msg)
             else:
-                band_indexes = None
+                self.band_indexes = None
 
         self._crs = cast(CRS, crs)
         self.res = cast(float, res)

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -368,6 +368,18 @@ class RasterDataset(GeoDataset):
                 f"No {self.__class__.__name__} data was found in '{root}'"
             )
 
+        if not self.separate_files:
+            if self.bands and self.all_bands:
+                band_indexes = [self.all_bands.index(i) + 1 for i in self.bands]
+            elif self.bands:
+                msg = (
+                    f"{self.__class__.__name__} is missing an `all_bands` attribute,"
+                    " so `bands` cannot be specified."
+                )
+                raise AssertionError(msg)
+            else:
+                band_indexes = None
+
         self._crs = cast(CRS, crs)
         self.res = cast(float, res)
 
@@ -410,18 +422,7 @@ class RasterDataset(GeoDataset):
                 data_list.append(self._merge_files(band_filepaths, query))
             data = torch.cat(data_list)
         else:
-            if self.bands and self.all_bands:
-                band_indexes = [self.all_bands.index(i) + 1 for i in self.bands]
-            elif self.bands:
-                msg = (
-                    f"{self.__class__.__name__} is missing an `all_bands` attribute,"
-                    " so `bands` cannot be specified."
-                )
-                raise AssertionError(msg)
-            else:
-                band_indexes = None
-
-            data = self._merge_files(filepaths, query, band_indexes)
+            data = self._merge_files(filepaths, query, self.band_indexes)
 
         sample = {"crs": self.crs, "bbox": query}
         if self.is_image:

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -421,7 +421,7 @@ class RasterDataset(GeoDataset):
             else:
                 band_indexes = None
 
-            data = self._merge_files(filepaths, query, self.band_indexes)
+            data = self._merge_files(filepaths, query, band_indexes)
 
         sample = {"crs": self.crs, "bbox": query}
         if self.is_image:

--- a/torchgeo/datasets/landsat.py
+++ b/torchgeo/datasets/landsat.py
@@ -47,8 +47,12 @@ class Landsat(RasterDataset, abc.ABC):
         \.
     """
 
-    default_bands: List[str] = []
     separate_files = True
+
+    @property
+    @abc.abstractmethod
+    def default_bands(self) -> List[str]:
+        """Bands to load by default."""
 
     def __init__(
         self,

--- a/torchgeo/datasets/landsat.py
+++ b/torchgeo/datasets/landsat.py
@@ -4,7 +4,7 @@
 """Landsat datasets."""
 
 import abc
-from typing import Any, Callable, Dict, Optional, Sequence
+from typing import Any, Callable, Dict, List, Optional, Sequence
 
 import matplotlib.pyplot as plt
 from rasterio.crs import CRS
@@ -47,6 +47,7 @@ class Landsat(RasterDataset, abc.ABC):
         \.
     """
 
+    default_bands: List[str] = []
     separate_files = True
 
     def __init__(

--- a/torchgeo/datasets/landsat.py
+++ b/torchgeo/datasets/landsat.py
@@ -74,7 +74,7 @@ class Landsat(RasterDataset, abc.ABC):
         Raises:
             FileNotFoundError: if no files are found in ``root``
         """
-        bands = bands or self.all_bands
+        bands = bands or self.default_bands
         self.filename_glob = self.filename_glob.format(bands[0])
 
         super().__init__(root, crs, res, bands, transforms, cache)
@@ -133,7 +133,7 @@ class Landsat1(Landsat):
 
     filename_glob = "LM01_*_{}.*"
 
-    all_bands = ["SR_B4", "SR_B5", "SR_B6", "SR_B7"]
+    default_bands = ["SR_B4", "SR_B5", "SR_B6", "SR_B7"]
     rgb_bands = ["SR_B6", "SR_B5", "SR_B4"]
 
 
@@ -154,7 +154,7 @@ class Landsat4MSS(Landsat):
 
     filename_glob = "LM04_*_{}.*"
 
-    all_bands = ["SR_B1", "SR_B2", "SR_B3", "SR_B4"]
+    default_bands = ["SR_B1", "SR_B2", "SR_B3", "SR_B4"]
     rgb_bands = ["SR_B3", "SR_B2", "SR_B1"]
 
 
@@ -163,7 +163,7 @@ class Landsat4TM(Landsat):
 
     filename_glob = "LT04_*_{}.*"
 
-    all_bands = ["SR_B1", "SR_B2", "SR_B3", "SR_B4", "SR_B5", "SR_B6", "SR_B7"]
+    default_bands = ["SR_B1", "SR_B2", "SR_B3", "SR_B4", "SR_B5", "SR_B6", "SR_B7"]
     rgb_bands = ["SR_B3", "SR_B2", "SR_B1"]
 
 
@@ -184,7 +184,16 @@ class Landsat7(Landsat):
 
     filename_glob = "LE07_*_{}.*"
 
-    all_bands = ["SR_B1", "SR_B2", "SR_B3", "SR_B4", "SR_B5", "SR_B6", "SR_B7", "SR_B8"]
+    default_bands = [
+        "SR_B1",
+        "SR_B2",
+        "SR_B3",
+        "SR_B4",
+        "SR_B5",
+        "SR_B6",
+        "SR_B7",
+        "SR_B8",
+    ]
     rgb_bands = ["SR_B3", "SR_B2", "SR_B1"]
 
 
@@ -193,7 +202,7 @@ class Landsat8(Landsat):
 
     filename_glob = "LC08_*_{}.*"
 
-    all_bands = [
+    default_bands = [
         "SR_B1",
         "SR_B2",
         "SR_B3",


### PR DESCRIPTION
This PR fixes multiple bugs related to band indexing in RasterDataset:

- [x] Fix support for datasets where `all_bands` does not actually contain _all_ bands (e.g., Landsat)
- [x] Fix support for datasets where `all_bands` is not defined and `separate_files` is True

The fix was simple. We don't need to compute `band_indexes` unless `separate_files` is False.

Confirmed that the tests I added fail without this fix, so this bug shouldn't pop back up in the next release.

Should we rename Landsat's `all_bands` to `default_bands`? In #504 we added support for all Level-1 and Level-2 products and decided not to list every possible band name because there are way too many and I can't easily confirm what they were all the way back to Landsat 1.

This bug was introduced in #687, apologies for not catching this during review.

Fixes #1134 @TolgaAktas