### PR TITLE
Deps: make omegaconf/tensorboard optional

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,7 +72,7 @@ jobs:
     - name: Install pip dependencies
       if: steps.cache.outputs.cache-hit != 'true'
       run: |
-        pip install .[docs,tests] planetary_computer pystac pytest-rerunfailure
+        pip install .[docs,tests] planetary_computer pystac pytest-rerunfailures
         pip list
     - name: Run notebook checks
       run: pytest --nbmake --durations=10 --reruns=10 docs/tutorials

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,7 +72,7 @@ jobs:
     - name: Install pip dependencies
       if: steps.cache.outputs.cache-hit != 'true'
       run: |
-        pip install .[docs,tests] planetary_computer pystac pytest-rerunfailures tensorboard
+        pip install .[docs,tests] planetary_computer pystac pytest-rerunfailure
         pip list
     - name: Run notebook checks
       run: pytest --nbmake --durations=10 --reruns=10 docs/tutorials

--- a/.github/workflows/tutorials.yaml
+++ b/.github/workflows/tutorials.yaml
@@ -30,7 +30,7 @@ jobs:
     - name: Install pip dependencies
       if: steps.cache.outputs.cache-hit != 'true'
       run: |
-        pip install .[docs,tests] planetary_computer pystac pytest-rerunfailures tensorboard
+        pip install .[docs,tests] planetary_computer pystac pytest-rerunfailures
         pip list
     - name: Run notebook checks
       run: pytest --nbmake --durations=10 --reruns=10 docs/tutorials

--- a/environment.yml
+++ b/environment.yml
@@ -46,7 +46,7 @@ dependencies:
     - segmentation-models-pytorch>=0.2
     - setuptools>=42
     - sphinx>=4,<6
-    - tensorboard>=1.6
+    - tensorboard>=2.9.1
     - timm>=0.4.12
     - torchmetrics>=0.10
     - zipfile-deflate64>=0.2

--- a/environment.yml
+++ b/environment.yml
@@ -46,6 +46,7 @@ dependencies:
     - segmentation-models-pytorch>=0.2
     - setuptools>=42
     - sphinx>=4,<6
+    - tensorboard>=1.6
     - timm>=0.4.12
     - torchmetrics>=0.10
     - zipfile-deflate64>=0.2

--- a/requirements/min-reqs.old
+++ b/requirements/min-reqs.old
@@ -8,7 +8,6 @@ kornia==0.6.5
 lightning==1.8.0
 matplotlib==3.3.0
 numpy==1.17.3
-omegaconf==2.1.0
 pillow==6.2.1
 pyproj==2.4.1
 rasterio==1.1.1
@@ -49,5 +48,7 @@ pyupgrade==2.4.0
 # tests
 mypy==0.900
 nbmake==1.3.3
+omegaconf==2.1.0
 pytest==6.1.2
 pytest-cov==2.4.0
+tensorboard==1.6.0

--- a/requirements/min-reqs.old
+++ b/requirements/min-reqs.old
@@ -51,4 +51,4 @@ nbmake==1.3.3
 omegaconf==2.1.0
 pytest==6.1.2
 pytest-cov==2.4.0
-tensorboard==1.6.0
+tensorboard==2.9.1

--- a/requirements/required.txt
+++ b/requirements/required.txt
@@ -5,10 +5,9 @@ setuptools==67.6.0
 einops==0.6.0
 fiona==1.9.2
 kornia==0.6.11
-lightning[extra]==2.0.1
+lightning==2.0.1
 matplotlib==3.7.1
 numpy==1.24.2
-omegaconf==2.3.0
 pillow==9.5.0
 pyproj==3.5.0
 rasterio==1.3.6

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,5 +1,7 @@
 # tests
 mypy==1.1.1
 nbmake==1.4.1
+omegaconf==2.3.0
 pytest==7.2.2
 pytest-cov==4.0.0
+tensorboard==2.12.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,13 +31,11 @@ install_requires =
     # kornia 0.6.5+ required due to change in kornia.augmentation API
     kornia>=0.6.5,<0.7
     # lightning 1.8+ is first release
-    lightning[extra]>=1.8,<2
+    lightning>=1.8,<2
     # matplotlib 3.3+ required for (H, W, 1) image support in plt.imshow
     matplotlib>=3.3,<4
     # numpy 1.17.3+ required by Python 3.8 wheels
     numpy>=1.17.3,<2
-    # omegaconf 2.1+ required for to_object method
-    omegaconf>=2.1,<3
     # pillow 6.2.1+ required for Python 3.8 wheels
     pillow>=6.2.1,<10
     # pyproj 2.4.1+ required for Python 3.8 wheels
@@ -123,10 +121,14 @@ tests =
     mypy>=0.900,<2
     # nbmake 1.3.3+ required for variable mocking
     nbmake>=1.3.3,<2
+    # omegaconf 2.1+ required for to_object method
+    omegaconf>=2.1,<3
     # pytest 6.1.2+ required by nbmake
     pytest>=6.1.2,<8
     # pytest-cov 2.4+ required for pytest --cov flags
     pytest-cov>=2.4,<5
+    # tensorboard 1.6+ is first release
+    tensorboard>=1.6,<3
 all =
     torchgeo[datasets,docs,style,tests]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -127,8 +127,8 @@ tests =
     pytest>=6.1.2,<8
     # pytest-cov 2.4+ required for pytest --cov flags
     pytest-cov>=2.4,<5
-    # tensorboard 1.6+ is first release
-    tensorboard>=1.6,<3
+    # tensorboard 2.9.1+ required by lightning
+    tensorboard>=2.9.1,<3
 all =
     torchgeo[datasets,docs,style,tests]
 


### PR DESCRIPTION
### Why optional?

TorchGeo does not import or require either of these dependencies. The only thing these deps are required for is our trainer tests, for [a single notebook](https://github.com/microsoft/torchgeo/pull/1189), and for train.py and friends. None of these files get installed when you run `pip install torchgeo`, so the dependency shouldn't be required.

### Why now?

Omegaconf was always an issue (every time you update the conda-forge recipe it complains that it isn't used), but the lightning/tensorboard issue is relatively new. Starting with lightning 1.9, tensorboard was moved from a required dependency to [an optional extra](https://github.com/Lightning-AI/lightning/pull/16349). However, our tests need tensorboard for coverage, so we added a dependency on `lightning[extra]` to pull in tensorboard. However, this pulls in [a lot of other deps](https://github.com/Lightning-AI/lightning/blob/master/requirements/pytorch/extra.txt) in addition to tensorboard. To minimize the deps we install, we should avoid using `[extra]`.

Also, Spack has trouble concretizing `py-lightning+extra` due to conflicting setuptools versions required.

### Why tensorboard and not tensorboardX?

Lightning used to install tensorboard, then [switched to tensorboardX](https://github.com/Lightning-AI/lightning/pull/15728) (both are compatible with the same API). The reason for this switch was that tensorboardX has fewer dependencies and is easier to install on more platforms. The only other difference I've seen between the two that affects us is that tensorboardX does not support the `%load_ext tensorboard` Jupyter magic that we use in our notebook. Since our notebook tests require tensorboard, I figured we should just go with that.

FYI @bugraaldal 