### PR TITLE
Add config files for SSL4EO-L downstream tasks

### DIFF
--- a/conf/l7irish.yaml
+++ b/conf/l7irish.yaml
@@ -1,0 +1,24 @@
+module:
+  _target_: torchgeo.trainers.SemanticSegmentationTask
+  model: "unet"
+  backbone: "resnet18"
+  weights: null
+  in_channels: 9
+  num_classes: 5
+  loss: "ce"
+  class_weights: [0, 0.90484679, 0.00920825, 0.05944526, 0.02649971]
+  ignore_index: 0
+  learning_rate: 1e-3
+  learning_rate_schedule_patience: 6
+
+datamodule:
+  _target_: torchgeo.datamodules.L7IrishDataModule
+  root: "data/l7irish"
+  batch_size: 64
+  patch_size: 224
+  num_workers: 16
+
+trainer:
+  _target_: lightning.pytorch.Trainer
+  min_epochs: 20
+  max_epochs: 100

--- a/conf/l8biome.yaml
+++ b/conf/l8biome.yaml
@@ -1,0 +1,24 @@
+module:
+  _target_: torchgeo.trainers.SemanticSegmentationTask
+  model: "unet"
+  backbone: "resnet18"
+  weights: null
+  in_channels: 11
+  num_classes: 5
+  loss: "ce"
+  class_weights: [0, 0.84585444, 0.02586814, 0.08889015, 0.03938727]
+  ignore_index: 0
+  learning_rate: 1e-3
+  learning_rate_schedule_patience: 6
+
+datamodule:
+  _target_: torchgeo.datamodules.L8BiomeDataModule
+  root: "data/l8biome"
+  batch_size: 64
+  patch_size: 224
+  num_workers: 16
+
+trainer:
+  _target_: lightning.pytorch.Trainer
+  min_epochs: 20
+  max_epochs: 100

--- a/conf/ssl4eo_benchmark_etm_sr_cdl.yaml
+++ b/conf/ssl4eo_benchmark_etm_sr_cdl.yaml
@@ -1,0 +1,26 @@
+module:
+  _target_: torchgeo.trainers.SemanticSegmentationTask
+  model: "unet"
+  backbone: "resnet18"
+  weights: null
+  in_channels: 6
+  num_classes: 18
+  loss: "ce"
+  class_weights: [0, 0.02932525, 0.03485261, 0.09073607, 0.12917486, 0.08291747, 0.07774719, 0.07817889, 0.04687388, 0.09088148, 0.13151367, 0.01256833, 0.011007, 0.04324573, 0.00584689, 0.00857053, 0.03110655, 0.09545359]
+  ignore_index: 0
+  learning_rate: 1e-3
+  learning_rate_schedule_patience: 6
+
+datamodule:
+  _target_: torchgeo.datamodules.SSL4EOLBenchmarkDataModule
+  root: "data/ssl4eo_benchmark"
+  sensor: "etm_sr"
+  product: "cdl"
+  classes: [0, 1, 5, 24, 36, 37, 61, 111, 121, 122, 131, 141, 142, 143, 152, 176, 190, 195]
+  batch_size: 64
+  num_workers: 16
+
+trainer:
+  _target_: lightning.pytorch.Trainer
+  min_epochs: 20
+  max_epochs: 100

--- a/conf/ssl4eo_benchmark_etm_sr_nlcd.yaml
+++ b/conf/ssl4eo_benchmark_etm_sr_nlcd.yaml
@@ -1,0 +1,26 @@
+module:
+  _target_: torchgeo.trainers.SemanticSegmentationTask
+  model: "unet"
+  backbone: "resnet18"
+  weights: null
+  in_channels: 6
+  num_classes: 14
+  loss: "ce"
+  class_weights: [0, 0.00640476, 0.11232852, 0.12934777, 0.05883383, 0.10792264, 0.00483846, 0.05689931, 0.0196849, 0.04278681, 0.05963887, 0.08670033, 0.1356737, 0.17894011]
+  ignore_index: 0
+  learning_rate: 1e-3
+  learning_rate_schedule_patience: 6
+
+datamodule:
+  _target_: torchgeo.datamodules.SSL4EOLBenchmarkDataModule
+  root: "data/ssl4eo_benchmark"
+  sensor: "etm_sr"
+  product: "nlcd"
+  classes: [0, 11, 21, 22, 31, 41, 42, 43, 52, 71, 81, 82, 90, 95]
+  batch_size: 64
+  num_workers: 16
+
+trainer:
+  _target_: lightning.pytorch.Trainer
+  min_epochs: 20
+  max_epochs: 100

