### PR TITLE
More robust GitHub Actions concurrency

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,5 +77,5 @@ jobs:
     - name: Run notebook checks
       run: pytest --nbmake --durations=10 --reruns=10 docs/tutorials
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -125,5 +125,5 @@ jobs:
     - name: Run pyupgrade checks
       run: pyupgrade --py39-plus $(find . -path ./docs/src -prune -o -name "*.py" -print)
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -115,5 +115,5 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/tutorials.yaml
+++ b/.github/workflows/tutorials.yaml
@@ -35,5 +35,5 @@ jobs:
     - name: Run notebook checks
       run: pytest --nbmake --durations=10 --reruns=10 docs/tutorials
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
### Rationale

GitHub Actions has a feature called concurrency that allows you to kill any remaining tests that are still running if a newer commit has been pushed. This helps reduce CPU cycles by only running tests on the latest commit.

Unfortunately there's a bug in our current concurrency group. We've seen several instances where PRs opened simultaneously will kill each others' tests, resulting in no PRs completing CI. This happens most often with auto-generated dependabot PRs which all open at the same time of day.

The issue appears to be with our `github.ref` property. According to [the docs](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context) (emphasis mine):

> `github.ref`: For workflows triggered by `push`, this is the branch or tag ref that was pushed. For workflows triggered by `pull_request`, **this is the pull request merge branch**.

The `push` behavior is correct, we want commits pushed to the same branch to kill previous jobs. The `pull_request` behavior is incorrect, this will almost always be `main` for all PRs.

### Implementation

The implementation proposed in this PR relies on fallback. We add one additional property to check:

> `github.head_ref`: The `head_ref` or source branch of the pull request in a workflow run. This property is only available when the event that triggers a workflow run is either `pull_request` or `pull_request_target`.

If I'm understanding the docs correctly, `head_ref` is the PR branch, while `base_ref` is the target branch. So the new concurrency group looks like:

```
 ${{ github.workflow }}-${{ github.head_ref || github.ref }}
```

The `github.workflow` property is needed to avoid one workflow (e.g., `tests / pytest (ubuntu-latest, 3.11) (push)`) killing another workflow (e.g., `tests / pytest (macos-latest, 3.9) (push)`) on the same commit. The `github.head_ref` property gives us the branch that the PR was submitted from. If this is a `push` event and not a `pull_request` event, we fall back on `github.ref`, which is the branch that was pushed. Actions are only triggered on `push` and `pull_request` events, so we don't need to worry about situations where neither property is defined.

The only other situation I can think of that would cause this concurrency group to fail is if multiple people submitted PRs with the same branch name. We'll see if `github.head_ref` or `github.ref` include the repo in addition to the branch. It's also possible that I completely misinterpreted the docs and this won't work. I don't know of an easy way to test this without first merging it.

### Documentation

* https://docs.github.com/en/actions/learn-github-actions/contexts
* https://docs.github.com/en/actions/using-jobs/using-concurrency

Closes #1412