### PR TITLE
SSL4EO: more generic download script

### DIFF
--- a/experiments/ssl4eo/download_l5_raw.sh
+++ b/experiments/ssl4eo/download_l5_raw.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash -euo pipefail
+#!/usr/bin/env bash
+
+set -euo pipefail
 
 # User-specific parameters
 SAVE_PATH=data/ssl4eo-l5-raw

--- a/experiments/ssl4eo/download_l5_raw.sh
+++ b/experiments/ssl4eo/download_l5_raw.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 ROOT_DIR=data
 SAVE_PATH="$ROOT_DIR/ssl4eo-l5-raw"
 MATCH_FILE="$ROOT_DIR/ssl4eo-l-60/sampled_locations.csv"
-NUM_WORKERS=28
+NUM_WORKERS=40
 START_INDEX=0
 END_INDEX=10
 

--- a/experiments/ssl4eo/download_l5_raw.sh
+++ b/experiments/ssl4eo/download_l5_raw.sh
@@ -18,6 +18,7 @@ YEAR=1991  # MSS data acquisitions over the United States ceased in 1992
 BANDS=(B1 B2 B3 B4)
 ORIGINAL_RESOLUTIONS=(60 60 60 30)
 NEW_RESOLUTIONS=60
+DEFAULT_VALUE=0
 
 # Generic parameters
 SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
@@ -39,6 +40,7 @@ time python3 "$SCRIPT_DIR/download_ssl4eo.py" \
     --original-resolutions ${ORIGINAL_RESOLUTIONS[@]} \
     --new-resolutions $NEW_RESOLUTIONS \
     --dtype $DTYPE \
+    --default-value $DEFAULT_VALUE \
     --num-workers $NUM_WORKERS \
     --log-freq $LOG_FREQ \
     --match-file "$MATCH_FILE" \

--- a/experiments/ssl4eo/download_l5_raw.sh
+++ b/experiments/ssl4eo/download_l5_raw.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash -euo pipefail
+
+# User-specific parameters
+SAVE_PATH=data/ssl4eo-l5-raw
+NUM_WORKERS=28
+MATCH_FILE=data/ssl4eo-l-60/sampled_locations.csv
+START_INDEX=0
+END_INDEX=10
+
+# Satellite-specific parameters
+COLLECTION=LANDSAT/LM05/C02/T1
+QA_BAND=QA_PIXEL
+QA_CLOUD_BIT=3
+META_CLOUD_NAME=CLOUD_COVER
+YEAR=1991  # MSS data acquisitions over the United States ceased in 1992
+BANDS=(B1 B2 B3 B4)
+ORIGINAL_RESOLUTIONS=(60 60 60 30)
+NEW_RESOLUTIONS=60
+
+# Generic parameters
+SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+CLOUD_PCT=20
+SIZE=264
+DTYPE=float32
+LOG_FREQ=1000
+
+time python3 "$SCRIPT_DIR/download_ssl4eo.py" \
+    --save-path "$SAVE_PATH" \
+    --collection $COLLECTION \
+    --qa-band $QA_BAND \
+    --qa-cloud-bit $QA_CLOUD_BIT \
+    --meta-cloud-name $META_CLOUD_NAME \
+    --cloud-pct $CLOUD_PCT \
+    --dates $YEAR-03-20 $YEAR-06-21 $YEAR-09-23 $YEAR-12-21 \
+    --radius $(($NEW_RESOLUTIONS * $SIZE / 2)) \
+    --bands ${BANDS[@]} \
+    --original-resolutions ${ORIGINAL_RESOLUTIONS[@]} \
+    --new-resolutions $NEW_RESOLUTIONS \
+    --dtype $DTYPE \
+    --num-workers $NUM_WORKERS \
+    --log-freq $LOG_FREQ \
+    --match-file "$MATCH_FILE" \
+    --indices-range $START_INDEX $END_INDEX --debug

--- a/experiments/ssl4eo/download_l5_raw.sh
+++ b/experiments/ssl4eo/download_l5_raw.sh
@@ -3,11 +3,13 @@
 set -euo pipefail
 
 # User-specific parameters
-SAVE_PATH=data/ssl4eo-l5-raw
+ROOT_DIR=data
+SAVE_PATH="$ROOT_DIR/ssl4eo-l5-raw"
+MATCH_FILE="$ROOT_DIR/ssl4eo-l-60/sampled_locations.csv"
 NUM_WORKERS=28
-MATCH_FILE=data/ssl4eo-l-60/sampled_locations.csv
+NUM_PROCESSES=10
 START_INDEX=0
-END_INDEX=10
+END_INDEX=100
 
 # Satellite-specific parameters
 COLLECTION=LANDSAT/LM05/C02/T1
@@ -27,21 +29,30 @@ SIZE=264
 DTYPE=float32
 LOG_FREQ=1000
 
-time python3 "$SCRIPT_DIR/download_ssl4eo.py" \
-    --save-path "$SAVE_PATH" \
-    --collection $COLLECTION \
-    --qa-band $QA_BAND \
-    --qa-cloud-bit $QA_CLOUD_BIT \
-    --meta-cloud-name $META_CLOUD_NAME \
-    --cloud-pct $CLOUD_PCT \
-    --dates $YEAR-03-20 $YEAR-06-21 $YEAR-09-23 $YEAR-12-21 \
-    --radius $(($NEW_RESOLUTIONS * $SIZE / 2)) \
-    --bands ${BANDS[@]} \
-    --original-resolutions ${ORIGINAL_RESOLUTIONS[@]} \
-    --new-resolutions $NEW_RESOLUTIONS \
-    --dtype $DTYPE \
-    --default-value $DEFAULT_VALUE \
-    --num-workers $NUM_WORKERS \
-    --log-freq $LOG_FREQ \
-    --match-file "$MATCH_FILE" \
-    --indices-range $START_INDEX $END_INDEX --debug
+INCREMENT=$(( ($END_INDEX - $START_INDEX) / $NUM_PROCESSES ))
+for i in $(seq 1 $NUM_PROCESSES)
+do
+    END=$(( $START_INDEX + ($i * $INCREMENT) ))
+    START=$(( $END - $INCREMENT ))
+
+    time python3 "$SCRIPT_DIR/download_ssl4eo.py" \
+        --save-path "$SAVE_PATH" \
+        --collection $COLLECTION \
+        --qa-band $QA_BAND \
+        --qa-cloud-bit $QA_CLOUD_BIT \
+        --meta-cloud-name $META_CLOUD_NAME \
+        --cloud-pct $CLOUD_PCT \
+        --dates $YEAR-03-20 $YEAR-06-21 $YEAR-09-23 $YEAR-12-21 \
+        --radius $(($NEW_RESOLUTIONS * $SIZE / 2)) \
+        --bands ${BANDS[@]} \
+        --original-resolutions ${ORIGINAL_RESOLUTIONS[@]} \
+        --new-resolutions $NEW_RESOLUTIONS \
+        --dtype $DTYPE \
+        --default-value $DEFAULT_VALUE \
+        --num-workers $NUM_WORKERS \
+        --log-freq $LOG_FREQ \
+        --match-file "$MATCH_FILE" \
+        --indices-range $START $END &
+done
+
+wait

--- a/experiments/ssl4eo/download_l5_raw.sh
+++ b/experiments/ssl4eo/download_l5_raw.sh
@@ -3,9 +3,10 @@
 set -euo pipefail
 
 # User-specific parameters
-SAVE_PATH=data/ssl4eo-l5-raw
+ROOT_DIR=data
+SAVE_PATH="$ROOT_DIR/ssl4eo-l5-raw"
+MATCH_FILE="$ROOT_DIR/ssl4eo-l-60/sampled_locations.csv"
 NUM_WORKERS=28
-MATCH_FILE=data/ssl4eo-l-60/sampled_locations.csv
 START_INDEX=0
 END_INDEX=10
 
