### PR TITLE
DataModules: improve error messages

### DIFF
--- a/torchgeo/datamodules/geo.py
+++ b/torchgeo/datamodules/geo.py
@@ -267,6 +267,7 @@ class GeoDataModule(BaseDataModule):
         batch_size = self._valid_attribute(f"{split}_batch_size", "batch_size")
 
         if isinstance(sampler, BatchGeoSampler):
+            batch_size = 1
             batch_sampler = sampler
             sampler = None
         else:

--- a/torchgeo/datamodules/geo.py
+++ b/torchgeo/datamodules/geo.py
@@ -267,7 +267,7 @@ class GeoDataModule(BaseDataModule):
         if isinstance(sampler, BatchGeoSampler):
             kwargs = {"batch_size": 1, "batch_sampler": sampler}
         else:
-            batch_size = getattr(self, f"{split}_batch_size", self.batch_size)
+            batch_size = self._valid_attribute(f"{split}_batch_size", "batch_size")
             kwargs = {"batch_size": batch_size, "sampler": sampler}
 
         return DataLoader(
@@ -408,7 +408,7 @@ class NonGeoDataModule(BaseDataModule):
                 dataset or sampler, or if the dataset or sampler has length 0.
         """
         dataset = self._valid_attribute(f"{split}_dataset", "dataset")
-        batch_size = getattr(self, f"{split}_batch_size", self.batch_size)
+        batch_size = self._valid_attribute(f"{split}_batch_size", "batch_size")
         return DataLoader(
             dataset,
             batch_size=batch_size,

--- a/torchgeo/datamodules/geo.py
+++ b/torchgeo/datamodules/geo.py
@@ -106,11 +106,12 @@ class BaseDataModule(LightningDataModule):
                 continue
 
             if not obj:
-                raise MisconfigurationException(f"'{arg}' has length 0")
+                msg = f"{self.__class__.__name__}.{arg} has length 0."
+                raise MisconfigurationException(msg)
 
             return obj
 
-        msg = f"{self.__class__.__name__}.setup must define one of {args}"
+        msg = f"{self.__class__.__name__}.setup must define one of {args}."
         raise MisconfigurationException(msg)
 
     def on_after_batch_transfer(

--- a/torchgeo/datamodules/geo.py
+++ b/torchgeo/datamodules/geo.py
@@ -263,15 +263,21 @@ class GeoDataModule(BaseDataModule):
         sampler = self._valid_attribute(
             f"{split}_batch_sampler", f"{split}_sampler", "batch_sampler", "sampler"
         )
+        batch_size = self._valid_attribute(f"{split}_batch_size", "batch_size")
 
         if isinstance(sampler, BatchGeoSampler):
-            kwargs = {"batch_size": 1, "batch_sampler": sampler}
+            batch_sampler = sampler
+            sampler = None
         else:
-            batch_size = self._valid_attribute(f"{split}_batch_size", "batch_size")
-            kwargs = {"batch_size": batch_size, "sampler": sampler}
+            batch_sampler = None
 
         return DataLoader(
-            dataset, num_workers=self.num_workers, collate_fn=self.collate_fn, **kwargs
+            dataset=dataset,
+            batch_size=batch_size,
+            sampler=sampler,
+            batch_sampler=batch_sampler,
+            num_workers=self.num_workers,
+            collate_fn=self.collate_fn,
         )
 
     def train_dataloader(self) -> DataLoader[dict[str, Tensor]]:
@@ -410,7 +416,7 @@ class NonGeoDataModule(BaseDataModule):
         dataset = self._valid_attribute(f"{split}_dataset", "dataset")
         batch_size = self._valid_attribute(f"{split}_batch_size", "batch_size")
         return DataLoader(
-            dataset,
+            dataset=dataset,
             batch_size=batch_size,
             shuffle=split == "train",
             num_workers=self.num_workers,

--- a/torchgeo/datamodules/geo.py
+++ b/torchgeo/datamodules/geo.py
@@ -131,6 +131,32 @@ class BaseDataModule(LightningDataModule):
             if hasattr(dataset, "plot"):
                 return dataset.plot(*args, **kwargs)
 
+    def _valid_attribute(self, *args: str) -> Any:
+        """Find a valid attribute with length > 0.
+
+        Args:
+            args: One or more names of attributes to check.
+
+        Returns:
+            The first valid attribute found.
+
+        Raises:
+            MisconfigurationException: If no attribute is defined, or has length 0.
+        """
+        for arg in args:
+            obj = getattr(self, arg)
+
+            if obj is None:
+                continue
+
+            if not obj:
+                raise MisconfigurationException(f"'{arg}' has length 0")
+
+            return obj
+
+        msg = f"{self.__class__.__name__} must define one of {args}"
+        raise MisconfigurationException(msg)
+
 
 class GeoDataModule(BaseDataModule):
     """Base class for data modules containing geospatial information.
@@ -220,6 +246,34 @@ class GeoDataModule(BaseDataModule):
                 self.test_dataset, self.patch_size, self.patch_size
             )
 
