### PR TITLE
Typo in sample_conus.py script

### DIFF
--- a/experiments/ssl4eo/sample_conus.py
+++ b/experiments/ssl4eo/sample_conus.py
@@ -32,7 +32,7 @@ def retrieve_rois_polygons(download_root: str) -> MultiPolygon:
 
     excluded_states = [
         "United States Virgin Islands",
-        "Commonwealth of the Northern Mariana Island",
+        "Commonwealth of the Northern Mariana Islands",
         "Puerto Rico",
         "Alaska",
         "Hawaii",


### PR DESCRIPTION
"Commonwealth of the Northern Mariana Island" was missing an S for "Islands".