@@ -44,4 +45,5 @@ time python3 "$SCRIPT_DIR/download_ssl4eo.py" \
     --num-workers $NUM_WORKERS \
     --log-freq $LOG_FREQ \
     --match-file "$MATCH_FILE" \
-    --indices-range $START_INDEX $END_INDEX --debug
+    --indices-range $START_INDEX $END_INDEX \
+    --debug

--- a/experiments/ssl4eo/download_l5_raw.sh
+++ b/experiments/ssl4eo/download_l5_raw.sh
@@ -3,13 +3,11 @@
 set -euo pipefail
 
 # User-specific parameters
-ROOT_DIR=data
-SAVE_PATH="$ROOT_DIR/ssl4eo-l5-raw"
-MATCH_FILE="$ROOT_DIR/ssl4eo-l-60/sampled_locations.csv"
+SAVE_PATH=data/ssl4eo-l5-raw
 NUM_WORKERS=28
-NUM_PROCESSES=10
+MATCH_FILE=data/ssl4eo-l-60/sampled_locations.csv
 START_INDEX=0
-END_INDEX=100
+END_INDEX=10
 
 # Satellite-specific parameters
 COLLECTION=LANDSAT/LM05/C02/T1
@@ -29,30 +27,21 @@ SIZE=264
 DTYPE=float32
 LOG_FREQ=1000
 
-INCREMENT=$(( ($END_INDEX - $START_INDEX) / $NUM_PROCESSES ))
-for i in $(seq 1 $NUM_PROCESSES)
-do
-    END=$(( $START_INDEX + ($i * $INCREMENT) ))
-    START=$(( $END - $INCREMENT ))
-
-    time python3 "$SCRIPT_DIR/download_ssl4eo.py" \
-        --save-path "$SAVE_PATH" \
-        --collection $COLLECTION \
-        --qa-band $QA_BAND \
-        --qa-cloud-bit $QA_CLOUD_BIT \
-        --meta-cloud-name $META_CLOUD_NAME \
-        --cloud-pct $CLOUD_PCT \
-        --dates $YEAR-03-20 $YEAR-06-21 $YEAR-09-23 $YEAR-12-21 \
-        --radius $(($NEW_RESOLUTIONS * $SIZE / 2)) \
-        --bands ${BANDS[@]} \
-        --original-resolutions ${ORIGINAL_RESOLUTIONS[@]} \
-        --new-resolutions $NEW_RESOLUTIONS \
-        --dtype $DTYPE \
-        --default-value $DEFAULT_VALUE \
-        --num-workers $NUM_WORKERS \
-        --log-freq $LOG_FREQ \
-        --match-file "$MATCH_FILE" \
-        --indices-range $START $END &
-done
-
-wait
+time python3 "$SCRIPT_DIR/download_ssl4eo.py" \
+    --save-path "$SAVE_PATH" \
+    --collection $COLLECTION \
+    --qa-band $QA_BAND \
+    --qa-cloud-bit $QA_CLOUD_BIT \
+    --meta-cloud-name $META_CLOUD_NAME \
+    --cloud-pct $CLOUD_PCT \
+    --dates $YEAR-03-20 $YEAR-06-21 $YEAR-09-23 $YEAR-12-21 \
+    --radius $(($NEW_RESOLUTIONS * $SIZE / 2)) \
+    --bands ${BANDS[@]} \
+    --original-resolutions ${ORIGINAL_RESOLUTIONS[@]} \
+    --new-resolutions $NEW_RESOLUTIONS \
+    --dtype $DTYPE \
+    --default-value $DEFAULT_VALUE \
+    --num-workers $NUM_WORKERS \
+    --log-freq $LOG_FREQ \
+    --match-file "$MATCH_FILE" \
+    --indices-range $START_INDEX $END_INDEX --debug

--- a/experiments/ssl4eo/download_l7_l1.sh
+++ b/experiments/ssl4eo/download_l7_l1.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash -euo pipefail
+
+# User-specific parameters
+SAVE_PATH=data/ssl4eo-l7-l1
+NUM_WORKERS=28
+MATCH_FILE=data/ssl4eo-l-30/sampled_locations.csv
+START_INDEX=0
+END_INDEX=10
+
+# Satellite-specific parameters
+COLLECTION=LANDSAT/LE07/C02/T1_TOA
+QA_BAND=QA_PIXEL
+QA_CLOUD_BIT=3
+META_CLOUD_NAME=CLOUD_COVER
+YEAR=2002  # SLC-on
+BANDS=(B1 B2 B3 B4 B5 B6_VCID_1 B6_VCID_2 B7 B8)
+ORIGINAL_RESOLUTIONS=(30 30 30 30 30 60 60 30 15)
+NEW_RESOLUTIONS=30
+
+# Generic parameters
+SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+CLOUD_PCT=20
+SIZE=264
+DTYPE=float32
+LOG_FREQ=1000
+
+time python3 "$SCRIPT_DIR/download_ssl4eo.py" \
+    --save-path "$SAVE_PATH" \
+    --collection $COLLECTION \
+    --qa-band $QA_BAND \
+    --qa-cloud-bit $QA_CLOUD_BIT \
+    --meta-cloud-name $META_CLOUD_NAME \
+    --cloud-pct $CLOUD_PCT \
+    --dates $YEAR-03-20 $YEAR-06-21 $YEAR-09-23 $YEAR-12-21 \
+    --radius $(($NEW_RESOLUTIONS * $SIZE / 2)) \
+    --bands ${BANDS[@]} \
+    --original-resolutions ${ORIGINAL_RESOLUTIONS[@]} \
+    --new-resolutions $NEW_RESOLUTIONS \
+    --dtype $DTYPE \
+    --num-workers $NUM_WORKERS \
+    --log-freq $LOG_FREQ \
+    --match-file "$MATCH_FILE" \
+    --indices-range $START_INDEX $END_INDEX

--- a/experiments/ssl4eo/download_l7_l1.sh
+++ b/experiments/ssl4eo/download_l7_l1.sh
@@ -3,11 +3,13 @@
 set -euo pipefail
 
 # User-specific parameters
-SAVE_PATH=data/ssl4eo-l7-l1
+ROOT_DIR=data
+SAVE_PATH="$ROOT_DIR/ssl4eo-l7-l1"
+MATCH_FILE="$ROOT_DIR/ssl4eo-l-30/sampled_locations.csv"
 NUM_WORKERS=28
-MATCH_FILE=data/ssl4eo-l-30/sampled_locations.csv
+NUM_PROCESSES=10
 START_INDEX=0
-END_INDEX=10
+END_INDEX=100
 
 # Satellite-specific parameters
 COLLECTION=LANDSAT/LE07/C02/T1_TOA
@@ -27,21 +29,30 @@ SIZE=264
 DTYPE=float32
 LOG_FREQ=1000
 
