### PR TITLE
RandomGrayscale: add new transform

### DIFF
--- a/tests/transforms/test_color.py
+++ b/tests/transforms/test_color.py
@@ -1,0 +1,58 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import pytest
+import torch
+from torch import Tensor
+
+from torchgeo.transforms import AugmentationSequential, RandomGrayscale
+
+
+@pytest.fixture
+def sample() -> dict[str, Tensor]:
+    return {
+        "image": torch.arange(3 * 4 * 4, dtype=torch.float).view(3, 4, 4),
+        "mask": torch.arange(4 * 4, dtype=torch.long).view(1, 4, 4),
+    }
+
+
+@pytest.fixture
+def batch() -> dict[str, Tensor]:
+    return {
+        "image": torch.arange(2 * 3 * 4 * 4, dtype=torch.float).view(2, 3, 4, 4),
+        "mask": torch.arange(2 * 4 * 4, dtype=torch.long).view(2, 1, 4, 4),
+    }
+
+
+@pytest.mark.parametrize(
+    "weights",
+    [
+        torch.tensor([1.0, 1.0, 1.0]),
+        torch.tensor([0.299, 0.587, 0.114]),
+        torch.tensor([1.0, 2.0, 3.0]),
+    ],
+)
+def test_random_grayscale_sample(weights: Tensor, sample: dict[str, Tensor]) -> None:
+    aug = AugmentationSequential(RandomGrayscale(weights, p=1), data_keys=["image"])
+    output = aug(sample)
+    assert output["image"].shape == sample["image"].shape
+    assert output["image"].sum() == sample["image"].sum()
+    for i in range(1, 3):
+        assert torch.allclose(output["image"][0, 0], output["image"][0, i])
+
+
+@pytest.mark.parametrize(
+    "weights",
+    [
+        torch.tensor([1.0, 1.0, 1.0]),
+        torch.tensor([0.299, 0.587, 0.114]),
+        torch.tensor([1.0, 2.0, 3.0]),
+    ],
+)
+def test_random_grayscale_batch(weights: Tensor, batch: dict[str, Tensor]) -> None:
+    aug = AugmentationSequential(RandomGrayscale(weights, p=1), data_keys=["image"])
+    output = aug(batch)
+    assert output["image"].shape == batch["image"].shape
+    assert output["image"].sum() == batch["image"].sum()
+    for i in range(1, 3):
+        assert torch.allclose(output["image"][0, 0], output["image"][0, i])

--- a/torchgeo/transforms/__init__.py
+++ b/torchgeo/transforms/__init__.py
@@ -3,6 +3,7 @@
 
 """TorchGeo transforms."""
 
+from .color import RandomGrayscale
 from .indices import (
     AppendBNDVI,
     AppendGBNDVI,
@@ -37,4 +38,5 @@ __all__ = (
     "AppendSWI",
     "AppendTriBandNormalizedDifferenceIndex",
     "AugmentationSequential",
+    "RandomGrayscale",
 )

--- a/torchgeo/transforms/color.py
+++ b/torchgeo/transforms/color.py
@@ -1,0 +1,77 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+"""TorchGeo color transforms."""
+
+from typing import Optional
+
+from kornia.augmentation import IntensityAugmentationBase2D
+from torch import Tensor
+
+
+class RandomGrayscale(IntensityAugmentationBase2D):
+    r"""Apply random transformation to grayscale according to a probability p value.
+
+    There is no single agreed upon definition of grayscale for MSI. Some possibilities
+    include:
+
+    * Average of all bands: :math:`\frac{1}{C}` where :math:`C` is the number of
+      spectral channels.
+    * RGB-only bands: :math:`\[0.299, 0.587, 0.114\]` for the RGB channels, 0 for
+      all other channels.
+    * PCA: the first principal component across the spectral axis computed via PCA,
+      minimizes redundant information.
+
+    The weight vector you provide will be automatically rescaled to sum to 1 in order
+    to avoid changing the intensity of the image.
+
+    .. versionadded:: 0.5
+    """
+
+    def __init__(
+        self,
+        weights: Tensor,
+        p: float = 0.1,
+        same_on_batch: bool = False,
+        keepdim: bool = False,
+    ) -> None:
+        """Initialize a new RandomGrayscale instance.
+
+        Args:
+            weights: Weights applied to each channel to compute a grayscale
+                representation. Should be the same length as the number of channels.
+            p: Probability of the image to be transformed to grayscale.
+            same_on_batch: Apply the same transformation across the batch.
+            keepdim: Whether to keep the output shape the same as input (True)
+                or broadcast it to the batch form (False).
+        """
+        super().__init__(p=p, same_on_batch=same_on_batch, keepdim=keepdim)
+
+        # Rescale to sum to 1
+        weights /= weights.sum()
+
+        self.flags = {"weights": weights}
+
+    def apply_transform(
+        self,
+        input: Tensor,
+        params: dict[str, Tensor],
+        flags: dict[str, Tensor],
+        transform: Optional[Tensor] = None,
+    ) -> Tensor:
+        """Apply the transform.
+
+        Args:
+            input: The input tensor.
+            params: Generated parameters.
+            flags: Static parameters.
+            transform: The geometric transformation tensor.
+
+        Returns:
+            The augmented input.
+        """
+        weights = flags["weights"][..., :, None, None]
+        out = input * weights
+        out = out.sum(dim=-3)
+        out = out.unsqueeze(-3).expand(input.shape)
+        return out


### PR DESCRIPTION
Each of these images are scaled from 0–1 for plotting, so the brightness of the image may not be comparable.

![avg](https://user-images.githubusercontent.com/12021217/235802275-efde5db8-097b-432e-b5e4-8330b8f6bdd1.png)
![rgb](https://user-images.githubusercontent.com/12021217/235802281-a9ba2895-0f2f-4357-86cd-4ddd8d17ca13.png)
![pca](https://user-images.githubusercontent.com/12021217/235802279-dd33730a-7075-4fe6-b1e8-2cc54de0b10c.png)