+    def _dataloader_factory(self, split: str) -> DataLoader[dict[str, Tensor]]:
+        """Implement one or more PyTorch DataLoaders.
+
+        Args:
+            split: Either 'train', 'val', 'test', or 'predict'.
+
+        Returns:
+            A collection of data loaders specifying samples.
+
+        Raises:
+            MisconfigurationException: If :meth:`setup` does not define a
+                dataset or sampler, or if the dataset or sampler has length 0.
+        """
+        dataset = self._valid_attribute(f"{split}_dataset", "dataset")
+        sampler = self._valid_attribute(
+            f"{split}_batch_sampler", f"{split}_sampler", "batch_sampler", "sampler"
+        )
+
+        if isinstance(sampler, BatchGeoSampler):
+            kwargs = {"batch_size": 1, "batch_sampler": sampler}
+        else:
+            batch_size = getattr(self, f"{split}_batch_size", self.batch_size)
+            kwargs = {"batch_size": batch_size, "sampler": sampler}
+
+        return DataLoader(
+            dataset, num_workers=self.num_workers, collate_fn=self.collate_fn, **kwargs
+        )
+
     def train_dataloader(self) -> DataLoader[dict[str, Tensor]]:
         """Implement one or more PyTorch DataLoaders for training.
 
@@ -228,27 +282,9 @@ class GeoDataModule(BaseDataModule):
 
         Raises:
             MisconfigurationException: If :meth:`setup` does not define a
-                'train_dataset'.
+                dataset or sampler, or if the dataset or sampler has length 0.
         """
-        dataset = self.train_dataset or self.dataset
-        sampler = self.train_sampler or self.sampler
-        batch_sampler = self.train_batch_sampler or self.batch_sampler
-        if dataset is not None and (sampler or batch_sampler) is not None:
-            batch_size = self.train_batch_size or self.batch_size
-            if batch_sampler is not None:
-                batch_size = 1
-                sampler = None
-            return DataLoader(
-                dataset=dataset,
-                batch_size=batch_size,
-                sampler=sampler,
-                batch_sampler=batch_sampler,
-                num_workers=self.num_workers,
-                collate_fn=self.collate_fn,
-            )
-        else:
-            msg = f"{self.__class__.__name__}.setup does not define a 'train_dataset'"
-            raise MisconfigurationException(msg)
+        return self._dataloader_factory("train")
 
     def val_dataloader(self) -> DataLoader[dict[str, Tensor]]:
         """Implement one or more PyTorch DataLoaders for validation.
@@ -258,27 +294,9 @@ class GeoDataModule(BaseDataModule):
 
         Raises:
             MisconfigurationException: If :meth:`setup` does not define a
-                'val_dataset'.
+                dataset or sampler, or if the dataset or sampler has length 0.
         """
