### PR TITLE
Add script to delete mismatched scenes

### DIFF
--- a/experiments/ssl4eo/delete_mismatch.py
+++ b/experiments/ssl4eo/delete_mismatch.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import shutil
+
+
+def delete_scene(directories: list[str], scene_id: str) -> None:
+    """Delete scene_id from all directories.
+
+    Args:
+        directories: directories to check
+        scene_id: scene to delete
+    """
+    print(f"Removing {scene_id}")
+    for directory in directories:
+       scene = os.path.join(directory, scene_id)
+       if os.path.exists(scene):
+           shutil.rmtree(scene)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("directories", nargs="+", help="directories to compare")
+    parser.add_argument(
+        "--delete-different-locations",
+        action="store_true",
+        help="delete scene locations that do not match",
+    )
+    parser.add_argument(
+        "--delete-different-dates",
+        action="store_true",
+        help="delete scene dates that do not match (must be same satellite)",
+    )
+    args = parser.parse_args()
+
+    print("Computing sets...")
+    scene_sets = [set(os.listdir(directory)) for directory in args.directories]
+
+    print("Computing union...")
+    union = set.union(*scene_sets)
+    total = len(union)
+
+    print("Computing intersection...")
+    intersection = set.intersection(*scene_sets)
+    remaining = len(intersection)
+
+    print("Computing difference...")
+    difference = union - intersection
+    delete_locations = len(difference)
+
+    if args.delete_different_locations:
+        for scene_id in difference:
+            delete_scene(args.directories, scene_id)
+
+    delete_times = 0
+    for scene_id in intersection:
+        time_sets = set.intersection(
+            *[
+                set(os.listdir(os.path.join(directory, scene_id)))
+                for directory in args.directories
+            ]
+        )
+        if len(time_sets) != 4:
+            if args.delete_different_dates:
+                delete_times += 1
+                delete_scene(args.directories, scene_id)
+
+    remaining -= delete_times
+    delete = delete_locations + delete_times
+    if not (args.delete_different_locations or args.delete_different_dates):
+        print(f"Would delete {delete} scenes, leaving {remaining} remaining scenes.")
+    else:
+        print(f"Deleted {delete} scenes, leaving {remaining} remaining scenes.")

--- a/experiments/ssl4eo/delete_mismatch.py
+++ b/experiments/ssl4eo/delete_mismatch.py
@@ -14,9 +14,9 @@ def delete_scene(directories: list[str], scene_id: str) -> None:
     """
     print(f"Removing {scene_id}")
     for directory in directories:
-       scene = os.path.join(directory, scene_id)
-       if os.path.exists(scene):
-           shutil.rmtree(scene)
+        scene = os.path.join(directory, scene_id)
+        if os.path.exists(scene):
+            shutil.rmtree(scene)
 
 
 if __name__ == "__main__":

--- a/experiments/ssl4eo/delete_mismatch.sh
+++ b/experiments/ssl4eo/delete_mismatch.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# User-specific parameters
+ROOT_DIR=data
+L7_L1="$ROOT_DIR/ssl4eo-l7-l1/imgs"
+L7_L2="$ROOT_DIR/ssl4eo-l7-l2/imgs"
+L8_L1="$ROOT_DIR/ssl4eo-l8-l1/imgs"
+L8_L2="$ROOT_DIR/ssl4eo-l8-l2/imgs"
+
+# Generic parameters
+SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+
+time python3 "$SCRIPT_DIR/delete_mismatch.py" "$L7_L1" "$L7_L2" --delete-different-locations --delete-different-dates
+time python3 "$SCRIPT_DIR/delete_mismatch.py" "$L8_L1" "$L8_L2" --delete-different-locations --delete-different-dates
+time python3 "$SCRIPT_DIR/delete_mismatch.py" "$L7_L1" "$L7_L2" "$L8_L1" "$L8_L2" --delete-different-locations


### PR DESCRIPTION
Given directories of downloaded data, this script deletes any scenes that are not common between all datasets. This lets us build a parallel corpus for all satellites. We delete all locations that are not shared, and all times that are not shared between Level-1 and Level-2 within a single satellite (L7 and L8 are from different decades so it doesn't make sense to require the same dates).

I didn't try parallelizing this script. I'm not sure how long it will take to delete all files, but a dry run on 600K L8 files takes 3.5 min (99% of time spent on looping over all directories to compare dates).

Unfortunately, this script requires all datasets to be on one system. We have enough storage/inodes for this, but transferring everything to our cluster will be slow. Alternatively, we could support lists of files containing the same filesystem hierarchy.