### PR TITLE
GASSL ResNet50 Weights

### DIFF
--- a/docs/api/resnet_pretrained_weights.csv
+++ b/docs/api/resnet_pretrained_weights.csv
@@ -2,6 +2,7 @@ Weight,Channels,Source,Citation,BigEarthNet,EuroSAT,So2Sat,OSCD
 ResNet18_Weights.SENTINEL2_ALL_MOCO,13,`link <https://github.com/zhu-xlab/SSL4EO-S12>`__,`link <https://arxiv.org/abs/2211.07044>`__,,,,
 ResNet18_Weights.SENTINEL2_RGB_MOCO, 3,`link <https://github.com/zhu-xlab/SSL4EO-S12>`__,`link <https://arxiv.org/abs/2211.07044>`__,,,,
 ResNet18_Weights.SENTINEL2_RGB_SECO, 3,`link <https://github.com/ServiceNow/seasonal-contrast>`__,`link <https://arxiv.org/abs/2103.16607>`__,87.27,93.14,,46.94
+ResNet50_Weights.FMOW_RGB_GASSL, 3,`link <https://github.com/sustainlab-group/geography-aware-ssl>`__,`link <https://arxiv.org/abs/2011.09980>`__,,,,
 ResNet50_Weights.SENTINEL1_ALL_MOCO, 2,`link <https://github.com/zhu-xlab/SSL4EO-S12>`__,`link <https://arxiv.org/abs/2211.07044>`__,,,,
 ResNet50_Weights.SENTINEL2_ALL_DINO,13,`link <https://github.com/zhu-xlab/SSL4EO-S12>`__,`link <https://arxiv.org/abs/2211.07044>`__,90.7,99.1,63.6,
 ResNet50_Weights.SENTINEL2_ALL_MOCO,13,`link <https://github.com/zhu-xlab/SSL4EO-S12>`__,`link <https://arxiv.org/abs/2211.07044>`__,91.8,99.1,60.9,

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -41,6 +41,17 @@ _seco_transforms = AugmentationSequential(
     data_keys=["image"],
 )
 
+# Normalization only available for RGB dataset, defined here:
+# https://github.com/sustainlab-group/geography-aware-ssl/blob/main/moco_fmow/main_moco_geo%2Btp.py#L287  # noqa: E501
+_mean = torch.tensor([0.485, 0.456, 0.406])
+_std = torch.tensor([0.229, 0.224, 0.225])
+_gassl_transforms = AugmentationSequential(
+    K.Resize(224),
+    K.Normalize(mean=torch.tensor(0), std=torch.tensor(255)),
+    K.Normalize(mean=_mean, std=_std),
+    data_keys=["image"],
+)
+
 # https://github.com/pytorch/vision/pull/6883
 # https://github.com/pytorch/vision/pull/7107
 # Can be removed once torchvision>=0.15 is required
@@ -105,6 +116,19 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
     .. versionadded:: 0.4
     """
 
+    FMOW_RGB_GASSL = Weights(
+        url="https://huggingface.co/torchgeo/resnet50_fmow_rgb_gassl/resolve/main/resnet50_fmow_rgb_gassl-da43d987.pth",  # noqa: E501
+        transforms=_gassl_transforms,
+        meta={
+            "dataset": "fMoW Dataset",
+            "in_chans": 3,
+            "model": "resnet50",
+            "publication": "https://arxiv.org/abs/2011.09980",
+            "repo": "https://github.com/sustainlab-group/geography-aware-ssl",
+            "ssl_method": "gassl",
+        },
+    )
+
     SENTINEL1_ALL_MOCO = Weights(
         url="https://huggingface.co/torchgeo/resnet50_sentinel1_all_moco/resolve/main/resnet50_sentinel1_all_moco-906e4356.pth",  # noqa: E501
         transforms=_zhu_xlab_transforms,
@@ -167,19 +191,6 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             "publication": "https://arxiv.org/abs/2103.16607",
             "repo": "https://github.com/ServiceNow/seasonal-contrast",
             "ssl_method": "seco",
-        },
-    )
-
-    FMOW_RGB_GASSL = Weights(
-        url="https://huggingface.co/torchgeo/resnet50_fmow_rgb_gassl/resolve/main/resnet50_fmow_rgb_gassl-44b4461b.pth",  # noqa: E501
-        transforms=_seco_transforms,
-        meta={
-            "dataset": "fMoW Dataset",
-            "in_chans": 3,
-            "model": "resnet50",
-            "publication": "https://arxiv.org/abs/2011.09980",
-            "repo": "https://github.com/sustainlab-group/geography-aware-ssl",
-            "ssl_method": "gassl",
         },
     )
 

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -170,6 +170,19 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
         },
     )
 
+    FMOW_RGB_GASSL = Weights(
+        url="https://huggingface.co/torchgeo/resnet50_fmow_rgb_gassl/resolve/main/resnet50_fmow_rgb_gassl-44b4461b.pth",  # noqa: E501
+        transforms=_seco_transforms,
+        meta={
+            "dataset": "fMoW Dataset",
+            "in_chans": 3,
+            "model": "resnet50",
+            "publication": "https://arxiv.org/abs/2011.09980",
+            "repo": "https://github.com/sustainlab-group/geography-aware-ssl",
+            "ssl_method": "gassl",
+        },
+    )
+
 
 def resnet18(
     weights: Optional[ResNet18_Weights] = None, *args: Any, **kwargs: Any


### PR DESCRIPTION
This PR adds the ResNet50 RGB weights trained on fMoW (mostly Maxar WorldView imagery) using the  [Geography Aware Self-supervised Learning (GASSL)](https://arxiv.org/abs/2011.09980) method. This is basically a modified MoCo-v2 with Geolocation as a pretext task (Geo) as well as temporal pairs contrastive learning (TP).

Weights taken from [this repo](https://github.com/sustainlab-group/geography-aware-ssl) and uploaded to huggingface.

Adding these weights is essential since it's being compared as a baseline in both the [SatMAE](https://arxiv.org/abs/2207.08051) and [Scale-MAE](https://arxiv.org/abs/2212.14532) papers.