### PR TITLE
IntersectionDataset: better error message when no overlap

### DIFF
--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -405,10 +405,20 @@ class TestIntersectionDataset:
             IntersectionDataset(ds1, ds2)  # type: ignore[arg-type]
 
     def test_different_crs(self) -> None:
-        ds1 = CustomGeoDataset(crs=CRS.from_epsg(3005))
-        ds2 = CustomGeoDataset(crs=CRS.from_epsg(32616))
+        ds1 = CustomGeoDataset(BoundingBox(0, 1, 0, 1, 0, 1), crs=CRS.from_epsg(3005))
+        ds2 = CustomGeoDataset(
+            BoundingBox(
+                -3547229.913123814,
+                6360089.518213182,
+                -3547229.913123814,
+                6360089.518213182,
+                -3547229.913123814,
+                6360089.518213182,
+            ),
+            crs=CRS.from_epsg(32616),
+        )
         ds = IntersectionDataset(ds1, ds2)
-        assert len(ds) == 0
+        assert len(ds) == 1
 
     def test_different_res(self) -> None:
         ds1 = CustomGeoDataset(res=1)
@@ -419,8 +429,9 @@ class TestIntersectionDataset:
     def test_no_overlap(self) -> None:
         ds1 = CustomGeoDataset(BoundingBox(0, 1, 2, 3, 4, 5))
         ds2 = CustomGeoDataset(BoundingBox(6, 7, 8, 9, 10, 11))
-        ds = IntersectionDataset(ds1, ds2)
-        assert len(ds) == 0
+        msg = "Datasets have no spatiotemporal intersection"
+        with pytest.raises(RuntimeError, match=msg):
+            IntersectionDataset(ds1, ds2)
 
     def test_invalid_query(self, dataset: IntersectionDataset) -> None:
         query = BoundingBox(0, 0, 0, 0, 0, 0)

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -811,6 +811,7 @@ class IntersectionDataset(GeoDataset):
                 entry and returns a transformed version
 
         Raises:
+            RuntimeError: if datasets have no spatiotemporal intersection
             ValueError: if either dataset is not a :class:`GeoDataset`
 
         .. versionadded:: 0.4

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -855,6 +855,9 @@ class IntersectionDataset(GeoDataset):
                 self.index.insert(i, tuple(box1 & box2))
                 i += 1
 
+        if i == 0:
+            raise RuntimeError("Datasets have no spatiotemporal intersection")
+
     def __getitem__(self, query: BoundingBox) -> Dict[str, Any]:
         """Retrieve image and metadata indexed by query.
 


### PR DESCRIPTION
To illustrate why this is needed, create two directories containing non-overlapping images, and run the following script:
```python
from torch.utils.data import DataLoader

from torchgeo.datasets import Landsat8
from torchgeo.samplers import RandomGeoSampler

bands = ["B1", "B2", "B3"]

ds1 = Landsat8("data/dir1", bands=bands)
ds2 = Landsat8("data/dir2", bands=bands)

ds = ds1 & ds2
rs = RandomGeoSampler(ds, 256, 10)
dl = DataLoader(ds, sampler=rs)
for batch in dl:
    pass
```

### Before

The previous error message was completely useless, and led to much confusion due to https://github.com/Toblerity/rtree/issues/204:
```
Traceback (most recent call last):
  File "/Users/Adam/torchgeo/test.py", line 12, in <module>
    rs = RandomGeoSampler(ds, 256, 10)
  File "/Users/Adam/torchgeo/torchgeo/samplers/single.py", line 102, in __init__
    super().__init__(dataset, roi)
  File "/Users/Adam/torchgeo/torchgeo/samplers/single.py", line 37, in __init__
    roi = BoundingBox(*self.index.bounds)
  File "<string>", line 9, in __init__
  File "/Users/Adam/torchgeo/torchgeo/datasets/utils.py", line 246, in __post_init__
    raise ValueError(
ValueError: Bounding box is invalid: 'minx=1.7976931348623157e+308' > 'maxx=-1.7976931348623157e+308'
```

### After

We now raise an error immediately when trying to compute the intersection with a clear and concise error message:
```
Traceback (most recent call last):
  File "/Users/Adam/torchgeo/test.py", line 11, in <module>
    ds = ds1 & ds2
  File "/Users/Adam/torchgeo/torchgeo/datasets/geo.py", line 134, in __and__
    return IntersectionDataset(self, other)
  File "/Users/Adam/torchgeo/torchgeo/datasets/geo.py", line 845, in __init__
    self._merge_dataset_indices()
  File "/Users/Adam/torchgeo/torchgeo/datasets/geo.py", line 859, in _merge_dataset_indices
    raise RuntimeError("Datasets have no spatiotemporal intersection")
RuntimeError: Datasets have no spatiotemporal intersection
```
Thanks to @TolgaAktas for reporting this!