### PR TITLE
Create matching CDL/NLCD chips for downstream tasks

### DIFF
--- a/experiments/ssl4eo/chip_landsat_downstream.py
+++ b/experiments/ssl4eo/chip_landsat_downstream.py
@@ -43,7 +43,6 @@ def retrieve_mask_chip(
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    # Can be same directory for in-place compression
     parser.add_argument(
         "--landsat-dir", help="directory to recursively search for files", required=True
     )

--- a/experiments/ssl4eo/chip_landsat_downstream.py
+++ b/experiments/ssl4eo/chip_landsat_downstream.py
@@ -15,13 +15,15 @@ from rasterio.windows import from_bounds
 from tqdm import tqdm
 
 
-def retrieve_mask_chip(img_src: DatasetReader, mask_src: DatasetReader) -> np.ndarray:
+def retrieve_mask_chip(
+    img_src: DatasetReader, mask_src: DatasetReader
+) -> np.typing.NDArray[np.float_]:
     """Retrieve the mask for a given landsat image.
 
     Args:
         img_src: input image for which to find a corresponding chip
-        mask_src: CRS aligned mask from which to retrieve a chip corresponding to
-            img_src
+        mask_src: CRS aligned mask from which to retrieve a chip
+            corresponding to img_src
 
     Returns:
         mask array
@@ -30,7 +32,7 @@ def retrieve_mask_chip(img_src: DatasetReader, mask_src: DatasetReader) -> np.nd
     out_width = round((query.right - query.left) / img_src.res[0])
     out_height = round((query.top - query.bottom) / img_src.res[1])
     out_shape = (1, out_height, out_width)
-    mask_chip = mask_src.read(
+    mask_chip: "np.typing.NDArray[np.float_]" = mask_src.read(
         out_shape=out_shape,
         window=from_bounds(
             query.left, query.bottom, query.right, query.top, mask_src.transform

--- a/experiments/ssl4eo/chip_landsat_downstream.py
+++ b/experiments/ssl4eo/chip_landsat_downstream.py
@@ -29,13 +29,13 @@ def retrieve_mask_chip(img_src: DatasetReader, mask_src: DatasetReader) -> np.nd
     out_width = round((query.right - query.left) / img_src.res[0])
     out_height = round((query.top - query.bottom) / img_src.res[1])
     out_shape = (1, out_height, out_width)
-    mask = mask_src.read(
+    mask_chip = mask_src.read(
         out_shape=out_shape,
         window=from_bounds(
-            query.left, query.bottom, query.right, query.top, img_src.transform
+            query.left, query.bottom, query.right, query.top, mask_src.transform
         ),
     )
-    return mask
+    return mask_chip
 
 
 if __name__ == "__main__":
@@ -88,6 +88,6 @@ if __name__ == "__main__":
         profile["count"] = 1
 
         with rasterio.open(
-            os.path.join(mask_id_dir, "mask.tif"), "w", **profile
+            os.path.join(mask_year_dir, "mask.tif"), "w", **profile
         ) as dst:
             dst.write(mask)

--- a/experiments/ssl4eo/chip_landsat_downstream.py
+++ b/experiments/ssl4eo/chip_landsat_downstream.py
@@ -67,21 +67,21 @@ if __name__ == "__main__":
     if mask_src.crs != img_crs:
         mask_src = WarpedVRT(mask_src, crs=img_crs)
 
-    for img_path in paths[0:100]:
+    for img_path in paths:
         img_src = rasterio.open(img_path)
 
         # retrieve mask
         mask = retrieve_mask_chip(img_src, mask_src)
 
-        # match directory structure
-        mask_num_dir = os.path.join(
-            mask_root_dir, os.path.dirname(img_path).split("/")[-2]
-        )
-        os.makedirs(mask_num_dir, exist_ok=True)
+        # directory structure mask <scene_id>/<year>/*.tif
         mask_id_dir = os.path.join(
-            mask_num_dir, os.path.dirname(img_path).split("/")[-1]
+            mask_root_dir, os.path.dirname(img_path).split("/")[-1]
         )
         os.makedirs(mask_id_dir, exist_ok=True)
+        mask_year_dir = os.path.join(
+            mask_id_dir, os.path.basename(mask_id_dir).split("_")[-1][:4]
+        )
+        os.makedirs(mask_year_dir, exist_ok=True)
 
         # write mask tif
         profile = img_src.profile

--- a/experiments/ssl4eo/chip_landsat_downstream.py
+++ b/experiments/ssl4eo/chip_landsat_downstream.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import argparse
+import glob
+import os
+
+import numpy as np
+import rasterio
+from rasterio.io import DatasetReader
+from rasterio.vrt import WarpedVRT
+from rasterio.windows import from_bounds
+
+
+def retrieve_mask_chip(img_src: DatasetReader, mask_src: DatasetReader) -> np.ndarray:
+    """Retrieve the mask for a given landsat image.
+
+    Args:
+        img_src: input image for which to find a corresponding chip
+        mask_src: CRS aligned mask from which to retrieve a chip corresponding to
+            img_src
+
+    Returns:
+        mask array
+    """
+    query = img_src.bounds
+    out_width = round((query.right - query.left) / img_src.res[0])
+    out_height = round((query.top - query.bottom) / img_src.res[1])
+    out_shape = (1, out_height, out_width)
+    mask = mask_src.read(
+        out_shape=out_shape,
+        window=from_bounds(
+            query.left, query.bottom, query.right, query.top, img_src.transform
+        ),
+    )
+    return mask
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    # Can be same directory for in-place compression
+    parser.add_argument(
+        "--landsat_dir", help="directory to recursively search for files"
+    )
+    parser.add_argument("--mask_path", help="path to downstream task mask to chip")
+    parser.add_argument("--suffix", default=".tif", help="file suffix")
+    # masks will be added as separate band to the *landsat_dir*
+
+    args = parser.parse_args()
+
+    mask_root_dir = os.path.join(args.landsat_dir, "masks")
+    os.makedirs(mask_root_dir, exist_ok=True)
+
+    # find all files in landsat dir
+    paths = sorted(
+        glob.glob(
+            os.path.join(args.landsat_dir, "imgs", "*", "*", f"*{args.suffix}"),
+            recursive=True,
+        )
+    )
+
+    mask_src = rasterio.open(args.mask_path)
+    img_crs = rasterio.open(paths[0]).crs
+
+    if mask_src.crs != img_crs:
+        mask_src = WarpedVRT(mask_src, crs=img_crs)
+
+    for img_path in paths[0:100]:
+        img_src = rasterio.open(img_path)
+
+        # retrieve mask
+        mask = retrieve_mask_chip(img_src, mask_src)
+
+        # match directory structure
+        mask_num_dir = os.path.join(
+            mask_root_dir, os.path.dirname(img_path).split("/")[-2]
+        )
+        os.makedirs(mask_num_dir, exist_ok=True)
+        mask_id_dir = os.path.join(
+            mask_num_dir, os.path.dirname(img_path).split("/")[-1]
+        )
+        os.makedirs(mask_id_dir, exist_ok=True)
+
+        # write mask tif
+        profile = img_src.profile
+        profile["count"] = 1
+
+        with rasterio.open(
+            os.path.join(mask_id_dir, "mask.tif"), "w", **profile
+        ) as dst:
+            dst.write(mask)


### PR DESCRIPTION
This PR adds a script to create matching mask chips for downstream evaluation tasks based on CONUS data. @adamjstewart 

Remaining Questions:
- what should be the proper directory structure for a sample, still the numerate/landsat_id/*.tif?
- how to add the no-data mask?

Issues:
- Currently all masks I am chipping are just plain zeros :/ and not sure why

![Screenshot from 2023-05-15 11-19-47](https://github.com/microsoft/torchgeo/assets/35272119/68a853b6-349d-4b25-a3c2-7b65e10a3889)