-time python3 "$SCRIPT_DIR/download_ssl4eo.py" \
-    --save-path "$SAVE_PATH" \
-    --collection $COLLECTION \
-    --qa-band $QA_BAND \
-    --qa-cloud-bit $QA_CLOUD_BIT \
-    --meta-cloud-name $META_CLOUD_NAME \
-    --cloud-pct $CLOUD_PCT \
-    --dates $YEAR-03-20 $YEAR-06-21 $YEAR-09-23 $YEAR-12-21 \
-    --radius $(($NEW_RESOLUTIONS * $SIZE / 2)) \
-    --bands ${BANDS[@]} \
-    --original-resolutions ${ORIGINAL_RESOLUTIONS[@]} \
-    --new-resolutions $NEW_RESOLUTIONS \
-    --dtype $DTYPE \
-    --default-value $DEFAULT_VALUE \
-    --num-workers $NUM_WORKERS \
-    --log-freq $LOG_FREQ \
-    --match-file "$MATCH_FILE" \
-    --indices-range $START_INDEX $END_INDEX
+INCREMENT=$(( ($END_INDEX - $START_INDEX) / $NUM_PROCESSES ))
+for i in $(seq 1 $NUM_PROCESSES)
+do
+    END=$(( $START_INDEX + ($i * $INCREMENT) ))
+    START=$(( $END - $INCREMENT ))
+
+    time python3 "$SCRIPT_DIR/download_ssl4eo.py" \
+        --save-path "$SAVE_PATH" \
+        --collection $COLLECTION \
+        --qa-band $QA_BAND \
+        --qa-cloud-bit $QA_CLOUD_BIT \
+        --meta-cloud-name $META_CLOUD_NAME \
+        --cloud-pct $CLOUD_PCT \
+        --dates $YEAR-03-20 $YEAR-06-21 $YEAR-09-23 $YEAR-12-21 \
+        --radius $(($NEW_RESOLUTIONS * $SIZE / 2)) \
+        --bands ${BANDS[@]} \
+        --original-resolutions ${ORIGINAL_RESOLUTIONS[@]} \
+        --new-resolutions $NEW_RESOLUTIONS \
+        --dtype $DTYPE \
+        --default-value $DEFAULT_VALUE \
+        --num-workers $NUM_WORKERS \
+        --log-freq $LOG_FREQ \
+        --match-file "$MATCH_FILE" \
+        --indices-range $START $END &
+done
+
+wait

--- a/experiments/ssl4eo/download_l7_l1.sh
+++ b/experiments/ssl4eo/download_l7_l1.sh
@@ -18,6 +18,7 @@ YEAR=2002  # SLC-on
 BANDS=(B1 B2 B3 B4 B5 B6_VCID_1 B6_VCID_2 B7 B8)
 ORIGINAL_RESOLUTIONS=(30 30 30 30 30 60 60 30 15)
 NEW_RESOLUTIONS=30
+DEFAULT_VALUE=-9999
 
 # Generic parameters
 SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
@@ -39,6 +40,7 @@ time python3 "$SCRIPT_DIR/download_ssl4eo.py" \
     --original-resolutions ${ORIGINAL_RESOLUTIONS[@]} \
     --new-resolutions $NEW_RESOLUTIONS \
     --dtype $DTYPE \
+    --default-value $DEFAULT_VALUE \
     --num-workers $NUM_WORKERS \
     --log-freq $LOG_FREQ \
     --match-file "$MATCH_FILE" \

--- a/experiments/ssl4eo/download_l7_l1.sh
+++ b/experiments/ssl4eo/download_l7_l1.sh
@@ -3,13 +3,11 @@
 set -euo pipefail
 
 # User-specific parameters
-ROOT_DIR=data
-SAVE_PATH="$ROOT_DIR/ssl4eo-l7-l1"
-MATCH_FILE="$ROOT_DIR/ssl4eo-l-30/sampled_locations.csv"
+SAVE_PATH=data/ssl4eo-l7-l1
 NUM_WORKERS=28
-NUM_PROCESSES=10
+MATCH_FILE=data/ssl4eo-l-30/sampled_locations.csv
 START_INDEX=0
-END_INDEX=100
+END_INDEX=10
 
 # Satellite-specific parameters
 COLLECTION=LANDSAT/LE07/C02/T1_TOA
@@ -29,30 +27,21 @@ SIZE=264
 DTYPE=float32
 LOG_FREQ=1000
 
-INCREMENT=$(( ($END_INDEX - $START_INDEX) / $NUM_PROCESSES ))
-for i in $(seq 1 $NUM_PROCESSES)
-do
-    END=$(( $START_INDEX + ($i * $INCREMENT) ))
-    START=$(( $END - $INCREMENT ))
-
-    time python3 "$SCRIPT_DIR/download_ssl4eo.py" \
-        --save-path "$SAVE_PATH" \
-        --collection $COLLECTION \
-        --qa-band $QA_BAND \
-        --qa-cloud-bit $QA_CLOUD_BIT \
-        --meta-cloud-name $META_CLOUD_NAME \
-        --cloud-pct $CLOUD_PCT \
-        --dates $YEAR-03-20 $YEAR-06-21 $YEAR-09-23 $YEAR-12-21 \
-        --radius $(($NEW_RESOLUTIONS * $SIZE / 2)) \
-        --bands ${BANDS[@]} \
-        --original-resolutions ${ORIGINAL_RESOLUTIONS[@]} \
-        --new-resolutions $NEW_RESOLUTIONS \
-        --dtype $DTYPE \
-        --default-value $DEFAULT_VALUE \
-        --num-workers $NUM_WORKERS \
-        --log-freq $LOG_FREQ \
-        --match-file "$MATCH_FILE" \
-        --indices-range $START $END &
-done
-
-wait
+time python3 "$SCRIPT_DIR/download_ssl4eo.py" \
+    --save-path "$SAVE_PATH" \
+    --collection $COLLECTION \
+    --qa-band $QA_BAND \
+    --qa-cloud-bit $QA_CLOUD_BIT \
+    --meta-cloud-name $META_CLOUD_NAME \
+    --cloud-pct $CLOUD_PCT \
+    --dates $YEAR-03-20 $YEAR-06-21 $YEAR-09-23 $YEAR-12-21 \
+    --radius $(($NEW_RESOLUTIONS * $SIZE / 2)) \
+    --bands ${BANDS[@]} \
+    --original-resolutions ${ORIGINAL_RESOLUTIONS[@]} \
+    --new-resolutions $NEW_RESOLUTIONS \
+    --dtype $DTYPE \
+    --default-value $DEFAULT_VALUE \
+    --num-workers $NUM_WORKERS \
+    --log-freq $LOG_FREQ \
+    --match-file "$MATCH_FILE" \
+    --indices-range $START_INDEX $END_INDEX

--- a/experiments/ssl4eo/download_l7_l1.sh
+++ b/experiments/ssl4eo/download_l7_l1.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash -euo pipefail
+#!/usr/bin/env bash
+
+set -euo pipefail
 
 # User-specific parameters
 SAVE_PATH=data/ssl4eo-l7-l1

--- a/experiments/ssl4eo/download_l7_l1.sh
+++ b/experiments/ssl4eo/download_l7_l1.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 ROOT_DIR=data
 SAVE_PATH="$ROOT_DIR/ssl4eo-l7-l1"
 MATCH_FILE="$ROOT_DIR/ssl4eo-l-30/sampled_locations.csv"
-NUM_WORKERS=28
+NUM_WORKERS=40
 START_INDEX=0
 END_INDEX=10
 

--- a/experiments/ssl4eo/download_l7_l1.sh
+++ b/experiments/ssl4eo/download_l7_l1.sh
@@ -3,9 +3,10 @@
 set -euo pipefail
 
 # User-specific parameters
-SAVE_PATH=data/ssl4eo-l7-l1
+ROOT_DIR=data
+SAVE_PATH="$ROOT_DIR/ssl4eo-l7-l1"
+MATCH_FILE="$ROOT_DIR/ssl4eo-l-30/sampled_locations.csv"
 NUM_WORKERS=28
-MATCH_FILE=data/ssl4eo-l-30/sampled_locations.csv
 START_INDEX=0
 END_INDEX=10
 
@@ -44,4 +45,5 @@ time python3 "$SCRIPT_DIR/download_ssl4eo.py" \
     --num-workers $NUM_WORKERS \
     --log-freq $LOG_FREQ \
     --match-file "$MATCH_FILE" \
-    --indices-range $START_INDEX $END_INDEX
+    --indices-range $START_INDEX $END_INDEX \
+    --debug

--- a/experiments/ssl4eo/download_l7_l2.sh
+++ b/experiments/ssl4eo/download_l7_l2.sh
@@ -18,6 +18,7 @@ YEAR=2002  # SLC-on
 BANDS=(SR_B1 SR_B2 SR_B3 SR_B4 SR_B5 SR_B7)
 ORIGINAL_RESOLUTIONS=30
 NEW_RESOLUTIONS=30
