### PR TITLE
Specify mode in ckpt callback

### DIFF
--- a/train.py
+++ b/train.py
@@ -196,6 +196,7 @@ def main(conf: DictConfig) -> None:
         dirpath=experiment_dir,
         save_top_k=1,
         save_last=True,
+        mode=mode,
     )
     early_stopping_callback = EarlyStopping(
         monitor=monitor_metric, min_delta=0.00, patience=18, mode=mode


### PR DESCRIPTION
Fixes an issue where mode defaulted to "min". This caused an issue while training a detection model where the best model was (incorrectly) thought to be the one with the lowest MAP.