### PR TITLE
Fix minimum tests, lightning missing websockets dep

### DIFF
--- a/requirements/min-reqs.old
+++ b/requirements/min-reqs.old
@@ -52,3 +52,7 @@ omegaconf==2.1.0
 pytest==6.1.2
 pytest-cov==2.4.0
 tensorboard==2.9.1
+
+# Required dependency of lightning, wasn't properly listed until 1.9
+# https://github.com/Lightning-AI/lightning/pull/16302
+websockets


### PR DESCRIPTION
Discovered by @yichiac.

See https://github.com/microsoft/torchgeo/actions/runs/4670725252/jobs/8270814132?pr=1229 for an example of the error that happens without this.

Older versions of lightning didn't properly list their dependencies until https://github.com/Lightning-AI/lightning/pull/16302. I'm guessing a different dependency was indirectly installing websockets before, but a new release dropped this dependency, so lightning started to fail all of a sudden. Not really preventable unless we want to use pip lock files and have dependabot update every indirect dep every day.

Alternative is to require a newer version of lightning. I don't see a great reason to limit ourselves, and the workaround is simple.