### PR TITLE
SSL4EO download script: don't download nodata pixels

### DIFF
--- a/experiments/ssl4eo/download_l5_raw.sh
+++ b/experiments/ssl4eo/download_l5_raw.sh
@@ -19,7 +19,6 @@ YEAR=1991  # MSS data acquisitions over the United States ceased in 1992
 BANDS=(B1 B2 B3 B4)
 ORIGINAL_RESOLUTIONS=(60 60 60 30)
 NEW_RESOLUTIONS=60
-DEFAULT_VALUE=0
 
 # Generic parameters
 SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
@@ -41,7 +40,6 @@ time python3 "$SCRIPT_DIR/download_ssl4eo.py" \
     --original-resolutions ${ORIGINAL_RESOLUTIONS[@]} \
     --new-resolutions $NEW_RESOLUTIONS \
     --dtype $DTYPE \
-    --default-value $DEFAULT_VALUE \
     --num-workers $NUM_WORKERS \
     --log-freq $LOG_FREQ \
     --match-file "$MATCH_FILE" \

--- a/experiments/ssl4eo/download_l7_l1.sh
+++ b/experiments/ssl4eo/download_l7_l1.sh
@@ -19,7 +19,6 @@ YEAR=2002  # SLC-on
 BANDS=(B1 B2 B3 B4 B5 B6_VCID_1 B6_VCID_2 B7 B8)
 ORIGINAL_RESOLUTIONS=(30 30 30 30 30 60 60 30 15)
 NEW_RESOLUTIONS=30
-DEFAULT_VALUE=-9999
 
 # Generic parameters
 SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
@@ -41,7 +40,6 @@ time python3 "$SCRIPT_DIR/download_ssl4eo.py" \
     --original-resolutions ${ORIGINAL_RESOLUTIONS[@]} \
     --new-resolutions $NEW_RESOLUTIONS \
     --dtype $DTYPE \
-    --default-value $DEFAULT_VALUE \
     --num-workers $NUM_WORKERS \
     --log-freq $LOG_FREQ \
     --match-file "$MATCH_FILE" \

--- a/experiments/ssl4eo/download_l7_l2.sh
+++ b/experiments/ssl4eo/download_l7_l2.sh
@@ -19,7 +19,6 @@ YEAR=2002  # SLC-on
 BANDS=(SR_B1 SR_B2 SR_B3 SR_B4 SR_B5 SR_B7)
 ORIGINAL_RESOLUTIONS=30
 NEW_RESOLUTIONS=30
-DEFAULT_VALUE=0
 
 # Generic parameters
 SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
@@ -41,7 +40,6 @@ time python3 "$SCRIPT_DIR/download_ssl4eo.py" \
     --original-resolutions $ORIGINAL_RESOLUTIONS \
     --new-resolutions $NEW_RESOLUTIONS \
     --dtype $DTYPE \
-    --default-value $DEFAULT_VALUE \
     --num-workers $NUM_WORKERS \
     --log-freq $LOG_FREQ \
     --match-file "$MATCH_FILE" \

--- a/experiments/ssl4eo/download_l8_l1.sh
+++ b/experiments/ssl4eo/download_l8_l1.sh
@@ -20,7 +20,6 @@ RES=30
 BANDS=(B1 B2 B3 B4 B5 B6 B7 B8 B9 B10 B11)
 ORIGINAL_RESOLUTIONS=(30 30 30 30 30 30 30 15 30 30 30)
 NEW_RESOLUTIONS=30
-DEFAULT_VALUE=-9999
 
 # Generic parameters
 SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
@@ -42,7 +41,6 @@ time python3 "$SCRIPT_DIR/download_ssl4eo.py" \
     --original-resolutions ${ORIGINAL_RESOLUTIONS[@]} \
     --new-resolutions $NEW_RESOLUTIONS \
     --dtype $DTYPE \
-    --default-value $DEFAULT_VALUE \
     --num-workers $NUM_WORKERS \
     --log-freq $LOG_FREQ \
     --match-file "$MATCH_FILE" \

--- a/experiments/ssl4eo/download_l8_l2.sh
+++ b/experiments/ssl4eo/download_l8_l2.sh
@@ -19,7 +19,6 @@ YEAR=2022
 BANDS=(SR_B1 SR_B2 SR_B3 SR_B4 SR_B5 SR_B6 SR_B7)
 ORIGINAL_RESOLUTIONS=30
 NEW_RESOLUTIONS=30
-DEFAULT_VALUE=0
 
 # Generic parameters
 SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
@@ -41,7 +40,6 @@ time python3 "$SCRIPT_DIR/download_ssl4eo.py" \
     --original-resolutions $ORIGINAL_RESOLUTIONS \
     --new-resolutions $NEW_RESOLUTIONS \
     --dtype $DTYPE \
-    --default-value $DEFAULT_VALUE \
     --num-workers $NUM_WORKERS \
     --log-freq $LOG_FREQ \
     --match-file "$MATCH_FILE" \

--- a/experiments/ssl4eo/download_ssl4eo.py
+++ b/experiments/ssl4eo/download_ssl4eo.py
@@ -169,9 +169,9 @@ def get_patch(
     original_resolutions: list[int],
     new_resolutions: list[int],
     dtype: str = "float32",
-    default_value: float = 0,
+    meta_cloud_name: str = "CLOUD_COVER",
 ) -> dict[str, Any]:
-    image = collection.sort("CLOUD_COVER").first()
+    image = collection.sort(meta_cloud_name).first()
     region = ee.Geometry.Point(center_coord).buffer(radius).bounds()
 
     # Group by original and new resolution
@@ -186,7 +186,7 @@ def get_patch(
         patch = image.select(*bands_group)
         if orig_res != new_res:
             patch = patch.reproject(patch.projection().crs(), scale=new_res)
-        patch = patch.sampleRectangle(region, defaultValue=default_value)
+        patch = patch.sampleRectangle(region)
         features = patch.getInfo()
         for i, band in zip(indices, bands_group):
             x = features["properties"][band]
@@ -214,7 +214,7 @@ def get_random_patches_match(
     original_resolutions: list[int],
     new_resolutions: list[int],
     dtype: str,
-    default_value: float,
+    meta_cloud_name: str,
     dates: list[Any],
     radius: float,
     debug: bool = False,
@@ -239,7 +239,7 @@ def get_random_patches_match(
                 original_resolutions,
                 new_resolutions,
                 dtype,
-                default_value,
+                meta_cloud_name,
             )
             for c in filtered_collections
         ]
@@ -385,9 +385,6 @@ if __name__ == "__main__":
         help="new band resolutions in meters",
     )
     parser.add_argument("--dtype", type=str, default="float32", help="data type")
-    parser.add_argument(
-        "--default-value", type=float, default=0, help="default fill value"
-    )
     # download settings
     parser.add_argument("--num-workers", type=int, default=8, help="number of workers")
     parser.add_argument("--log-freq", type=int, default=10, help="print frequency")
@@ -481,7 +478,7 @@ if __name__ == "__main__":
             original_resolutions,
             new_resolutions,
             dtype,
-            args.default_value,
+            args.meta_cloud_name,
             dates,
             radius=args.radius,
             debug=args.debug,


### PR DESCRIPTION
If we don't provide any defaultValue, `ee.Image.sampleRectangle` will raise an error and the sample will be skipped. This is much simpler than filtering samples out after the download finishes. Thanks @wangyi111 for the idea!

Also fixes an instance where `--meta-cloud-name` was hard-coded in the script.