### PR TITLE
fix SeCo transforms

### DIFF
--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -39,7 +39,7 @@ _seco_transforms = AugmentationSequential(
     K.Normalize(mean=_min, std=_max - _min),
     K.Normalize(mean=torch.tensor(0), std=1 / torch.tensor(255)),
     Lambda(lambda x: torch.clamp(x, min=0.0, max=255.0)),
-    Lambda(lambda x: x.to(torch.uint8))
+    Lambda(lambda x: x.to(torch.uint8)),
     K.Normalize(mean=torch.tensor(0), std=torch.tensor(255)),
     K.Normalize(mean=_mean, std=_std),
     data_keys=["image"],

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -8,6 +8,7 @@ from typing import Any, Optional
 import kornia.augmentation as K
 import timm
 import torch
+from kornia.contrib import Lambda
 from timm.models import ResNet
 from torchvision.models._api import Weights, WeightsEnum
 
@@ -37,6 +38,8 @@ _seco_transforms = AugmentationSequential(
     K.CenterCrop(224),
     K.Normalize(mean=_min, std=_max - _min),
     K.Normalize(mean=torch.tensor(0), std=1 / torch.tensor(255)),
+    Lambda(lambda x: torch.clamp(x, min=0.0, max=255.0)),
+    K.Normalize(mean=torch.tensor(0), std=torch.tensor(255)),
     K.Normalize(mean=_mean, std=_std),
     data_keys=["image"],
 )

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -39,7 +39,7 @@ _seco_transforms = AugmentationSequential(
     K.Normalize(mean=_min, std=_max - _min),
     K.Normalize(mean=torch.tensor(0), std=1 / torch.tensor(255)),
     Lambda(lambda x: torch.clamp(x, min=0.0, max=255.0)),
-    Lambda(lambda x: x.to(torch.uint8).to(torch.float)),
+    Lambda(lambda x: x.to(torch.uint8).to(torch.float)),  # type: ignore[no-any-return]
     K.Normalize(mean=torch.tensor(0), std=torch.tensor(255)),
     K.Normalize(mean=_mean, std=_std),
     data_keys=["image"],

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -39,6 +39,7 @@ _seco_transforms = AugmentationSequential(
     K.Normalize(mean=_min, std=_max - _min),
     K.Normalize(mean=torch.tensor(0), std=1 / torch.tensor(255)),
     Lambda(lambda x: torch.clamp(x, min=0.0, max=255.0)),
+    Lambda(lambda x: x.to(torch.uint8))
     K.Normalize(mean=torch.tensor(0), std=torch.tensor(255)),
     K.Normalize(mean=_mean, std=_std),
     data_keys=["image"],

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -39,7 +39,7 @@ _seco_transforms = AugmentationSequential(
     K.Normalize(mean=_min, std=_max - _min),
     K.Normalize(mean=torch.tensor(0), std=1 / torch.tensor(255)),
     Lambda(lambda x: torch.clamp(x, min=0.0, max=255.0)),
-    Lambda(lambda x: x.to(torch.uint8)),
+    Lambda(lambda x: x.to(torch.uint8).to(torch.float)),
     K.Normalize(mean=torch.tensor(0), std=torch.tensor(255)),
     K.Normalize(mean=_mean, std=_std),
     data_keys=["image"],

--- a/torchgeo/transforms/transforms.py
+++ b/torchgeo/transforms/transforms.py
@@ -45,7 +45,9 @@ class AugmentationSequential(Module):
             else:
                 keys.append(key)
 
-        self.augs = K.AugmentationSequential(*args, data_keys=keys)
+        self.augs = K.AugmentationSequential(
+            *args, data_keys=keys  # type: ignore[arg-type]
+        )
 
     def forward(self, batch: dict[str, Tensor]) -> dict[str, Tensor]:
         """Perform augmentations and update data dict.

--- a/torchgeo/transforms/transforms.py
+++ b/torchgeo/transforms/transforms.py
@@ -8,6 +8,7 @@ from typing import Any, Optional, Union
 import kornia.augmentation as K
 import torch
 from einops import rearrange
+from kornia.contrib import Lambda
 from kornia.geometry import crop_by_indices
 from torch import Tensor
 from torch.nn.modules import Module
@@ -23,7 +24,7 @@ class AugmentationSequential(Module):
 
     def __init__(
         self,
-        *args: Union[K.base._AugmentationBase, K.ImageSequential],
+        *args: Union[K.base._AugmentationBase, K.ImageSequential, Lambda],
         data_keys: list[str],
     ) -> None:
         """Initialize a new augmentation sequential instance.


### PR DESCRIPTION
The current SeCo transforms do the following:

- resize
- center crop
- normalize using the quantiles
- multiply by 255
- normalize using imagenet stats

However in the [script](https://github.com/ServiceNow/seasonal-contrast/blob/8285173ec205b64bc3e53b880344dd6c3f79fa7a/datasets/seco_dataset.py) they actually do the following:

- resize
- center crop
- normalize using the quantiles
- multiply by 255
- clip to [0. 255]
- convert to uint8
- divide by 255
- normalize using imagenet stats
