### PR TITLE
Revert "PyVista: fix intersphinx link"

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -110,7 +110,7 @@ intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable/", None),
     "python": ("https://docs.python.org/3", None),
     "lightning": ("https://lightning.ai/docs/pytorch/stable/", None),
-    "pyvista": ("https://docs.pyvista.org/version/stable/", None),
+    "pyvista": ("https://docs.pyvista.org/", None),
     "rasterio": ("https://rasterio.readthedocs.io/en/stable/", None),
     "rtree": ("https://rtree.readthedocs.io/en/stable/", None),
     "segmentation_models_pytorch": ("https://smp.readthedocs.io/en/stable/", None),


### PR DESCRIPTION
Reverts microsoft/torchgeo#1251

Seems like the docs were moved back??