### PR TITLE
MoCo/SimCLR: better default lr

### DIFF
--- a/torchgeo/trainers/moco.py
+++ b/torchgeo/trainers/moco.py
@@ -173,7 +173,7 @@ class MoCoTask(LightningModule):  # type: ignore[misc]
             output_dim: Number of output dimensions in projection head
                 (not used in v1, 128 for v2, 256 for v3).
             lr: Learning rate
-                (0.03 x batch_size / 256 for v1/2, 0.0375 x batch_size / 256 for v3).
+                (0.03 x batch_size / 256 for v1/2, 0.6 x batch_size / 256 for v3).
             weight_decay: Weight decay coefficient (1e-4 for v1/2, 1e-6 for v3).
             momentum: Momentum of SGD solver (v1/2 only).
             schedule: Epochs at which to drop lr by 10x (v1/2 only).

--- a/torchgeo/trainers/moco.py
+++ b/torchgeo/trainers/moco.py
@@ -172,7 +172,8 @@ class MoCoTask(LightningModule):  # type: ignore[misc]
                 (not used in v1, 2048 for v2, 4096 for v3).
             output_dim: Number of output dimensions in projection head
                 (not used in v1, 128 for v2, 256 for v3).
-            lr: Learning rate (0.6 x batch_size / 256 is recommended).
+            lr: Learning rate
+                (0.03 x batch_size / 256 for v1/2, 0.0375 x batch_size / 256 for v3).
             weight_decay: Weight decay coefficient (1e-4 for v1/2, 1e-6 for v3).
             momentum: Momentum of SGD solver (v1/2 only).
             schedule: Epochs at which to drop lr by 10x (v1/2 only).

--- a/torchgeo/trainers/simclr.py
+++ b/torchgeo/trainers/simclr.py
@@ -104,7 +104,7 @@ class SimCLRTask(LightningModule):  # type: ignore[misc]
                 (defaults to output dimension of model).
             output_dim: Number of output dimensions in projection head
                 (defaults to output dimension of model).
-            lr: Learning rate (0.3 x batch_size / 256 recommended).
+            lr: Learning rate (0.3 x batch_size / 256 is recommended).
             weight_decay: Weight decay coefficient (1e-6 for v1, 1e-4 for v2).
             temperature: Temperature used in NT-Xent loss.
             memory_bank_size: Size of memory bank (0 for v1, 64K for v2).

--- a/torchgeo/trainers/simclr.py
+++ b/torchgeo/trainers/simclr.py
@@ -104,8 +104,7 @@ class SimCLRTask(LightningModule):  # type: ignore[misc]
                 (defaults to output dimension of model).
             output_dim: Number of output dimensions in projection head
                 (defaults to output dimension of model).
-            lr: Learning rate
-                (0.3 x batch_size / 256 for v1, 0.3 x sqrt(batch size) for v2).
+            lr: Learning rate (0.3 x batch_size / 256 recommended).
             weight_decay: Weight decay coefficient (1e-6 for v1, 1e-4 for v2).
             temperature: Temperature used in NT-Xent loss.
             memory_bank_size: Size of memory bank (0 for v1, 64K for v2).


### PR DESCRIPTION
The recommended learning rates I initially had are all wrong.

### MoCo

The MoCo v1 paper explicitly mentions using an initial lr of 0.03 for a batch size of 256. They also mention using linear lr scaling (i.e., lr = 0.03 * batch_size / 256). I couldn't find any mention of learning rate in the MoCo v2 paper, but the MoCo v3 paper also mentions using linear lr scaling.

The MoCo v1/v2 GitHub uses an lr of 0.03 and bs of 256, so that matches the v1 paper. The MoCo v3 GitHub uses an lr of (0.6 x batch_size / 256), so that was already correct.

### SimCLR

The SimCLR v1 paper uses a lr of (0.3 * batch_size / 256), but mentions that this works better for SGD/Momentum based optimizers, while a lr of (0.075 * sqrt(batch_size)) works better for the LARS optimizer. The SimCLR v2 paper uses a lr of (0.1 * sqrt(batch_size)) and the LARS optimizer.

The SimCLR v1/v2 GitHub repo actually uses linear scaling with a lr of (0.3 * batch_size / 256) and a bs of 256 by default, although there is an option to change it to sqrt scaling.

Since we're using Adam instead of LARS, I think it makes more sense to go with linear scaling for both versions.