### PR TITLE
Landsat: better default bands

### DIFF
--- a/torchgeo/datasets/landsat.py
+++ b/torchgeo/datasets/landsat.py
@@ -203,6 +203,7 @@ class Landsat8(Landsat):
 
 
 class Landsat9(Landsat8):
-    """Landsat 9 Operational Land Imager (OLI) and Thermal Infrared Sensor (TIRS)."""
+    """Landsat 9 Operational Land Imager (OLI-2) and Thermal Infrared Sensor (TIRS-2).
+    """
 
     filename_glob = "LC09_*_{}.*"

--- a/torchgeo/datasets/landsat.py
+++ b/torchgeo/datasets/landsat.py
@@ -138,8 +138,8 @@ class Landsat1(Landsat):
 
     filename_glob = "LM01_*_{}.*"
 
-    default_bands = ["SR_B4", "SR_B5", "SR_B6", "SR_B7"]
-    rgb_bands = ["SR_B6", "SR_B5", "SR_B4"]
+    default_bands = ["B4", "B5", "B6", "B7"]
+    rgb_bands = ["B6", "B5", "B4"]
 
 
 class Landsat2(Landsat1):
@@ -159,8 +159,8 @@ class Landsat4MSS(Landsat):
 
     filename_glob = "LM04_*_{}.*"
 
-    default_bands = ["SR_B1", "SR_B2", "SR_B3", "SR_B4"]
-    rgb_bands = ["SR_B3", "SR_B2", "SR_B1"]
+    default_bands = ["B1", "B2", "B3", "B4"]
+    rgb_bands = ["B3", "B2", "B1"]
 
 
 class Landsat4TM(Landsat):

--- a/torchgeo/datasets/landsat.py
+++ b/torchgeo/datasets/landsat.py
@@ -203,7 +203,6 @@ class Landsat8(Landsat):
 
 
 class Landsat9(Landsat8):
-    """Landsat 9 Operational Land Imager (OLI-2) and Thermal Infrared Sensor (TIRS-2).
-    """
+    """Landsat 9 Operational Land Imager (OLI-2) and Thermal Infrared Sensor (TIRS-2)."""  # noqa: E501
 
     filename_glob = "LC09_*_{}.*"

--- a/torchgeo/datasets/landsat.py
+++ b/torchgeo/datasets/landsat.py
@@ -189,16 +189,7 @@ class Landsat7(Landsat):
 
     filename_glob = "LE07_*_{}.*"
 
-    default_bands = [
-        "SR_B1",
-        "SR_B2",
-        "SR_B3",
-        "SR_B4",
-        "SR_B5",
-        "SR_B6",
-        "SR_B7",
-        "SR_B8",
-    ]
+    default_bands = ["SR_B1", "SR_B2", "SR_B3", "SR_B4", "SR_B5", "SR_B6", "SR_B7"]
     rgb_bands = ["SR_B3", "SR_B2", "SR_B1"]
 
 
@@ -207,19 +198,7 @@ class Landsat8(Landsat):
 
     filename_glob = "LC08_*_{}.*"
 
-    default_bands = [
-        "SR_B1",
-        "SR_B2",
-        "SR_B3",
-        "SR_B4",
-        "SR_B5",
-        "SR_B6",
-        "SR_B7",
-        "SR_B8",
-        "SR_B9",
-        "SR_B10",
-        "SR_B11",
-    ]
+    default_bands = ["SR_B1", "SR_B2", "SR_B3", "SR_B4", "SR_B5", "SR_B6", "SR_B7"]
     rgb_bands = ["SR_B4", "SR_B3", "SR_B2"]
 
 


### PR DESCRIPTION
For Landsat, B8–B11 only exist for raw imagery and top of atmosphere reflectance, not surface reflectance. I still think it makes sense to default to surface reflectance, but we should not include bands that don't exist for it.

At least on Google Earth Engine (GEE), Landsat 1–5 Multispectral Scanner (MSS) do not have surface reflectance, so default to the band names for raw imagery.

References:

* [SR](https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LC09_C02_T1_L2)
* [TOA](https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LC09_C02_T1_TOA)
* [raw](https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LC09_C02_T1)