### PR TITLE
Windows CI: replace pacman with choco

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -67,7 +67,7 @@ jobs:
     - name: Install pacman dependencies (Windows)
       shell: cmd
       run: |
-        set "PATH=%PATH%;c:\msys64\usr\bin"
+        set 'PATH=%PATH%;c:\msys64\usr\bin'
         pacman -S --noconfirm --needed unrar
       if: ${{ runner.os == 'Windows' }}
     - name: Install pip dependencies
@@ -81,7 +81,7 @@ jobs:
     - name: Run pytest checks (Windows)
       shell: cmd
       run: |
-        set "PATH=%PATH%;c:\msys64\usr\bin"
+        set 'PATH=%PATH%;c:\msys64\usr\bin'
         pytest --cov=torchgeo --cov-report=xml --durations=10
       if: ${{ runner.os == 'Windows' }}
     - name: Report coverage

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -64,26 +64,16 @@ jobs:
     - name: Install brew dependencies (macOS)
       run: brew install rar
       if: ${{ runner.os == 'macOS' }}
-    - name: Install pacman dependencies (Windows)
-      shell: cmd
-      run: |
-        set 'PATH=%PATH%;c:\msys64\usr\bin'
-        pacman -S --noconfirm --needed unrar
+    - name: Install choco dependencies (Windows)
+      run: choco install unrar
       if: ${{ runner.os == 'Windows' }}
     - name: Install pip dependencies
       if: steps.cache.outputs.cache-hit != 'true'
       run: |
         pip install -r requirements/required.txt -r requirements/datasets.txt -r requirements/tests.txt
         pip list
-    - name: Run pytest checks (Linux/macOS)
+    - name: Run pytest checks
       run: pytest --cov=torchgeo --cov-report=xml --durations=10
-      if: ${{ runner.os != 'Windows' }}
-    - name: Run pytest checks (Windows)
-      shell: cmd
-      run: |
-        set 'PATH=%PATH%;c:\msys64\usr\bin'
-        pytest --cov=torchgeo --cov-report=xml --durations=10
-      if: ${{ runner.os == 'Windows' }}
     - name: Report coverage
       uses: codecov/codecov-action@v3.1.2
       with:


### PR DESCRIPTION
Honestly not sure how this ever worked. My text editor marks `\b` as the ASCII backspace character. Using single quotes instead of double quotes avoids backslash being interpreted as a special character. I'm guessing the reason it works is because the YAML interpreter GitHub uses doesn't register `\b`? Anyway, this fix makes my editor happy.