--- a/conf/ssl4eo_benchmark_etm_toa_cdl.yaml
+++ b/conf/ssl4eo_benchmark_etm_toa_cdl.yaml
@@ -1,0 +1,26 @@
+module:
+  _target_: torchgeo.trainers.SemanticSegmentationTask
+  model: "unet"
+  backbone: "resnet18"
+  weights: null
+  in_channels: 9
+  num_classes: 18
+  loss: "ce"
+  class_weights: [0, 0.02932525, 0.03485261, 0.09073607, 0.12917486, 0.08291747, 0.07774719, 0.07817889, 0.04687388, 0.09088148, 0.13151367, 0.01256833, 0.011007, 0.04324573, 0.00584689, 0.00857053, 0.03110655, 0.09545359]
+  ignore_index: 0
+  learning_rate: 1e-3
+  learning_rate_schedule_patience: 6
+
+datamodule:
+  _target_: torchgeo.datamodules.SSL4EOLBenchmarkDataModule
+  root: "data/ssl4eo_benchmark"
+  sensor: "etm_toa"
+  product: "cdl"
+  classes: [0, 1, 5, 24, 36, 37, 61, 111, 121, 122, 131, 141, 142, 143, 152, 176, 190, 195]
+  batch_size: 64
+  num_workers: 16
+
+trainer:
+  _target_: lightning.pytorch.Trainer
+  min_epochs: 20
+  max_epochs: 100

--- a/conf/ssl4eo_benchmark_etm_toa_nlcd.yaml
+++ b/conf/ssl4eo_benchmark_etm_toa_nlcd.yaml
@@ -1,0 +1,26 @@
+module:
+  _target_: torchgeo.trainers.SemanticSegmentationTask
+  model: "unet"
+  backbone: "resnet18"
+  weights: null
+  in_channels: 9
+  num_classes: 14
+  loss: "ce"
+  class_weights: [0, 0.00640476, 0.11232852, 0.12934777, 0.05883383, 0.10792264, 0.00483846, 0.05689931, 0.0196849, 0.04278681, 0.05963887, 0.08670033, 0.1356737, 0.17894011]
+  ignore_index: 0
+  learning_rate: 1e-3
+  learning_rate_schedule_patience: 6
+
+datamodule:
+  _target_: torchgeo.datamodules.SSL4EOLBenchmarkDataModule
+  root: "data/ssl4eo_benchmark"
+  sensor: "etm_toa"
+  product: "nlcd"
+  classes: [0, 11, 21, 22, 31, 41, 42, 43, 52, 71, 81, 82, 90, 95]
+  batch_size: 64
+  num_workers: 16
+
+trainer:
+  _target_: lightning.pytorch.Trainer
+  min_epochs: 20
+  max_epochs: 100

--- a/conf/ssl4eo_benchmark_oli_sr_cdl.yaml
+++ b/conf/ssl4eo_benchmark_oli_sr_cdl.yaml
@@ -1,0 +1,26 @@
+module:
+  _target_: torchgeo.trainers.SemanticSegmentationTask
+  model: "unet"
+  backbone: "resnet18"
+  weights: null
+  in_channels: 7
+  num_classes: 18
+  loss: "ce"
+  class_weights: [0, 0.02932525, 0.03485261, 0.09073607, 0.12917486, 0.08291747, 0.07774719, 0.07817889, 0.04687388, 0.09088148, 0.13151367, 0.01256833, 0.011007, 0.04324573, 0.00584689, 0.00857053, 0.03110655, 0.09545359]
+  ignore_index: 0
+  learning_rate: 1e-3
+  learning_rate_schedule_patience: 6
+
+datamodule:
+  _target_: torchgeo.datamodules.SSL4EOLBenchmarkDataModule
+  root: "data/ssl4eo_benchmark"
+  sensor: "oli_sr"
+  product: "cdl"
+  classes: [0, 1, 5, 24, 36, 37, 61, 111, 121, 122, 131, 141, 142, 143, 152, 176, 190, 195]
+  batch_size: 64
+  num_workers: 16
+
+trainer:
+  _target_: lightning.pytorch.Trainer
+  min_epochs: 20
+  max_epochs: 100