+DEFAULT_VALUE=0
 
 # Generic parameters
 SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
@@ -39,6 +40,7 @@ time python3 "$SCRIPT_DIR/download_ssl4eo.py" \
     --original-resolutions $ORIGINAL_RESOLUTIONS \
     --new-resolutions $NEW_RESOLUTIONS \
     --dtype $DTYPE \
+    --default-value $DEFAULT_VALUE \
     --num-workers $NUM_WORKERS \
     --log-freq $LOG_FREQ \
     --match-file "$MATCH_FILE" \

--- a/experiments/ssl4eo/download_l7_l2.sh
+++ b/experiments/ssl4eo/download_l7_l2.sh
@@ -3,13 +3,11 @@
 set -euo pipefail
 
 # User-specific parameters
-ROOT_DIR=data
-SAVE_PATH="$ROOT_DIR/ssl4eo-l7-l2"
-MATCH_FILE="$ROOT_DIR/ssl4eo-l-30/sampled_locations.csv"
+SAVE_PATH=data/ssl4eo-l7-l2
 NUM_WORKERS=28
-NUM_PROCESSES=10
+MATCH_FILE=data/ssl4eo-l-30/sampled_locations.csv
 START_INDEX=0
-END_INDEX=100
+END_INDEX=10
 
 # Satellite-specific parameters
 COLLECTION=LANDSAT/LE07/C02/T1_L2
@@ -29,30 +27,21 @@ SIZE=264
 DTYPE=float32
 LOG_FREQ=1000
 
-INCREMENT=$(( ($END_INDEX - $START_INDEX) / $NUM_PROCESSES ))
-for i in $(seq 1 $NUM_PROCESSES)
-do
-    END=$(( $START_INDEX + ($i * $INCREMENT) ))
-    START=$(( $END - $INCREMENT ))
-
-    time python3 "$SCRIPT_DIR/download_ssl4eo.py" \
-        --save-path "$SAVE_PATH" \
-        --collection $COLLECTION \
-        --qa-band $QA_BAND \
-        --qa-cloud-bit $QA_CLOUD_BIT \
-        --meta-cloud-name $META_CLOUD_NAME \
-        --cloud-pct $CLOUD_PCT \
-        --dates $YEAR-03-20 $YEAR-06-21 $YEAR-09-23 $YEAR-12-21 \
-        --radius $(($NEW_RESOLUTIONS * $SIZE / 2)) \
-        --bands ${BANDS[@]} \
-        --original-resolutions $ORIGINAL_RESOLUTIONS \
-        --new-resolutions $NEW_RESOLUTIONS \
-        --dtype $DTYPE \
-        --default-value $DEFAULT_VALUE \
-        --num-workers $NUM_WORKERS \
-        --log-freq $LOG_FREQ \
-        --match-file "$MATCH_FILE" \
-        --indices-range $START $END &
-done
-
-wait
+time python3 "$SCRIPT_DIR/download_ssl4eo.py" \
+    --save-path "$SAVE_PATH" \
+    --collection $COLLECTION \
+    --qa-band $QA_BAND \
+    --qa-cloud-bit $QA_CLOUD_BIT \
+    --meta-cloud-name $META_CLOUD_NAME \
+    --cloud-pct $CLOUD_PCT \
+    --dates $YEAR-03-20 $YEAR-06-21 $YEAR-09-23 $YEAR-12-21 \
+    --radius $(($NEW_RESOLUTIONS * $SIZE / 2)) \
+    --bands ${BANDS[@]} \
+    --original-resolutions $ORIGINAL_RESOLUTIONS \
+    --new-resolutions $NEW_RESOLUTIONS \
+    --dtype $DTYPE \
+    --default-value $DEFAULT_VALUE \
+    --num-workers $NUM_WORKERS \
+    --log-freq $LOG_FREQ \
+    --match-file "$MATCH_FILE" \
+    --indices-range $START_INDEX $END_INDEX

--- a/experiments/ssl4eo/download_l7_l2.sh
+++ b/experiments/ssl4eo/download_l7_l2.sh
@@ -3,9 +3,10 @@
 set -euo pipefail
 
 # User-specific parameters
-SAVE_PATH=data/ssl4eo-l7-l2
+ROOT_DIR=data
+SAVE_PATH="$ROOT_DIR/ssl4eo-l7-l2"
+MATCH_FILE="$ROOT_DIR/ssl4eo-l-30/sampled_locations.csv"
 NUM_WORKERS=28
-MATCH_FILE=data/ssl4eo-l-30/sampled_locations.csv
 START_INDEX=0
 END_INDEX=10
 
@@ -44,4 +45,5 @@ time python3 "$SCRIPT_DIR/download_ssl4eo.py" \
     --num-workers $NUM_WORKERS \
     --log-freq $LOG_FREQ \
     --match-file "$MATCH_FILE" \
-    --indices-range $START_INDEX $END_INDEX
+    --indices-range $START_INDEX $END_INDEX \
+    --debug

--- a/experiments/ssl4eo/download_l7_l2.sh
+++ b/experiments/ssl4eo/download_l7_l2.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash -euo pipefail
+
+# User-specific parameters
+SAVE_PATH=data/ssl4eo-l7-l2
+NUM_WORKERS=28
+MATCH_FILE=data/ssl4eo-l-30/sampled_locations.csv
+START_INDEX=0
+END_INDEX=10
+
+# Satellite-specific parameters
+COLLECTION=LANDSAT/LE07/C02/T1_L2
+QA_BAND=QA_PIXEL
+QA_CLOUD_BIT=3
+META_CLOUD_NAME=CLOUD_COVER
+YEAR=2002  # SLC-on
+BANDS=(SR_B1 SR_B2 SR_B3 SR_B4 SR_B5 SR_B7)
+ORIGINAL_RESOLUTIONS=30
+NEW_RESOLUTIONS=30
+
+# Generic parameters
+SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+CLOUD_PCT=20
+SIZE=264
+DTYPE=float32
+LOG_FREQ=1000
+
+time python3 "$SCRIPT_DIR/download_ssl4eo.py" \
+    --save-path "$SAVE_PATH" \
+    --collection $COLLECTION \
+    --qa-band $QA_BAND \
+    --qa-cloud-bit $QA_CLOUD_BIT \
+    --meta-cloud-name $META_CLOUD_NAME \
+    --cloud-pct $CLOUD_PCT \
+    --dates $YEAR-03-20 $YEAR-06-21 $YEAR-09-23 $YEAR-12-21 \
+    --radius $(($NEW_RESOLUTIONS * $SIZE / 2)) \
+    --bands ${BANDS[@]} \
+    --original-resolutions $ORIGINAL_RESOLUTIONS \
+    --new-resolutions $NEW_RESOLUTIONS \
+    --dtype $DTYPE \
+    --num-workers $NUM_WORKERS \
+    --log-freq $LOG_FREQ \
+    --match-file "$MATCH_FILE" \
+    --indices-range $START_INDEX $END_INDEX

--- a/experiments/ssl4eo/download_l7_l2.sh
+++ b/experiments/ssl4eo/download_l7_l2.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash -euo pipefail
+#!/usr/bin/env bash
+
+set -euo pipefail
 
 # User-specific parameters
 SAVE_PATH=data/ssl4eo-l7-l2

--- a/experiments/ssl4eo/download_l7_l2.sh
+++ b/experiments/ssl4eo/download_l7_l2.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 ROOT_DIR=data
 SAVE_PATH="$ROOT_DIR/ssl4eo-l7-l2"
 MATCH_FILE="$ROOT_DIR/ssl4eo-l-30/sampled_locations.csv"