-        dataset = self.val_dataset or self.dataset
-        sampler = self.val_sampler or self.sampler
-        batch_sampler = self.val_batch_sampler or self.batch_sampler
-        if dataset is not None and (sampler or batch_sampler) is not None:
-            batch_size = self.val_batch_size or self.batch_size
-            if batch_sampler is not None:
-                batch_size = 1
-                sampler = None
-            return DataLoader(
-                dataset=dataset,
-                batch_size=batch_size,
-                sampler=sampler,
-                batch_sampler=batch_sampler,
-                num_workers=self.num_workers,
-                collate_fn=self.collate_fn,
-            )
-        else:
-            msg = f"{self.__class__.__name__}.setup does not define a 'val_dataset'"
-            raise MisconfigurationException(msg)
+        return self._dataloader_factory("val")
 
     def test_dataloader(self) -> DataLoader[dict[str, Tensor]]:
         """Implement one or more PyTorch DataLoaders for testing.
@@ -288,27 +306,9 @@ class GeoDataModule(BaseDataModule):
 
         Raises:
             MisconfigurationException: If :meth:`setup` does not define a
-                'test_dataset'.
+                dataset or sampler, or if the dataset or sampler has length 0.
         """
-        dataset = self.test_dataset or self.dataset
-        sampler = self.test_sampler or self.sampler
-        batch_sampler = self.test_batch_sampler or self.batch_sampler
-        if dataset is not None and (sampler or batch_sampler) is not None:
-            batch_size = self.test_batch_size or self.batch_size
-            if batch_sampler is not None:
-                batch_size = 1
-                sampler = None
-            return DataLoader(
-                dataset=dataset,
-                batch_size=batch_size,
-                sampler=sampler,
-                batch_sampler=batch_sampler,
-                num_workers=self.num_workers,
-                collate_fn=self.collate_fn,
-            )
-        else:
-            msg = f"{self.__class__.__name__}.setup does not define a 'test_dataset'"
-            raise MisconfigurationException(msg)
+        return self._dataloader_factory("test")
 
     def predict_dataloader(self) -> DataLoader[dict[str, Tensor]]:
         """Implement one or more PyTorch DataLoaders for prediction.
@@ -318,27 +318,9 @@ class GeoDataModule(BaseDataModule):
 
         Raises:
             MisconfigurationException: If :meth:`setup` does not define a
-                'predict_dataset'.
+                dataset or sampler, or if the dataset or sampler has length 0.
         """
-        dataset = self.predict_dataset or self.dataset
-        sampler = self.predict_sampler or self.sampler
-        batch_sampler = self.predict_batch_sampler or self.batch_sampler
-        if dataset is not None and (sampler or batch_sampler) is not None:
-            batch_size = self.predict_batch_size or self.batch_size
-            if batch_sampler is not None:
-                batch_size = 1
-                sampler = None
-            return DataLoader(
-                dataset=dataset,
-                batch_size=batch_size,
-                sampler=sampler,
-                batch_sampler=batch_sampler,
-                num_workers=self.num_workers,
-                collate_fn=self.collate_fn,
-            )
-        else:
-            msg = f"{self.__class__.__name__}.setup does not define a 'predict_dataset'"
-            raise MisconfigurationException(msg)
+        return self._dataloader_factory("predict")
 
     def transfer_batch_to_device(
         self, batch: dict[str, Tensor], device: torch.device, dataloader_idx: int
@@ -412,6 +394,29 @@ class NonGeoDataModule(BaseDataModule):
                 split="test", **self.kwargs
             )
 
+    def _dataloader_factory(self, split: str) -> DataLoader[dict[str, Tensor]]:
+        """Implement one or more PyTorch DataLoaders.
+
+        Args:
+            split: Either 'train', 'val', 'test', or 'predict'.
+
+        Returns:
+            A collection of data loaders specifying samples.
+
+        Raises:
+            MisconfigurationException: If :meth:`setup` does not define a
+                dataset or sampler, or if the dataset or sampler has length 0.
+        """
+        dataset = self._valid_attribute(f"{split}_dataset", "dataset")
+        batch_size = getattr(self, f"{split}_batch_size", self.batch_size)
+        return DataLoader(
+            dataset,
+            batch_size=batch_size,
+            shuffle=split == "train",
+            num_workers=self.num_workers,
+            collate_fn=self.collate_fn,
+        )
+
     def train_dataloader(self) -> DataLoader[dict[str, Tensor]]:
         """Implement one or more PyTorch DataLoaders for training.
 
@@ -420,20 +425,9 @@ class NonGeoDataModule(BaseDataModule):
 
         Raises:
             MisconfigurationException: If :meth:`setup` does not define a
-                'train_dataset'.
+                dataset, or if the dataset has length 0.
         """
