### PR TITLE
Optional arguments to override RasterDataset's filenames

### DIFF
--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -53,8 +53,10 @@ class CustomSentinelDataset(Sentinel2):
     all_bands: list[str] = []
     separate_files = False
 
+
 class CustomRasterDataset(RasterDataset):
     filename_glob = "*missing"
+
 
 class CustomNonGeoDataset(NonGeoDataset):
     def __getitem__(self, index: int) -> dict[str, int]:
@@ -228,11 +230,13 @@ class TestRasterDataset:
             CustomSentinelDataset(root, bands=bands, transforms=transforms, cache=cache)
 
     def test_filename_args(self) -> None:
-        root  = os.path.join("tests", "data", "raster", "res_2_epsg_4087")
+        root = os.path.join("tests", "data", "raster", "res_2_epsg_4087")
         msg = "No CustomRasterDataset data was found"
         with pytest.raises(FileNotFoundError, match=msg):
             CustomRasterDataset(root)
-        assert isinstance(CustomRasterDataset(root, filename_glob="*.tif"), RasterDataset)
+        assert isinstance(
+            CustomRasterDataset(root, filename_glob="*.tif"), RasterDataset
+        )
 
 
 class TestVectorDataset:

--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -231,8 +231,9 @@ class TestRasterDataset:
 
     def test_filename_args(self) -> None:
         root = os.path.join("tests", "data", "raster", "res_2_epsg_4087")
-        msg = "No CustomRasterDataset data was found"
-        with pytest.raises(FileNotFoundError, match=msg):
+        with pytest.raises(
+            FileNotFoundError, match="No CustomRasterDataset data was found"
+        ):
             CustomRasterDataset(root)
         assert isinstance(
             CustomRasterDataset(root, filename_glob="*.tif"), RasterDataset

--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -53,6 +53,8 @@ class CustomSentinelDataset(Sentinel2):
     all_bands: list[str] = []
     separate_files = False
 
+class CustomRasterDataset(RasterDataset):
+    filename_glob = "*missing"
 
 class CustomNonGeoDataset(NonGeoDataset):
     def __getitem__(self, index: int) -> dict[str, int]:
@@ -224,6 +226,13 @@ class TestRasterDataset:
 
         with pytest.raises(AssertionError, match=msg):
             CustomSentinelDataset(root, bands=bands, transforms=transforms, cache=cache)
+
+    def test_filename_args(self) -> None:
+        root  = os.path.join("tests", "data", "raster", "res_2_epsg_4087")
+        msg = "No CustomRasterDataset data was found"
+        with pytest.raises(FileNotFoundError, match=msg):
+            CustomRasterDataset(root)
+        assert isinstance(CustomRasterDataset(root, filename_glob="*.tif"), RasterDataset)
 
 
 class TestVectorDataset:

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -335,6 +335,8 @@ class RasterDataset(GeoDataset):
         bands: Optional[Sequence[str]] = None,
         transforms: Optional[Callable[[dict[str, Any]], dict[str, Any]]] = None,
         cache: bool = True,
+        filename_glob: Optional[str] = None,
+        filename_regex: Optional[str] = None,
     ) -> None:
         """Initialize a new Dataset instance.
 
@@ -357,6 +359,8 @@ class RasterDataset(GeoDataset):
         self.root = root
         self.bands = bands or self.all_bands
         self.cache = cache
+        self.filename_glob = filename_glob or self.filename_glob
+        self.filename_regex = filename_regex or self.filename_regex
 
         # Populate the dataset index
         i = 0

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -10,7 +10,7 @@ import os
 import re
 import sys
 from collections.abc import Sequence
-from typing import Any, Callable, Optional, cast
+from typing import Any, Callable, Optional, cast, Union, Pattern
 
 import fiona
 import fiona.transform
@@ -335,8 +335,8 @@ class RasterDataset(GeoDataset):
         bands: Optional[Sequence[str]] = None,
         transforms: Optional[Callable[[dict[str, Any]], dict[str, Any]]] = None,
         cache: bool = True,
-        filename_glob: Optional[str] = None,
-        filename_regex: Optional[str] = None,
+        filename_glob: Optional[Union[str, Pattern[str]]] = None,
+        filename_regex: Optional[Union[str, Pattern[str]]] = None,
     ) -> None:
         """Initialize a new Dataset instance.
 


### PR DESCRIPTION
A project that we are collaborating on has [a scenario here](https://github.com/Pale-Blue-Dot-97/Minerva/blob/d22807917f5db1026a0ad6c9cbc1e7bdc3dcca6c/minerva/datasets.py#L501) where it would be very useful to be able to set the `filename_glob` and `filename_regex` arguments to a `RasterDataset` subclass when it's being initialised, rather than always depend on them being set as class attributes. 

In our scenario we could be creating a `PairedDataset` (a `RasterDataset` subclass) out of many different, user-supplied `RasterDataset` types:
```
return PairedDataset(
                dataset_class,
                root=root,
                transforms=_transformations,
                **subdataset_params["params"],
            )
```

This PR suggests a change to replace the class attributes for `filename_glob` and `filename_regex` with optional arguments, if they're set, plus a small associated test.

