### PR TITLE
RasterDataset: better error message when no data found

### DIFF
--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -364,9 +364,10 @@ class RasterDataset(GeoDataset):
                     i += 1
 
         if i == 0:
-            raise FileNotFoundError(
-                f"No {self.__class__.__name__} data was found in '{root}'"
-            )
+            msg = f"No {self.__class__.__name__} data was found in `root='{self.root}'`"
+            if self.bands:
+                msg += f" with `bands={self.bands}`"
+            raise FileNotFoundError(msg)
 
         if not self.separate_files:
             self.band_indexes = None
@@ -582,9 +583,8 @@ class VectorDataset(GeoDataset):
                 i += 1
 
         if i == 0:
-            raise FileNotFoundError(
-                f"No {self.__class__.__name__} data was found in '{root}'"
-            )
+            msg = f"No {self.__class__.__name__} data was found in `root='{root}'`"
+            raise FileNotFoundError(msg)
 
         self._crs = crs
 


### PR DESCRIPTION
Datasets like Landsat have different band names for TOA and SR products. Although we default to SR, many users use TOA data and are confused when no data is found because they didn't change the default `bands`. This PR adds `bands` to the error message, which should hopefully make it easier to realize that `bands` needs to be changed. To test, run this script:
```python
from torchgeo.datasets import Landsat8

Landsat8("data/landsat8/toa")
```

### Before

Doesn't give any reason why no data was found:
```
Traceback (most recent call last):
  File "/Users/Adam/torchgeo/test.py", line 3, in <module>
    Landsat8("data/landsat8/toa")
  File "/Users/Adam/torchgeo/torchgeo/datasets/landsat.py", line 85, in __init__
    super().__init__(root, crs, res, bands, transforms, cache)
  File "/Users/Adam/torchgeo/torchgeo/datasets/geo.py", line 367, in __init__
    raise FileNotFoundError(
FileNotFoundError: No Landsat8 data was found in 'data/landsat8/toa'
```

### After

Tells you both the root directory and band selection used, hinting that changing the bands may help:
```
Traceback (most recent call last):
  File "/Users/Adam/torchgeo/test.py", line 3, in <module>
    Landsat8("data/landsat8/toa")
  File "/Users/Adam/torchgeo/torchgeo/datasets/landsat.py", line 85, in __init__
    super().__init__(root, crs, res, bands, transforms, cache)
  File "/Users/Adam/torchgeo/torchgeo/datasets/geo.py", line 370, in __init__
    raise FileNotFoundError(msg)
FileNotFoundError: No Landsat8 data was found in `root='data/landsat8/toa'` with `bands=['SR_B1', 'SR_B2', 'SR_B3', 'SR_B4', 'SR_B5', 'SR_B6', 'SR_B7']`
```
Thanks @TolgaAktas for reporting this!

Closes #1055