-        dataset = self.train_dataset or self.dataset
-        if dataset is not None:
-            return DataLoader(
-                dataset=dataset,
-                batch_size=self.train_batch_size or self.batch_size,
-                shuffle=True,
-                num_workers=self.num_workers,
-                collate_fn=self.collate_fn,
-            )
-        else:
-            msg = f"{self.__class__.__name__}.setup does not define a 'train_dataset'"
-            raise MisconfigurationException(msg)
+        return self._dataloader_factory("train")
 
     def val_dataloader(self) -> DataLoader[dict[str, Tensor]]:
         """Implement one or more PyTorch DataLoaders for validation.
@@ -443,20 +437,9 @@ class NonGeoDataModule(BaseDataModule):
 
         Raises:
             MisconfigurationException: If :meth:`setup` does not define a
-                'val_dataset'.
+                dataset, or if the dataset has length 0.
         """
-        dataset = self.val_dataset or self.dataset
-        if dataset is not None:
-            return DataLoader(
-                dataset=dataset,
-                batch_size=self.val_batch_size or self.batch_size,
-                shuffle=False,
-                num_workers=self.num_workers,
-                collate_fn=self.collate_fn,
-            )
-        else:
-            msg = f"{self.__class__.__name__}.setup does not define a 'val_dataset'"
-            raise MisconfigurationException(msg)
+        return self._dataloader_factory("val")
 
     def test_dataloader(self) -> DataLoader[dict[str, Tensor]]:
         """Implement one or more PyTorch DataLoaders for testing.
@@ -466,20 +449,9 @@ class NonGeoDataModule(BaseDataModule):
 
         Raises:
             MisconfigurationException: If :meth:`setup` does not define a
-                'test_dataset'.
+                dataset, or if the dataset has length 0.
         """
-        dataset = self.test_dataset or self.dataset
-        if dataset is not None:
-            return DataLoader(
-                dataset=dataset,
-                batch_size=self.test_batch_size or self.batch_size,
-                shuffle=False,
-                num_workers=self.num_workers,
-                collate_fn=self.collate_fn,
-            )
-        else:
-            msg = f"{self.__class__.__name__}.setup does not define a 'test_dataset'"
-            raise MisconfigurationException(msg)
+        return self._dataloader_factory("test")
 
     def predict_dataloader(self) -> DataLoader[dict[str, Tensor]]:
         """Implement one or more PyTorch DataLoaders for prediction.
@@ -489,17 +461,6 @@ class NonGeoDataModule(BaseDataModule):
 
         Raises:
             MisconfigurationException: If :meth:`setup` does not define a
-                'predict_dataset'.
+                dataset, or if the dataset has length 0.
         """
-        dataset = self.predict_dataset or self.dataset
-        if dataset is not None:
-            return DataLoader(
-                dataset=dataset,
-                batch_size=self.predict_batch_size or self.batch_size,
-                shuffle=False,
-                num_workers=self.num_workers,
-                collate_fn=self.collate_fn,
-            )
-        else:
-            msg = f"{self.__class__.__name__}.setup does not define a 'predict_dataset'"
-            raise MisconfigurationException(msg)
+        return self._dataloader_factory("predict")


### PR DESCRIPTION
Closes #1307 

This implementation defines two new helper functions:

* `_valid_attribute`: checks if at least one of the datasets or samplers has length > 0
* `_dataloader_factory`: defines a `*_dataloader` depending on the split

The former handles all error messages and provides more specific and helpful error messages. Another bonus is that we avoid the majority of code duplication in these base classes, chopping off 30+ lines of code.

@yichiac I know you've run into this error message too many times, hopefully this will help with debugging.