-NUM_WORKERS=28
+NUM_WORKERS=40
 START_INDEX=0
 END_INDEX=10
 

--- a/experiments/ssl4eo/download_l8_l1.sh
+++ b/experiments/ssl4eo/download_l8_l1.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 ROOT_DIR=data
 SAVE_PATH="$ROOT_DIR/ssl4eo-l8-l1"
 MATCH_FILE="$ROOT_DIR/ssl4eo-l-30/sampled_locations.csv"
-NUM_WORKERS=28
+NUM_WORKERS=40
 START_INDEX=0
 END_INDEX=10
 

--- a/experiments/ssl4eo/download_l8_l1.sh
+++ b/experiments/ssl4eo/download_l8_l1.sh
@@ -3,9 +3,10 @@
 set -euo pipefail
 
 # User-specific parameters
-SAVE_PATH=data/ssl4eo-l8-l1
+ROOT_DIR=data
+SAVE_PATH="$ROOT_DIR/ssl4eo-l8-l1"
+MATCH_FILE="$ROOT_DIR/ssl4eo-l-30/sampled_locations.csv"
 NUM_WORKERS=28
-MATCH_FILE=data/ssl4eo-l-30/sampled_locations.csv
 START_INDEX=0
 END_INDEX=10
 
@@ -45,4 +46,5 @@ time python3 "$SCRIPT_DIR/download_ssl4eo.py" \
     --num-workers $NUM_WORKERS \
     --log-freq $LOG_FREQ \
     --match-file "$MATCH_FILE" \
-    --indices-range $START_INDEX $END_INDEX
+    --indices-range $START_INDEX $END_INDEX \
+    --debug

--- a/experiments/ssl4eo/download_l8_l1.sh
+++ b/experiments/ssl4eo/download_l8_l1.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash -euo pipefail
+#!/usr/bin/env bash
+
+set -euo pipefail
 
 # User-specific parameters
 SAVE_PATH=data/ssl4eo-l8-l1

--- a/experiments/ssl4eo/download_l8_l1.sh
+++ b/experiments/ssl4eo/download_l8_l1.sh
@@ -19,6 +19,7 @@ RES=30
 BANDS=(B1 B2 B3 B4 B5 B6 B7 B8 B9 B10 B11)
 ORIGINAL_RESOLUTIONS=(30 30 30 30 30 30 30 15 30 30 30)
 NEW_RESOLUTIONS=30
+DEFAULT_VALUE=-9999
 
 # Generic parameters
 SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
@@ -40,6 +41,7 @@ time python3 "$SCRIPT_DIR/download_ssl4eo.py" \
     --original-resolutions ${ORIGINAL_RESOLUTIONS[@]} \
     --new-resolutions $NEW_RESOLUTIONS \
     --dtype $DTYPE \
+    --default-value $DEFAULT_VALUE \
     --num-workers $NUM_WORKERS \
     --log-freq $LOG_FREQ \
     --match-file "$MATCH_FILE" \

--- a/experiments/ssl4eo/download_l8_l1.sh
+++ b/experiments/ssl4eo/download_l8_l1.sh
@@ -3,11 +3,13 @@
 set -euo pipefail
 
 # User-specific parameters
-SAVE_PATH=data/ssl4eo-l8-l1
+ROOT_DIR=data
+SAVE_PATH="$ROOT_DIR/ssl4eo-l8-l1"
+MATCH_FILE="$ROOT_DIR/ssl4eo-l-30/sampled_locations.csv"
 NUM_WORKERS=28
-MATCH_FILE=data/ssl4eo-l-30/sampled_locations.csv
+NUM_PROCESSES=10
 START_INDEX=0
-END_INDEX=10
+END_INDEX=100
 
 # Satellite-specific parameters
 COLLECTION=LANDSAT/LC08/C02/T1_TOA
@@ -28,21 +30,30 @@ SIZE=264
 DTYPE=float32
 LOG_FREQ=1000
 
-time python3 "$SCRIPT_DIR/download_ssl4eo.py" \
-    --save-path "$SAVE_PATH" \
-    --collection $COLLECTION \
-    --qa-band $QA_BAND \
-    --qa-cloud-bit $QA_CLOUD_BIT \
-    --meta-cloud-name $META_CLOUD_NAME \
-    --cloud-pct $CLOUD_PCT \
-    --dates $YEAR-03-20 $YEAR-06-21 $YEAR-09-23 $YEAR-12-21 \
-    --radius $(($NEW_RESOLUTIONS * $SIZE / 2)) \
-    --bands ${BANDS[@]} \
-    --original-resolutions ${ORIGINAL_RESOLUTIONS[@]} \
-    --new-resolutions $NEW_RESOLUTIONS \
-    --dtype $DTYPE \
-    --default-value $DEFAULT_VALUE \
-    --num-workers $NUM_WORKERS \
-    --log-freq $LOG_FREQ \
-    --match-file "$MATCH_FILE" \
-    --indices-range $START_INDEX $END_INDEX
+INCREMENT=$(( ($END_INDEX - $START_INDEX) / $NUM_PROCESSES ))
+for i in $(seq 1 $NUM_PROCESSES)
+do
+    END=$(( $START_INDEX + ($i * $INCREMENT) ))
+    START=$(( $END - $INCREMENT ))
+
+    time python3 "$SCRIPT_DIR/download_ssl4eo.py" \
+        --save-path "$SAVE_PATH" \
+        --collection $COLLECTION \
+        --qa-band $QA_BAND \
+        --qa-cloud-bit $QA_CLOUD_BIT \
+        --meta-cloud-name $META_CLOUD_NAME \
+        --cloud-pct $CLOUD_PCT \
+        --dates $YEAR-03-20 $YEAR-06-21 $YEAR-09-23 $YEAR-12-21 \
+        --radius $(($NEW_RESOLUTIONS * $SIZE / 2)) \
+        --bands ${BANDS[@]} \
+        --original-resolutions ${ORIGINAL_RESOLUTIONS[@]} \
+        --new-resolutions $NEW_RESOLUTIONS \
+        --dtype $DTYPE \
+        --default-value $DEFAULT_VALUE \
+        --num-workers $NUM_WORKERS \
+        --log-freq $LOG_FREQ \
+        --match-file "$MATCH_FILE" \
+        --indices-range $START $END &
+done
+
+wait

--- a/experiments/ssl4eo/download_l8_l1.sh
+++ b/experiments/ssl4eo/download_l8_l1.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash -euo pipefail
+
+# User-specific parameters
+SAVE_PATH=data/ssl4eo-l8-l1
+NUM_WORKERS=28
+MATCH_FILE=data/ssl4eo-l-30/sampled_locations.csv
+START_INDEX=0
+END_INDEX=10
+
+# Satellite-specific parameters
+COLLECTION=LANDSAT/LC08/C02/T1_TOA
+QA_BAND=QA_PIXEL
+QA_CLOUD_BIT=3
+META_CLOUD_NAME=CLOUD_COVER
+YEAR=2022
+RES=30
+BANDS=(B1 B2 B3 B4 B5 B6 B7 B8 B9 B10 B11)
+ORIGINAL_RESOLUTIONS=(30 30 30 30 30 30 30 15 30 30 30)
+NEW_RESOLUTIONS=30
+
+# Generic parameters
+SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+CLOUD_PCT=20
+SIZE=264
+DTYPE=float32
+LOG_FREQ=1000
+
+time python3 "$SCRIPT_DIR/download_ssl4eo.py" \
+    --save-path "$SAVE_PATH" \
+    --collection $COLLECTION \
+    --qa-band $QA_BAND \
+    --qa-cloud-bit $QA_CLOUD_BIT \
+    --meta-cloud-name $META_CLOUD_NAME \
+    --cloud-pct $CLOUD_PCT \
+    --dates $YEAR-03-20 $YEAR-06-21 $YEAR-09-23 $YEAR-12-21 \
+    --radius $(($NEW_RESOLUTIONS * $SIZE / 2)) \
+    --bands ${BANDS[@]} \
+    --original-resolutions ${ORIGINAL_RESOLUTIONS[@]} \
+    --new-resolutions $NEW_RESOLUTIONS \
+    --dtype $DTYPE \
+    --num-workers $NUM_WORKERS \
+    --log-freq $LOG_FREQ \
+    --match-file "$MATCH_FILE" \
+    --indices-range $START_INDEX $END_INDEX

