### PR TITLE
GeoDataModules: automatically infer length by default

### DIFF
--- a/torchgeo/datamodules/chesapeake.py
+++ b/torchgeo/datamodules/chesapeake.py
@@ -3,7 +3,7 @@
 
 """Chesapeake Bay High-Resolution Land Cover Project datamodule."""
 
-from typing import Any
+from typing import Any, Optional
 
 import kornia.augmentation as K
 import torch.nn as nn
@@ -63,7 +63,7 @@ class ChesapeakeCVPRDataModule(GeoDataModule):
         test_splits: list[str],
         batch_size: int = 64,
         patch_size: int = 256,
-        length: int = 1000,
+        length: Optional[int] = None,
         num_workers: int = 0,
         class_set: int = 7,
         use_prior_labels: bool = False,

--- a/torchgeo/datamodules/geo.py
+++ b/torchgeo/datamodules/geo.py
@@ -37,7 +37,7 @@ class GeoDataModule(LightningDataModule):  # type: ignore[misc]
         dataset_class: type[GeoDataset],
         batch_size: int = 1,
         patch_size: Union[int, tuple[int, int]] = 64,
-        length: int = 1000,
+        length: Optional[int] = None,
         num_workers: int = 0,
         **kwargs: Any,
     ) -> None:

--- a/torchgeo/datamodules/l7irish.py
+++ b/torchgeo/datamodules/l7irish.py
@@ -3,7 +3,7 @@
 
 """L7 Irish datamodule."""
 
-from typing import Any, Union
+from typing import Any, Optional, Union
 
 import torch
 
@@ -25,7 +25,7 @@ class L7IrishDataModule(GeoDataModule):
         self,
         batch_size: int = 1,
         patch_size: Union[int, tuple[int, int]] = 32,
-        length: int = 5,
+        length: Optional[int] = None,
         num_workers: int = 0,
         **kwargs: Any,
     ) -> None:

--- a/torchgeo/datamodules/l8biome.py
+++ b/torchgeo/datamodules/l8biome.py
@@ -3,7 +3,7 @@
 
 """L8 Biome datamodule."""
 
-from typing import Any, Union
+from typing import Any, Optional, Union
 
 import torch
 
@@ -25,7 +25,7 @@ class L8BiomeDataModule(GeoDataModule):
         self,
         batch_size: int = 1,
         patch_size: Union[int, tuple[int, int]] = 32,
-        length: int = 5,
+        length: Optional[int] = None,
         num_workers: int = 0,
         **kwargs: Any,
     ) -> None:

--- a/torchgeo/datamodules/naip.py
+++ b/torchgeo/datamodules/naip.py
@@ -3,7 +3,7 @@
 
 """National Agriculture Imagery Program (NAIP) datamodule."""
 
-from typing import Any, Union
+from typing import Any, Optional, Union
 
 import kornia.augmentation as K
 import matplotlib.pyplot as plt
@@ -24,7 +24,7 @@ class NAIPChesapeakeDataModule(GeoDataModule):
         self,
         batch_size: int = 64,
         patch_size: Union[int, tuple[int, int]] = 256,
-        length: int = 1000,
+        length: Optional[int] = None,
         num_workers: int = 0,
         **kwargs: Any,
     ) -> None:


### PR DESCRIPTION
#755 added a default length for all GeoSamplers. We should use this by default instead of requiring users to know how long an epoch should be.

@yichiac @shradhasehgal