### PR TITLE
Usa vars label bug

### DIFF
--- a/torchgeo/datasets/usavars.py
+++ b/torchgeo/datasets/usavars.py
@@ -30,13 +30,15 @@ class USAVars(NonGeoDataset):
     cover percentage, elevation, and population density.
 
     Dataset format:
+
     * images are 4-channel GeoTIFFs
     * labels are singular float values
 
     Dataset labels:
-    * tree cover ('treecover')
-    * elevation ('elevation')
-    * population density ('population')
+
+    * tree cover
+    * elevation
+    * population density
 
     If you use this dataset in your research, please cite the following paper:
 

--- a/torchgeo/datasets/usavars.py
+++ b/torchgeo/datasets/usavars.py
@@ -34,9 +34,9 @@ class USAVars(NonGeoDataset):
     * labels are singular float values
 
     Dataset labels:
-    * tree cover
-    * elevation
-    * population density
+    * tree cover ('treecover')
+    * elevation ('elevation')
+    * population density ('population')
 
     If you use this dataset in your research, please cite the following paper:
 
@@ -89,7 +89,7 @@ class USAVars(NonGeoDataset):
         },
     }
 
-    ALL_LABELS = list(label_urls.keys())
+    ALL_LABELS = ["treecover", "elevation", "population"]
 
     def __init__(
         self,


### PR DESCRIPTION
The current implementation of the USAVars dataset only suppports three labels like the documentation says, but as default all labels are included, so if you run the dataset with default arguments, errors will be thrown. 

This PR has two simple changes:
- `ALL_LABELS` to only be the available labels
- documentation indent for proper bullet points rendering on docs