--- a/experiments/ssl4eo/download_l8_l1.sh
+++ b/experiments/ssl4eo/download_l8_l1.sh
@@ -3,13 +3,11 @@
 set -euo pipefail
 
 # User-specific parameters
-ROOT_DIR=data
-SAVE_PATH="$ROOT_DIR/ssl4eo-l8-l1"
-MATCH_FILE="$ROOT_DIR/ssl4eo-l-30/sampled_locations.csv"
+SAVE_PATH=data/ssl4eo-l8-l1
 NUM_WORKERS=28
-NUM_PROCESSES=10
+MATCH_FILE=data/ssl4eo-l-30/sampled_locations.csv
 START_INDEX=0
-END_INDEX=100
+END_INDEX=10
 
 # Satellite-specific parameters
 COLLECTION=LANDSAT/LC08/C02/T1_TOA
@@ -30,30 +28,21 @@ SIZE=264
 DTYPE=float32
 LOG_FREQ=1000
 
-INCREMENT=$(( ($END_INDEX - $START_INDEX) / $NUM_PROCESSES ))
-for i in $(seq 1 $NUM_PROCESSES)
-do
-    END=$(( $START_INDEX + ($i * $INCREMENT) ))
-    START=$(( $END - $INCREMENT ))
-
-    time python3 "$SCRIPT_DIR/download_ssl4eo.py" \
-        --save-path "$SAVE_PATH" \
-        --collection $COLLECTION \
-        --qa-band $QA_BAND \
-        --qa-cloud-bit $QA_CLOUD_BIT \
-        --meta-cloud-name $META_CLOUD_NAME \
-        --cloud-pct $CLOUD_PCT \
-        --dates $YEAR-03-20 $YEAR-06-21 $YEAR-09-23 $YEAR-12-21 \
-        --radius $(($NEW_RESOLUTIONS * $SIZE / 2)) \
-        --bands ${BANDS[@]} \
-        --original-resolutions ${ORIGINAL_RESOLUTIONS[@]} \
-        --new-resolutions $NEW_RESOLUTIONS \
-        --dtype $DTYPE \
-        --default-value $DEFAULT_VALUE \
-        --num-workers $NUM_WORKERS \
-        --log-freq $LOG_FREQ \
-        --match-file "$MATCH_FILE" \
-        --indices-range $START $END &
-done
-
-wait
+time python3 "$SCRIPT_DIR/download_ssl4eo.py" \
+    --save-path "$SAVE_PATH" \
+    --collection $COLLECTION \
+    --qa-band $QA_BAND \
+    --qa-cloud-bit $QA_CLOUD_BIT \
+    --meta-cloud-name $META_CLOUD_NAME \
+    --cloud-pct $CLOUD_PCT \
+    --dates $YEAR-03-20 $YEAR-06-21 $YEAR-09-23 $YEAR-12-21 \
+    --radius $(($NEW_RESOLUTIONS * $SIZE / 2)) \
+    --bands ${BANDS[@]} \
+    --original-resolutions ${ORIGINAL_RESOLUTIONS[@]} \
+    --new-resolutions $NEW_RESOLUTIONS \
+    --dtype $DTYPE \
+    --default-value $DEFAULT_VALUE \
+    --num-workers $NUM_WORKERS \
+    --log-freq $LOG_FREQ \
+    --match-file "$MATCH_FILE" \
+    --indices-range $START_INDEX $END_INDEX

--- a/experiments/ssl4eo/download_l8_l2.sh
+++ b/experiments/ssl4eo/download_l8_l2.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash -euo pipefail
+
+# User-specific parameters
+SAVE_PATH=data/ssl4eo-l8-l2
+NUM_WORKERS=28
+MATCH_FILE=data/ssl4eo-l-30/sampled_locations.csv
+START_INDEX=0
+END_INDEX=10
+
+# Satellite-specific parameters
+COLLECTION=LANDSAT/LC08/C02/T1_L2
+QA_BAND=QA_PIXEL
+QA_CLOUD_BIT=3
+META_CLOUD_NAME=CLOUD_COVER
+YEAR=2022
+BANDS=(SR_B1 SR_B2 SR_B3 SR_B4 SR_B5 SR_B6 SR_B7)
+ORIGINAL_RESOLUTIONS=30
+NEW_RESOLUTIONS=30
+
+# Generic parameters
+SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+CLOUD_PCT=20
+SIZE=264
+DTYPE=float32
+LOG_FREQ=1000
+
+time python3 "$SCRIPT_DIR/download_ssl4eo.py" \
+    --save-path "$SAVE_PATH" \
+    --collection $COLLECTION \
+    --qa-band $QA_BAND \
+    --qa-cloud-bit $QA_CLOUD_BIT \
+    --meta-cloud-name $META_CLOUD_NAME \
+    --cloud-pct $CLOUD_PCT \
+    --dates $YEAR-03-20 $YEAR-06-21 $YEAR-09-23 $YEAR-12-21 \
+    --radius $(($NEW_RESOLUTIONS * $SIZE / 2)) \
+    --bands ${BANDS[@]} \
+    --original-resolutions $ORIGINAL_RESOLUTIONS \
+    --new-resolutions $NEW_RESOLUTIONS \
+    --dtype $DTYPE \
+    --num-workers $NUM_WORKERS \
+    --log-freq $LOG_FREQ \
+    --match-file "$MATCH_FILE" \
+    --indices-range $START_INDEX $END_INDEX

--- a/experiments/ssl4eo/download_l8_l2.sh
+++ b/experiments/ssl4eo/download_l8_l2.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 ROOT_DIR=data
 SAVE_PATH="$ROOT_DIR/ssl4eo-l8-l2"
 MATCH_FILE="$ROOT_DIR/ssl4eo-l-30/sampled_locations.csv"
-NUM_WORKERS=28
+NUM_WORKERS=40
 START_INDEX=0
 END_INDEX=10
 

--- a/experiments/ssl4eo/download_l8_l2.sh
+++ b/experiments/ssl4eo/download_l8_l2.sh
@@ -3,13 +3,11 @@
 set -euo pipefail
 
 # User-specific parameters
-ROOT_DIR=data
-SAVE_PATH="$ROOT_DIR/ssl4eo-l8-l2"
-MATCH_FILE="$ROOT_DIR/ssl4eo-l-30/sampled_locations.csv"
+SAVE_PATH=data/ssl4eo-l8-l2
 NUM_WORKERS=28
-NUM_PROCESSES=10
+MATCH_FILE=data/ssl4eo-l-30/sampled_locations.csv
 START_INDEX=0
-END_INDEX=100
+END_INDEX=10
 
 # Satellite-specific parameters
 COLLECTION=LANDSAT/LC08/C02/T1_L2
@@ -29,30 +27,21 @@ SIZE=264
 DTYPE=float32
 LOG_FREQ=1000
 
