### PR TITLE
Load Segmentation Trainer Weights

### DIFF
--- a/torchgeo/trainers/utils.py
+++ b/torchgeo/trainers/utils.py
@@ -46,6 +46,14 @@ def extract_backbone(path: str) -> tuple[str, "OrderedDict[str, Tensor]"]:
         state_dict = OrderedDict(
             {k.replace("model.backbone.model.", ""): v for k, v in state_dict.items()}
         )
+    elif checkpoint["model"] in ["deeplabv3+", "unet"]:
+        state_dict = OrderedDict(
+            {
+                k.replace("encoder.", ""): v
+                for k, v in state_dict.items()
+                if "encoder" in k
+            }
+        )
     else:
         raise ValueError(
             "Unknown checkpoint task. Only backbone or model extraction is supported"


### PR DESCRIPTION
This PR changes the loading of a checkpoint in the segmentation model. Given that I have trained a model with a torchgeo trainer, I might want to do with the `weights` argument:
- load the entire model (encoder and decoder)
- load just a backbone
- use only the model backbone from a trained model in a different task or at least make it available for other tasks

Not sure which of all should be supported by default, or whether there should be suggestions on how to do each of these (or other things).