### PR TITLE
sample_ssl4eo: faster top 10K population cities

### DIFF
--- a/experiments/ssl4eo/sample_ssl4eo.py
+++ b/experiments/ssl4eo/sample_ssl4eo.py
@@ -53,7 +53,7 @@ def get_world_cities(
     cols = ["city", "lat", "lng", "population"]
     cities = pd.read_csv(os.path.join(download_root, filename), usecols=cols)
     cities.at[8436, "population"] = 50789  # fix one bug (Tecax) in the csv file
-    cities = cities.sort_values(by=["population"], ascending=False).head(size)
+    cities = cities.nlargest("population", size)
     return cities
 
 


### PR DESCRIPTION
From https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.nlargest.html:

> This method is equivalent to `df.sort_values(columns, ascending=False).head(n)`, but more performant.

@wangyi111