### PR TITLE
Revert "Tests: downloaded weights have different number of classes"

### DIFF
--- a/tests/trainers/test_classification.py
+++ b/tests/trainers/test_classification.py
@@ -188,8 +188,7 @@ class TestClassificationTask:
         model_kwargs["model"] = weights.meta["model"]
         model_kwargs["in_channels"] = weights.meta["in_chans"]
         model_kwargs["weights"] = weights
-        with pytest.warns(UserWarning):
-            ClassificationTask(**model_kwargs)
+        ClassificationTask(**model_kwargs)
 
     @pytest.mark.slow
     def test_weight_str_download(
@@ -198,8 +197,7 @@ class TestClassificationTask:
         model_kwargs["model"] = weights.meta["model"]
         model_kwargs["in_channels"] = weights.meta["in_chans"]
         model_kwargs["weights"] = str(weights)
-        with pytest.warns(UserWarning):
-            ClassificationTask(**model_kwargs)
+        ClassificationTask(**model_kwargs)
 
     def test_invalid_loss(self, model_kwargs: Dict[str, Any]) -> None:
         model_kwargs["loss"] = "invalid_loss"

--- a/tests/trainers/test_regression.py
+++ b/tests/trainers/test_regression.py
@@ -151,8 +151,7 @@ class TestRegressionTask:
         model_kwargs["model"] = weights.meta["model"]
         model_kwargs["in_channels"] = weights.meta["in_chans"]
         model_kwargs["weights"] = weights
-        with pytest.warns(UserWarning):
-            RegressionTask(**model_kwargs)
+        RegressionTask(**model_kwargs)
 
     @pytest.mark.slow
     def test_weight_str_download(
@@ -161,8 +160,7 @@ class TestRegressionTask:
         model_kwargs["model"] = weights.meta["model"]
         model_kwargs["in_channels"] = weights.meta["in_chans"]
         model_kwargs["weights"] = str(weights)
-        with pytest.warns(UserWarning):
-            RegressionTask(**model_kwargs)
+        RegressionTask(**model_kwargs)
 
     def test_no_rgb(
         self, monkeypatch: MonkeyPatch, model_kwargs: Dict[Any, Any], fast_dev_run: bool


### PR DESCRIPTION
Reverts microsoft/torchgeo#1229

This was not the right approach. It fixes the tests for the SeCo weights, but breaks the tests for all other weights. The correct fix is to ensure that the SeCo weights can be loaded without warnings.