### PR TITLE
Landsat 5 TOA also needs to be downloaded

### DIFF
--- a/experiments/ssl4eo/delete_mismatch.sh
+++ b/experiments/ssl4eo/delete_mismatch.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 # User-specific parameters
 ROOT_DIR=data
+L5_L1="$ROOT_DIR/ssl4eo-l5-l1/imgs"
 L7_L1="$ROOT_DIR/ssl4eo-l7-l1/imgs"
 L7_L2="$ROOT_DIR/ssl4eo-l7-l2/imgs"
 L8_L1="$ROOT_DIR/ssl4eo-l8-l1/imgs"
@@ -14,4 +15,4 @@ SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
 
 time python3 "$SCRIPT_DIR/delete_mismatch.py" "$L7_L1" "$L7_L2" --delete-different-locations --delete-different-dates
 time python3 "$SCRIPT_DIR/delete_mismatch.py" "$L8_L1" "$L8_L2" --delete-different-locations --delete-different-dates
-time python3 "$SCRIPT_DIR/delete_mismatch.py" "$L7_L1" "$L7_L2" "$L8_L1" "$L8_L2" --delete-different-locations
+time python3 "$SCRIPT_DIR/delete_mismatch.py" "$L5_L1" "$L7_L1" "$L7_L2" "$L8_L1" "$L8_L2" --delete-different-locations

--- a/experiments/ssl4eo/download_l5_l1.sh
+++ b/experiments/ssl4eo/download_l5_l1.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+set -euo pipefail
+
+# User-specific parameters
+ROOT_DIR=data
+SAVE_PATH="$ROOT_DIR/ssl4eo-l5-l1"
+MATCH_FILE="$ROOT_DIR/ssl4eo-l-30/sampled_locations.csv"
+NUM_WORKERS=40
+START_INDEX=0
+END_INDEX=10
+
+# Satellite-specific parameters
+COLLECTION=LANDSAT/LT05/C02/T1_TOA
+QA_BAND=QA_PIXEL
+QA_CLOUD_BIT=3
+META_CLOUD_NAME=CLOUD_COVER
+YEAR=2010  # TM sensor failed in Nov 2011
+BANDS=(B1 B2 B3 B4 B5 B6 B7)
+ORIGINAL_RESOLUTIONS=(30 30 30 30 30 30 30)
+NEW_RESOLUTIONS=30
+
+# Generic parameters
+SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+CLOUD_PCT=20
+SIZE=264
+DTYPE=float32
+LOG_FREQ=1000
+
+time python3 "$SCRIPT_DIR/download_ssl4eo.py" \
+    --save-path "$SAVE_PATH" \
+    --collection $COLLECTION \
+    --qa-band $QA_BAND \
+    --qa-cloud-bit $QA_CLOUD_BIT \
+    --meta-cloud-name $META_CLOUD_NAME \
+    --cloud-pct $CLOUD_PCT \
+    --dates $YEAR-03-20 $YEAR-06-21 $YEAR-09-23 $YEAR-12-21 \
+    --radius $(($NEW_RESOLUTIONS * $SIZE / 2)) \
+    --bands ${BANDS[@]} \
+    --original-resolutions ${ORIGINAL_RESOLUTIONS[@]} \
+    --new-resolutions $NEW_RESOLUTIONS \
+    --dtype $DTYPE \
+    --num-workers $NUM_WORKERS \
+    --log-freq $LOG_FREQ \
+    --match-file "$MATCH_FILE" \
+    --indices-range $START_INDEX $END_INDEX \
+    --debug


### PR DESCRIPTION
We we're planning on using L7 as a proxy for L5. On paper, all we have to do is drop the panchromatic band, and decrease resolution of the thermal band. But GEE splits the thermal band into low-gain and high-gain, only for L7 TOA. So we need to download a separate L5 TOA dataset.