-INCREMENT=$(( ($END_INDEX - $START_INDEX) / $NUM_PROCESSES ))
-for i in $(seq 1 $NUM_PROCESSES)
-do
-    END=$(( $START_INDEX + ($i * $INCREMENT) ))
-    START=$(( $END - $INCREMENT ))
-
-    time python3 "$SCRIPT_DIR/download_ssl4eo.py" \
-        --save-path "$SAVE_PATH" \
-        --collection $COLLECTION \
-        --qa-band $QA_BAND \
-        --qa-cloud-bit $QA_CLOUD_BIT \
-        --meta-cloud-name $META_CLOUD_NAME \
-        --cloud-pct $CLOUD_PCT \
-        --dates $YEAR-03-20 $YEAR-06-21 $YEAR-09-23 $YEAR-12-21 \
-        --radius $(($NEW_RESOLUTIONS * $SIZE / 2)) \
-        --bands ${BANDS[@]} \
-        --original-resolutions $ORIGINAL_RESOLUTIONS \
-        --new-resolutions $NEW_RESOLUTIONS \
-        --dtype $DTYPE \
-        --default-value $DEFAULT_VALUE \
-        --num-workers $NUM_WORKERS \
-        --log-freq $LOG_FREQ \
-        --match-file "$MATCH_FILE" \
-        --indices-range $START $END &
-done
-
-wait
+time python3 "$SCRIPT_DIR/download_ssl4eo.py" \
+    --save-path "$SAVE_PATH" \
+    --collection $COLLECTION \
+    --qa-band $QA_BAND \
+    --qa-cloud-bit $QA_CLOUD_BIT \
+    --meta-cloud-name $META_CLOUD_NAME \
+    --cloud-pct $CLOUD_PCT \
+    --dates $YEAR-03-20 $YEAR-06-21 $YEAR-09-23 $YEAR-12-21 \
+    --radius $(($NEW_RESOLUTIONS * $SIZE / 2)) \
+    --bands ${BANDS[@]} \
+    --original-resolutions $ORIGINAL_RESOLUTIONS \
+    --new-resolutions $NEW_RESOLUTIONS \
+    --dtype $DTYPE \
+    --default-value $DEFAULT_VALUE \
+    --num-workers $NUM_WORKERS \
+    --log-freq $LOG_FREQ \
+    --match-file "$MATCH_FILE" \
+    --indices-range $START_INDEX $END_INDEX

--- a/experiments/ssl4eo/download_l8_l2.sh
+++ b/experiments/ssl4eo/download_l8_l2.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash -euo pipefail
+#!/usr/bin/env bash
+
+set -euo pipefail
 
 # User-specific parameters
 SAVE_PATH=data/ssl4eo-l8-l2

--- a/experiments/ssl4eo/download_l8_l2.sh
+++ b/experiments/ssl4eo/download_l8_l2.sh
@@ -3,11 +3,13 @@
 set -euo pipefail
 
 # User-specific parameters
-SAVE_PATH=data/ssl4eo-l8-l2
+ROOT_DIR=data
+SAVE_PATH="$ROOT_DIR/ssl4eo-l8-l2"
+MATCH_FILE="$ROOT_DIR/ssl4eo-l-30/sampled_locations.csv"
 NUM_WORKERS=28
-MATCH_FILE=data/ssl4eo-l-30/sampled_locations.csv
+NUM_PROCESSES=10
 START_INDEX=0
-END_INDEX=10
+END_INDEX=100
 
 # Satellite-specific parameters
 COLLECTION=LANDSAT/LC08/C02/T1_L2
@@ -27,21 +29,30 @@ SIZE=264
 DTYPE=float32
 LOG_FREQ=1000
 
-time python3 "$SCRIPT_DIR/download_ssl4eo.py" \
-    --save-path "$SAVE_PATH" \
-    --collection $COLLECTION \
-    --qa-band $QA_BAND \
-    --qa-cloud-bit $QA_CLOUD_BIT \
-    --meta-cloud-name $META_CLOUD_NAME \
-    --cloud-pct $CLOUD_PCT \
-    --dates $YEAR-03-20 $YEAR-06-21 $YEAR-09-23 $YEAR-12-21 \
-    --radius $(($NEW_RESOLUTIONS * $SIZE / 2)) \
-    --bands ${BANDS[@]} \
-    --original-resolutions $ORIGINAL_RESOLUTIONS \
-    --new-resolutions $NEW_RESOLUTIONS \
-    --dtype $DTYPE \
-    --default-value $DEFAULT_VALUE \
-    --num-workers $NUM_WORKERS \
-    --log-freq $LOG_FREQ \
-    --match-file "$MATCH_FILE" \
-    --indices-range $START_INDEX $END_INDEX
+INCREMENT=$(( ($END_INDEX - $START_INDEX) / $NUM_PROCESSES ))
+for i in $(seq 1 $NUM_PROCESSES)
+do
+    END=$(( $START_INDEX + ($i * $INCREMENT) ))
+    START=$(( $END - $INCREMENT ))
+
+    time python3 "$SCRIPT_DIR/download_ssl4eo.py" \
+        --save-path "$SAVE_PATH" \
+        --collection $COLLECTION \
+        --qa-band $QA_BAND \
+        --qa-cloud-bit $QA_CLOUD_BIT \
+        --meta-cloud-name $META_CLOUD_NAME \
+        --cloud-pct $CLOUD_PCT \
+        --dates $YEAR-03-20 $YEAR-06-21 $YEAR-09-23 $YEAR-12-21 \
+        --radius $(($NEW_RESOLUTIONS * $SIZE / 2)) \
+        --bands ${BANDS[@]} \
+        --original-resolutions $ORIGINAL_RESOLUTIONS \
+        --new-resolutions $NEW_RESOLUTIONS \
+        --dtype $DTYPE \
+        --default-value $DEFAULT_VALUE \
+        --num-workers $NUM_WORKERS \
+        --log-freq $LOG_FREQ \
+        --match-file "$MATCH_FILE" \
+        --indices-range $START $END &
+done
+
+wait

--- a/experiments/ssl4eo/download_l8_l2.sh
+++ b/experiments/ssl4eo/download_l8_l2.sh
@@ -18,6 +18,7 @@ YEAR=2022
 BANDS=(SR_B1 SR_B2 SR_B3 SR_B4 SR_B5 SR_B6 SR_B7)
 ORIGINAL_RESOLUTIONS=30
 NEW_RESOLUTIONS=30
+DEFAULT_VALUE=0
 
 # Generic parameters
 SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
@@ -39,6 +40,7 @@ time python3 "$SCRIPT_DIR/download_ssl4eo.py" \
     --original-resolutions $ORIGINAL_RESOLUTIONS \
     --new-resolutions $NEW_RESOLUTIONS \
     --dtype $DTYPE \
+    --default-value $DEFAULT_VALUE \
     --num-workers $NUM_WORKERS \
     --log-freq $LOG_FREQ \
     --match-file "$MATCH_FILE" \

--- a/experiments/ssl4eo/download_l8_l2.sh
+++ b/experiments/ssl4eo/download_l8_l2.sh
@@ -3,9 +3,10 @@
 set -euo pipefail
 
 # User-specific parameters
-SAVE_PATH=data/ssl4eo-l8-l2
+ROOT_DIR=data
+SAVE_PATH="$ROOT_DIR/ssl4eo-l8-l2"
+MATCH_FILE="$ROOT_DIR/ssl4eo-l-30/sampled_locations.csv"
 NUM_WORKERS=28
-MATCH_FILE=data/ssl4eo-l-30/sampled_locations.csv
 START_INDEX=0
 END_INDEX=10
 
@@ -44,4 +45,5 @@ time python3 "$SCRIPT_DIR/download_ssl4eo.py" \
     --num-workers $NUM_WORKERS \
     --log-freq $LOG_FREQ \
     --match-file "$MATCH_FILE" \
-    --indices-range $START_INDEX $END_INDEX
+    --indices-range $START_INDEX $END_INDEX \
+    --debug