--- a/conf/ssl4eo_benchmark_oli_sr_nlcd.yaml
+++ b/conf/ssl4eo_benchmark_oli_sr_nlcd.yaml
@@ -1,0 +1,26 @@
+module:
+  _target_: torchgeo.trainers.SemanticSegmentationTask
+  model: "unet"
+  backbone: "resnet18"
+  weights: null
+  in_channels: 7
+  num_classes: 14
+  loss: "ce"
+  class_weights: [0, 0.00640476, 0.11232852, 0.12934777, 0.05883383, 0.10792264, 0.00483846, 0.05689931, 0.0196849, 0.04278681, 0.05963887, 0.08670033, 0.1356737, 0.17894011]
+  ignore_index: 0
+  learning_rate: 1e-3
+  learning_rate_schedule_patience: 6
+
+datamodule:
+  _target_: torchgeo.datamodules.SSL4EOLBenchmarkDataModule
+  root: "data/ssl4eo_benchmark"
+  sensor: "oli_sr"
+  product: "nlcd"
+  classes: [0, 11, 21, 22, 31, 41, 42, 43, 52, 71, 81, 82, 90, 95]
+  batch_size: 64
+  num_workers: 16
+
+trainer:
+  _target_: lightning.pytorch.Trainer
+  min_epochs: 20
+  max_epochs: 100

--- a/conf/ssl4eo_benchmark_oli_tirs_toa_cdl.yaml
+++ b/conf/ssl4eo_benchmark_oli_tirs_toa_cdl.yaml
@@ -1,0 +1,26 @@
+module:
+  _target_: torchgeo.trainers.SemanticSegmentationTask
+  model: "unet"
+  backbone: "resnet18"
+  weights: null
+  in_channels: 11
+  num_classes: 18
+  loss: "ce"
+  class_weights: [0, 0.02932525, 0.03485261, 0.09073607, 0.12917486, 0.08291747, 0.07774719, 0.07817889, 0.04687388, 0.09088148, 0.13151367, 0.01256833, 0.011007, 0.04324573, 0.00584689, 0.00857053, 0.03110655, 0.09545359]
+  ignore_index: 0
+  learning_rate: 1e-3
+  learning_rate_schedule_patience: 6
+
+datamodule:
+  _target_: torchgeo.datamodules.SSL4EOLBenchmarkDataModule
+  root: "data/ssl4eo_benchmark"
+  sensor: "oli_tirs_toa"
+  product: "cdl"
+  classes: [0, 1, 5, 24, 36, 37, 61, 111, 121, 122, 131, 141, 142, 143, 152, 176, 190, 195]
+  batch_size: 64
+  num_workers: 16
+
+trainer:
+  _target_: lightning.pytorch.Trainer
+  min_epochs: 20
+  max_epochs: 100

