### PR TITLE
RasterDataset: fix bug when separate_files and no date in regex

### DIFF
--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -415,7 +415,7 @@ class RasterDataset(GeoDataset):
                     directory = os.path.dirname(filepath)
                     match = re.match(filename_regex, filename)
                     if match:
-                        if "date" in match.groupdict():
+                        if "band" in match.groupdict():
                             start = match.start("band")
                             end = match.end("band")
                             filename = filename[:start] + band + filename[end:]


### PR DESCRIPTION
Fixes a bug introduced by yours truly waaaaay back in #75.

The reason we haven't discovered this bug until now is that it has extremely limited scope. It only affects `RasterDataset`s where `separate_files = True` and `filename_regex` does not contain a `date` group. This is exactly 0 of our builtin datasets, but is unfortunately exactly what happened to @TolgaAktas in #1182.

Thanks for reporting this @TolgaAktas!