### PR TITLE
fix typo in docs: ucmerced n=2,100 not n=21,000

### DIFF
--- a/docs/api/non_geo_datasets.csv
+++ b/docs/api/non_geo_datasets.csv
@@ -33,7 +33,7 @@ Dataset,Task,Source,# Samples,# Classes,Size (px),Resolution (m),Bands
 `SSL4EO`_,T,Sentinel-1/2,1M,-,264x264,10,"SAR, MSI"
 `SustainBench Crop Yield`_,R,MODIS,11k,-,32x32,-,MSI
 `Tropical Cyclone`_,R,GOES 8--16,"108,110",-,256x256,4K--8K,MSI
-`UC Merced`_,C,USGS National Map,"21,000",21,256x256,0.3,RGB
+`UC Merced`_,C,USGS National Map,"2,100",21,256x256,0.3,RGB
 `USAVars`_,R,NAIP Aerial,100K,-,-,4,"RGB, NIR"
 `Vaihingen`_,S,Aerial,33,6,"1,281--3,816",0.09,RGB
 `VHR-10`_,I,"Google Earth, Vaihingen",800,10,"358--1,728",0.08--2,RGB


### PR DESCRIPTION
I would like to fix a small typo in the documentation. The UC Merced land-use dataset consists of 2,100 images, not 21,000 (although it would be nice if it were more extensive). As far as I've seen, n=21,000 is only referenced in the table, while the actual UC Merced dataset class refers to the correct n=2,100. 