--- a/experiments/ssl4eo/download_ssl4eo.py
+++ b/experiments/ssl4eo/download_ssl4eo.py
@@ -139,7 +139,7 @@ def center_crop(
     crop_height = crop_width = out_size
     pad_height = max(crop_height - image_height, 0)
     pad_width = max(crop_width - image_width, 0)
-    img = np.pad(img, (pad_height, pad_width), mode="edge")
+    img = np.pad(img, ((pad_height, 0), (pad_width, 0), (0, 0)), mode="edge")
     crop_top = (image_height - crop_height + 1) // 2
     crop_left = (image_width - crop_width + 1) // 2
     return img[crop_top : crop_top + crop_height, crop_left : crop_left + crop_width]

--- a/experiments/ssl4eo/download_ssl4eo.py
+++ b/experiments/ssl4eo/download_ssl4eo.py
@@ -181,16 +181,16 @@ def get_patch(
     # Reproject (if necessary) and download all bands
     raster = {}
     for (orig_res, new_res), value in band_groups.items():
-        indices, bands = zip(*value)
-        patch = image.select(*bands)
+        indices, bands_group = zip(*value)
+        patch = image.select(*bands_group)
         if orig_res != new_res:
             patch = patch.reproject(patch.projection().crs(), scale=new_res)
         patch = patch.sampleRectangle(region, defaultValue=0)
         features = patch.getInfo()
-        for i, band in zip(indices, bands):
+        for i, band in zip(indices, bands_group):
             x = features["properties"][band]
             x = np.atleast_3d(x)
-            x = center_crop(x, out_size=2 * radius // new_res)
+            x = center_crop(x, out_size=int(2 * radius // new_res))
             raster[i] = x.astype(dtype)
 
     # Compute coordinates after cropping
@@ -266,7 +266,7 @@ def save_geotiff(
 
 
 def save_patch(
-    raster: dict[str, Any],
+    raster: dict[int, Any],
     coords: list[list[float]],
     metadata: dict[str, Any],
     bands: list[str],

--- a/experiments/ssl4eo/download_ssl4eo.py
+++ b/experiments/ssl4eo/download_ssl4eo.py
@@ -473,6 +473,7 @@ if __name__ == "__main__":
         if str(idx) in ext_coords.keys():
             return
 
+        worker_start = time.time()
         patches, center_coord = get_random_patches_match(
             idx,
             collection,
@@ -516,6 +517,13 @@ if __name__ == "__main__":
                 success = 0
             data = [idx, *center_coord, success]
             writer.writerow(data)
+
+        # Throttle throughput to avoid exceeding GEE quota:
+        # https://developers.google.com/earth-engine/guides/usage
+        worker_end = time.time()
+        elapsed = worker_end - worker_start
+        num_workers = max(1, args.num_workers)
+        time.sleep(max(0, num_workers / 100 - elapsed))
 
         return
 

--- a/experiments/ssl4eo/download_ssl4eo.py
+++ b/experiments/ssl4eo/download_ssl4eo.py
@@ -185,7 +185,7 @@ def get_patch(
         patch = image.select(*bands_group)
         if orig_res != new_res:
             patch = patch.reproject(patch.projection().crs(), scale=new_res)
-        patch = patch.sampleRectangle(region, defaultValue=0)
+        patch = patch.sampleRectangle(region, defaultValue=-9999)
         features = patch.getInfo()
         for i, band in zip(indices, bands_group):
             x = features["properties"][band]

--- a/experiments/ssl4eo/sample_30.sh
+++ b/experiments/ssl4eo/sample_30.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash -euo pipefail
+
+# User-specific parameters
+SAVE_PATH=data/ssl4eo-l-30
+START_INDEX=0
+END_INDEX=10
+
+# Generic parameters
+SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+RES=30
+SIZE=264
+NUM_CITIES=10000
+STD=50
+
+time python3 "$SCRIPT_DIR/sample_ssl4eo.py" \
+    --save-path "$SAVE_PATH" \
+    --size $(($RES * $SIZE / 2)) \
+    --num-cities $NUM_CITIES \
+    --std $STD \
+    --indices-range $START_INDEX $END_INDEX

--- a/experiments/ssl4eo/sample_30.sh
+++ b/experiments/ssl4eo/sample_30.sh
@@ -3,10 +3,9 @@
 set -euo pipefail
 
 # User-specific parameters
-ROOT_DIR=data
-SAVE_PATH="$ROOT_DIR/ssl4eo-l-30"
+SAVE_PATH=data/ssl4eo-l-30
 START_INDEX=0
-END_INDEX=100
+END_INDEX=10
 
 # Generic parameters
 SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)

--- a/experiments/ssl4eo/sample_30.sh
+++ b/experiments/ssl4eo/sample_30.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash -euo pipefail
+#!/usr/bin/env bash
+
+set -euo pipefail
 
 # User-specific parameters
 SAVE_PATH=data/ssl4eo-l-30

--- a/experiments/ssl4eo/sample_30.sh
+++ b/experiments/ssl4eo/sample_30.sh
@@ -3,9 +3,10 @@
 set -euo pipefail
 
 # User-specific parameters
-SAVE_PATH=data/ssl4eo-l-30
+ROOT_DIR=data
+SAVE_PATH="$ROOT_DIR/ssl4eo-l-30"
 START_INDEX=0
-END_INDEX=10
+END_INDEX=100
 
 # Generic parameters
 SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)

--- a/experiments/ssl4eo/sample_60.sh
+++ b/experiments/ssl4eo/sample_60.sh
@@ -3,9 +3,10 @@
 set -euo pipefail
 
 # User-specific parameters
-SAVE_PATH=data/ssl4eo-l-60
+ROOT_DIR=data
+SAVE_PATH="$ROOT_DIR/ssl4eo-l-60"
 START_INDEX=0
-END_INDEX=10
+END_INDEX=100
 
 # Generic parameters
 SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)

--- a/experiments/ssl4eo/sample_60.sh
+++ b/experiments/ssl4eo/sample_60.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash -euo pipefail
+
+# User-specific parameters
+SAVE_PATH=data/ssl4eo-l-60
+START_INDEX=0
+END_INDEX=10
+
+# Generic parameters
+SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+RES=60
+SIZE=264
+NUM_CITIES=10000
+STD=50
+
+time python3 "$SCRIPT_DIR/sample_ssl4eo.py" \
+    --save-path "$SAVE_PATH" \
+    --size $(($RES * $SIZE / 2)) \
+    --num-cities $NUM_CITIES \
+    --std $STD \
+    --indices-range $START_INDEX $END_INDEX

--- a/experiments/ssl4eo/sample_60.sh
+++ b/experiments/ssl4eo/sample_60.sh
@@ -3,10 +3,9 @@
 set -euo pipefail
 
 # User-specific parameters
-ROOT_DIR=data
-SAVE_PATH="$ROOT_DIR/ssl4eo-l-60"
+SAVE_PATH=data/ssl4eo-l-60
 START_INDEX=0
-END_INDEX=100
+END_INDEX=10
 
 # Generic parameters
 SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)

--- a/experiments/ssl4eo/sample_60.sh
+++ b/experiments/ssl4eo/sample_60.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash -euo pipefail
+#!/usr/bin/env bash
+
+set -euo pipefail
 
 # User-specific parameters
 SAVE_PATH=data/ssl4eo-l-60


### PR DESCRIPTION
#1223 included https://github.com/microsoft/torchgeo/pull/1223/commits/53a776e67f5a7abb24d38c31dce95e03b670029e, which hacked the script to resize the panchromatic band on Landsat 8. Unfortunately, this resulted in the script only working for Landsat 8 Level-1 data. This PR further generalizes this feature to support both resampling all bands to a single resolution and keeping all bands in their original resolution. It also includes scripts to bash scripts to download data for each satellite.

I tested all scripts to make sure they are able to download data and the images look correct (all bands have the same dimensions and spatial extent). There are still a few garbage images (clouds, nodata pixels, noise) but there isn't much we can do about that at this stage.

Note that there is almost no data for Landsat 5, especially near populated cities. It's unclear if we'll be able to train or evaluate models for Landsat 5 MSS.

@wangyi111