### PR TITLE
SSL4EO-L Benchmark ETM+: copy nodata pixels from img to mask

### DIFF
--- a/experiments/ssl4eo/chip_landsat_downstream.py
+++ b/experiments/ssl4eo/chip_landsat_downstream.py
@@ -17,7 +17,7 @@ from tqdm import tqdm
 
 def retrieve_mask_chip(
     img_src: DatasetReader, mask_src: DatasetReader
-) -> "np.typing.NDArray[np.float_]":
+) -> "np.typing.NDArray[np.uint8]":
     """Retrieve the mask for a given landsat image.
 
     Args:
@@ -32,12 +32,16 @@ def retrieve_mask_chip(
     out_width = round((query.right - query.left) / img_src.res[0])
     out_height = round((query.top - query.bottom) / img_src.res[1])
     out_shape = (1, out_height, out_width)
-    mask_chip: "np.typing.NDArray[np.float_]" = mask_src.read(
+    mask_chip: "np.typing.NDArray[np.uint8]" = mask_src.read(
         out_shape=out_shape,
-        window=from_bounds(
-            query.left, query.bottom, query.right, query.top, mask_src.transform
-        ),
+        window=from_bounds(*query, mask_src.transform),
     )
+
+    # Copy nodata pixels from image to mask (Landsat 7 ETM+ SLC-off only)
+    if "LE07" in img_src.files[0]:
+        img_chip = img_src.read(1)
+        mask_chip[0][img_chip == 0] = 0
+
     return mask_chip
 
 
@@ -75,8 +79,7 @@ if __name__ == "__main__":
             mask = retrieve_mask_chip(img_src, mask_src)
 
             # directory structure mask <7-digit id>/<scene_id>/<cdl>_<year>.tif
-            digit_id = img_path.split(os.sep)[-3]
-            scene_id = img_path.split(os.sep)[-2]
+            digit_id, scene_id = img_path.split(os.sep)[-3:-1]
             year = scene_id.split("_")[-1][:4]
             mask_dir = os.path.join(args.save_dir, digit_id, scene_id)
             os.makedirs(mask_dir, exist_ok=True)

--- a/experiments/ssl4eo/chip_landsat_downstream.py
+++ b/experiments/ssl4eo/chip_landsat_downstream.py
@@ -28,12 +28,9 @@ def retrieve_mask_chip(
     Returns:
         mask array
     """
-    query = img_src.bounds
-    out_width = round((query.right - query.left) / img_src.res[0])
-    out_height = round((query.top - query.bottom) / img_src.res[1])
-    out_shape = (1, out_height, out_width)
+    out_shape = (1, *img_src.shape)
     mask_chip: "np.typing.NDArray[np.uint8]" = mask_src.read(
-        out_shape=out_shape, window=from_bounds(*query, mask_src.transform)
+        out_shape=out_shape, window=from_bounds(*img_src.bounds, mask_src.transform)
     )
 
     # Copy nodata pixels from image to mask (Landsat 7 ETM+ SLC-off only)

--- a/experiments/ssl4eo/chip_landsat_downstream.py
+++ b/experiments/ssl4eo/chip_landsat_downstream.py
@@ -33,8 +33,7 @@ def retrieve_mask_chip(
     out_height = round((query.top - query.bottom) / img_src.res[1])
     out_shape = (1, out_height, out_width)
     mask_chip: "np.typing.NDArray[np.uint8]" = mask_src.read(
-        out_shape=out_shape,
-        window=from_bounds(*query, mask_src.transform),
+        out_shape=out_shape, window=from_bounds(*query, mask_src.transform)
     )
 
     # Copy nodata pixels from image to mask (Landsat 7 ETM+ SLC-off only)

--- a/torchgeo/datasets/ssl4eo_benchmark.py
+++ b/torchgeo/datasets/ssl4eo_benchmark.py
@@ -70,8 +70,8 @@ class SSL4EOLBenchmark(NonGeoDataset):
             "nlcd": "261149d7614fcfdcb3be368eefa825c7",
         },
         "etm": {
-            "cdl": "dd2560b18b89dfe7f0e867fcf7217bd0",
-            "nlcd": "916f4a433df6c8abca15b45b60d005d3",
+            "cdl": "008098c968544049eaf7b307e14241de",
+            "nlcd": "9c031049d665202ba42ac1d89b687999",
         },
         "oli": {
             "cdl": "1cb057de6eafeca975deb35cb9fb036f",


### PR DESCRIPTION
We were using the mask from NLCD/CDL but not copying the nodata pixels from the Landsat 7 ETM+ SLC-off image. Therefore, the model was being penalized for not correctly predicting classes where it didn't even have imagery to use.

Example:

![cdl_nodata](https://github.com/microsoft/torchgeo/assets/12021217/03d38513-223f-478b-aff0-654dc1f726f8)
![nlcd_nodata](https://github.com/microsoft/torchgeo/assets/12021217/928b37f6-9b86-4b6b-8b48-46eda6416b1f)
