### PR TITLE
Revert "GASSL ResNet50 Weights"

### DIFF
--- a/docs/api/resnet_pretrained_weights.csv
+++ b/docs/api/resnet_pretrained_weights.csv
@@ -2,7 +2,6 @@ Weight,Channels,Source,Citation,BigEarthNet,EuroSAT,So2Sat,OSCD
 ResNet18_Weights.SENTINEL2_ALL_MOCO,13,`link <https://github.com/zhu-xlab/SSL4EO-S12>`__,`link <https://arxiv.org/abs/2211.07044>`__,,,,
 ResNet18_Weights.SENTINEL2_RGB_MOCO, 3,`link <https://github.com/zhu-xlab/SSL4EO-S12>`__,`link <https://arxiv.org/abs/2211.07044>`__,,,,
 ResNet18_Weights.SENTINEL2_RGB_SECO, 3,`link <https://github.com/ServiceNow/seasonal-contrast>`__,`link <https://arxiv.org/abs/2103.16607>`__,87.27,93.14,,46.94
-ResNet50_Weights.FMOW_RGB_GASSL, 3,`link <https://github.com/sustainlab-group/geography-aware-ssl>`__,`link <https://arxiv.org/abs/2011.09980>`__,,,,
 ResNet50_Weights.SENTINEL1_ALL_MOCO, 2,`link <https://github.com/zhu-xlab/SSL4EO-S12>`__,`link <https://arxiv.org/abs/2211.07044>`__,,,,
 ResNet50_Weights.SENTINEL2_ALL_DINO,13,`link <https://github.com/zhu-xlab/SSL4EO-S12>`__,`link <https://arxiv.org/abs/2211.07044>`__,90.7,99.1,63.6,
 ResNet50_Weights.SENTINEL2_ALL_MOCO,13,`link <https://github.com/zhu-xlab/SSL4EO-S12>`__,`link <https://arxiv.org/abs/2211.07044>`__,91.8,99.1,60.9,

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -41,17 +41,6 @@ _seco_transforms = AugmentationSequential(
     data_keys=["image"],
 )
 
-# Normalization only available for RGB dataset, defined here:
-# https://github.com/sustainlab-group/geography-aware-ssl/blob/main/moco_fmow/main_moco_geo%2Btp.py#L287  # noqa: E501
-_mean = torch.tensor([0.485, 0.456, 0.406])
-_std = torch.tensor([0.229, 0.224, 0.225])
-_gassl_transforms = AugmentationSequential(
-    K.Resize(224),
-    K.Normalize(mean=torch.tensor(0), std=torch.tensor(255)),
-    K.Normalize(mean=_mean, std=_std),
-    data_keys=["image"],
-)
-
 # https://github.com/pytorch/vision/pull/6883
 # https://github.com/pytorch/vision/pull/7107
 # Can be removed once torchvision>=0.15 is required
@@ -115,19 +104,6 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
 
     .. versionadded:: 0.4
     """
-
-    FMOW_RGB_GASSL = Weights(
-        url="https://huggingface.co/torchgeo/resnet50_fmow_rgb_gassl/resolve/main/resnet50_fmow_rgb_gassl-da43d987.pth",  # noqa: E501
-        transforms=_gassl_transforms,
-        meta={
-            "dataset": "fMoW Dataset",
-            "in_chans": 3,
-            "model": "resnet50",
-            "publication": "https://arxiv.org/abs/2011.09980",
-            "repo": "https://github.com/sustainlab-group/geography-aware-ssl",
-            "ssl_method": "gassl",
-        },
-    )
 
     SENTINEL1_ALL_MOCO = Weights(
         url="https://huggingface.co/torchgeo/resnet50_sentinel1_all_moco/resolve/main/resnet50_sentinel1_all_moco-906e4356.pth",  # noqa: E501


### PR DESCRIPTION
Reverts microsoft/torchgeo#1325

PRs have been failing ever since this PR was merged. Curious to see if the errors go away if we remove it. Failure is always on Windows, and always looks like:
```
RuntimeError: [enforce fail at ..\c10\core\impl\alloc_cpu.cpp:72] data. DefaultCPUAllocator: not enough memory: you tried to allocate 4194304 bytes.
```
The failing tests are always when our trainers try to load our mocked model weights. Not sure what we can do other than load fewer weights. We might be able to only load 1 ResNet, but we'll still have to load all of them on the release branch, so we can't just avoid the problem. Maybe we need to clear memory after each test somehow? We can't really fake the model to something smaller since that won't work on the release branch. I wonder if we could get Microsoft to pay for larger GitHub Actions runners... (@calebrob6?)

This PR is half test and half serious. Like I don't want to remove these weights, but we also can't let our tests keep failing forever. We could revert until we have time to figure out how to get this working properly.