### PR TITLE
Various fixes to SSL4EO sampler

### DIFF
--- a/experiments/ssl4eo/download_ssl4eo.py
+++ b/experiments/ssl4eo/download_ssl4eo.py
@@ -52,7 +52,6 @@ import csv
 import json
 import os
 import time
-import warnings
 from collections import defaultdict
 from datetime import date, datetime, timedelta
 from multiprocessing.dummy import Lock, Pool
@@ -62,8 +61,6 @@ import ee
 import numpy as np
 import rasterio
 from rasterio.transform import Affine
-
-warnings.simplefilter("ignore", UserWarning)
 
 
 def date2str(date: datetime) -> str:
@@ -445,7 +442,7 @@ if __name__ == "__main__":
         with open(ext_path) as csv_file:
             reader = csv.reader(csv_file)
             for row in reader:
-                key = row[0]
+                key = int(row[0])
                 val1 = float(row[1])
                 val2 = float(row[2])
                 ext_coords[key] = (val1, val2)  # lon, lat
@@ -467,7 +464,7 @@ if __name__ == "__main__":
     counter = Counter()
 
     def worker(idx: int) -> None:
-        if str(idx) in ext_coords.keys():
+        if idx in ext_coords.keys():
             return
 
         worker_start = time.time()

--- a/experiments/ssl4eo/download_ssl4eo.py
+++ b/experiments/ssl4eo/download_ssl4eo.py
@@ -52,6 +52,7 @@ import csv
 import json
 import os
 import time
+import warnings
 from collections import defaultdict
 from datetime import date, datetime, timedelta
 from multiprocessing.dummy import Lock, Pool
@@ -61,6 +62,8 @@ import ee
 import numpy as np
 import rasterio
 from rasterio.transform import Affine
+
+warnings.simplefilter("ignore", UserWarning)
 
 
 def date2str(date: datetime) -> str:
@@ -442,7 +445,7 @@ if __name__ == "__main__":
         with open(ext_path) as csv_file:
             reader = csv.reader(csv_file)
             for row in reader:
-                key = int(row[0])
+                key = row[0]
                 val1 = float(row[1])
                 val2 = float(row[2])
                 ext_coords[key] = (val1, val2)  # lon, lat
@@ -455,7 +458,7 @@ if __name__ == "__main__":
     with open(args.match_file) as csv_file:
         reader = csv.reader(csv_file)
         for row in reader:
-            key = int(row[0])
+            key = row[0]
             val1 = float(row[1])
             val2 = float(row[2])
             match_coords[key] = (val1, val2)  # lon, lat
@@ -464,7 +467,7 @@ if __name__ == "__main__":
     counter = Counter()
 
     def worker(idx: int) -> None:
-        if idx in ext_coords.keys():
+        if str(idx) in ext_coords.keys():
             return
 
         worker_start = time.time()

--- a/experiments/ssl4eo/download_ssl4eo.py
+++ b/experiments/ssl4eo/download_ssl4eo.py
@@ -455,7 +455,7 @@ if __name__ == "__main__":
     with open(args.match_file) as csv_file:
         reader = csv.reader(csv_file)
         for row in reader:
-            key = row[0]
+            key = int(row[0])
             val1 = float(row[1])
             val2 = float(row[2])
             match_coords[key] = (val1, val2)  # lon, lat

--- a/experiments/ssl4eo/sample_ssl4eo.py
+++ b/experiments/ssl4eo/sample_ssl4eo.py
@@ -152,6 +152,7 @@ if __name__ == "__main__":
             new_coords[i] = new_coord
             data = [i, *new_coord]
             writer.writerow(data)
+            f.flush()
 
     elapsed = time.time() - start_time
     print(f"Sampled locations saved to {path} in {elapsed:.2f} seconds.")

--- a/experiments/ssl4eo/sample_ssl4eo.py
+++ b/experiments/ssl4eo/sample_ssl4eo.py
@@ -49,8 +49,7 @@ def get_world_cities(
 ) -> pd.DataFrame:
     url = "https://simplemaps.com/static/data/world-cities/basic/simplemaps_worldcities_basicv1.71.zip"  # noqa: E501
     filename = "worldcities.csv"
-    if not os.path.exists(os.path.join(download_root, os.path.basename(url))):
-        download_and_extract_archive(url, download_root)
+    download_and_extract_archive(url, download_root)
     cols = ["city", "lat", "lng", "population"]
     cities = pd.read_csv(os.path.join(download_root, filename), usecols=cols)
     cities.at[8436, "population"] = 50789  # fix one bug (Tecax) in the csv file
@@ -136,7 +135,6 @@ if __name__ == "__main__":
     # Sample locations and save to file
     print("Sampling new locations...")
     start_time = time.time()
-    new_coords = {}
     with open(path, "a") as f:
         writer = csv.writer(f)
         for i in tqdm(range(*args.indices_range)):
@@ -149,7 +147,6 @@ if __name__ == "__main__":
                     break
 
             rtree_coords.insert(i, bbox)
-            new_coords[i] = new_coord
             data = [i, *new_coord]
             writer.writerow(data)
             f.flush()


### PR DESCRIPTION
This PR contains the following improvements to our sampler script:

- [x] Don't ignore warnings (they're there for a reason)
- [x] Resume is boolean, not a file (save_path already tells us where the file is)
- [x] Populate R-tree at the same time as we read the resume file (no need to loop twice)
- [x] Delete the old sample file if it already exists (previously, indices_range of 0 10 followed by 0 100 would result in a single file with 110 entries, 10 duplicated, and with different, possibly overlapping bboxes for those 10)
- [x] Don't check ext_coords for every index (no longer allows sampling in reverse order, but we don't need that, and this is faster)
- [x] Save to sample file at the same time as R-tree population (allows resuming even if script is killed due to timeout)

I wanted to add `np.random.seed(0)` to the script, but that would result in the first `indices_range[1]` samples we draw already being present in the resume file, meaning we would just skip them. I don't know of an easy way to update the random seed to the prior state without saving it.

@wangyi111