### PR TITLE
EuroSAT100: add new dataset/datamodule

### DIFF
--- a/docs/api/datamodules.rst
+++ b/docs/api/datamodules.rst
@@ -43,6 +43,7 @@ EuroSAT
 ^^^^^^^
 
 .. autoclass:: EuroSATDataModule
+.. autoclass:: EuroSAT100DataModule
 
 FAIR1M
 ^^^^^^

--- a/docs/api/datasets.rst
+++ b/docs/api/datasets.rst
@@ -195,6 +195,7 @@ EuroSAT
 ^^^^^^^
 
 .. autoclass:: EuroSAT
+.. autoclass:: EuroSAT100
 
 FAIR1M
 ^^^^^^


### PR DESCRIPTION
#1130 added the classes and will be backported to 0.4.1, this PR adds it to the documentation and should be in 0.5.0.

When adding this to the release notes, we should leave #1130 out of 0.4.1 and instead add it to 0.5.0. If I remember, I'll change the milestone from 0.4.1 to 0.5.0 after 0.4.1 is released.