--- a/conf/ssl4eo_benchmark_oli_tirs_toa_nlcd.yaml
+++ b/conf/ssl4eo_benchmark_oli_tirs_toa_nlcd.yaml
@@ -1,0 +1,26 @@
+module:
+  _target_: torchgeo.trainers.SemanticSegmentationTask
+  model: "unet"
+  backbone: "resnet18"
+  weights: null
+  in_channels: 11
+  num_classes: 14
+  loss: "ce"
+  class_weights: [0, 0.00640476, 0.11232852, 0.12934777, 0.05883383, 0.10792264, 0.00483846, 0.05689931, 0.0196849, 0.04278681, 0.05963887, 0.08670033, 0.1356737, 0.17894011]
+  ignore_index: 0
+  learning_rate: 1e-3
+  learning_rate_schedule_patience: 6
+
+datamodule:
+  _target_: torchgeo.datamodules.SSL4EOLBenchmarkDataModule
+  root: "data/ssl4eo_benchmark"
+  sensor: "oli_tirs_toa"
+  product: "nlcd"
+  classes: [0, 11, 21, 22, 31, 41, 42, 43, 52, 71, 81, 82, 90, 95]
+  batch_size: 64
+  num_workers: 16
+
+trainer:
+  _target_: lightning.pytorch.Trainer
+  min_epochs: 20
+  max_epochs: 100

--- a/conf/ssl4eo_benchmark_tm_toa_cdl.yaml
+++ b/conf/ssl4eo_benchmark_tm_toa_cdl.yaml
@@ -1,0 +1,26 @@
+module:
+  _target_: torchgeo.trainers.SemanticSegmentationTask
+  model: "unet"
+  backbone: "resnet18"
+  weights: null
+  in_channels: 7
+  num_classes: 17
+  loss: "ce"
+  class_weights: [0, 0.02998364, 0.03868365, 0.07884247, 0.11655159, 0.10411567, 0.08276836, 0.04239249, 0.09606748, 0.13189518, 0.01140147, 0.01095707, 0.09087003, 0.00635215, 0.00702828, 0.03600399, 0.11608647]
+  ignore_index: 0
+  learning_rate: 1e-3
+  learning_rate_schedule_patience: 6
+
+datamodule:
+  _target_: torchgeo.datamodules.SSL4EOLBenchmarkDataModule
+  root: "data/ssl4eo_benchmark"
+  sensor: "tm_toa"
+  product: "cdl"
+  classes: [0, 1, 5, 24, 37, 61, 111, 121, 122, 131, 141, 142, 143, 152, 176, 190, 195]
+  batch_size: 64
+  num_workers: 16
+
+trainer:
+  _target_: lightning.pytorch.Trainer
+  min_epochs: 20
+  max_epochs: 100

--- a/conf/ssl4eo_benchmark_tm_toa_nlcd.yaml
+++ b/conf/ssl4eo_benchmark_tm_toa_nlcd.yaml
@@ -1,0 +1,26 @@
+module:
+  _target_: torchgeo.trainers.SemanticSegmentationTask
+  model: "unet"
+  backbone: "resnet18"
+  weights: null
+  in_channels: 7
+  num_classes: 13
+  loss: "ce"
+  class_weights: [0, 0.06580504, 0.12853303, 0.20803019, 0.03772181, 0.03033833, 0.10384083, 0.01620425, 0.02508288, 0.05459147, 0.02185647, 0.07901643, 0.22897927]
+  ignore_index: 0
+  learning_rate: 1e-3
+  learning_rate_schedule_patience: 6
+
+datamodule:
+  _target_: torchgeo.datamodules.SSL4EOLBenchmarkDataModule
+  root: "data/ssl4eo_benchmark"
+  sensor: "tm_toa"
+  product: "nlcd"
+  classes: [0, 11, 21, 22, 41, 42, 43, 52, 71, 81, 82, 90, 95]
+  batch_size: 64
+  num_workers: 16
+
+trainer:
+  _target_: lightning.pytorch.Trainer
+  min_epochs: 20
+  max_epochs: 100


### PR DESCRIPTION
@yichiac @shradhasehgal I believe these are the config files we want. I changed several things from #1343 and #1346:

- [x] Add `class_weights` based on #1389 
- [x] Change patch size to 224 (I think this is actually required for U-Net)
- [x] Fix `in_channels` for `L8Biome` (I don't see how this ever worked)
- [x] Removed device stuff (it will be chosen automatically in Lightning 2.0)

The `run_*_experiments.py` files are basically identical for all datasets so I didn't bother including those. Honestly, we should consider removing those and making one script to rule them all.