### PR TITLE
fix: Support tensors and arrays for class_weight

### DIFF
--- a/tests/trainers/test_segmentation.py
+++ b/tests/trainers/test_segmentation.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 from typing import Any, cast
 
+import numpy as np
 import pytest
 import segmentation_models_pytorch as smp
 import timm
@@ -262,3 +263,23 @@ class TestSemanticSegmentationTask:
                 for param in model.model.segmentation_head.parameters()
             ]
         )
+
+    @pytest.mark.parametrize(
+        "class_weights", [torch.tensor([1, 2, 3]), np.array([1, 2, 3]), [1, 2, 3]]
+    )
+    def test_classweights_valid(
+        self, class_weights: Any, model_kwargs: dict[Any, Any]
+    ) -> None:
+        model_kwargs["class_weights"] = class_weights
+        sst = SemanticSegmentationTask(**model_kwargs)
+        assert isinstance(sst.loss.weight, torch.Tensor)
+        assert torch.equal(sst.loss.weight, torch.tensor([1.0, 2.0, 3.0]))
+        assert sst.loss.weight.dtype == torch.float32
+
+    @pytest.mark.parametrize("class_weights", [[], None])
+    def test_classweights_empty(
+        self, class_weights: Any, model_kwargs: dict[Any, Any]
+    ) -> None:
+        model_kwargs["class_weights"] = class_weights
+        sst = SemanticSegmentationTask(**model_kwargs)
+        assert sst.loss.weight is None

--- a/torchgeo/trainers/segmentation.py
+++ b/torchgeo/trainers/segmentation.py
@@ -65,9 +65,12 @@ class SemanticSegmentationTask(LightningModule):
         if self.hyperparams["loss"] == "ce":
             ignore_value = -1000 if self.ignore_index is None else self.ignore_index
 
-            class_weights = (
-                torch.FloatTensor(self.class_weights) if self.class_weights else None
-            )
+            class_weights = None
+            if isinstance(self.class_weights, torch.Tensor):
+                class_weights = self.class_weights.to(dtype=torch.float32)
+            elif hasattr(self.class_weights, "__array__") or self.class_weights:
+                class_weights = torch.tensor(self.class_weights, dtype=torch.float32)
+
             self.loss = nn.CrossEntropyLoss(
                 ignore_index=ignore_value, weight=class_weights
             )


### PR DESCRIPTION
Avoids ambiguous truth value `ValueError` when the class_weight input parameter is either a PyTorch tensor or a NumPy array.

Repro follows—also fails with `np.array` instead `torch.tensor`, succeeds with Python sequence.

```
import torch
from torchgeo.trainers.segmentation import SemanticSegmentationTask

SemanticSegmentationTask(
    model='unet',
    backbone='resnet101',
    loss='ce',
    learning_rate=0.01,
    weights=None,
    class_weights=torch.tensor([0.25, 0.5, 0.25]),
    in_channels=1,
    num_classes=3,
    ignore_index=None
)
```

Expected:

```
<prints PyTorch model>
```

Actual:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<path>/torchgeo/torchgeo/trainers/segmentation.py", line 171, in __init__
    self.config_task()
  File "<path>/torchgeo/torchgeo/trainers/segmentation.py", line 69, in config_task
    torch.FloatTensor(self.class_weights) if self.class_weights else None
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```