### PR TITLE
Fix lat/lon in Western USA Live Fuel Moisture Dataset.

### DIFF
--- a/torchgeo/datasets/western_usa_live_fuel_moisture.py
+++ b/torchgeo/datasets/western_usa_live_fuel_moisture.py
@@ -298,8 +298,8 @@ class WesternUSALiveFuelMoisture(NonGeoDataset):
             with open(path) as f:
                 content = json.load(f)
                 data_dict = content["properties"]
-                data_dict["lat"] = content["geometry"]["coordinates"][0]
-                data_dict["lon"] = content["geometry"]["coordinates"][1]
+                data_dict["lon"] = content["geometry"]["coordinates"][0]
+                data_dict["lat"] = content["geometry"]["coordinates"][1]
                 data_rows.append(data_dict)
 
         df: pd.DataFrame = pd.DataFrame(data_rows)


### PR DESCRIPTION
I had switched the lat/lon from the dataset, which I discovered when trying to do the following plot:

```
import matplotlib.pyplot as plt
import geopandas
import geoplot as gplt
target = ds.dataframe["percent(t)"]
fig, ax = plt.subplots(ncols=2)

gdf = geopandas.GeoDataFrame(
    target,
    geometry=geopandas.points_from_xy(self.dataframe.lon, self.dataframe.lat),
)
contiguous_usa = geopandas.read_file(gplt.datasets.get_path('contiguous_usa'))
gplt.polyplot(contiguous_usa, ax=ax[0])
gplt.pointplot(
    gdf, hue="percent(t)", legend=True, ax=ax[0],
)

ax[0].set_title(
    f"Spatial Distribution of Live Fuel Moisture for the full dataset."
)

ax[1].violinplot(self.dataframe["percent(t)"].values)
ax[1].set_title("Distribution of Moisture Percentage Full dataset.")
ax[1].set_ylabel("Live Fuel Moisture Percentage")
```

With the corrected order in this PR I can produce this plot:


![Screenshot from 2023-04-20 11-36-07](https://user-images.githubusercontent.com/35272119/233325721-df137c64-1ecc-489b-bc4e-640e798f8b4c.png)


