### PR TITLE
Test Python 3.11

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,6 @@ updates:
     schedule:
       interval: "daily"
     ignore:
-      # scikit-image does not support latest scipy
-      # https://github.com/scikit-image/scikit-image/pull/6773
-      - dependency-name: "scipy"
       # setuptools releases new versions almost daily
       - dependency-name: "setuptools"
         update-types: ["version-update:semver-patch"]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v4.6.0
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - name: Cache dependencies
       uses: actions/cache@v3.3.1
       id: cache
@@ -39,7 +39,7 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v4.6.0
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - name: Cache dependencies
       uses: actions/cache@v3.3.1
       id: cache
@@ -62,7 +62,7 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v4.6.0
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - name: Cache dependencies
       uses: actions/cache@v3.3.1
       id: cache

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v4.6.0
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - name: Cache dependencies
       uses: actions/cache@v3.3.1
       id: cache
@@ -41,7 +41,7 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v4.6.0
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - name: Cache dependencies
       uses: actions/cache@v3.3.1
       id: cache
@@ -64,7 +64,7 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v4.6.0
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - name: Cache dependencies
       uses: actions/cache@v3.3.1
       id: cache
@@ -87,7 +87,7 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v4.6.0
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - name: Cache dependencies
       uses: actions/cache@v3.3.1
       id: cache
@@ -110,7 +110,7 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v4.6.0
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - name: Cache dependencies
       uses: actions/cache@v3.3.1
       id: cache

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v4.6.0
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - name: Cache dependencies
       uses: actions/cache@v3.3.1
       id: cache
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.10']
+        python-version: ['3.9', '3.10', '3.11']
     steps:
     - name: Clone repo
       uses: actions/checkout@v3.5.2

--- a/.github/workflows/tutorials.yaml
+++ b/.github/workflows/tutorials.yaml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v4.6.0
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - name: Cache dependencies
       uses: actions/cache@v3.3.1
       id: cache

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.11"
 
 # Configuration of the Python environment to be used
 python:

--- a/requirements/datasets.txt
+++ b/requirements/datasets.txt
@@ -7,6 +7,6 @@ pycocotools==2.0.6
 pyvista==0.39.1
 radiant-mlhub==0.4.1
 rarfile==4.0
-scikit-image==0.20.0
+scikit-image==0.21.0rc1
 scipy==1.9.1
 zipfile-deflate64==0.2.0

--- a/requirements/datasets.txt
+++ b/requirements/datasets.txt
@@ -8,5 +8,5 @@ pyvista==0.39.1
 radiant-mlhub==0.4.1
 rarfile==4.0
 scikit-image==0.21.0rc1
-scipy==1.9.1
+scipy==1.10.1
 zipfile-deflate64==0.2.0

--- a/requirements/required.txt
+++ b/requirements/required.txt
@@ -13,9 +13,9 @@ pillow==9.5.0
 pyproj==3.5.0
 rasterio==1.3.7
 rtree==1.0.1
-segmentation-models-pytorch==0.3.2
+segmentation-models-pytorch==0.3.3
 shapely==2.0.1
-timm==0.6.12
+timm==0.9.2
 torch==2.0.1
 torchmetrics==0.11.4
 torchvision==0.15.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ classifiers =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Topic :: Scientific/Engineering :: Artificial Intelligence

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ install_requires =
     # shapely 1.7.1+ required for Python 3.9 wheels
     shapely>=1.7.1,<3
     # timm 0.4.12 required by segmentation-models-pytorch
-    timm>=0.4.12,<0.7
+    timm>=0.4.12,<0.10
     # torch 1.12+ required by torchvision
     torch>=1.12,<3
     # torchmetrics 0.10+ required for binary/multiclass/multilabel classification metrics
@@ -88,7 +88,7 @@ datasets =
     rarfile>=4,<5
     # scikit-image 0.18+ required for numpy 1.17+ compatibility
     # https://github.com/scikit-image/scikit-image/issues/3655
-    scikit-image>=0.18,<0.21
+    scikit-image>=0.18,<0.22
     # scipy 1.6.2+ required for scikit-image 0.18+ compatibility
     scipy>=1.6.2,<2
     # zipfile-deflate64 0.2+ required for extraction bugfix:


### PR DESCRIPTION
Now that PyTorch 2.0 is out, which adds Python 3.11 support, we should see how many of our other dependencies support Python 3.11 and make sure TorchGeo supports it as well. This PR adds Python 3.11 to our unit tests.

Still waiting on the following dependencies:

- [x] scikit-image: https://github.com/scikit-image/scikit-image/pull/6773
- [x] segmentation-models-pytorch: https://github.com/qubvel/segmentation_models.pytorch/issues/731
- [x] timm: https://github.com/huggingface/pytorch-image-models/issues/1723