### PR TITLE
Refactor trainers

### DIFF
--- a/conf/bigearthnet.yaml
+++ b/conf/bigearthnet.yaml
@@ -2,8 +2,8 @@ module:
   _target_: torchgeo.trainers.MultiLabelClassificationTask
   loss: "bce"
   model: "resnet18"
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   weights: null
   in_channels: 14
   num_classes: 19

--- a/conf/chesapeake_cvpr.yaml
+++ b/conf/chesapeake_cvpr.yaml
@@ -4,8 +4,8 @@ module:
   model: "unet"
   backbone: "resnet18"
   weights: null
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   in_channels: 4
   num_classes: 7
   num_filters: 256

--- a/conf/cowc_counting.yaml
+++ b/conf/cowc_counting.yaml
@@ -4,8 +4,8 @@ module:
   weights: null
   num_outputs: 1
   in_channels: 3
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 2
+  lr: 1e-3
+  patience: 2
 
 datamodule:
   _target_: torchgeo.datamodules.COWCCountingDataModule

--- a/conf/cyclone.yaml
+++ b/conf/cyclone.yaml
@@ -4,8 +4,8 @@ module:
   weights: null
   num_outputs: 1
   in_channels: 3
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 2
+  lr: 1e-3
+  patience: 2
 
 datamodule:
   _target_: torchgeo.datamodules.TropicalCycloneDataModule

--- a/conf/deepglobelandcover.yaml
+++ b/conf/deepglobelandcover.yaml
@@ -4,8 +4,8 @@ module:
   model: "unet"
   backbone: "resnet18"
   weights: null
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   verbose: false
   in_channels: 3
   num_classes: 7

--- a/conf/deepglobelandcover.yaml
+++ b/conf/deepglobelandcover.yaml
@@ -6,7 +6,6 @@ module:
   weights: null
   lr: 1e-3
   patience: 6
-  verbose: false
   in_channels: 3
   num_classes: 7
   num_filters: 1

--- a/conf/etci2021.yaml
+++ b/conf/etci2021.yaml
@@ -4,8 +4,8 @@ module:
   model: "unet"
   backbone: "resnet18"
   weights: true
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   in_channels: 6
   num_classes: 2
   ignore_index: 0

--- a/conf/eurosat.yaml
+++ b/conf/eurosat.yaml
@@ -2,8 +2,8 @@ module:
   _target_: torchgeo.trainers.ClassificationTask
   loss: "ce"
   model: "resnet18"
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   weights: null
   in_channels: 13
   num_classes: 10

--- a/conf/gid15.yaml
+++ b/conf/gid15.yaml
@@ -6,7 +6,6 @@ module:
   weights: null
   lr: 1e-3
   patience: 6
-  verbose: false
   in_channels: 3
   num_classes: 16
   num_filters: 1

--- a/conf/gid15.yaml
+++ b/conf/gid15.yaml
@@ -4,8 +4,8 @@ module:
   model: "unet"
   backbone: "resnet18"
   weights: null
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   verbose: false
   in_channels: 3
   num_classes: 16

--- a/conf/inria.yaml
+++ b/conf/inria.yaml
@@ -4,8 +4,8 @@ module:
   model: "unet"
   backbone: "resnet18"
   weights: true
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   in_channels: 3
   num_classes: 2
   ignore_index: null

--- a/conf/l7irish.yaml
+++ b/conf/l7irish.yaml
@@ -7,8 +7,8 @@ module:
   num_classes: 5
   loss: "ce"
   ignore_index: 0
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
 
 datamodule:
   _target_: torchgeo.datamodules.L7IrishDataModule

--- a/conf/l8biome.yaml
+++ b/conf/l8biome.yaml
@@ -7,8 +7,8 @@ module:
   num_classes: 5
   loss: "ce"
   ignore_index: 0
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
 
 datamodule:
   _target_: torchgeo.datamodules.L8BiomeDataModule

--- a/conf/landcoverai.yaml
+++ b/conf/landcoverai.yaml
@@ -4,8 +4,8 @@ module:
   model: "unet"
   backbone: "resnet18"
   weights: true
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   in_channels: 3
   num_classes: 5
   num_filters: 256

--- a/conf/naipchesapeake.yaml
+++ b/conf/naipchesapeake.yaml
@@ -4,8 +4,8 @@ module:
   model: "deeplabv3+"
   backbone: "resnet34"
   weights: true
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 2
+  lr: 1e-3
+  patience: 2
   in_channels: 4
   num_classes: 14
   num_filters: 64

--- a/conf/nasa_marine_debris.yaml
+++ b/conf/nasa_marine_debris.yaml
@@ -3,8 +3,8 @@ module:
   model: "faster-rcnn"
   backbone: "resnet50"
   num_classes: 2
-  learning_rate: 1.2e-4
-  learning_rate_schedule_patience: 6
+  lr: 1.2e-4
+  patience: 6
   verbose: false
 
 datamodule:

--- a/conf/nasa_marine_debris.yaml
+++ b/conf/nasa_marine_debris.yaml
@@ -5,7 +5,6 @@ module:
   num_classes: 2
   lr: 1.2e-4
   patience: 6
-  verbose: false
 
 datamodule:
   _target_: torchgeo.datamodules.NASAMarineDebrisDataModule

--- a/conf/potsdam2d.yaml
+++ b/conf/potsdam2d.yaml
@@ -6,7 +6,6 @@ module:
   weights: null
   lr: 1e-3
   patience: 6
-  verbose: false
   in_channels: 4
   num_classes: 6
   num_filters: 1

--- a/conf/potsdam2d.yaml
+++ b/conf/potsdam2d.yaml
@@ -4,8 +4,8 @@ module:
   model: "unet"
   backbone: "resnet18"
   weights: null
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   verbose: false
   in_channels: 4
   num_classes: 6

--- a/conf/resisc45.yaml
+++ b/conf/resisc45.yaml
@@ -2,8 +2,8 @@ module:
   _target_: torchgeo.trainers.ClassificationTask
   loss: "ce"
   model: "resnet18"
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   weights: null
   in_channels: 3
   num_classes: 45

--- a/conf/seco_100k.yaml
+++ b/conf/seco_100k.yaml
@@ -3,8 +3,8 @@ module:
   in_channels: 12
   backbone: "resnet18"
   weights: True
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   optimizer: "Adam"
 
 datamodule:

--- a/conf/sen12ms.yaml
+++ b/conf/sen12ms.yaml
@@ -4,8 +4,8 @@ module:
   model: "unet"
   backbone: "resnet18"
   weights: null
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 2
+  lr: 1e-3
+  patience: 2
   in_channels: 15
   num_classes: 11
   ignore_index: null

--- a/conf/so2sat.yaml
+++ b/conf/so2sat.yaml
@@ -2,8 +2,8 @@ module:
   _target_: torchgeo.trainers.ClassificationTask
   loss: "ce"
   model: "resnet18"
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   weights: null
   in_channels: 18
   num_classes: 17

--- a/conf/spacenet1.yaml
+++ b/conf/spacenet1.yaml
@@ -4,8 +4,8 @@ module:
   model: "unet"
   backbone: "resnet18"
   weights: true
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   in_channels: 3
   num_classes: 3
   ignore_index: 0

--- a/conf/ssl4eo_benchmark_etm_sr_cdl.yaml
+++ b/conf/ssl4eo_benchmark_etm_sr_cdl.yaml
@@ -7,8 +7,8 @@ module:
   num_classes: 18
   loss: "ce"
   ignore_index: 0
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
 
 datamodule:
   _target_: torchgeo.datamodules.SSL4EOLBenchmarkDataModule

--- a/conf/ssl4eo_benchmark_etm_sr_nlcd.yaml
+++ b/conf/ssl4eo_benchmark_etm_sr_nlcd.yaml
@@ -7,8 +7,8 @@ module:
   num_classes: 14
   loss: "ce"
   ignore_index: 0
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
 
 datamodule:
   _target_: torchgeo.datamodules.SSL4EOLBenchmarkDataModule

--- a/conf/ssl4eo_benchmark_etm_toa_cdl.yaml
+++ b/conf/ssl4eo_benchmark_etm_toa_cdl.yaml
@@ -7,8 +7,8 @@ module:
   num_classes: 18
   loss: "ce"
   ignore_index: 0
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
 
 datamodule:
   _target_: torchgeo.datamodules.SSL4EOLBenchmarkDataModule

--- a/conf/ssl4eo_benchmark_etm_toa_nlcd.yaml
+++ b/conf/ssl4eo_benchmark_etm_toa_nlcd.yaml
@@ -7,8 +7,8 @@ module:
   num_classes: 14
   loss: "ce"
   ignore_index: 0
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
 
 datamodule:
   _target_: torchgeo.datamodules.SSL4EOLBenchmarkDataModule

--- a/conf/ssl4eo_benchmark_oli_sr_cdl.yaml
+++ b/conf/ssl4eo_benchmark_oli_sr_cdl.yaml
@@ -7,8 +7,8 @@ module:
   num_classes: 18
   loss: "ce"
   ignore_index: 0
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
 
 datamodule:
   _target_: torchgeo.datamodules.SSL4EOLBenchmarkDataModule

--- a/conf/ssl4eo_benchmark_oli_sr_nlcd.yaml
+++ b/conf/ssl4eo_benchmark_oli_sr_nlcd.yaml
@@ -7,8 +7,8 @@ module:
   num_classes: 14
   loss: "ce"
   ignore_index: 0
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
 
 datamodule:
   _target_: torchgeo.datamodules.SSL4EOLBenchmarkDataModule

--- a/conf/ssl4eo_benchmark_oli_tirs_toa_cdl.yaml
+++ b/conf/ssl4eo_benchmark_oli_tirs_toa_cdl.yaml
@@ -7,8 +7,8 @@ module:
   num_classes: 18
   loss: "ce"
   ignore_index: 0
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
 
 datamodule:
   _target_: torchgeo.datamodules.SSL4EOLBenchmarkDataModule

--- a/conf/ssl4eo_benchmark_oli_tirs_toa_nlcd.yaml
+++ b/conf/ssl4eo_benchmark_oli_tirs_toa_nlcd.yaml
@@ -7,8 +7,8 @@ module:
   num_classes: 14
   loss: "ce"
   ignore_index: 0
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
 
 datamodule:
   _target_: torchgeo.datamodules.SSL4EOLBenchmarkDataModule

--- a/conf/ssl4eo_benchmark_tm_toa_cdl.yaml
+++ b/conf/ssl4eo_benchmark_tm_toa_cdl.yaml
@@ -7,8 +7,8 @@ module:
   num_classes: 18
   loss: "ce"
   ignore_index: 0
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
 
 datamodule:
   _target_: torchgeo.datamodules.SSL4EOLBenchmarkDataModule

--- a/conf/ssl4eo_benchmark_tm_toa_nlcd.yaml
+++ b/conf/ssl4eo_benchmark_tm_toa_nlcd.yaml
@@ -7,8 +7,8 @@ module:
   num_classes: 14
   loss: "ce"
   ignore_index: 0
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
 
 datamodule:
   _target_: torchgeo.datamodules.SSL4EOLBenchmarkDataModule

--- a/conf/ucmerced.yaml
+++ b/conf/ucmerced.yaml
@@ -3,8 +3,8 @@ module:
   loss: "ce"
   model: "resnet18"
   weights: null
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   in_channels: 3
   num_classes: 21
 

--- a/conf/vaihingen2d.yaml
+++ b/conf/vaihingen2d.yaml
@@ -4,8 +4,8 @@ module:
   model: "unet"
   backbone: "resnet18"
   weights: null
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   verbose: false
   in_channels: 3
   num_classes: 7

--- a/conf/vaihingen2d.yaml
+++ b/conf/vaihingen2d.yaml
@@ -6,7 +6,6 @@ module:
   weights: null
   lr: 1e-3
   patience: 6
-  verbose: false
   in_channels: 3
   num_classes: 7
   num_filters: 1

--- a/tests/conf/bigearthnet_all.yaml
+++ b/tests/conf/bigearthnet_all.yaml
@@ -2,9 +2,6 @@ module:
   _target_: torchgeo.trainers.MultiLabelClassificationTask
   loss: "bce"
   model: "resnet18"
-  lr: 1e-3
-  patience: 6
-  weights: null
   in_channels: 14
   num_classes: 19
 

--- a/tests/conf/bigearthnet_all.yaml
+++ b/tests/conf/bigearthnet_all.yaml
@@ -2,8 +2,8 @@ module:
   _target_: torchgeo.trainers.MultiLabelClassificationTask
   loss: "bce"
   model: "resnet18"
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   weights: null
   in_channels: 14
   num_classes: 19

--- a/tests/conf/bigearthnet_s1.yaml
+++ b/tests/conf/bigearthnet_s1.yaml
@@ -2,8 +2,8 @@ module:
   _target_: torchgeo.trainers.MultiLabelClassificationTask
   loss: "bce"
   model: "resnet18"
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   weights: null
   in_channels: 2
   num_classes: 19

--- a/tests/conf/bigearthnet_s1.yaml
+++ b/tests/conf/bigearthnet_s1.yaml
@@ -2,9 +2,6 @@ module:
   _target_: torchgeo.trainers.MultiLabelClassificationTask
   loss: "bce"
   model: "resnet18"
-  lr: 1e-3
-  patience: 6
-  weights: null
   in_channels: 2
   num_classes: 19
 

--- a/tests/conf/bigearthnet_s2.yaml
+++ b/tests/conf/bigearthnet_s2.yaml
@@ -2,8 +2,8 @@ module:
   _target_: torchgeo.trainers.MultiLabelClassificationTask
   loss: "bce"
   model: "resnet18"
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   weights: null
   in_channels: 12
   num_classes: 19

--- a/tests/conf/bigearthnet_s2.yaml
+++ b/tests/conf/bigearthnet_s2.yaml
@@ -2,9 +2,6 @@ module:
   _target_: torchgeo.trainers.MultiLabelClassificationTask
   loss: "bce"
   model: "resnet18"
-  lr: 1e-3
-  patience: 6
-  weights: null
   in_channels: 12
   num_classes: 19
 

--- a/tests/conf/chesapeake_cvpr_5.yaml
+++ b/tests/conf/chesapeake_cvpr_5.yaml
@@ -3,9 +3,6 @@ module:
   loss: "ce"
   model: "unet"
   backbone: "resnet50"
-  weights: null
-  lr: 1e-3
-  patience: 6
   in_channels: 4
   num_classes: 5
   num_filters: 1

--- a/tests/conf/chesapeake_cvpr_5.yaml
+++ b/tests/conf/chesapeake_cvpr_5.yaml
@@ -4,8 +4,8 @@ module:
   model: "unet"
   backbone: "resnet50"
   weights: null
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   in_channels: 4
   num_classes: 5
   num_filters: 1

--- a/tests/conf/chesapeake_cvpr_7.yaml
+++ b/tests/conf/chesapeake_cvpr_7.yaml
@@ -3,8 +3,8 @@ module:
   loss: "ce"
   model: "unet"
   backbone: "resnet18"
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   in_channels: 4
   num_classes: 7
   num_filters: 1

--- a/tests/conf/chesapeake_cvpr_7.yaml
+++ b/tests/conf/chesapeake_cvpr_7.yaml
@@ -3,13 +3,10 @@ module:
   loss: "ce"
   model: "unet"
   backbone: "resnet18"
-  lr: 1e-3
-  patience: 6
   in_channels: 4
   num_classes: 7
   num_filters: 1
   ignore_index: null
-  weights: null
 
 datamodule:
   _target_: torchgeo.datamodules.ChesapeakeCVPRDataModule

--- a/tests/conf/chesapeake_cvpr_prior_byol.yaml
+++ b/tests/conf/chesapeake_cvpr_prior_byol.yaml
@@ -2,9 +2,6 @@ module:
   _target_: torchgeo.trainers.BYOLTask
   in_channels: 4
   model: "resnet18"
-  lr: 1e-3
-  patience: 6
-  weights: null
 
 datamodule:
   _target_: torchgeo.datamodules.ChesapeakeCVPRDataModule

--- a/tests/conf/chesapeake_cvpr_prior_byol.yaml
+++ b/tests/conf/chesapeake_cvpr_prior_byol.yaml
@@ -1,7 +1,7 @@
 module:
   _target_: torchgeo.trainers.BYOLTask
   in_channels: 4
-  backbone: "resnet18"
+  model: "resnet18"
   lr: 1e-3
   patience: 6
   weights: null

--- a/tests/conf/chesapeake_cvpr_prior_byol.yaml
+++ b/tests/conf/chesapeake_cvpr_prior_byol.yaml
@@ -2,8 +2,8 @@ module:
   _target_: torchgeo.trainers.BYOLTask
   in_channels: 4
   backbone: "resnet18"
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   weights: null
 
 datamodule:

--- a/tests/conf/cowc_counting.yaml
+++ b/tests/conf/cowc_counting.yaml
@@ -4,8 +4,8 @@ module:
   weights: null
   num_outputs: 1
   in_channels: 3
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 2
+  lr: 1e-3
+  patience: 2
   loss: "mse"
 
 datamodule:

--- a/tests/conf/cowc_counting.yaml
+++ b/tests/conf/cowc_counting.yaml
@@ -1,11 +1,8 @@
 module:
   _target_: torchgeo.trainers.RegressionTask
   model: resnet18
-  weights: null
   num_outputs: 1
   in_channels: 3
-  lr: 1e-3
-  patience: 2
   loss: "mse"
 
 datamodule:

--- a/tests/conf/cyclone.yaml
+++ b/tests/conf/cyclone.yaml
@@ -1,11 +1,8 @@
 module:
   _target_: torchgeo.trainers.RegressionTask
   model: "resnet18"
-  weights: null
   num_outputs: 1
   in_channels: 3
-  lr: 1e-3
-  patience: 2
   loss: "mse"
 
 datamodule:

--- a/tests/conf/cyclone.yaml
+++ b/tests/conf/cyclone.yaml
@@ -4,8 +4,8 @@ module:
   weights: null
   num_outputs: 1
   in_channels: 3
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 2
+  lr: 1e-3
+  patience: 2
   loss: "mse"
 
 datamodule:

--- a/tests/conf/deepglobelandcover.yaml
+++ b/tests/conf/deepglobelandcover.yaml
@@ -4,8 +4,8 @@ module:
   model: "unet"
   backbone: "resnet18"
   weights: null
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   verbose: false
   in_channels: 3
   num_classes: 7

--- a/tests/conf/deepglobelandcover.yaml
+++ b/tests/conf/deepglobelandcover.yaml
@@ -6,7 +6,6 @@ module:
   weights: null
   lr: 1e-3
   patience: 6
-  verbose: false
   in_channels: 3
   num_classes: 7
   num_filters: 1

--- a/tests/conf/deepglobelandcover.yaml
+++ b/tests/conf/deepglobelandcover.yaml
@@ -3,9 +3,6 @@ module:
   loss: "ce"
   model: "unet"
   backbone: "resnet18"
-  weights: null
-  lr: 1e-3
-  patience: 6
   in_channels: 3
   num_classes: 7
   num_filters: 1

--- a/tests/conf/etci2021.yaml
+++ b/tests/conf/etci2021.yaml
@@ -4,8 +4,8 @@ module:
   model: "unet"
   backbone: "resnet18"
   weights: null
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   in_channels: 6
   num_classes: 2
   ignore_index: 0

--- a/tests/conf/etci2021.yaml
+++ b/tests/conf/etci2021.yaml
@@ -3,9 +3,6 @@ module:
   loss: "ce"
   model: "unet"
   backbone: "resnet18"
-  weights: null
-  lr: 1e-3
-  patience: 6
   in_channels: 6
   num_classes: 2
   ignore_index: 0

--- a/tests/conf/eurosat.yaml
+++ b/tests/conf/eurosat.yaml
@@ -2,8 +2,8 @@ module:
   _target_: torchgeo.trainers.ClassificationTask
   loss: "ce"
   model: "resnet18"
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   weights: null
   in_channels: 13
   num_classes: 2

--- a/tests/conf/eurosat.yaml
+++ b/tests/conf/eurosat.yaml
@@ -2,9 +2,6 @@ module:
   _target_: torchgeo.trainers.ClassificationTask
   loss: "ce"
   model: "resnet18"
-  lr: 1e-3
-  patience: 6
-  weights: null
   in_channels: 13
   num_classes: 2
 

--- a/tests/conf/eurosat100.yaml
+++ b/tests/conf/eurosat100.yaml
@@ -2,8 +2,8 @@ module:
   _target_: torchgeo.trainers.ClassificationTask
   loss: "ce"
   model: "resnet18"
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   weights: null
   in_channels: 13
   num_classes: 2

--- a/tests/conf/eurosat100.yaml
+++ b/tests/conf/eurosat100.yaml
@@ -2,9 +2,6 @@ module:
   _target_: torchgeo.trainers.ClassificationTask
   loss: "ce"
   model: "resnet18"
-  lr: 1e-3
-  patience: 6
-  weights: null
   in_channels: 13
   num_classes: 2
 

--- a/tests/conf/fire_risk.yaml
+++ b/tests/conf/fire_risk.yaml
@@ -3,8 +3,8 @@ module:
   loss: "ce"
   model: "resnet18"
   weights: null
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   in_channels: 3
   num_classes: 5
 

--- a/tests/conf/fire_risk.yaml
+++ b/tests/conf/fire_risk.yaml
@@ -2,9 +2,6 @@ module:
   _target_: torchgeo.trainers.ClassificationTask
   loss: "ce"
   model: "resnet18"
-  weights: null
-  lr: 1e-3
-  patience: 6
   in_channels: 3
   num_classes: 5
 

--- a/tests/conf/gid15.yaml
+++ b/tests/conf/gid15.yaml
@@ -3,9 +3,6 @@ module:
   loss: "ce"
   model: "unet"
   backbone: "resnet18"
-  weights: null
-  lr: 1e-3
-  patience: 6
   in_channels: 3
   num_classes: 16
   num_filters: 1

--- a/tests/conf/gid15.yaml
+++ b/tests/conf/gid15.yaml
@@ -6,7 +6,6 @@ module:
   weights: null
   lr: 1e-3
   patience: 6
-  verbose: false
   in_channels: 3
   num_classes: 16
   num_filters: 1

--- a/tests/conf/gid15.yaml
+++ b/tests/conf/gid15.yaml
@@ -4,8 +4,8 @@ module:
   model: "unet"
   backbone: "resnet18"
   weights: null
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   verbose: false
   in_channels: 3
   num_classes: 16

--- a/tests/conf/inria.yaml
+++ b/tests/conf/inria.yaml
@@ -3,9 +3,6 @@ module:
   loss: "ce"
   model: "unet"
   backbone: "resnet18"
-  weights: null
-  lr: 1e-3
-  patience: 6
   in_channels: 3
   num_classes: 2
   ignore_index: null

--- a/tests/conf/inria.yaml
+++ b/tests/conf/inria.yaml
@@ -4,8 +4,8 @@ module:
   model: "unet"
   backbone: "resnet18"
   weights: null
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   in_channels: 3
   num_classes: 2
   ignore_index: null

--- a/tests/conf/l7irish.yaml
+++ b/tests/conf/l7irish.yaml
@@ -4,8 +4,8 @@ module:
   model: "unet"
   backbone: "resnet18"
   weights: null
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   verbose: false
   in_channels: 9
   num_classes: 5

--- a/tests/conf/l7irish.yaml
+++ b/tests/conf/l7irish.yaml
@@ -6,7 +6,6 @@ module:
   weights: null
   lr: 1e-3
   patience: 6
-  verbose: false
   in_channels: 9
   num_classes: 5
   num_filters: 1

--- a/tests/conf/l7irish.yaml
+++ b/tests/conf/l7irish.yaml
@@ -3,9 +3,6 @@ module:
   loss: "ce"
   model: "unet"
   backbone: "resnet18"
-  weights: null
-  lr: 1e-3
-  patience: 6
   in_channels: 9
   num_classes: 5
   num_filters: 1

--- a/tests/conf/l8biome.yaml
+++ b/tests/conf/l8biome.yaml
@@ -6,7 +6,6 @@ module:
   weights: null
   lr: 1e-3
   patience: 6
-  verbose: false
   in_channels: 11
   num_classes: 5
   num_filters: 1

--- a/tests/conf/l8biome.yaml
+++ b/tests/conf/l8biome.yaml
@@ -3,9 +3,6 @@ module:
   loss: "ce"
   model: "unet"
   backbone: "resnet18"
-  weights: null
-  lr: 1e-3
-  patience: 6
   in_channels: 11
   num_classes: 5
   num_filters: 1

--- a/tests/conf/l8biome.yaml
+++ b/tests/conf/l8biome.yaml
@@ -4,8 +4,8 @@ module:
   model: "unet"
   backbone: "resnet18"
   weights: null
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   verbose: false
   in_channels: 11
   num_classes: 5

--- a/tests/conf/landcoverai.yaml
+++ b/tests/conf/landcoverai.yaml
@@ -6,7 +6,6 @@ module:
   weights: null
   lr: 1e-3
   patience: 6
-  verbose: false
   in_channels: 3
   num_classes: 6
   num_filters: 1

--- a/tests/conf/landcoverai.yaml
+++ b/tests/conf/landcoverai.yaml
@@ -4,8 +4,8 @@ module:
   model: "unet"
   backbone: "resnet18"
   weights: null
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   verbose: false
   in_channels: 3
   num_classes: 6

--- a/tests/conf/landcoverai.yaml
+++ b/tests/conf/landcoverai.yaml
@@ -3,9 +3,6 @@ module:
   loss: "ce"
   model: "unet"
   backbone: "resnet18"
-  weights: null
-  lr: 1e-3
-  patience: 6
   in_channels: 3
   num_classes: 6
   num_filters: 1

--- a/tests/conf/loveda.yaml
+++ b/tests/conf/loveda.yaml
@@ -3,9 +3,6 @@ module:
   loss: "ce"
   model: "unet"
   backbone: "resnet18"
-  weights: null
-  lr: 1e-3
-  patience: 6
   in_channels: 3
   num_classes: 8
   num_filters: 1

--- a/tests/conf/loveda.yaml
+++ b/tests/conf/loveda.yaml
@@ -4,8 +4,8 @@ module:
   model: "unet"
   backbone: "resnet18"
   weights: null
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   verbose: false
   in_channels: 3
   num_classes: 8

--- a/tests/conf/loveda.yaml
+++ b/tests/conf/loveda.yaml
@@ -6,7 +6,6 @@ module:
   weights: null
   lr: 1e-3
   patience: 6
-  verbose: false
   in_channels: 3
   num_classes: 8
   num_filters: 1

--- a/tests/conf/naipchesapeake.yaml
+++ b/tests/conf/naipchesapeake.yaml
@@ -3,9 +3,6 @@ module:
   loss: "ce"
   model: "deeplabv3+"
   backbone: "resnet34"
-  weights: null
-  lr: 1e-3
-  patience: 2
   in_channels: 4
   num_classes: 14
   num_filters: 1

--- a/tests/conf/naipchesapeake.yaml
+++ b/tests/conf/naipchesapeake.yaml
@@ -4,8 +4,8 @@ module:
   model: "deeplabv3+"
   backbone: "resnet34"
   weights: null
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 2
+  lr: 1e-3
+  patience: 2
   in_channels: 4
   num_classes: 14
   num_filters: 1

--- a/tests/conf/nasa_marine_debris.yaml
+++ b/tests/conf/nasa_marine_debris.yaml
@@ -3,8 +3,8 @@ module:
   model: "faster-rcnn"
   backbone: "resnet18"
   num_classes: 2
-  learning_rate: 1.2e-4
-  learning_rate_schedule_patience: 6
+  lr: 1.2e-4
+  patience: 6
   verbose: false
 
 datamodule:

--- a/tests/conf/nasa_marine_debris.yaml
+++ b/tests/conf/nasa_marine_debris.yaml
@@ -3,8 +3,6 @@ module:
   model: "faster-rcnn"
   backbone: "resnet18"
   num_classes: 2
-  lr: 1.2e-4
-  patience: 6
 
 datamodule:
   _target_: torchgeo.datamodules.NASAMarineDebrisDataModule

--- a/tests/conf/nasa_marine_debris.yaml
+++ b/tests/conf/nasa_marine_debris.yaml
@@ -5,7 +5,6 @@ module:
   num_classes: 2
   lr: 1.2e-4
   patience: 6
-  verbose: false
 
 datamodule:
   _target_: torchgeo.datamodules.NASAMarineDebrisDataModule

--- a/tests/conf/potsdam2d.yaml
+++ b/tests/conf/potsdam2d.yaml
@@ -6,7 +6,6 @@ module:
   weights: null
   lr: 1e-3
   patience: 6
-  verbose: false
   in_channels: 4
   num_classes: 6
   num_filters: 1

--- a/tests/conf/potsdam2d.yaml
+++ b/tests/conf/potsdam2d.yaml
@@ -3,9 +3,6 @@ module:
   loss: "ce"
   model: "unet"
   backbone: "resnet18"
-  weights: null
-  lr: 1e-3
-  patience: 6
   in_channels: 4
   num_classes: 6
   num_filters: 1

--- a/tests/conf/potsdam2d.yaml
+++ b/tests/conf/potsdam2d.yaml
@@ -4,8 +4,8 @@ module:
   model: "unet"
   backbone: "resnet18"
   weights: null
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   verbose: false
   in_channels: 4
   num_classes: 6

--- a/tests/conf/resisc45.yaml
+++ b/tests/conf/resisc45.yaml
@@ -2,8 +2,8 @@ module:
   _target_: torchgeo.trainers.ClassificationTask
   loss: "ce"
   model: "resnet18"
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   weights: null
   in_channels: 3
   num_classes: 3

--- a/tests/conf/resisc45.yaml
+++ b/tests/conf/resisc45.yaml
@@ -2,9 +2,6 @@ module:
   _target_: torchgeo.trainers.ClassificationTask
   loss: "ce"
   model: "resnet18"
-  lr: 1e-3
-  patience: 6
-  weights: null
   in_channels: 3
   num_classes: 3
 

--- a/tests/conf/seco_byol_1.yaml
+++ b/tests/conf/seco_byol_1.yaml
@@ -2,8 +2,8 @@ module:
   _target_: torchgeo.trainers.BYOLTask
   in_channels: 3
   backbone: "resnet18"
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   weights: null
 
 datamodule:

--- a/tests/conf/seco_byol_1.yaml
+++ b/tests/conf/seco_byol_1.yaml
@@ -2,9 +2,6 @@ module:
   _target_: torchgeo.trainers.BYOLTask
   in_channels: 3
   model: "resnet18"
-  lr: 1e-3
-  patience: 6
-  weights: null
 
 datamodule:
   _target_: torchgeo.datamodules.SeasonalContrastS2DataModule

--- a/tests/conf/seco_byol_1.yaml
+++ b/tests/conf/seco_byol_1.yaml
@@ -1,7 +1,7 @@
 module:
   _target_: torchgeo.trainers.BYOLTask
   in_channels: 3
-  backbone: "resnet18"
+  model: "resnet18"
   lr: 1e-3
   patience: 6
   weights: null

--- a/tests/conf/seco_byol_2.yaml
+++ b/tests/conf/seco_byol_2.yaml
@@ -2,8 +2,8 @@ module:
   _target_: torchgeo.trainers.BYOLTask
   in_channels: 3
   backbone: "resnet18"
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   weights: null
 
 datamodule:

--- a/tests/conf/seco_byol_2.yaml
+++ b/tests/conf/seco_byol_2.yaml
@@ -2,9 +2,6 @@ module:
   _target_: torchgeo.trainers.BYOLTask
   in_channels: 3
   model: "resnet18"
-  lr: 1e-3
-  patience: 6
-  weights: null
 
 datamodule:
   _target_: torchgeo.datamodules.SeasonalContrastS2DataModule

--- a/tests/conf/seco_byol_2.yaml
+++ b/tests/conf/seco_byol_2.yaml
@@ -1,7 +1,7 @@
 module:
   _target_: torchgeo.trainers.BYOLTask
   in_channels: 3
-  backbone: "resnet18"
+  model: "resnet18"
   lr: 1e-3
   patience: 6
   weights: null

--- a/tests/conf/sen12ms_all.yaml
+++ b/tests/conf/sen12ms_all.yaml
@@ -3,9 +3,6 @@ module:
   loss: "ce"
   model: "unet"
   backbone: "resnet18"
-  weights: null
-  lr: 1e-3
-  patience: 2
   in_channels: 15
   num_classes: 11
   ignore_index: null

--- a/tests/conf/sen12ms_all.yaml
+++ b/tests/conf/sen12ms_all.yaml
@@ -4,8 +4,8 @@ module:
   model: "unet"
   backbone: "resnet18"
   weights: null
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 2
+  lr: 1e-3
+  patience: 2
   in_channels: 15
   num_classes: 11
   ignore_index: null

--- a/tests/conf/sen12ms_s1.yaml
+++ b/tests/conf/sen12ms_s1.yaml
@@ -4,9 +4,6 @@ module:
   model: "fcn"
   num_filters: 1
   backbone: "resnet18"
-  weights: null
-  lr: 1e-3
-  patience: 2
   in_channels: 2
   num_classes: 11
   ignore_index: null

--- a/tests/conf/sen12ms_s1.yaml
+++ b/tests/conf/sen12ms_s1.yaml
@@ -5,8 +5,8 @@ module:
   num_filters: 1
   backbone: "resnet18"
   weights: null
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 2
+  lr: 1e-3
+  patience: 2
   in_channels: 2
   num_classes: 11
   ignore_index: null

--- a/tests/conf/sen12ms_s2_all.yaml
+++ b/tests/conf/sen12ms_s2_all.yaml
@@ -4,8 +4,8 @@ module:
   model: "unet"
   backbone: "resnet18"
   weights: null
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 2
+  lr: 1e-3
+  patience: 2
   in_channels: 13
   num_classes: 11
   ignore_index: null

--- a/tests/conf/sen12ms_s2_all.yaml
+++ b/tests/conf/sen12ms_s2_all.yaml
@@ -3,9 +3,6 @@ module:
   loss: "ce"
   model: "unet"
   backbone: "resnet18"
-  weights: null
-  lr: 1e-3
-  patience: 2
   in_channels: 13
   num_classes: 11
   ignore_index: null

--- a/tests/conf/sen12ms_s2_reduced.yaml
+++ b/tests/conf/sen12ms_s2_reduced.yaml
@@ -4,8 +4,8 @@ module:
   model: "unet"
   backbone: "resnet18"
   weights: null
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 2
+  lr: 1e-3
+  patience: 2
   in_channels: 6
   num_classes: 11
   ignore_index: null

--- a/tests/conf/sen12ms_s2_reduced.yaml
+++ b/tests/conf/sen12ms_s2_reduced.yaml
@@ -3,9 +3,6 @@ module:
   loss: "ce"
   model: "unet"
   backbone: "resnet18"
-  weights: null
-  lr: 1e-3
-  patience: 2
   in_channels: 6
   num_classes: 11
   ignore_index: null

--- a/tests/conf/skippd.yaml
+++ b/tests/conf/skippd.yaml
@@ -1,11 +1,8 @@
 module:
   _target_: torchgeo.trainers.RegressionTask
   model: "resnet18"
-  weights: null
   num_outputs: 1
   in_channels: 3
-  lr: 1e-3
-  patience: 2
   loss: "mse"
 
 datamodule:

--- a/tests/conf/skippd.yaml
+++ b/tests/conf/skippd.yaml
@@ -4,8 +4,8 @@ module:
   weights: null
   num_outputs: 1
   in_channels: 3
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 2
+  lr: 1e-3
+  patience: 2
   loss: "mse"
 
 datamodule:

--- a/tests/conf/so2sat_all.yaml
+++ b/tests/conf/so2sat_all.yaml
@@ -2,8 +2,8 @@ module:
   _target_: torchgeo.trainers.ClassificationTask
   loss: "ce"
   model: "resnet18"
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   weights: null
   in_channels: 18
   num_classes: 17

--- a/tests/conf/so2sat_all.yaml
+++ b/tests/conf/so2sat_all.yaml
@@ -2,9 +2,6 @@ module:
   _target_: torchgeo.trainers.ClassificationTask
   loss: "ce"
   model: "resnet18"
-  lr: 1e-3
-  patience: 6
-  weights: null
   in_channels: 18
   num_classes: 17
 

--- a/tests/conf/so2sat_rgb.yaml
+++ b/tests/conf/so2sat_rgb.yaml
@@ -2,8 +2,8 @@ module:
   _target_: torchgeo.trainers.ClassificationTask
   loss: "ce"
   model: "resnet18"
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   weights: null
   in_channels: 3
   num_classes: 17

--- a/tests/conf/so2sat_rgb.yaml
+++ b/tests/conf/so2sat_rgb.yaml
@@ -2,9 +2,6 @@ module:
   _target_: torchgeo.trainers.ClassificationTask
   loss: "ce"
   model: "resnet18"
-  lr: 1e-3
-  patience: 6
-  weights: null
   in_channels: 3
   num_classes: 17
 

--- a/tests/conf/so2sat_s1.yaml
+++ b/tests/conf/so2sat_s1.yaml
@@ -2,8 +2,8 @@ module:
   _target_: torchgeo.trainers.ClassificationTask
   loss: "focal"
   model: "resnet18"
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   weights: null
   in_channels: 8
   num_classes: 17

--- a/tests/conf/so2sat_s1.yaml
+++ b/tests/conf/so2sat_s1.yaml
@@ -2,9 +2,6 @@ module:
   _target_: torchgeo.trainers.ClassificationTask
   loss: "focal"
   model: "resnet18"
-  lr: 1e-3
-  patience: 6
-  weights: null
   in_channels: 8
   num_classes: 17
 

--- a/tests/conf/so2sat_s2.yaml
+++ b/tests/conf/so2sat_s2.yaml
@@ -2,8 +2,8 @@ module:
   _target_: torchgeo.trainers.ClassificationTask
   loss: "jaccard"
   model: "resnet18"
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   weights: null
   in_channels: 10
   num_classes: 17

--- a/tests/conf/so2sat_s2.yaml
+++ b/tests/conf/so2sat_s2.yaml
@@ -2,9 +2,6 @@ module:
   _target_: torchgeo.trainers.ClassificationTask
   loss: "jaccard"
   model: "resnet18"
-  lr: 1e-3
-  patience: 6
-  weights: null
   in_channels: 10
   num_classes: 17
 

--- a/tests/conf/spacenet1.yaml
+++ b/tests/conf/spacenet1.yaml
@@ -4,8 +4,8 @@ module:
   model: "unet"
   backbone: "resnet18"
   weights: null
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   verbose: false
   in_channels: 3
   num_classes: 3

--- a/tests/conf/spacenet1.yaml
+++ b/tests/conf/spacenet1.yaml
@@ -6,7 +6,6 @@ module:
   weights: null
   lr: 1e-3
   patience: 6
-  verbose: false
   in_channels: 3
   num_classes: 3
   num_filters: 1

--- a/tests/conf/spacenet1.yaml
+++ b/tests/conf/spacenet1.yaml
@@ -3,9 +3,6 @@ module:
   loss: "ce"
   model: "unet"
   backbone: "resnet18"
-  weights: null
-  lr: 1e-3
-  patience: 6
   in_channels: 3
   num_classes: 3
   num_filters: 1

--- a/tests/conf/ssl4eo_l_benchmark_cdl.yaml
+++ b/tests/conf/ssl4eo_l_benchmark_cdl.yaml
@@ -4,8 +4,8 @@ module:
   model: "unet"
   backbone: "resnet18"
   weights: null
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   in_channels: 7
   num_classes: 134
   num_filters: 1

--- a/tests/conf/ssl4eo_l_benchmark_cdl.yaml
+++ b/tests/conf/ssl4eo_l_benchmark_cdl.yaml
@@ -3,9 +3,6 @@ module:
   loss: "ce"
   model: "unet"
   backbone: "resnet18"
-  weights: null
-  lr: 1e-3
-  patience: 6
   in_channels: 7
   num_classes: 134
   num_filters: 1

--- a/tests/conf/ssl4eo_l_benchmark_nlcd.yaml
+++ b/tests/conf/ssl4eo_l_benchmark_nlcd.yaml
@@ -4,8 +4,8 @@ module:
   model: "unet"
   backbone: "resnet18"
   weights: null
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   in_channels: 6
   num_classes: 17
   num_filters: 1

--- a/tests/conf/ssl4eo_l_benchmark_nlcd.yaml
+++ b/tests/conf/ssl4eo_l_benchmark_nlcd.yaml
@@ -3,9 +3,6 @@ module:
   loss: "ce"
   model: "unet"
   backbone: "resnet18"
-  weights: null
-  lr: 1e-3
-  patience: 6
   in_channels: 6
   num_classes: 17
   num_filters: 1

--- a/tests/conf/ssl4eo_l_byol_1.yaml
+++ b/tests/conf/ssl4eo_l_byol_1.yaml
@@ -2,9 +2,6 @@ module:
   _target_: torchgeo.trainers.BYOLTask
   in_channels: 7
   model: "resnet18"
-  lr: 1e-3
-  patience: 6
-  weights: null
 
 datamodule:
   _target_: torchgeo.datamodules.SSL4EOLDataModule

--- a/tests/conf/ssl4eo_l_byol_1.yaml
+++ b/tests/conf/ssl4eo_l_byol_1.yaml
@@ -2,8 +2,8 @@ module:
   _target_: torchgeo.trainers.BYOLTask
   in_channels: 7
   backbone: "resnet18"
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   weights: null
 
 datamodule:

--- a/tests/conf/ssl4eo_l_byol_1.yaml
+++ b/tests/conf/ssl4eo_l_byol_1.yaml
@@ -1,7 +1,7 @@
 module:
   _target_: torchgeo.trainers.BYOLTask
   in_channels: 7
-  backbone: "resnet18"
+  model: "resnet18"
   lr: 1e-3
   patience: 6
   weights: null

--- a/tests/conf/ssl4eo_l_byol_2.yaml
+++ b/tests/conf/ssl4eo_l_byol_2.yaml
@@ -2,9 +2,6 @@ module:
   _target_: torchgeo.trainers.BYOLTask
   in_channels: 6
   model: "resnet18"
-  lr: 1e-3
-  patience: 6
-  weights: null
 
 datamodule:
   _target_: torchgeo.datamodules.SSL4EOLDataModule

--- a/tests/conf/ssl4eo_l_byol_2.yaml
+++ b/tests/conf/ssl4eo_l_byol_2.yaml
@@ -1,7 +1,7 @@
 module:
   _target_: torchgeo.trainers.BYOLTask
   in_channels: 6
-  backbone: "resnet18"
+  model: "resnet18"
   lr: 1e-3
   patience: 6
   weights: null

--- a/tests/conf/ssl4eo_l_byol_2.yaml
+++ b/tests/conf/ssl4eo_l_byol_2.yaml
@@ -2,8 +2,8 @@ module:
   _target_: torchgeo.trainers.BYOLTask
   in_channels: 6
   backbone: "resnet18"
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   weights: null
 
 datamodule:

--- a/tests/conf/ssl4eo_s12_byol_1.yaml
+++ b/tests/conf/ssl4eo_s12_byol_1.yaml
@@ -1,7 +1,7 @@
 module:
   _target_: torchgeo.trainers.BYOLTask
   in_channels: 2
-  backbone: "resnet18"
+  model: "resnet18"
   lr: 1e-3
   patience: 6
   weights: null

--- a/tests/conf/ssl4eo_s12_byol_1.yaml
+++ b/tests/conf/ssl4eo_s12_byol_1.yaml
@@ -2,8 +2,8 @@ module:
   _target_: torchgeo.trainers.BYOLTask
   in_channels: 2
   backbone: "resnet18"
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   weights: null
 
 datamodule:

--- a/tests/conf/ssl4eo_s12_byol_1.yaml
+++ b/tests/conf/ssl4eo_s12_byol_1.yaml
@@ -2,9 +2,6 @@ module:
   _target_: torchgeo.trainers.BYOLTask
   in_channels: 2
   model: "resnet18"
-  lr: 1e-3
-  patience: 6
-  weights: null
 
 datamodule:
   _target_: torchgeo.datamodules.SSL4EOS12DataModule

--- a/tests/conf/ssl4eo_s12_byol_2.yaml
+++ b/tests/conf/ssl4eo_s12_byol_2.yaml
@@ -2,9 +2,6 @@ module:
   _target_: torchgeo.trainers.BYOLTask
   in_channels: 13
   model: "resnet18"
-  lr: 1e-3
-  patience: 6
-  weights: null
 
 datamodule:
   _target_: torchgeo.datamodules.SSL4EOS12DataModule

--- a/tests/conf/ssl4eo_s12_byol_2.yaml
+++ b/tests/conf/ssl4eo_s12_byol_2.yaml
@@ -2,8 +2,8 @@ module:
   _target_: torchgeo.trainers.BYOLTask
   in_channels: 13
   backbone: "resnet18"
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   weights: null
 
 datamodule:

--- a/tests/conf/ssl4eo_s12_byol_2.yaml
+++ b/tests/conf/ssl4eo_s12_byol_2.yaml
@@ -1,7 +1,7 @@
 module:
   _target_: torchgeo.trainers.BYOLTask
   in_channels: 13
-  backbone: "resnet18"
+  model: "resnet18"
   lr: 1e-3
   patience: 6
   weights: null

--- a/tests/conf/sustainbench_crop_yield.yaml
+++ b/tests/conf/sustainbench_crop_yield.yaml
@@ -1,11 +1,8 @@
 module:
   _target_: torchgeo.trainers.RegressionTask
   model: "resnet18"
-  weights: null
   num_outputs: 1
   in_channels: 9
-  lr: 1e-3
-  patience: 2
   loss: "mse"
 
 datamodule:

--- a/tests/conf/sustainbench_crop_yield.yaml
+++ b/tests/conf/sustainbench_crop_yield.yaml
@@ -4,8 +4,8 @@ module:
   weights: null
   num_outputs: 1
   in_channels: 9
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 2
+  lr: 1e-3
+  patience: 2
   loss: "mse"
 
 datamodule:

--- a/tests/conf/ucmerced.yaml
+++ b/tests/conf/ucmerced.yaml
@@ -3,8 +3,8 @@ module:
   loss: "ce"
   model: "resnet18"
   weights: null
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   in_channels: 3
   num_classes: 2
 

--- a/tests/conf/ucmerced.yaml
+++ b/tests/conf/ucmerced.yaml
@@ -2,9 +2,6 @@ module:
   _target_: torchgeo.trainers.ClassificationTask
   loss: "ce"
   model: "resnet18"
-  weights: null
-  lr: 1e-3
-  patience: 6
   in_channels: 3
   num_classes: 2
 

--- a/tests/conf/vaihingen2d.yaml
+++ b/tests/conf/vaihingen2d.yaml
@@ -4,8 +4,8 @@ module:
   model: "unet"
   backbone: "resnet18"
   weights: null
-  learning_rate: 1e-3
-  learning_rate_schedule_patience: 6
+  lr: 1e-3
+  patience: 6
   verbose: false
   in_channels: 3
   num_classes: 7

--- a/tests/conf/vaihingen2d.yaml
+++ b/tests/conf/vaihingen2d.yaml
@@ -6,7 +6,6 @@ module:
   weights: null
   lr: 1e-3
   patience: 6
-  verbose: false
   in_channels: 3
   num_classes: 7
   num_filters: 1

--- a/tests/conf/vaihingen2d.yaml
+++ b/tests/conf/vaihingen2d.yaml
@@ -3,9 +3,6 @@ module:
   loss: "ce"
   model: "unet"
   backbone: "resnet18"
-  weights: null
-  lr: 1e-3
-  patience: 6
   in_channels: 3
   num_classes: 7
   num_filters: 1

--- a/tests/trainers/test_byol.py
+++ b/tests/trainers/test_byol.py
@@ -86,7 +86,7 @@ class TestBYOLTask:
 
     @pytest.fixture
     def model_kwargs(self) -> dict[str, Any]:
-        return {"model": "resnet18", "in_channels": 13, "weights": None}
+        return {"model": "resnet18", "in_channels": 13}
 
     @pytest.fixture
     def weights(self) -> WeightsEnum:

--- a/tests/trainers/test_byol.py
+++ b/tests/trainers/test_byol.py
@@ -85,10 +85,6 @@ class TestBYOLTask:
         trainer.fit(model=model, datamodule=datamodule)
 
     @pytest.fixture
-    def model_kwargs(self) -> dict[str, Any]:
-        return {"model": "resnet18", "in_channels": 13}
-
-    @pytest.fixture
     def weights(self) -> WeightsEnum:
         return ResNet18_Weights.SENTINEL2_ALL_MOCO
 
@@ -108,41 +104,36 @@ class TestBYOLTask:
         monkeypatch.setattr(torchvision.models._api, "load_state_dict_from_url", load)
         return weights
 
-    def test_weight_file(self, model_kwargs: dict[str, Any], checkpoint: str) -> None:
-        model_kwargs["weights"] = checkpoint
+    def test_weight_file(self, checkpoint: str) -> None:
         with pytest.warns(UserWarning):
-            BYOLTask(**model_kwargs)
+            BYOLTask(model="resnet18", in_channels=13, weights=checkpoint)
 
-    def test_weight_enum(
-        self, model_kwargs: dict[str, Any], mocked_weights: WeightsEnum
-    ) -> None:
-        model_kwargs["model"] = mocked_weights.meta["model"]
-        model_kwargs["in_channels"] = mocked_weights.meta["in_chans"]
-        model_kwargs["weights"] = mocked_weights
-        BYOLTask(**model_kwargs)
+    def test_weight_enum(self, mocked_weights: WeightsEnum) -> None:
+        BYOLTask(
+            model=mocked_weights.meta["model"],
+            weights=mocked_weights,
+            in_channels=mocked_weights.meta["in_chans"],
+        )
 
-    def test_weight_str(
-        self, model_kwargs: dict[str, Any], mocked_weights: WeightsEnum
-    ) -> None:
-        model_kwargs["model"] = mocked_weights.meta["model"]
-        model_kwargs["in_channels"] = mocked_weights.meta["in_chans"]
-        model_kwargs["weights"] = str(mocked_weights)
-        BYOLTask(**model_kwargs)
+    def test_weight_str(self, mocked_weights: WeightsEnum) -> None:
+        BYOLTask(
+            model=mocked_weights.meta["model"],
+            weights=str(mocked_weights),
+            in_channels=mocked_weights.meta["in_chans"],
+        )
 
     @pytest.mark.slow
-    def test_weight_enum_download(
-        self, model_kwargs: dict[str, Any], weights: WeightsEnum
-    ) -> None:
-        model_kwargs["model"] = weights.meta["model"]
-        model_kwargs["in_channels"] = weights.meta["in_chans"]
-        model_kwargs["weights"] = weights
-        BYOLTask(**model_kwargs)
+    def test_weight_enum_download(self, weights: WeightsEnum) -> None:
+        BYOLTask(
+            model=weights.meta["model"],
+            weights=weights,
+            in_channels=weights.meta["in_chans"],
+        )
 
     @pytest.mark.slow
-    def test_weight_str_download(
-        self, model_kwargs: dict[str, Any], weights: WeightsEnum
-    ) -> None:
-        model_kwargs["model"] = weights.meta["model"]
-        model_kwargs["in_channels"] = weights.meta["in_chans"]
-        model_kwargs["weights"] = str(weights)
-        BYOLTask(**model_kwargs)
+    def test_weight_str_download(self, weights: WeightsEnum) -> None:
+        BYOLTask(
+            model=weights.meta["model"],
+            weights=str(weights),
+            in_channels=weights.meta["in_chans"],
+        )

--- a/tests/trainers/test_byol.py
+++ b/tests/trainers/test_byol.py
@@ -22,8 +22,6 @@ from torchgeo.models import ResNet18_Weights
 from torchgeo.trainers import BYOLTask
 from torchgeo.trainers.byol import BYOL, SimCLRAugmentation
 
-from .test_segmentation import SegmentationTestModel
-
 
 def load(url: str, *args: Any, **kwargs: Any) -> dict[str, Any]:
     state_dict: dict[str, Any] = torch.load(url)
@@ -32,8 +30,8 @@ def load(url: str, *args: Any, **kwargs: Any) -> dict[str, Any]:
 
 class TestBYOL:
     def test_custom_augment_fn(self) -> None:
-        backbone = resnet18()
-        layer = backbone.conv1
+        model = resnet18()
+        layer = model.conv1
         new_layer = nn.Conv2d(
             in_channels=4,
             out_channels=layer.out_channels,
@@ -42,9 +40,9 @@ class TestBYOL:
             padding=layer.padding,
             bias=layer.bias,
         ).requires_grad_()
-        backbone.conv1 = new_layer
+        model.conv1 = new_layer
         augment_fn = SimCLRAugmentation((2, 2))
-        BYOL(backbone, augment_fn=augment_fn)
+        BYOL(model, augment_fn=augment_fn)
 
 
 class TestBYOLTask:
@@ -76,7 +74,6 @@ class TestBYOLTask:
 
         # Instantiate model
         model = instantiate(conf.module)
-        model.backbone = SegmentationTestModel(**conf.module)
 
         # Instantiate trainer
         trainer = Trainer(
@@ -89,13 +86,7 @@ class TestBYOLTask:
 
     @pytest.fixture
     def model_kwargs(self) -> dict[str, Any]:
-        return {
-            "backbone": "resnet18",
-            "in_channels": 13,
-            "loss": "ce",
-            "num_classes": 10,
-            "weights": None,
-        }
+        return {"model": "resnet18", "in_channels": 13, "weights": None}
 
     @pytest.fixture
     def weights(self) -> WeightsEnum:
@@ -125,7 +116,7 @@ class TestBYOLTask:
     def test_weight_enum(
         self, model_kwargs: dict[str, Any], mocked_weights: WeightsEnum
     ) -> None:
-        model_kwargs["backbone"] = mocked_weights.meta["model"]
+        model_kwargs["model"] = mocked_weights.meta["model"]
         model_kwargs["in_channels"] = mocked_weights.meta["in_chans"]
         model_kwargs["weights"] = mocked_weights
         BYOLTask(**model_kwargs)
@@ -133,7 +124,7 @@ class TestBYOLTask:
     def test_weight_str(
         self, model_kwargs: dict[str, Any], mocked_weights: WeightsEnum
     ) -> None:
-        model_kwargs["backbone"] = mocked_weights.meta["model"]
+        model_kwargs["model"] = mocked_weights.meta["model"]
         model_kwargs["in_channels"] = mocked_weights.meta["in_chans"]
         model_kwargs["weights"] = str(mocked_weights)
         BYOLTask(**model_kwargs)
@@ -142,7 +133,7 @@ class TestBYOLTask:
     def test_weight_enum_download(
         self, model_kwargs: dict[str, Any], weights: WeightsEnum
     ) -> None:
-        model_kwargs["backbone"] = weights.meta["model"]
+        model_kwargs["model"] = weights.meta["model"]
         model_kwargs["in_channels"] = weights.meta["in_chans"]
         model_kwargs["weights"] = weights
         BYOLTask(**model_kwargs)
@@ -151,7 +142,7 @@ class TestBYOLTask:
     def test_weight_str_download(
         self, model_kwargs: dict[str, Any], weights: WeightsEnum
     ) -> None:
-        model_kwargs["backbone"] = weights.meta["model"]
+        model_kwargs["model"] = weights.meta["model"]
         model_kwargs["in_channels"] = weights.meta["in_chans"]
         model_kwargs["weights"] = str(weights)
         BYOLTask(**model_kwargs)

--- a/tests/trainers/test_classification.py
+++ b/tests/trainers/test_classification.py
@@ -115,13 +115,7 @@ class TestClassificationTask:
 
     @pytest.fixture
     def model_kwargs(self) -> dict[str, Any]:
-        return {
-            "model": "resnet18",
-            "in_channels": 13,
-            "loss": "ce",
-            "num_classes": 10,
-            "weights": None,
-        }
+        return {"model": "resnet18", "in_channels": 13, "loss": "ce", "num_classes": 10}
 
     @pytest.fixture
     def weights(self) -> WeightsEnum:
@@ -274,7 +268,6 @@ class TestMultiLabelClassificationTask:
             "in_channels": 14,
             "loss": "bce",
             "num_classes": 19,
-            "weights": None,
         }
 
     def test_invalid_loss(self, model_kwargs: dict[str, Any]) -> None:

--- a/tests/trainers/test_classification.py
+++ b/tests/trainers/test_classification.py
@@ -114,10 +114,6 @@ class TestClassificationTask:
             pass
 
     @pytest.fixture
-    def model_kwargs(self) -> dict[str, Any]:
-        return {"model": "resnet18", "in_channels": 13, "loss": "ce", "num_classes": 10}
-
-    @pytest.fixture
     def weights(self) -> WeightsEnum:
         return ResNet18_Weights.SENTINEL2_ALL_MOCO
 
@@ -137,61 +133,59 @@ class TestClassificationTask:
         monkeypatch.setattr(torchvision.models._api, "load_state_dict_from_url", load)
         return weights
 
-    def test_weight_file(self, model_kwargs: dict[str, Any], checkpoint: str) -> None:
-        model_kwargs["weights"] = checkpoint
+    def test_weight_file(self, checkpoint: str) -> None:
         with pytest.warns(UserWarning):
-            ClassificationTask(**model_kwargs)
+            ClassificationTask(
+                model="resnet18", weights=checkpoint, in_channels=13, num_classes=10
+            )
 
-    def test_weight_enum(
-        self, model_kwargs: dict[str, Any], mocked_weights: WeightsEnum
-    ) -> None:
-        model_kwargs["model"] = mocked_weights.meta["model"]
-        model_kwargs["in_channels"] = mocked_weights.meta["in_chans"]
-        model_kwargs["weights"] = mocked_weights
+    def test_weight_enum(self, mocked_weights: WeightsEnum) -> None:
         with pytest.warns(UserWarning):
-            ClassificationTask(**model_kwargs)
+            ClassificationTask(
+                model=mocked_weights.meta["model"],
+                weights=mocked_weights,
+                in_channels=mocked_weights.meta["in_chans"],
+                num_classes=10,
+            )
 
-    def test_weight_str(
-        self, model_kwargs: dict[str, Any], mocked_weights: WeightsEnum
-    ) -> None:
-        model_kwargs["model"] = mocked_weights.meta["model"]
-        model_kwargs["in_channels"] = mocked_weights.meta["in_chans"]
-        model_kwargs["weights"] = str(mocked_weights)
+    def test_weight_str(self, mocked_weights: WeightsEnum) -> None:
         with pytest.warns(UserWarning):
-            ClassificationTask(**model_kwargs)
+            ClassificationTask(
+                model=mocked_weights.meta["model"],
+                weights=str(mocked_weights),
+                in_channels=mocked_weights.meta["in_chans"],
+                num_classes=10,
+            )
 
     @pytest.mark.slow
-    def test_weight_enum_download(
-        self, model_kwargs: dict[str, Any], weights: WeightsEnum
-    ) -> None:
-        model_kwargs["model"] = weights.meta["model"]
-        model_kwargs["in_channels"] = weights.meta["in_chans"]
-        model_kwargs["weights"] = weights
-        ClassificationTask(**model_kwargs)
+    def test_weight_enum_download(self, weights: WeightsEnum) -> None:
+        ClassificationTask(
+            model=weights.meta["model"],
+            weights=weights,
+            in_channels=weights.meta["in_chans"],
+            num_classes=10,
+        )
 
     @pytest.mark.slow
-    def test_weight_str_download(
-        self, model_kwargs: dict[str, Any], weights: WeightsEnum
-    ) -> None:
-        model_kwargs["model"] = weights.meta["model"]
-        model_kwargs["in_channels"] = weights.meta["in_chans"]
-        model_kwargs["weights"] = str(weights)
-        ClassificationTask(**model_kwargs)
+    def test_weight_str_download(self, weights: WeightsEnum) -> None:
+        ClassificationTask(
+            model=weights.meta["model"],
+            weights=str(weights),
+            in_channels=weights.meta["in_chans"],
+            num_classes=10,
+        )
 
-    def test_invalid_loss(self, model_kwargs: dict[str, Any]) -> None:
-        model_kwargs["loss"] = "invalid_loss"
+    def test_invalid_loss(self) -> None:
         match = "Loss type 'invalid_loss' is not valid."
         with pytest.raises(ValueError, match=match):
-            ClassificationTask(**model_kwargs)
+            ClassificationTask(model="resnet18", loss="invalid_loss")
 
-    def test_no_rgb(
-        self, monkeypatch: MonkeyPatch, model_kwargs: dict[Any, Any], fast_dev_run: bool
-    ) -> None:
+    def test_no_rgb(self, monkeypatch: MonkeyPatch, fast_dev_run: bool) -> None:
         monkeypatch.setattr(EuroSATDataModule, "plot", plot)
         datamodule = EuroSATDataModule(
             root="tests/data/eurosat", batch_size=1, num_workers=0
         )
-        model = ClassificationTask(**model_kwargs)
+        model = ClassificationTask(model="resnet18", in_channels=13, num_classes=10)
         trainer = Trainer(
             accelerator="cpu",
             fast_dev_run=fast_dev_run,
@@ -200,11 +194,11 @@ class TestClassificationTask:
         )
         trainer.validate(model=model, datamodule=datamodule)
 
-    def test_predict(self, model_kwargs: dict[Any, Any], fast_dev_run: bool) -> None:
+    def test_predict(self, fast_dev_run: bool) -> None:
         datamodule = PredictClassificationDataModule(
             root="tests/data/eurosat", batch_size=1, num_workers=0
         )
-        model = ClassificationTask(**model_kwargs)
+        model = ClassificationTask(model="resnet18", in_channels=13, num_classes=10)
         trainer = Trainer(
             accelerator="cpu",
             fast_dev_run=fast_dev_run,
@@ -216,12 +210,8 @@ class TestClassificationTask:
     @pytest.mark.parametrize(
         "model_name", ["resnet18", "efficientnetv2_s", "vit_base_patch16_384"]
     )
-    def test_freeze_backbone(
-        self, model_name: str, model_kwargs: dict[Any, Any]
-    ) -> None:
-        model_kwargs["freeze_backbone"] = True
-        model_kwargs["model"] = model_name
-        model = ClassificationTask(**model_kwargs)
+    def test_freeze_backbone(self, model_name: str) -> None:
+        model = ClassificationTask(model=model_name, freeze_backbone=True)
         assert not all([param.requires_grad for param in model.model.parameters()])
         assert all(
             [param.requires_grad for param in model.model.get_classifier().parameters()]
@@ -261,29 +251,19 @@ class TestMultiLabelClassificationTask:
         except MisconfigurationException:
             pass
 
-    @pytest.fixture
-    def model_kwargs(self) -> dict[str, Any]:
-        return {
-            "model": "resnet18",
-            "in_channels": 14,
-            "loss": "bce",
-            "num_classes": 19,
-        }
-
-    def test_invalid_loss(self, model_kwargs: dict[str, Any]) -> None:
-        model_kwargs["loss"] = "invalid_loss"
+    def test_invalid_loss(self) -> None:
         match = "Loss type 'invalid_loss' is not valid."
         with pytest.raises(ValueError, match=match):
-            MultiLabelClassificationTask(**model_kwargs)
+            MultiLabelClassificationTask(model="resnet18", loss="invalid_loss")
 
-    def test_no_rgb(
-        self, monkeypatch: MonkeyPatch, model_kwargs: dict[Any, Any], fast_dev_run: bool
-    ) -> None:
+    def test_no_rgb(self, monkeypatch: MonkeyPatch, fast_dev_run: bool) -> None:
         monkeypatch.setattr(BigEarthNetDataModule, "plot", plot)
         datamodule = BigEarthNetDataModule(
             root="tests/data/bigearthnet", batch_size=1, num_workers=0
         )
-        model = MultiLabelClassificationTask(**model_kwargs)
+        model = MultiLabelClassificationTask(
+            model="resnet18", in_channels=14, num_classes=19, loss="bce"
+        )
         trainer = Trainer(
             accelerator="cpu",
             fast_dev_run=fast_dev_run,
@@ -292,11 +272,13 @@ class TestMultiLabelClassificationTask:
         )
         trainer.validate(model=model, datamodule=datamodule)
 
-    def test_predict(self, model_kwargs: dict[Any, Any], fast_dev_run: bool) -> None:
+    def test_predict(self, fast_dev_run: bool) -> None:
         datamodule = PredictMultiLabelClassificationDataModule(
             root="tests/data/bigearthnet", batch_size=1, num_workers=0
         )
-        model = MultiLabelClassificationTask(**model_kwargs)
+        model = MultiLabelClassificationTask(
+            model="resnet18", in_channels=14, num_classes=19, loss="bce"
+        )
         trainer = Trainer(
             accelerator="cpu",
             fast_dev_run=fast_dev_run,

--- a/tests/trainers/test_detection.py
+++ b/tests/trainers/test_detection.py
@@ -114,8 +114,8 @@ class TestObjectDetectionTask:
         with pytest.raises(ValueError, match=match):
             ObjectDetectionTask(**model_kwargs)
 
-    def test_non_pretrained_backbone(self, model_kwargs: dict[Any, Any]) -> None:
-        model_kwargs["weights"] = False
+    def test_pretrained_backbone(self, model_kwargs: dict[Any, Any]) -> None:
+        model_kwargs["weights"] = True
         ObjectDetectionTask(**model_kwargs)
 
     def test_no_rgb(

--- a/tests/trainers/test_detection.py
+++ b/tests/trainers/test_detection.py
@@ -98,34 +98,25 @@ class TestObjectDetectionTask:
         except MisconfigurationException:
             pass
 
-    @pytest.fixture
-    def model_kwargs(self) -> dict[Any, Any]:
-        return {"model": "faster-rcnn", "backbone": "resnet18", "num_classes": 2}
-
-    def test_invalid_model(self, model_kwargs: dict[Any, Any]) -> None:
-        model_kwargs["model"] = "invalid_model"
+    def test_invalid_model(self) -> None:
         match = "Model type 'invalid_model' is not valid."
         with pytest.raises(ValueError, match=match):
-            ObjectDetectionTask(**model_kwargs)
+            ObjectDetectionTask(model="invalid_model")
 
-    def test_invalid_backbone(self, model_kwargs: dict[Any, Any]) -> None:
-        model_kwargs["backbone"] = "invalid_backbone"
+    def test_invalid_backbone(self) -> None:
         match = "Backbone type 'invalid_backbone' is not valid."
         with pytest.raises(ValueError, match=match):
-            ObjectDetectionTask(**model_kwargs)
+            ObjectDetectionTask(backbone="invalid_backbone")
 
-    def test_pretrained_backbone(self, model_kwargs: dict[Any, Any]) -> None:
-        model_kwargs["weights"] = True
-        ObjectDetectionTask(**model_kwargs)
+    def test_pretrained_backbone(self) -> None:
+        ObjectDetectionTask(backbone="resnet18", weights=True)
 
-    def test_no_rgb(
-        self, monkeypatch: MonkeyPatch, model_kwargs: dict[Any, Any], fast_dev_run: bool
-    ) -> None:
+    def test_no_rgb(self, monkeypatch: MonkeyPatch, fast_dev_run: bool) -> None:
         monkeypatch.setattr(NASAMarineDebrisDataModule, "plot", plot)
         datamodule = NASAMarineDebrisDataModule(
             root="tests/data/nasa_marine_debris", batch_size=1, num_workers=0
         )
-        model = ObjectDetectionTask(**model_kwargs)
+        model = ObjectDetectionTask(backbone="resnet18", num_classes=2)
         trainer = Trainer(
             accelerator="cpu",
             fast_dev_run=fast_dev_run,
@@ -134,11 +125,11 @@ class TestObjectDetectionTask:
         )
         trainer.validate(model=model, datamodule=datamodule)
 
-    def test_predict(self, model_kwargs: dict[Any, Any], fast_dev_run: bool) -> None:
+    def test_predict(self, fast_dev_run: bool) -> None:
         datamodule = PredictObjectDetectionDataModule(
             root="tests/data/nasa_marine_debris", batch_size=1, num_workers=0
         )
-        model = ObjectDetectionTask(**model_kwargs)
+        model = ObjectDetectionTask(backbone="resnet18", num_classes=2)
         trainer = Trainer(
             accelerator="cpu",
             fast_dev_run=fast_dev_run,
@@ -148,10 +139,8 @@ class TestObjectDetectionTask:
         trainer.predict(model=model, datamodule=datamodule)
 
     @pytest.mark.parametrize("model_name", ["faster-rcnn", "fcos", "retinanet"])
-    def test_freeze_backbone(
-        self, model_name: str, model_kwargs: dict[Any, Any]
-    ) -> None:
-        model_kwargs["freeze_backbone"] = True
-        model_kwargs["model"] = model_name
-        model = ObjectDetectionTask(**model_kwargs)
+    def test_freeze_backbone(self, model_name: str) -> None:
+        model = ObjectDetectionTask(
+            model=model_name, backbone="resnet18", freeze_backbone=True
+        )
         assert not all([param.requires_grad for param in model.model.parameters()])

--- a/tests/trainers/test_detection.py
+++ b/tests/trainers/test_detection.py
@@ -115,7 +115,7 @@ class TestObjectDetectionTask:
             ObjectDetectionTask(**model_kwargs)
 
     def test_non_pretrained_backbone(self, model_kwargs: dict[Any, Any]) -> None:
-        model_kwargs["pretrained"] = False
+        model_kwargs["weights"] = False
         ObjectDetectionTask(**model_kwargs)
 
     def test_no_rgb(

--- a/tests/trainers/test_moco.py
+++ b/tests/trainers/test_moco.py
@@ -105,49 +105,44 @@ class TestMoCoTask:
         return weights
 
     def test_weight_file(self, checkpoint: str) -> None:
-        model_kwargs: dict[str, Any] = {"model": "resnet18", "weights": checkpoint}
         match = "num classes .* != num classes in pretrained model"
         with pytest.warns(UserWarning, match=match):
-            MoCoTask(**model_kwargs)
+            MoCoTask(model="resnet18", weights=checkpoint)
 
     def test_weight_enum(self, mocked_weights: WeightsEnum) -> None:
-        model_kwargs: dict[str, Any] = {
-            "model": mocked_weights.meta["model"],
-            "weights": mocked_weights,
-            "in_channels": mocked_weights.meta["in_chans"],
-        }
         match = "num classes .* != num classes in pretrained model"
         with pytest.warns(UserWarning, match=match):
-            MoCoTask(**model_kwargs)
+            MoCoTask(
+                model=mocked_weights.meta["model"],
+                weights=mocked_weights,
+                in_channels=mocked_weights.meta["in_chans"],
+            )
 
     def test_weight_str(self, mocked_weights: WeightsEnum) -> None:
-        model_kwargs: dict[str, Any] = {
-            "model": mocked_weights.meta["model"],
-            "weights": str(mocked_weights),
-            "in_channels": mocked_weights.meta["in_chans"],
-        }
         match = "num classes .* != num classes in pretrained model"
         with pytest.warns(UserWarning, match=match):
-            MoCoTask(**model_kwargs)
+            MoCoTask(
+                model=mocked_weights.meta["model"],
+                weights=str(mocked_weights),
+                in_channels=mocked_weights.meta["in_chans"],
+            )
 
     @pytest.mark.slow
     def test_weight_enum_download(self, weights: WeightsEnum) -> None:
-        model_kwargs: dict[str, Any] = {
-            "model": weights.meta["model"],
-            "weights": weights,
-            "in_channels": weights.meta["in_chans"],
-        }
         match = "num classes .* != num classes in pretrained model"
         with pytest.warns(UserWarning, match=match):
-            MoCoTask(**model_kwargs)
+            MoCoTask(
+                model=weights.meta["model"],
+                weights=weights,
+                in_channels=weights.meta["in_chans"],
+            )
 
     @pytest.mark.slow
     def test_weight_str_download(self, weights: WeightsEnum) -> None:
-        model_kwargs: dict[str, Any] = {
-            "model": weights.meta["model"],
-            "weights": str(weights),
-            "in_channels": weights.meta["in_chans"],
-        }
         match = "num classes .* != num classes in pretrained model"
         with pytest.warns(UserWarning, match=match):
-            MoCoTask(**model_kwargs)
+            MoCoTask(
+                model=weights.meta["model"],
+                weights=str(weights),
+                in_channels=weights.meta["in_chans"],
+            )

--- a/tests/trainers/test_regression.py
+++ b/tests/trainers/test_regression.py
@@ -97,13 +97,7 @@ class TestRegressionTask:
 
     @pytest.fixture
     def model_kwargs(self) -> dict[str, Any]:
-        return {
-            "model": "resnet18",
-            "weights": None,
-            "num_outputs": 1,
-            "in_channels": 3,
-            "loss": "mse",
-        }
+        return {"model": "resnet18", "num_outputs": 1, "in_channels": 3}
 
     @pytest.fixture
     def weights(self) -> WeightsEnum:
@@ -284,12 +278,8 @@ class TestPixelwiseRegressionTask:
         return {
             "model": "unet",
             "backbone": "resnet18",
-            "weights": None,
             "num_outputs": 1,
             "in_channels": 3,
-            "loss": "mse",
-            "lr": 1e-3,
-            "patience": 6,
         }
 
     @pytest.fixture

--- a/tests/trainers/test_regression.py
+++ b/tests/trainers/test_regression.py
@@ -288,8 +288,8 @@ class TestPixelwiseRegressionTask:
             "num_outputs": 1,
             "in_channels": 3,
             "loss": "mse",
-            "learning_rate": 1e-3,
-            "learning_rate_schedule_patience": 6,
+            "lr": 1e-3,
+            "patience": 6,
         }
 
     @pytest.fixture

--- a/tests/trainers/test_regression.py
+++ b/tests/trainers/test_regression.py
@@ -96,10 +96,6 @@ class TestRegressionTask:
             pass
 
     @pytest.fixture
-    def model_kwargs(self) -> dict[str, Any]:
-        return {"model": "resnet18", "num_outputs": 1, "in_channels": 3}
-
-    @pytest.fixture
     def weights(self) -> WeightsEnum:
         return ResNet18_Weights.SENTINEL2_ALL_MOCO
 
@@ -119,55 +115,48 @@ class TestRegressionTask:
         monkeypatch.setattr(torchvision.models._api, "load_state_dict_from_url", load)
         return weights
 
-    def test_weight_file(self, model_kwargs: dict[str, Any], checkpoint: str) -> None:
-        model_kwargs["weights"] = checkpoint
+    def test_weight_file(self, checkpoint: str) -> None:
         with pytest.warns(UserWarning):
-            RegressionTask(**model_kwargs)
+            RegressionTask(model="resnet18", weights=checkpoint)
 
-    def test_weight_enum(
-        self, model_kwargs: dict[str, Any], mocked_weights: WeightsEnum
-    ) -> None:
-        model_kwargs["model"] = mocked_weights.meta["model"]
-        model_kwargs["in_channels"] = mocked_weights.meta["in_chans"]
-        model_kwargs["weights"] = mocked_weights
+    def test_weight_enum(self, mocked_weights: WeightsEnum) -> None:
         with pytest.warns(UserWarning):
-            RegressionTask(**model_kwargs)
+            RegressionTask(
+                model=mocked_weights.meta["model"],
+                weights=mocked_weights,
+                in_channels=mocked_weights.meta["in_chans"],
+            )
 
-    def test_weight_str(
-        self, model_kwargs: dict[str, Any], mocked_weights: WeightsEnum
-    ) -> None:
-        model_kwargs["model"] = mocked_weights.meta["model"]
-        model_kwargs["in_channels"] = mocked_weights.meta["in_chans"]
-        model_kwargs["weights"] = str(mocked_weights)
+    def test_weight_str(self, mocked_weights: WeightsEnum) -> None:
         with pytest.warns(UserWarning):
-            RegressionTask(**model_kwargs)
+            RegressionTask(
+                model=mocked_weights.meta["model"],
+                weights=str(mocked_weights),
+                in_channels=mocked_weights.meta["in_chans"],
+            )
 
     @pytest.mark.slow
-    def test_weight_enum_download(
-        self, model_kwargs: dict[str, Any], weights: WeightsEnum
-    ) -> None:
-        model_kwargs["model"] = weights.meta["model"]
-        model_kwargs["in_channels"] = weights.meta["in_chans"]
-        model_kwargs["weights"] = weights
-        RegressionTask(**model_kwargs)
+    def test_weight_enum_download(self, weights: WeightsEnum) -> None:
+        RegressionTask(
+            model=weights.meta["model"],
+            weights=weights,
+            in_channels=weights.meta["in_chans"],
+        )
 
     @pytest.mark.slow
-    def test_weight_str_download(
-        self, model_kwargs: dict[str, Any], weights: WeightsEnum
-    ) -> None:
-        model_kwargs["model"] = weights.meta["model"]
-        model_kwargs["in_channels"] = weights.meta["in_chans"]
-        model_kwargs["weights"] = str(weights)
-        RegressionTask(**model_kwargs)
+    def test_weight_str_download(self, weights: WeightsEnum) -> None:
+        RegressionTask(
+            model=weights.meta["model"],
+            weights=str(weights),
+            in_channels=weights.meta["in_chans"],
+        )
 
-    def test_no_rgb(
-        self, monkeypatch: MonkeyPatch, model_kwargs: dict[Any, Any], fast_dev_run: bool
-    ) -> None:
+    def test_no_rgb(self, monkeypatch: MonkeyPatch, fast_dev_run: bool) -> None:
         monkeypatch.setattr(TropicalCycloneDataModule, "plot", plot)
         datamodule = TropicalCycloneDataModule(
             root="tests/data/cyclone", batch_size=1, num_workers=0
         )
-        model = RegressionTask(**model_kwargs)
+        model = RegressionTask(model="resnet18")
         trainer = Trainer(
             accelerator="cpu",
             fast_dev_run=fast_dev_run,
@@ -176,11 +165,11 @@ class TestRegressionTask:
         )
         trainer.validate(model=model, datamodule=datamodule)
 
-    def test_predict(self, model_kwargs: dict[Any, Any], fast_dev_run: bool) -> None:
+    def test_predict(self, fast_dev_run: bool) -> None:
         datamodule = PredictRegressionDataModule(
             root="tests/data/cyclone", batch_size=1, num_workers=0
         )
-        model = RegressionTask(**model_kwargs)
+        model = RegressionTask(model="resnet18")
         trainer = Trainer(
             accelerator="cpu",
             fast_dev_run=fast_dev_run,
@@ -189,21 +178,16 @@ class TestRegressionTask:
         )
         trainer.predict(model=model, datamodule=datamodule)
 
-    def test_invalid_loss(self, model_kwargs: dict[str, Any]) -> None:
-        model_kwargs["loss"] = "invalid_loss"
+    def test_invalid_loss(self) -> None:
         match = "Loss type 'invalid_loss' is not valid."
         with pytest.raises(ValueError, match=match):
-            RegressionTask(**model_kwargs)
+            RegressionTask(model="resnet18", loss="invalid_loss")
 
     @pytest.mark.parametrize(
         "model_name", ["resnet18", "efficientnetv2_s", "vit_base_patch16_384"]
     )
-    def test_freeze_backbone(
-        self, model_name: str, model_kwargs: dict[Any, Any]
-    ) -> None:
-        model_kwargs["freeze_backbone"] = True
-        model_kwargs["model"] = model_name
-        model = RegressionTask(**model_kwargs)
+    def test_freeze_backbone(self, model_name: str) -> None:
+        model = RegressionTask(model=model_name, freeze_backbone=True)
         assert not all([param.requires_grad for param in model.model.parameters()])
         assert all(
             [param.requires_grad for param in model.model.get_classifier().parameters()]
@@ -227,7 +211,6 @@ class TestPixelwiseRegressionTask:
         loss: str,
         model_type: str,
         fast_dev_run: bool,
-        model_kwargs: dict[str, Any],
     ) -> None:
         conf = OmegaConf.load(os.path.join("tests", "conf", name + ".yaml"))
 
@@ -238,16 +221,11 @@ class TestPixelwiseRegressionTask:
         # Instantiate model
         monkeypatch.setattr(smp, "Unet", create_model)
         monkeypatch.setattr(smp, "DeepLabV3Plus", create_model)
-        model_kwargs["model"] = model_type
-        model_kwargs["loss"] = loss
 
-        if model_type == "fcn":
-            model_kwargs["num_filters"] = 2
-
-        model = PixelwiseRegressionTask(**model_kwargs)
-        model.model = PixelwiseRegressionTestModel(
-            in_channels=model_kwargs["in_channels"]
+        model = PixelwiseRegressionTask(
+            model=model_type, backbone="resnet18", loss=loss
         )
+        model.model = PixelwiseRegressionTestModel()
 
         # Instantiate trainer
         trainer = Trainer(
@@ -267,20 +245,10 @@ class TestPixelwiseRegressionTask:
         except MisconfigurationException:
             pass
 
-    def test_invalid_model(self, model_kwargs: dict[str, Any]) -> None:
-        model_kwargs["model"] = "invalid_model"
+    def test_invalid_model(self) -> None:
         match = "Model type 'invalid_model' is not valid."
         with pytest.raises(ValueError, match=match):
-            PixelwiseRegressionTask(**model_kwargs)
-
-    @pytest.fixture
-    def model_kwargs(self) -> dict[str, Any]:
-        return {
-            "model": "unet",
-            "backbone": "resnet18",
-            "num_outputs": 1,
-            "in_channels": 3,
-        }
+            PixelwiseRegressionTask(model="invalid_model")
 
     @pytest.fixture
     def weights(self) -> WeightsEnum:
@@ -302,55 +270,51 @@ class TestPixelwiseRegressionTask:
         monkeypatch.setattr(torchvision.models._api, "load_state_dict_from_url", load)
         return weights
 
-    def test_weight_file(self, model_kwargs: dict[str, Any], checkpoint: str) -> None:
-        model_kwargs["weights"] = checkpoint
-        PixelwiseRegressionTask(**model_kwargs)
+    def test_weight_file(self, checkpoint: str) -> None:
+        PixelwiseRegressionTask(model="unet", backbone="resnet18", weights=checkpoint)
 
-    def test_weight_enum(
-        self, model_kwargs: dict[str, Any], mocked_weights: WeightsEnum
-    ) -> None:
-        model_kwargs["backbone"] = mocked_weights.meta["model"]
-        model_kwargs["in_channels"] = mocked_weights.meta["in_chans"]
-        model_kwargs["weights"] = mocked_weights
-        PixelwiseRegressionTask(**model_kwargs)
+    def test_weight_enum(self, mocked_weights: WeightsEnum) -> None:
+        PixelwiseRegressionTask(
+            model="unet",
+            backbone=mocked_weights.meta["model"],
+            weights=mocked_weights,
+            in_channels=mocked_weights.meta["in_chans"],
+        )
 
-    def test_weight_str(
-        self, model_kwargs: dict[str, Any], mocked_weights: WeightsEnum
-    ) -> None:
-        model_kwargs["backbone"] = mocked_weights.meta["model"]
-        model_kwargs["in_channels"] = mocked_weights.meta["in_chans"]
-        model_kwargs["weights"] = str(mocked_weights)
-        PixelwiseRegressionTask(**model_kwargs)
-
-    @pytest.mark.slow
-    def test_weight_enum_download(
-        self, model_kwargs: dict[str, Any], weights: WeightsEnum
-    ) -> None:
-        model_kwargs["backbone"] = weights.meta["model"]
-        model_kwargs["in_channels"] = weights.meta["in_chans"]
-        model_kwargs["weights"] = weights
-        PixelwiseRegressionTask(**model_kwargs)
+    def test_weight_str(self, mocked_weights: WeightsEnum) -> None:
+        PixelwiseRegressionTask(
+            model="unet",
+            backbone=mocked_weights.meta["model"],
+            weights=str(mocked_weights),
+            in_channels=mocked_weights.meta["in_chans"],
+        )
 
     @pytest.mark.slow
-    def test_weight_str_download(
-        self, model_kwargs: dict[str, Any], weights: WeightsEnum
-    ) -> None:
-        model_kwargs["backbone"] = weights.meta["model"]
-        model_kwargs["in_channels"] = weights.meta["in_chans"]
-        model_kwargs["weights"] = str(weights)
-        PixelwiseRegressionTask(**model_kwargs)
+    def test_weight_enum_download(self, weights: WeightsEnum) -> None:
+        PixelwiseRegressionTask(
+            model="unet",
+            backbone=weights.meta["model"],
+            weights=weights,
+            in_channels=weights.meta["in_chans"],
+        )
 
+    @pytest.mark.slow
+    def test_weight_str_download(self, weights: WeightsEnum) -> None:
+        PixelwiseRegressionTask(
+            model="unet",
+            backbone=weights.meta["model"],
+            weights=str(weights),
+            in_channels=weights.meta["in_chans"],
+        )
+
+    @pytest.mark.parametrize("model_name", ["unet", "deeplabv3+"])
     @pytest.mark.parametrize(
         "backbone", ["resnet18", "mobilenet_v2", "efficientnet-b0"]
     )
-    @pytest.mark.parametrize("model_name", ["unet", "deeplabv3+"])
-    def test_freeze_backbone(
-        self, backbone: str, model_name: str, model_kwargs: dict[Any, Any]
-    ) -> None:
-        model_kwargs["freeze_backbone"] = True
-        model_kwargs["model"] = model_name
-        model_kwargs["backbone"] = backbone
-        model = PixelwiseRegressionTask(**model_kwargs)
+    def test_freeze_backbone(self, model_name: str, backbone: str) -> None:
+        model = PixelwiseRegressionTask(
+            model=model_name, backbone=backbone, freeze_backbone=True
+        )
         assert all(
             [param.requires_grad is False for param in model.model.encoder.parameters()]
         )
@@ -363,12 +327,10 @@ class TestPixelwiseRegressionTask:
         )
 
     @pytest.mark.parametrize("model_name", ["unet", "deeplabv3+"])
-    def test_freeze_decoder(
-        self, model_name: str, model_kwargs: dict[Any, Any]
-    ) -> None:
-        model_kwargs["freeze_decoder"] = True
-        model_kwargs["model"] = model_name
-        model = PixelwiseRegressionTask(**model_kwargs)
+    def test_freeze_decoder(self, model_name: str) -> None:
+        model = PixelwiseRegressionTask(
+            model=model_name, backbone="resnet18", freeze_decoder=True
+        )
         assert all(
             [param.requires_grad is False for param in model.model.decoder.parameters()]
         )

--- a/tests/trainers/test_segmentation.py
+++ b/tests/trainers/test_segmentation.py
@@ -5,7 +5,6 @@ import os
 from pathlib import Path
 from typing import Any, cast
 
-import numpy as np
 import pytest
 import segmentation_models_pytorch as smp
 import timm
@@ -194,12 +193,6 @@ class TestSemanticSegmentationTask:
         with pytest.raises(ValueError, match=match):
             SemanticSegmentationTask(**model_kwargs)
 
-    def test_invalid_ignoreindex(self, model_kwargs: dict[Any, Any]) -> None:
-        model_kwargs["ignore_index"] = "0"
-        match = "ignore_index must be an int or None"
-        with pytest.raises(ValueError, match=match):
-            SemanticSegmentationTask(**model_kwargs)
-
     def test_ignoreindex_with_jaccard(self, model_kwargs: dict[Any, Any]) -> None:
         model_kwargs["loss"] = "jaccard"
         model_kwargs["ignore_index"] = 0
@@ -263,23 +256,3 @@ class TestSemanticSegmentationTask:
                 for param in model.model.segmentation_head.parameters()
             ]
         )
-
-    @pytest.mark.parametrize(
-        "class_weights", [torch.tensor([1, 2, 3]), np.array([1, 2, 3]), [1, 2, 3]]
-    )
-    def test_classweights_valid(
-        self, class_weights: Any, model_kwargs: dict[Any, Any]
-    ) -> None:
-        model_kwargs["class_weights"] = class_weights
-        sst = SemanticSegmentationTask(**model_kwargs)
-        assert isinstance(sst.loss.weight, torch.Tensor)
-        assert torch.equal(sst.loss.weight, torch.tensor([1.0, 2.0, 3.0]))
-        assert sst.loss.weight.dtype == torch.float32
-
-    @pytest.mark.parametrize("class_weights", [[], None])
-    def test_classweights_empty(
-        self, class_weights: Any, model_kwargs: dict[Any, Any]
-    ) -> None:
-        model_kwargs["class_weights"] = class_weights
-        sst = SemanticSegmentationTask(**model_kwargs)
-        assert sst.loss.weight is None

--- a/tests/trainers/test_segmentation.py
+++ b/tests/trainers/test_segmentation.py
@@ -116,10 +116,8 @@ class TestSemanticSegmentationTask:
         return {
             "model": "unet",
             "backbone": "resnet18",
-            "weights": None,
             "in_channels": 3,
             "num_classes": 6,
-            "loss": "ce",
             "ignore_index": 0,
         }
 

--- a/tests/trainers/test_segmentation.py
+++ b/tests/trainers/test_segmentation.py
@@ -112,16 +112,6 @@ class TestSemanticSegmentationTask:
             pass
 
     @pytest.fixture
-    def model_kwargs(self) -> dict[Any, Any]:
-        return {
-            "model": "unet",
-            "backbone": "resnet18",
-            "in_channels": 3,
-            "num_classes": 6,
-            "ignore_index": 0,
-        }
-
-    @pytest.fixture
     def weights(self) -> WeightsEnum:
         return ResNet18_Weights.SENTINEL2_ALL_MOCO
 
@@ -141,72 +131,62 @@ class TestSemanticSegmentationTask:
         monkeypatch.setattr(torchvision.models._api, "load_state_dict_from_url", load)
         return weights
 
-    def test_weight_file(self, model_kwargs: dict[str, Any], checkpoint: str) -> None:
-        model_kwargs["weights"] = checkpoint
-        SemanticSegmentationTask(**model_kwargs)
+    def test_weight_file(self, checkpoint: str) -> None:
+        SemanticSegmentationTask(backbone="resnet18", weights=checkpoint, num_classes=6)
 
-    def test_weight_enum(
-        self, model_kwargs: dict[str, Any], mocked_weights: WeightsEnum
-    ) -> None:
-        model_kwargs["backbone"] = mocked_weights.meta["model"]
-        model_kwargs["in_channels"] = mocked_weights.meta["in_chans"]
-        model_kwargs["weights"] = mocked_weights
-        SemanticSegmentationTask(**model_kwargs)
+    def test_weight_enum(self, mocked_weights: WeightsEnum) -> None:
+        SemanticSegmentationTask(
+            backbone=mocked_weights.meta["model"],
+            weights=mocked_weights,
+            in_channels=mocked_weights.meta["in_chans"],
+        )
 
-    def test_weight_str(
-        self, model_kwargs: dict[str, Any], mocked_weights: WeightsEnum
-    ) -> None:
-        model_kwargs["backbone"] = mocked_weights.meta["model"]
-        model_kwargs["in_channels"] = mocked_weights.meta["in_chans"]
-        model_kwargs["weights"] = str(mocked_weights)
-        SemanticSegmentationTask(**model_kwargs)
+    def test_weight_str(self, mocked_weights: WeightsEnum) -> None:
+        SemanticSegmentationTask(
+            backbone=mocked_weights.meta["model"],
+            weights=str(mocked_weights),
+            in_channels=mocked_weights.meta["in_chans"],
+        )
 
     @pytest.mark.slow
-    def test_weight_enum_download(
-        self, model_kwargs: dict[str, Any], weights: WeightsEnum
-    ) -> None:
-        model_kwargs["backbone"] = weights.meta["model"]
-        model_kwargs["in_channels"] = weights.meta["in_chans"]
-        model_kwargs["weights"] = weights
-        SemanticSegmentationTask(**model_kwargs)
+    def test_weight_enum_download(self, weights: WeightsEnum) -> None:
+        SemanticSegmentationTask(
+            backbone=weights.meta["model"],
+            weights=weights,
+            in_channels=weights.meta["in_chans"],
+        )
 
     @pytest.mark.slow
-    def test_weight_str_download(
-        self, model_kwargs: dict[str, Any], weights: WeightsEnum
-    ) -> None:
-        model_kwargs["backbone"] = weights.meta["model"]
-        model_kwargs["in_channels"] = weights.meta["in_chans"]
-        model_kwargs["weights"] = str(weights)
-        SemanticSegmentationTask(**model_kwargs)
+    def test_weight_str_download(self, weights: WeightsEnum) -> None:
+        SemanticSegmentationTask(
+            backbone=weights.meta["model"],
+            weights=str(weights),
+            in_channels=weights.meta["in_chans"],
+        )
 
-    def test_invalid_model(self, model_kwargs: dict[Any, Any]) -> None:
-        model_kwargs["model"] = "invalid_model"
+    def test_invalid_model(self) -> None:
         match = "Model type 'invalid_model' is not valid."
         with pytest.raises(ValueError, match=match):
-            SemanticSegmentationTask(**model_kwargs)
+            SemanticSegmentationTask(model="invalid_model")
 
-    def test_invalid_loss(self, model_kwargs: dict[Any, Any]) -> None:
-        model_kwargs["loss"] = "invalid_loss"
+    def test_invalid_loss(self) -> None:
         match = "Loss type 'invalid_loss' is not valid."
         with pytest.raises(ValueError, match=match):
-            SemanticSegmentationTask(**model_kwargs)
+            SemanticSegmentationTask(loss="invalid_loss")
 
-    def test_ignoreindex_with_jaccard(self, model_kwargs: dict[Any, Any]) -> None:
-        model_kwargs["loss"] = "jaccard"
-        model_kwargs["ignore_index"] = 0
+    def test_ignoreindex_with_jaccard(self) -> None:
         match = "ignore_index has no effect on training when loss='jaccard'"
         with pytest.warns(UserWarning, match=match):
-            SemanticSegmentationTask(**model_kwargs)
+            SemanticSegmentationTask(loss="jaccard", ignore_index=0)
 
-    def test_no_rgb(
-        self, monkeypatch: MonkeyPatch, model_kwargs: dict[Any, Any], fast_dev_run: bool
-    ) -> None:
-        model_kwargs["in_channels"] = 15
+    def test_no_rgb(self, monkeypatch: MonkeyPatch, fast_dev_run: bool) -> None:
         monkeypatch.setattr(SEN12MSDataModule, "plot", plot)
         datamodule = SEN12MSDataModule(
             root="tests/data/sen12ms", batch_size=1, num_workers=0
         )
-        model = SemanticSegmentationTask(**model_kwargs)
+        model = SemanticSegmentationTask(
+            backbone="resnet18", in_channels=15, num_classes=6
+        )
         trainer = Trainer(
             accelerator="cpu",
             fast_dev_run=fast_dev_run,
@@ -215,17 +195,14 @@ class TestSemanticSegmentationTask:
         )
         trainer.validate(model=model, datamodule=datamodule)
 
+    @pytest.mark.parametrize("model_name", ["unet", "deeplabv3+"])
     @pytest.mark.parametrize(
         "backbone", ["resnet18", "mobilenet_v2", "efficientnet-b0"]
     )
-    @pytest.mark.parametrize("model_name", ["unet", "deeplabv3+"])
-    def test_freeze_backbone(
-        self, backbone: str, model_name: str, model_kwargs: dict[Any, Any]
-    ) -> None:
-        model_kwargs["freeze_backbone"] = True
-        model_kwargs["model"] = model_name
-        model_kwargs["backbone"] = backbone
-        model = SemanticSegmentationTask(**model_kwargs)
+    def test_freeze_backbone(self, model_name: str, backbone: str) -> None:
+        model = SemanticSegmentationTask(
+            model=model_name, backbone=backbone, freeze_backbone=True
+        )
         assert all(
             [param.requires_grad is False for param in model.model.encoder.parameters()]
         )
@@ -238,12 +215,8 @@ class TestSemanticSegmentationTask:
         )
 
     @pytest.mark.parametrize("model_name", ["unet", "deeplabv3+"])
-    def test_freeze_decoder(
-        self, model_name: str, model_kwargs: dict[Any, Any]
-    ) -> None:
-        model_kwargs["freeze_decoder"] = True
-        model_kwargs["model"] = model_name
-        model = SemanticSegmentationTask(**model_kwargs)
+    def test_freeze_decoder(self, model_name: str) -> None:
+        model = SemanticSegmentationTask(model=model_name, freeze_decoder=True)
         assert all(
             [param.requires_grad is False for param in model.model.decoder.parameters()]
         )

--- a/tests/trainers/test_simclr.py
+++ b/tests/trainers/test_simclr.py
@@ -103,49 +103,44 @@ class TestSimCLRTask:
         return weights
 
     def test_weight_file(self, checkpoint: str) -> None:
-        model_kwargs: dict[str, Any] = {"model": "resnet18", "weights": checkpoint}
         match = "num classes .* != num classes in pretrained model"
         with pytest.warns(UserWarning, match=match):
-            SimCLRTask(**model_kwargs)
+            SimCLRTask(model="resnet18", weights=checkpoint)
 
     def test_weight_enum(self, mocked_weights: WeightsEnum) -> None:
-        model_kwargs: dict[str, Any] = {
-            "model": mocked_weights.meta["model"],
-            "weights": mocked_weights,
-            "in_channels": mocked_weights.meta["in_chans"],
-        }
         match = "num classes .* != num classes in pretrained model"
         with pytest.warns(UserWarning, match=match):
-            SimCLRTask(**model_kwargs)
+            SimCLRTask(
+                model=mocked_weights.meta["model"],
+                weights=mocked_weights,
+                in_channels=mocked_weights.meta["in_chans"],
+            )
 
     def test_weight_str(self, mocked_weights: WeightsEnum) -> None:
-        model_kwargs: dict[str, Any] = {
-            "model": mocked_weights.meta["model"],
-            "weights": str(mocked_weights),
-            "in_channels": mocked_weights.meta["in_chans"],
-        }
         match = "num classes .* != num classes in pretrained model"
         with pytest.warns(UserWarning, match=match):
-            SimCLRTask(**model_kwargs)
+            SimCLRTask(
+                model=mocked_weights.meta["model"],
+                weights=str(mocked_weights),
+                in_channels=mocked_weights.meta["in_chans"],
+            )
 
     @pytest.mark.slow
     def test_weight_enum_download(self, weights: WeightsEnum) -> None:
-        model_kwargs: dict[str, Any] = {
-            "model": weights.meta["model"],
-            "weights": weights,
-            "in_channels": weights.meta["in_chans"],
-        }
         match = "num classes .* != num classes in pretrained model"
         with pytest.warns(UserWarning, match=match):
-            SimCLRTask(**model_kwargs)
+            SimCLRTask(
+                model=weights.meta["model"],
+                weights=weights,
+                in_channels=weights.meta["in_chans"],
+            )
 
     @pytest.mark.slow
     def test_weight_str_download(self, weights: WeightsEnum) -> None:
-        model_kwargs: dict[str, Any] = {
-            "model": weights.meta["model"],
-            "weights": str(weights),
-            "in_channels": weights.meta["in_chans"],
-        }
         match = "num classes .* != num classes in pretrained model"
         with pytest.warns(UserWarning, match=match):
-            SimCLRTask(**model_kwargs)
+            SimCLRTask(
+                model=weights.meta["model"],
+                weights=str(weights),
+                in_channels=weights.meta["in_chans"],
+            )

--- a/torchgeo/trainers/__init__.py
+++ b/torchgeo/trainers/__init__.py
@@ -3,6 +3,7 @@
 
 """TorchGeo trainers."""
 
+from .base import BaseTask
 from .byol import BYOLTask
 from .classification import ClassificationTask, MultiLabelClassificationTask
 from .detection import ObjectDetectionTask
@@ -12,13 +13,17 @@ from .segmentation import SemanticSegmentationTask
 from .simclr import SimCLRTask
 
 __all__ = (
-    "BYOLTask",
+    # Supervised
     "ClassificationTask",
-    "MoCoTask",
     "MultiLabelClassificationTask",
     "ObjectDetectionTask",
     "PixelwiseRegressionTask",
     "RegressionTask",
     "SemanticSegmentationTask",
+    # Self-supervised
+    "BYOLTask",
+    "MoCoTask",
     "SimCLRTask",
+    # Base classes
+    "BaseTask",
 )

--- a/torchgeo/trainers/base.py
+++ b/torchgeo/trainers/base.py
@@ -1,0 +1,53 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+"""Base class for all :mod:`torchgeo` trainers."""
+
+from typing import Any
+
+from lightning.pytorch import LightningModule
+from torch.optim import AdamW
+from torch.optim.lr_scheduler import ReduceLROnPlateau
+
+
+class BaseTask(LightningModule):
+    """Base class for all TorchGeo trainers.
+
+    .. versionadded:: 0.5
+    """
+
+    #: Model to train
+    model: Any
+
+    #: Performance metric to monitor in learning rate scheduler and callbacks
+    monitor = "val_loss"
+
+    def __init__(self) -> None:
+        """Initialize a new BaseTask instance."""
+        super().__init__()
+        self.save_hyperparameters()
+
+    def forward(self, *args: Any, **kwargs: Any) -> Any:
+        """Forward pass of the model.
+
+        Args:
+            args: Arguments to pass to model.
+            kwargs: Keyword arguments to pass to model.
+
+        Returns:
+            Output of the model.
+        """
+        return self.model(*args, **kwargs)
+
+    def configure_optimizers(self) -> dict[str, Any]:
+        """Initialize the optimizer and learning rate scheduler.
+
+        Returns:
+            Optimizer and learning rate scheduler.
+        """
+        optimizer = AdamW(self.parameters(), lr=self.hparams["lr"])
+        scheduler = ReduceLROnPlateau(optimizer, patience=self.hparams["patience"])
+        return {
+            "optimizer": optimizer,
+            "lr_scheduler": {"scheduler": scheduler, "monitor": self.monitor},
+        }

--- a/torchgeo/trainers/base.py
+++ b/torchgeo/trainers/base.py
@@ -1,8 +1,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-"""Base class for all :mod:`torchgeo` trainers."""
+"""Base classes for all :mod:`torchgeo` trainers."""
 
+from abc import ABC, abstractmethod
 from typing import Any
 
 from lightning.pytorch import LightningModule
@@ -10,8 +11,8 @@ from torch.optim import AdamW
 from torch.optim.lr_scheduler import ReduceLROnPlateau
 
 
-class BaseTask(LightningModule):
-    """Base class for all TorchGeo trainers.
+class BaseTask(LightningModule, ABC):
+    """Abstract base class for all TorchGeo trainers.
 
     .. versionadded:: 0.5
     """
@@ -26,18 +27,19 @@ class BaseTask(LightningModule):
         """Initialize a new BaseTask instance."""
         super().__init__()
         self.save_hyperparameters()
+        self.configure_losses()
+        self.configure_metrics()
+        self.configure_models()
 
-    def forward(self, *args: Any, **kwargs: Any) -> Any:
-        """Forward pass of the model.
+    def configure_losses(self) -> None:
+        """Initialize the loss criterion."""
 
-        Args:
-            args: Arguments to pass to model.
-            kwargs: Keyword arguments to pass to model.
+    def configure_metrics(self) -> None:
+        """Initialize the performance metrics."""
 
-        Returns:
-            Output of the model.
-        """
-        return self.model(*args, **kwargs)
+    @abstractmethod
+    def configure_models(self) -> None:
+        """Initialize the model."""
 
     def configure_optimizers(self) -> dict[str, Any]:
         """Initialize the optimizer and learning rate scheduler.
@@ -51,3 +53,15 @@ class BaseTask(LightningModule):
             "optimizer": optimizer,
             "lr_scheduler": {"scheduler": scheduler, "monitor": self.monitor},
         }
+
+    def forward(self, *args: Any, **kwargs: Any) -> Any:
+        """Forward pass of the model.
+
+        Args:
+            args: Arguments to pass to model.
+            kwargs: Keyword arguments to pass to model.
+
+        Returns:
+            Output of the model.
+        """
+        return self.model(*args, **kwargs)

--- a/torchgeo/trainers/byol.py
+++ b/torchgeo/trainers/byol.py
@@ -18,7 +18,7 @@ from torch.optim.lr_scheduler import ReduceLROnPlateau
 from torchvision.models._api import WeightsEnum
 
 from ..models import get_weight
-from .utils import extract_backbone, load_state_dict
+from . import utils
 
 
 def normalized_mse(x: Tensor, y: Tensor) -> Tensor:
@@ -125,7 +125,7 @@ class BackboneWrapper(nn.Module):
     * The forward call returns the output of the projection head
 
     .. versionchanged 0.4: Name changed from *EncoderWrapper* to
-        *BackboneWrapper*.
+       *BackboneWrapper*.
     """
 
     def __init__(
@@ -306,7 +306,8 @@ class BYOLTask(LightningModule):
         """Initialize a new BYOLTask instance.
 
         Args:
-            model: Name of the timm model to use.
+            model: Name of the `timm
+                <https://huggingface.co/docs/timm/reference/models>`__ model to use.
             weights: Initial model weights. Either a weight enum, the string
                 representation of a weight enum, True for ImageNet weights, False
                 or None for random weights, or the path to a saved model state dict.
@@ -315,13 +316,13 @@ class BYOLTask(LightningModule):
             weight_decay: Weight decay (L2 penalty).
             patience: Patience for learning rate scheduler.
 
-        .. versionchanged:: 0.5
-           *backbone*, *learning_rate*, and *learning_rate_schedule_patience* were
-           renamed to *model*, *lr*, and *patience*.
-
         .. versionchanged:: 0.4
            *backbone_name* was renamed to *backbone*. Changed backbone support from
            torchvision.models to timm.
+
+        .. versionchanged:: 0.5
+           *backbone*, *learning_rate*, and *learning_rate_schedule_patience* were
+           renamed to *model*, *lr*, and *patience*.
         """
         super().__init__()
 
@@ -337,10 +338,10 @@ class BYOLTask(LightningModule):
             if isinstance(weights, WeightsEnum):
                 state_dict = weights.get_state_dict(progress=True)
             elif os.path.exists(weights):
-                _, state_dict = extract_backbone(weights)
+                _, state_dict = utils.extract_backbone(weights)
             else:
                 state_dict = get_weight(weights).get_state_dict(progress=True)
-            backbone = load_state_dict(backbone, state_dict)
+            backbone = utils.load_state_dict(backbone, state_dict)
 
         self.model = BYOL(backbone, in_channels=in_channels, image_size=(224, 224))
 

--- a/torchgeo/trainers/byol.py
+++ b/torchgeo/trainers/byol.py
@@ -4,7 +4,7 @@
 """BYOL trainer for self-supervised learning (SSL)."""
 
 import os
-from typing import Any, Optional, Union, cast
+from typing import Any, Optional, Union
 
 import timm
 import torch
@@ -76,7 +76,8 @@ class SimCLRAugmentation(nn.Module):
         Returns:
             an augmented batch of imagery
         """
-        return cast(Tensor, self.augmentation(x))
+        z: Tensor = self.augmentation(x)
+        return z
 
 
 class MLP(nn.Module):
@@ -109,7 +110,8 @@ class MLP(nn.Module):
         Returns:
             embedded version of the input
         """
-        return cast(Tensor, self.mlp(x))
+        z: Tensor = self.mlp(x)
+        return z
 
 
 class BackboneWrapper(nn.Module):
@@ -271,7 +273,8 @@ class BYOL(nn.Module):
         Returns:
             output from the model
         """
-        return cast(Tensor, self.predictor(self.backbone(x)))
+        z: Tensor = self.predictor(self.backbone(x))
+        return z
 
     def update_target(self) -> None:
         """Method to update the "target" model weights."""
@@ -350,8 +353,8 @@ class BYOLTask(LightningModule):
         Returns:
             Output from the model.
         """
-        z = self.model(x)
-        return cast(Tensor, z)
+        z: Tensor = self.model(x)
+        return z
 
     def training_step(
         self, batch: Any, batch_idx: int, dataloader_idx: int = 0

--- a/torchgeo/trainers/byol.py
+++ b/torchgeo/trainers/byol.py
@@ -324,9 +324,14 @@ class BYOLTask(BaseTask):
         """
         super().__init__()
 
+    def configure_models(self) -> None:
+        """Initialize the model."""
+        weights: Optional[Union[WeightsEnum, str, bool]] = self.hparams["weights"]
+        in_channels: int = self.hparams["in_channels"]
+
         # Create backbone
         backbone = timm.create_model(
-            model, in_chans=in_channels, pretrained=weights is True
+            self.hparams["model"], in_chans=in_channels, pretrained=weights is True
         )
 
         # Load weights

--- a/torchgeo/trainers/byol.py
+++ b/torchgeo/trainers/byol.py
@@ -18,7 +18,7 @@ from torch.optim.lr_scheduler import ReduceLROnPlateau
 from torchvision.models._api import WeightsEnum
 
 from ..models import get_weight
-from .utils import OptSched, extract_backbone, load_state_dict
+from .utils import extract_backbone, load_state_dict
 
 
 def normalized_mse(x: Tensor, y: Tensor) -> Tensor:
@@ -409,7 +409,7 @@ class BYOLTask(LightningModule):
     def predict_step(self, batch: Any, batch_idx: int, dataloader_idx: int = 0) -> None:
         """No-op, does nothing."""
 
-    def configure_optimizers(self) -> OptSched:
+    def configure_optimizers(self) -> dict[str, Any]:
         """Initialize the optimizer and learning rate scheduler.
 
         Returns:

--- a/torchgeo/trainers/classification.py
+++ b/torchgeo/trainers/classification.py
@@ -27,7 +27,7 @@ from torchvision.models._api import WeightsEnum
 
 from ..datasets import unbind_samples
 from ..models import get_weight
-from .utils import OptSched, extract_backbone, load_state_dict
+from .utils import extract_backbone, load_state_dict
 
 
 class ClassificationTask(LightningModule):
@@ -247,7 +247,7 @@ class ClassificationTask(LightningModule):
         y_hat: Tensor = self(x).softmax(dim=-1)
         return y_hat
 
-    def configure_optimizers(self) -> OptSched:
+    def configure_optimizers(self) -> dict[str, Any]:
         """Initialize the optimizer and learning rate scheduler.
 
         Returns:

--- a/torchgeo/trainers/classification.py
+++ b/torchgeo/trainers/classification.py
@@ -13,7 +13,7 @@ import torch.nn as nn
 from lightning.pytorch import LightningModule
 from segmentation_models_pytorch.losses import FocalLoss, JaccardLoss
 from torch import Tensor
-from torch.optim import AdamW, Optimizer
+from torch.optim import AdamW
 from torch.optim.lr_scheduler import ReduceLROnPlateau
 from torchmetrics import MetricCollection
 from torchmetrics.classification import (
@@ -27,7 +27,7 @@ from torchvision.models._api import WeightsEnum
 
 from ..datasets import unbind_samples
 from ..models import get_weight
-from . import utils
+from .utils import OptSched, extract_backbone, load_state_dict
 
 
 class ClassificationTask(LightningModule):
@@ -86,10 +86,10 @@ class ClassificationTask(LightningModule):
             if isinstance(weights, WeightsEnum):
                 state_dict = weights.get_state_dict(progress=True)
             elif os.path.exists(weights):
-                _, state_dict = utils.extract_backbone(weights)
+                _, state_dict = extract_backbone(weights)
             else:
                 state_dict = get_weight(weights).get_state_dict(progress=True)
-            self.model = utils.load_state_dict(self.model, state_dict)
+            self.model = load_state_dict(self.model, state_dict)
 
         # Freeze backbone and unfreeze classifier head
         if freeze_backbone:
@@ -247,15 +247,18 @@ class ClassificationTask(LightningModule):
         y_hat: Tensor = self(x).softmax(dim=-1)
         return y_hat
 
-    def configure_optimizers(self) -> tuple[list[Optimizer], list[ReduceLROnPlateau]]:
+    def configure_optimizers(self) -> OptSched:
         """Initialize the optimizer and learning rate scheduler.
 
         Returns:
             Optimizer and learning rate scheduler.
         """
         optimizer = AdamW(self.parameters(), lr=self.hparams["lr"])
-        lr_scheduler = ReduceLROnPlateau(optimizer, patience=self.hparams["patience"])
-        return [optimizer], [lr_scheduler]
+        scheduler = ReduceLROnPlateau(optimizer, patience=self.hparams["patience"])
+        return {
+            "optimizer": optimizer,
+            "lr_scheduler": {"scheduler": scheduler, "monitor": "val_loss"},
+        }
 
 
 class MultiLabelClassificationTask(ClassificationTask):

--- a/torchgeo/trainers/classification.py
+++ b/torchgeo/trainers/classification.py
@@ -4,7 +4,7 @@
 """Trainers for image classification."""
 
 import os
-from typing import Any, Optional, Union, cast
+from typing import Any, Optional, Union
 
 import matplotlib.pyplot as plt
 import timm
@@ -142,8 +142,8 @@ class ClassificationTask(LightningModule):
         Returns:
             Output from the model.
         """
-        z = self.model(x)
-        return cast(Tensor, z)
+        z: Tensor = self.model(x)
+        return z
 
     def training_step(
         self, batch: Any, batch_idx: int, dataloader_idx: int = 0
@@ -163,12 +163,12 @@ class ClassificationTask(LightningModule):
         y_hat = self(x)
         y_hat_hard = y_hat.argmax(dim=1)
 
-        loss = self.loss(y_hat, y)
+        loss: Tensor = self.loss(y_hat, y)
 
         self.log("train_loss", loss)
         self.train_metrics(y_hat_hard, y)
 
-        return cast(Tensor, loss)
+        return loss
 
     def validation_step(
         self, batch: Any, batch_idx: int, dataloader_idx: int = 0
@@ -301,12 +301,12 @@ class MultiLabelClassificationTask(ClassificationTask):
         y_hat = self(x)
         y_hat_hard = torch.sigmoid(y_hat)
 
-        loss = self.loss(y_hat, y.to(torch.float))
+        loss: Tensor = self.loss(y_hat, y.to(torch.float))
 
         self.log("train_loss", loss)
         self.train_metrics(y_hat_hard, y)
 
-        return cast(Tensor, loss)
+        return loss
 
     def validation_step(
         self, batch: Any, batch_idx: int, dataloader_idx: int = 0

--- a/torchgeo/trainers/classification.py
+++ b/torchgeo/trainers/classification.py
@@ -27,7 +27,7 @@ from torchvision.models._api import WeightsEnum
 
 from ..datasets import unbind_samples
 from ..models import get_weight
-from .utils import extract_backbone, load_state_dict
+from . import utils
 
 
 class ClassificationTask(LightningModule):
@@ -47,7 +47,8 @@ class ClassificationTask(LightningModule):
         """Initialize a new ClassificationTask instance.
 
         Args:
-            model: Name of the timm model to use.
+            model: Name of the `timm
+                <https://huggingface.co/docs/timm/reference/models>`__ model to use.
             weights: Initial model weights. Either a weight enum, the string
                 representation of a weight enum, True for ImageNet weights, False
                 or None for random weights, or the path to a saved model state dict.
@@ -59,15 +60,15 @@ class ClassificationTask(LightningModule):
             freeze_backbone: Freeze the backbone network to linear probe
                 the classifier head.
 
+        .. versionchanged:: 0.4
+           *classification_model* was renamed to *model*.
+
         .. versionadded:: 0.5
            The *freeze_backbone* parameter.
 
         .. versionchanged:: 0.5
            *learning_rate* and *learning_rate_schedule_patience* were renamed to
            *lr* and *patience*.
-
-        .. versionchanged:: 0.4
-           *classification_model* was renamed to *model*.
         """
         super().__init__()
 
@@ -86,10 +87,10 @@ class ClassificationTask(LightningModule):
             if isinstance(weights, WeightsEnum):
                 state_dict = weights.get_state_dict(progress=True)
             elif os.path.exists(weights):
-                _, state_dict = extract_backbone(weights)
+                _, state_dict = utils.extract_backbone(weights)
             else:
                 state_dict = get_weight(weights).get_state_dict(progress=True)
-            self.model = load_state_dict(self.model, state_dict)
+            self.model = utils.load_state_dict(self.model, state_dict)
 
         # Freeze backbone and unfreeze classifier head
         if freeze_backbone:

--- a/torchgeo/trainers/classification.py
+++ b/torchgeo/trainers/classification.py
@@ -113,7 +113,6 @@ class ClassificationTask(LightningModule):
 
     def _configure_metrics(self) -> None:
         """Initialize the performance metrics."""
-
         self.train_metrics = MetricCollection(
             {
                 "OverallAccuracy": MulticlassAccuracy(
@@ -264,7 +263,6 @@ class MultiLabelClassificationTask(ClassificationTask):
 
     def _configure_metrics(self) -> None:
         """Initialize the performance metrics."""
-
         self.train_metrics = MetricCollection(
             {
                 "OverallAccuracy": MultilabelAccuracy(

--- a/torchgeo/trainers/detection.py
+++ b/torchgeo/trainers/detection.py
@@ -51,18 +51,6 @@ BACKBONE_WEIGHT_MAP = {
 class ObjectDetectionTask(LightningModule):
     """Object detection.
 
-    Currently, supports Faster R-CNN, FCOS, and RetinaNet models from
-    `torchvision
-    <https://pytorch.org/vision/stable/models.html
-    #object-detection-instance-segmentation-and-person-keypoint-detection>`_ with
-    one of the following *backbone* arguments:
-
-    .. code-block:: python
-
-       ['resnet18', 'resnet34', 'resnet50', 'resnet101', 'resnet152',
-       'resnext50_32x4d', 'resnext101_32x8d',
-       'wide_resnet50_2', 'wide_resnet101_2']
-
     .. versionadded:: 0.4
     """
 
@@ -81,8 +69,14 @@ class ObjectDetectionTask(LightningModule):
         """Initialize a new ObjectDetectionTask instance.
 
         Args:
-            model: Name of the torchvision model to use.
-            backbone: Name of the model backbone to use.
+            model: Name of the `torchvision
+                <https://pytorch.org/vision/stable/models.html#object-detection>`__
+                model to use. One of 'faster-rcnn', 'fcos', or 'retinanet'.
+            backbone: Name of the `torchvision
+                <https://pytorch.org/vision/stable/models.html#classification>`__
+                backbone to use. One of 'resnet18', 'resnet34', 'resnet50',
+                'resnet101', 'resnet152', 'resnext50_32x4d', 'resnext101_32x8d',
+                'wide_resnet50_2', or 'wide_resnet101_2'.
             weights: Initial model weights. True for ImageNet weights, False or None
                 for random weights.
             in_channels: Number of input channels to model.
@@ -96,15 +90,15 @@ class ObjectDetectionTask(LightningModule):
         Raises:
             ValueError: If any arguments are invalid.
 
-        .. versionchanged:: 0.5
-           *pretrained*, *learning_rate*, and *learning_rate_schedule_patience* were
-           renamed to *weights*, *lr*, and *patience*.
-
         .. versionchanged:: 0.4
            *detection_model* was renamed to *model*.
 
         .. versionadded:: 0.5
            The *freeze_backbone* parameter.
+
+        .. versionchanged:: 0.5
+           *pretrained*, *learning_rate*, and *learning_rate_schedule_patience* were
+           renamed to *weights*, *lr*, and *patience*.
         """
         super().__init__()
 

--- a/torchgeo/trainers/detection.py
+++ b/torchgeo/trainers/detection.py
@@ -213,7 +213,7 @@ class ObjectDetectionTask(LightningModule):
     def training_step(
         self, batch: Any, batch_idx: int, dataloader_idx: int = 0
     ) -> Tensor:
-        """Compute the training loss and additional metrics.
+        """Compute the training loss.
 
         Args:
             batch: The output of your DataLoader.
@@ -239,7 +239,7 @@ class ObjectDetectionTask(LightningModule):
     def validation_step(
         self, batch: Any, batch_idx: int, dataloader_idx: int = 0
     ) -> None:
-        """Compute the validation loss and additional metrics.
+        """Compute the validation metrics.
 
         Args:
             batch: The output of your DataLoader.
@@ -283,7 +283,7 @@ class ObjectDetectionTask(LightningModule):
                 pass
 
     def on_validation_epoch_end(self) -> None:
-        """Logs epoch level validation metrics."""
+        """Log epoch level validation metrics."""
         # TODO: why is this method necessary?
         metrics = self.val_metrics.compute()
 
@@ -294,7 +294,7 @@ class ObjectDetectionTask(LightningModule):
         self.val_metrics.reset()
 
     def test_step(self, batch: Any, batch_idx: int, dataloader_idx: int = 0) -> None:
-        """Compute the test loss and additional metrics.
+        """Compute the test metrics.
 
         Args:
             batch: The output of your DataLoader.
@@ -314,7 +314,7 @@ class ObjectDetectionTask(LightningModule):
     def predict_step(
         self, batch: Any, batch_idx: int, dataloader_idx: int = 0
     ) -> list[dict[str, Tensor]]:
-        """Compute the predicted class probabilities.
+        """Compute the predicted bounding boxes.
 
         Args:
             batch: The output of your DataLoader.

--- a/torchgeo/trainers/detection.py
+++ b/torchgeo/trainers/detection.py
@@ -105,11 +105,11 @@ class ObjectDetectionTask(BaseTask):
         Raises:
             ValueError: If *model* or *backbone* are invalid.
         """
-        backbone = self.hparams["backbone"]
-        model = self.hparams["model"]
-        weights = self.hparams["weights"]
-        num_classes = self.hparams["num_classes"]
-        freeze_backbone = self.hparams["freeze_backbone"]
+        backbone: str = self.hparams["backbone"]
+        model: str = self.hparams["model"]
+        weights: Optional[bool] = self.hparams["weights"]
+        num_classes: int = self.hparams["num_classes"]
+        freeze_backbone: bool = self.hparams["freeze_backbone"]
 
         if backbone in BACKBONE_LAT_DIM_MAP:
             kwargs = {

--- a/torchgeo/trainers/detection.py
+++ b/torchgeo/trainers/detection.py
@@ -202,17 +202,20 @@ class ObjectDetectionTask(LightningModule):
         self.val_metrics = metrics.clone(prefix="val_")
         self.test_metrics = metrics.clone(prefix="test_")
 
-    def forward(self, x: Tensor) -> Tensor:
+    def forward(
+        self, x: list[Tensor], y: Optional[list[dict[str, Tensor]]] = None
+    ) -> tuple[dict[str, Tensor], list[dict[str, Tensor]]]:
         """Forward pass of the model.
 
         Args:
             x: Mini-batch of images.
+            y: Optional ground truth boxes present in the image.
 
         Returns:
             Output from the model.
         """
-        z = self.model(x)
-        return cast(Tensor, z)
+        out: tuple[dict[str, Tensor], list[dict[str, Tensor]]] = self.model(x, y)
+        return out
 
     def training_step(
         self, batch: Any, batch_idx: int, dataloader_idx: int = 0

--- a/torchgeo/trainers/detection.py
+++ b/torchgeo/trainers/detection.py
@@ -4,7 +4,7 @@
 """Trainers for object detection."""
 
 from functools import partial
-from typing import Any, Optional, cast
+from typing import Any, Optional
 
 import matplotlib.pyplot as plt
 import torch
@@ -236,11 +236,11 @@ class ObjectDetectionTask(LightningModule):
             for i in range(batch_size)
         ]
         loss_dict = self(x, y)
-        train_loss = sum(loss_dict.values())
+        train_loss: Tensor = sum(loss_dict.values())
 
         self.log_dict(loss_dict)
 
-        return cast(Tensor, train_loss)
+        return train_loss
 
     def validation_step(
         self, batch: Any, batch_idx: int, dataloader_idx: int = 0

--- a/torchgeo/trainers/moco.py
+++ b/torchgeo/trainers/moco.py
@@ -31,7 +31,7 @@ from torchvision.models._api import WeightsEnum
 import torchgeo.transforms as T
 
 from ..models import get_weight
-from .utils import extract_backbone, load_state_dict
+from . import utils
 
 try:
     from torch.optim.lr_scheduler import LRScheduler
@@ -160,7 +160,8 @@ class MoCoTask(LightningModule):
         """Initialize a new MoCoTask instance.
 
         Args:
-            model: Name of the timm model to use.
+            model: Name of the `timm
+                <https://huggingface.co/docs/timm/reference/models>`__ model to use.
             weights: Initial model weights. Either a weight enum, the string
                 representation of a weight enum, True for ImageNet weights, False
                 or None for random weights, or the path to a saved model state dict.
@@ -237,10 +238,10 @@ class MoCoTask(LightningModule):
             if isinstance(weights, WeightsEnum):
                 state_dict = weights.get_state_dict(progress=True)
             elif os.path.exists(weights):
-                _, state_dict = extract_backbone(weights)
+                _, state_dict = utils.extract_backbone(weights)
             else:
                 state_dict = get_weight(weights).get_state_dict(progress=True)
-            self.backbone = load_state_dict(self.backbone, state_dict)
+            self.backbone = utils.load_state_dict(self.backbone, state_dict)
 
         # Create projection (and prediction) head
         batch_norm = version == 3

--- a/torchgeo/trainers/moco.py
+++ b/torchgeo/trainers/moco.py
@@ -19,7 +19,7 @@ from lightly.models.utils import deactivate_requires_grad, update_momentum
 from lightly.utils.scheduler import cosine_schedule
 from lightning import LightningModule
 from torch import Tensor
-from torch.optim import SGD, AdamW
+from torch.optim import SGD, AdamW, Optimizer
 from torch.optim.lr_scheduler import (
     CosineAnnealingLR,
     LinearLR,
@@ -32,6 +32,11 @@ import torchgeo.transforms as T
 
 from ..models import get_weight
 from .utils import extract_backbone, load_state_dict
+
+try:
+    from torch.optim.lr_scheduler import LRScheduler
+except ImportError:
+    from torch.optim.lr_scheduler import _LRScheduler as LRScheduler
 
 
 def moco_augmentations(
@@ -375,7 +380,7 @@ class MoCoTask(LightningModule):
             Optimizer and learning rate scheduler.
         """
         if self.hparams["version"] == 3:
-            optimizer = AdamW(
+            optimizer: Optimizer = AdamW(
                 params=self.parameters(),
                 lr=self.hparams["lr"],
                 weight_decay=self.hparams["weight_decay"],
@@ -384,7 +389,7 @@ class MoCoTask(LightningModule):
             max_epochs = 200
             if self.trainer and self.trainer.max_epochs:
                 max_epochs = self.trainer.max_epochs
-            scheduler = SequentialLR(
+            scheduler: LRScheduler = SequentialLR(
                 optimizer,
                 schedulers=[
                     LinearLR(

--- a/torchgeo/trainers/moco.py
+++ b/torchgeo/trainers/moco.py
@@ -19,7 +19,7 @@ from lightly.models.utils import deactivate_requires_grad, update_momentum
 from lightly.utils.scheduler import cosine_schedule
 from lightning import LightningModule
 from torch import Tensor
-from torch.optim import SGD, AdamW, Optimizer
+from torch.optim import SGD, AdamW
 from torch.optim.lr_scheduler import (
     CosineAnnealingLR,
     LinearLR,
@@ -31,12 +31,7 @@ from torchvision.models._api import WeightsEnum
 import torchgeo.transforms as T
 
 from ..models import get_weight
-from .utils import OptSched, extract_backbone, load_state_dict
-
-try:
-    from torch.optim.lr_scheduler import LRScheduler
-except ImportError:
-    from torch.optim.lr_scheduler import _LRScheduler as LRScheduler
+from .utils import extract_backbone, load_state_dict
 
 
 def moco_augmentations(
@@ -373,14 +368,14 @@ class MoCoTask(LightningModule):
     def predict_step(self, batch: Any, batch_idx: int, dataloader_idx: int = 0) -> None:
         """No-op, does nothing."""
 
-    def configure_optimizers(self) -> OptSched:
+    def configure_optimizers(self) -> dict[str, Any]:
         """Initialize the optimizer and learning rate scheduler.
 
         Returns:
             Optimizer and learning rate scheduler.
         """
         if self.hparams["version"] == 3:
-            optimizer: Optimizer = AdamW(
+            optimizer = AdamW(
                 params=self.parameters(),
                 lr=self.hparams["lr"],
                 weight_decay=self.hparams["weight_decay"],
@@ -389,7 +384,7 @@ class MoCoTask(LightningModule):
             max_epochs = 200
             if self.trainer and self.trainer.max_epochs:
                 max_epochs = self.trainer.max_epochs
-            scheduler: LRScheduler = SequentialLR(
+            scheduler = SequentialLR(
                 optimizer,
                 schedulers=[
                     LinearLR(

--- a/torchgeo/trainers/moco.py
+++ b/torchgeo/trainers/moco.py
@@ -6,7 +6,7 @@
 import os
 import warnings
 from collections.abc import Sequence
-from typing import Any, Optional, Union, cast
+from typing import Any, Optional, Union
 
 import kornia.augmentation as K
 import timm
@@ -273,13 +273,13 @@ class MoCoTask(LightningModule):
         Returns:
             Output from the model and backbone
         """
-        h = self.backbone(x)
+        h: Tensor = self.backbone(x)
         q = h
         if self.hparams["version"] > 1:
             q = self.projection_head(q)
         if self.hparams["version"] == 3:
             q = self.prediction_head(q)
-        return cast(Tensor, q), cast(Tensor, h)
+        return q, h
 
     def forward_momentum(self, x: Tensor) -> Tensor:
         """Forward pass of the momentum model.
@@ -290,10 +290,10 @@ class MoCoTask(LightningModule):
         Returns:
             Output from the momentum model.
         """
-        k = self.backbone_momentum(x)
+        k: Tensor = self.backbone_momentum(x)
         if self.hparams["version"] > 1:
             k = self.projection_head_momentum(k)
-        return cast(Tensor, k)
+        return k
 
     def training_step(
         self, batch: Any, batch_idx: int, dataloader_idx: int = 0
@@ -330,7 +330,7 @@ class MoCoTask(LightningModule):
             with torch.no_grad():
                 update_momentum(self.backbone, self.backbone_momentum, m)
                 k = self.forward_momentum(x2)
-            loss = self.criterion(q, k)
+            loss: Tensor = self.criterion(q, k)
         elif self.hparams["version"] == 2:
             q, h1 = self.forward(x1)
             with torch.no_grad():
@@ -360,7 +360,7 @@ class MoCoTask(LightningModule):
         self.log("train_ssl_std", self.avg_output_std)
         self.log("train_loss", loss)
 
-        return cast(Tensor, loss)
+        return loss
 
     def validation_step(
         self, batch: Any, batch_idx: int, dataloader_idx: int = 0

--- a/torchgeo/trainers/moco.py
+++ b/torchgeo/trainers/moco.py
@@ -234,13 +234,13 @@ class MoCoTask(BaseTask):
 
     def configure_models(self) -> None:
         """Initialize the model."""
-        model = self.hparams["model"]
-        weights = self.hparams["weights"]
-        in_channels = self.hparams["in_channels"]
-        version = self.hparams["version"]
-        layers = self.hparams["layers"]
-        hidden_dim = self.hparams["hidden_dim"]
-        output_dim = self.hparams["output_dim"]
+        model: str = self.hparams["model"]
+        weights: Optional[Union[WeightsEnum, str, bool]] = self.hparams["weights"]
+        in_channels: int = self.hparams["in_channels"]
+        version: int = self.hparams["version"]
+        layers: int = self.hparams["layers"]
+        hidden_dim: int = self.hparams["hidden_dim"]
+        output_dim: int = self.hparams["output_dim"]
 
         # Create backbone
         self.backbone = timm.create_model(

--- a/torchgeo/trainers/moco.py
+++ b/torchgeo/trainers/moco.py
@@ -217,12 +217,12 @@ class MoCoTask(BaseTask):
             if memory_bank_size > 0:
                 warnings.warn("MoCo v3 does not use a memory bank")
 
+        super().__init__()
+
         grayscale_weights = grayscale_weights or torch.ones(in_channels)
         aug1, aug2 = moco_augmentations(version, size, grayscale_weights)
         self.augmentation1 = augmentation1 or aug1
         self.augmentation2 = augmentation2 or aug2
-
-        super().__init__()
 
     def configure_losses(self) -> None:
         """Initialize the loss criterion."""

--- a/torchgeo/trainers/regression.py
+++ b/torchgeo/trainers/regression.py
@@ -9,6 +9,7 @@ from typing import Any, Optional, Union, cast
 import matplotlib.pyplot as plt
 import segmentation_models_pytorch as smp
 import timm
+import torch
 import torch.nn as nn
 from lightning.pytorch import LightningModule
 from torch import Tensor
@@ -156,7 +157,8 @@ class RegressionTask(LightningModule):
             The loss tensor.
         """
         x = batch["image"]
-        y = batch[self.target_key]
+        # TODO: remove .to(...) once we have a real pixelwise regression dataset
+        y = batch[self.target_key].to(torch.float)
         y_hat = self(x)
 
         if y_hat.ndim != y.ndim:
@@ -179,7 +181,8 @@ class RegressionTask(LightningModule):
             dataloader_idx: Index of the current dataloader.
         """
         x = batch["image"]
-        y = batch[self.target_key]
+        # TODO: remove .to(...) once we have a real pixelwise regression dataset
+        y = batch[self.target_key].to(torch.float)
         y_hat = self(x)
 
         if y_hat.ndim != y.ndim:
@@ -223,7 +226,8 @@ class RegressionTask(LightningModule):
             dataloader_idx: Index of the current dataloader.
         """
         x = batch["image"]
-        y = batch[self.target_key]
+        # TODO: remove .to(...) once we have a real pixelwise regression dataset
+        y = batch[self.target_key].to(torch.float)
         y_hat = self(x)
 
         if y_hat.ndim != y.ndim:

--- a/torchgeo/trainers/regression.py
+++ b/torchgeo/trainers/regression.py
@@ -1,18 +1,18 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-"""Regression tasks."""
+"""Trainers for regression."""
 
 import os
-from typing import Any, cast
+from typing import Any, Optional, Union, cast
 
 import matplotlib.pyplot as plt
 import segmentation_models_pytorch as smp
 import timm
-import torch
 import torch.nn as nn
 from lightning.pytorch import LightningModule
 from torch import Tensor
+from torch.optim import AdamW, Optimizer
 from torch.optim.lr_scheduler import ReduceLROnPlateau
 from torchmetrics import MeanAbsoluteError, MeanSquaredError, MetricCollection
 from torchvision.models._api import WeightsEnum
@@ -23,29 +23,93 @@ from . import utils
 
 
 class RegressionTask(LightningModule):
-    """LightningModule for training models on regression datasets.
-
-    Supports any available `Timm model
-    <https://huggingface.co/docs/timm/index>`_
-    as an architecture choice. To see a list of available
-    models, you can do:
-
-    .. code-block:: python
-
-        import timm
-        print(timm.list_models())
-    """
+    """Regression."""
 
     target_key: str = "label"
 
-    def config_model(self) -> None:
-        """Configures the model based on kwargs parameters."""
+    def __init__(
+        self,
+        model: str = "resnet50",
+        backbone: str = "resnet50",
+        weights: Optional[Union[WeightsEnum, str, bool]] = None,
+        in_channels: int = 3,
+        num_outputs: int = 1,
+        num_filters: int = 3,
+        loss: str = "mse",
+        lr: float = 1e-3,
+        patience: int = 10,
+        freeze_backbone: bool = False,
+        freeze_decoder: bool = False,
+    ) -> None:
+        """Initialize a new RegressionTask instance.
+
+        Args:
+            model: Name of the timm or segmentation_models_pytorch model to use.
+            backbone: Name of the timm model to use.
+                Only applicable to PixelwiseRegressionTask.
+            weights: Initial model weights. Either a weight enum, the string
+                representation of a weight enum, True for ImageNet weights, False
+                or None for random weights, or the path to a saved model state dict.
+            in_channels: Number of input channels to model.
+            num_outputs: Number of prediction outputs.
+            num_filters: Number of filters. Only applicable when model='fcn'.
+            loss: One of 'mse' or 'mae'.
+            lr: Learning rate for optimizer.
+            patience: Patience for learning rate scheduler.
+            freeze_backbone: Freeze the backbone network to linear probe
+                the regression head. Does not support FCN models.
+            freeze_decoder: Freeze the decoder network to linear probe
+                the regression head. Does not support FCN models.
+                Only applicable to PixelwiseRegressionTask.
+
+        Raises:
+            ValueError: If any arguments are invalid.
+
+        .. versionadded:: 0.5
+           The *freeze_backbone* and *freeze_decoder* parameters.
+
+        .. versionchanged:: 0.5
+           *learning_rate* and *learning_rate_schedule_patience* were renamed to
+           *lr* and *patience*.
+
+        .. versionchanged:: 0.4
+           Change regression model support from torchvision.models to timm
+        """
+        super().__init__()
+
+        self.save_hyperparameters()
+        self._configure_models()
+
+        self.loss: nn.Module
+        if loss == "mse":
+            self.loss = nn.MSELoss()
+        elif loss == "mae":
+            self.loss = nn.L1Loss()
+        else:
+            raise ValueError(
+                f"Loss type '{loss}' is not valid. "
+                "Currently, supports 'mse' or 'mae' loss."
+            )
+
+        self.train_metrics = MetricCollection(
+            {
+                "RMSE": MeanSquaredError(squared=False),
+                "MSE": MeanSquaredError(squared=True),
+                "MAE": MeanAbsoluteError(),
+            },
+            prefix="train_",
+        )
+        self.val_metrics = self.train_metrics.clone(prefix="val_")
+        self.test_metrics = self.train_metrics.clone(prefix="test_")
+
+    def _configure_models(self) -> None:
+        """Initialize the model."""
         # Create model
-        weights = self.hyperparams["weights"]
+        weights = self.hparams["weights"]
         self.model = timm.create_model(
-            self.hyperparams["model"],
-            num_classes=self.hyperparams["num_outputs"],
-            in_chans=self.hyperparams["in_channels"],
+            self.hparams["model"],
+            num_classes=self.hparams["num_outputs"],
+            in_chans=self.hparams["in_channels"],
             pretrained=weights is True,
         )
 
@@ -60,90 +124,37 @@ class RegressionTask(LightningModule):
             self.model = utils.load_state_dict(self.model, state_dict)
 
         # Freeze backbone and unfreeze classifier head
-        if self.hyperparams.get("freeze_backbone", False):
+        if self.hparams["freeze_backbone"]:
             for param in self.model.parameters():
                 param.requires_grad = False
             for param in self.model.get_classifier().parameters():
                 param.requires_grad = True
 
-    def config_task(self) -> None:
-        """Configures the task based on kwargs parameters."""
-        self.config_model()
-
-        self.loss: nn.Module
-        if self.hyperparams["loss"] == "mse":
-            self.loss = nn.MSELoss()
-        elif self.hyperparams["loss"] == "mae":
-            self.loss = nn.L1Loss()
-        else:
-            raise ValueError(
-                f"Loss type '{self.hyperparams['loss']}' is not valid. "
-                f"Currently, supports 'mse' or 'mae' loss."
-            )
-
-    def __init__(self, **kwargs: Any) -> None:
-        """Initialize a new LightningModule for training simple regression models.
-
-        Keyword Args:
-            model: Name of the timm model to use
-            weights: Either a weight enum, the string representation of a weight enum,
-                True for ImageNet weights, False or None for random weights,
-                or the path to a saved model state dict.
-            num_outputs: Number of prediction outputs
-            in_channels: Number of input channels to model
-            learning_rate: Learning rate for optimizer
-            learning_rate_schedule_patience: Patience for learning rate scheduler
-            freeze_backbone: Freeze the backbone network to linear probe
-                the regression head. Does not support FCN models.
-            freeze_decoder: Freeze the decoder network to linear probe
-                the regression head. Does not support FCN models.
-                Only applicable to PixelwiseRegressionTask.
-
-        .. versionchanged:: 0.4
-            Change regression model support from torchvision.models to timm
-
-        .. versionadded:: 0.5
-           The *freeze_backbone* and *freeze_decoder* parameters.
-        """
-        super().__init__()
-
-        # Creates `self.hparams` from kwargs
-        self.save_hyperparameters()
-        self.hyperparams = cast(dict[str, Any], self.hparams)
-        self.config_task()
-
-        self.train_metrics = MetricCollection(
-            {
-                "RMSE": MeanSquaredError(squared=False),
-                "MSE": MeanSquaredError(squared=True),
-                "MAE": MeanAbsoluteError(),
-            },
-            prefix="train_",
-        )
-        self.val_metrics = self.train_metrics.clone(prefix="val_")
-        self.test_metrics = self.train_metrics.clone(prefix="test_")
-
-    def forward(self, *args: Any, **kwargs: Any) -> Any:
+    def forward(self, x: Tensor) -> Tensor:
         """Forward pass of the model.
 
         Args:
-            x: tensor of data to run through the model
+            x: Mini-batch of images.
 
         Returns:
-            output from the model
+            Output from the model.
         """
-        return self.model(*args, **kwargs)
+        z = self.model(x)
+        return cast(Tensor, z)
 
-    def training_step(self, *args: Any, **kwargs: Any) -> Tensor:
-        """Compute and return the training loss.
+    def training_step(
+        self, batch: Any, batch_idx: int, dataloader_idx: int = 0
+    ) -> Tensor:
+        """Compute the training loss and additional metrics.
 
         Args:
-            batch: the output of your DataLoader
+            batch: The output of your DataLoader.
+            batch_idx: Integer displaying index of this batch.
+            dataloader_idx: Index of the current dataloader.
 
         Returns:
-            training loss
+            The loss tensor.
         """
-        batch = args[0]
         x = batch["image"]
         y = batch[self.target_key]
         y_hat = self(x)
@@ -151,26 +162,22 @@ class RegressionTask(LightningModule):
         if y_hat.ndim != y.ndim:
             y = y.unsqueeze(dim=1)
 
-        loss: Tensor = self.loss(y_hat, y.to(torch.float))
-        self.log("train_loss", loss)  # logging to TensorBoard
-        self.train_metrics(y_hat, y.to(torch.float))
+        loss: Tensor = self.loss(y_hat, y)
+        self.log("train_loss", loss)
+        self.train_metrics(y_hat, y)
 
         return loss
 
-    def on_train_epoch_end(self) -> None:
-        """Logs epoch-level training metrics."""
-        self.log_dict(self.train_metrics.compute())
-        self.train_metrics.reset()
-
-    def validation_step(self, *args: Any, **kwargs: Any) -> None:
-        """Compute validation loss and log example predictions.
+    def validation_step(
+        self, batch: Any, batch_idx: int, dataloader_idx: int = 0
+    ) -> None:
+        """Compute the validation loss and additional metrics.
 
         Args:
-            batch: the output of your DataLoader
-            batch_idx: the index of this batch
+            batch: The output of your DataLoader.
+            batch_idx: Integer displaying index of this batch.
+            dataloader_idx: Index of the current dataloader.
         """
-        batch = args[0]
-        batch_idx = args[1]
         x = batch["image"]
         y = batch[self.target_key]
         y_hat = self(x)
@@ -178,9 +185,9 @@ class RegressionTask(LightningModule):
         if y_hat.ndim != y.ndim:
             y = y.unsqueeze(dim=1)
 
-        loss = self.loss(y_hat, y.to(torch.float))
+        loss = self.loss(y_hat, y)
         self.log("val_loss", loss)
-        self.val_metrics(y_hat, y.to(torch.float))
+        self.val_metrics(y_hat, y)
 
         if (
             batch_idx < 10
@@ -207,18 +214,14 @@ class RegressionTask(LightningModule):
             except ValueError:
                 pass
 
-    def on_validation_epoch_end(self) -> None:
-        """Logs epoch level validation metrics."""
-        self.log_dict(self.val_metrics.compute())
-        self.val_metrics.reset()
-
-    def test_step(self, *args: Any, **kwargs: Any) -> None:
-        """Compute test loss.
+    def test_step(self, batch: Any, batch_idx: int, dataloader_idx: int = 0) -> None:
+        """Compute the test loss and additional metrics.
 
         Args:
-            batch: the output of your DataLoader
+            batch: The output of your DataLoader.
+            batch_idx: Integer displaying index of this batch.
+            dataloader_idx: Index of the current dataloader.
         """
-        batch = args[0]
         x = batch["image"]
         y = batch[self.target_key]
         y_hat = self(x)
@@ -226,47 +229,36 @@ class RegressionTask(LightningModule):
         if y_hat.ndim != y.ndim:
             y = y.unsqueeze(dim=1)
 
-        loss = self.loss(y_hat, y.to(torch.float))
+        loss = self.loss(y_hat, y)
         self.log("test_loss", loss)
-        self.test_metrics(y_hat, y.to(torch.float))
+        self.test_metrics(y_hat, y)
 
-    def on_test_epoch_end(self) -> None:
-        """Logs epoch level test metrics."""
-        self.log_dict(self.test_metrics.compute())
-        self.test_metrics.reset()
-
-    def predict_step(self, *args: Any, **kwargs: Any) -> Tensor:
-        """Compute and return the predictions.
+    def predict_step(
+        self, batch: Any, batch_idx: int, dataloader_idx: int = 0
+    ) -> Tensor:
+        """Compute the predicted class probabilities.
 
         Args:
-            batch: the output of your DataLoader
+            batch: The output of your DataLoader.
+            batch_idx: Integer displaying index of this batch.
+            dataloader_idx: Index of the current dataloader.
+
         Returns:
-            predicted values
+            Output predicted probabilities.
         """
-        batch = args[0]
         x = batch["image"]
         y_hat: Tensor = self(x)
         return y_hat
 
-    def configure_optimizers(self) -> dict[str, Any]:
+    def configure_optimizers(self) -> tuple[list[Optimizer], list[ReduceLROnPlateau]]:
         """Initialize the optimizer and learning rate scheduler.
 
         Returns:
-            learning rate dictionary
+            Optimizer and learning rate scheduler.
         """
-        optimizer = torch.optim.AdamW(
-            self.model.parameters(), lr=self.hyperparams["learning_rate"]
-        )
-        return {
-            "optimizer": optimizer,
-            "lr_scheduler": {
-                "scheduler": ReduceLROnPlateau(
-                    optimizer,
-                    patience=self.hyperparams["learning_rate_schedule_patience"],
-                ),
-                "monitor": "val_loss",
-            },
-        }
+        optimizer = AdamW(self.parameters(), lr=self.hparams["lr"])
+        lr_scheduler = ReduceLROnPlateau(optimizer, patience=self.hparams["patience"])
+        return [optimizer], [lr_scheduler]
 
 
 class PixelwiseRegressionTask(RegressionTask):
@@ -282,37 +274,37 @@ class PixelwiseRegressionTask(RegressionTask):
 
     target_key: str = "mask"
 
-    def config_model(self) -> None:
-        """Configures the model based on kwargs parameters."""
-        weights = self.hyperparams["weights"]
+    def _configure_models(self) -> None:
+        """Initialize the model."""
+        weights = self.hparams["weights"]
 
-        if self.hyperparams["model"] == "unet":
+        if self.hparams["model"] == "unet":
             self.model = smp.Unet(
-                encoder_name=self.hyperparams["backbone"],
+                encoder_name=self.hparams["backbone"],
                 encoder_weights="imagenet" if weights is True else None,
-                in_channels=self.hyperparams["in_channels"],
+                in_channels=self.hparams["in_channels"],
                 classes=1,
             )
-        elif self.hyperparams["model"] == "deeplabv3+":
+        elif self.hparams["model"] == "deeplabv3+":
             self.model = smp.DeepLabV3Plus(
-                encoder_name=self.hyperparams["backbone"],
+                encoder_name=self.hparams["backbone"],
                 encoder_weights="imagenet" if weights is True else None,
-                in_channels=self.hyperparams["in_channels"],
+                in_channels=self.hparams["in_channels"],
                 classes=1,
             )
-        elif self.hyperparams["model"] == "fcn":
+        elif self.hparams["model"] == "fcn":
             self.model = FCN(
-                in_channels=self.hyperparams["in_channels"],
+                in_channels=self.hparams["in_channels"],
                 classes=1,
-                num_filters=self.hyperparams["num_filters"],
+                num_filters=self.hparams["num_filters"],
             )
         else:
             raise ValueError(
-                f"Model type '{self.hyperparams['model']}' is not valid. "
-                f"Currently, only supports 'unet', 'deeplabv3+' and 'fcn'."
+                f"Model type '{self.hparams['model']}' is not valid. "
+                "Currently, only supports 'unet', 'deeplabv3+' and 'fcn'."
             )
 
-        if self.hyperparams["model"] != "fcn":
+        if self.hparams["model"] != "fcn":
             if weights and weights is not True:
                 if isinstance(weights, WeightsEnum):
                     state_dict = weights.get_state_dict(progress=True)
@@ -323,15 +315,17 @@ class PixelwiseRegressionTask(RegressionTask):
                 self.model.encoder.load_state_dict(state_dict)
 
         # Freeze backbone
-        if self.hyperparams.get("freeze_backbone", False) and self.hyperparams[
-            "model"
-        ] in ["unet", "deeplabv3+"]:
+        if self.hparams.get("freeze_backbone", False) and self.hparams["model"] in [
+            "unet",
+            "deeplabv3+",
+        ]:
             for param in self.model.encoder.parameters():
                 param.requires_grad = False
 
         # Freeze decoder
-        if self.hyperparams.get("freeze_decoder", False) and self.hyperparams[
-            "model"
-        ] in ["unet", "deeplabv3+"]:
+        if self.hparams.get("freeze_decoder", False) and self.hparams["model"] in [
+            "unet",
+            "deeplabv3+",
+        ]:
             for param in self.model.decoder.parameters():
                 param.requires_grad = False

--- a/torchgeo/trainers/regression.py
+++ b/torchgeo/trainers/regression.py
@@ -244,7 +244,7 @@ class RegressionTask(LightningModule):
     def predict_step(
         self, batch: Any, batch_idx: int, dataloader_idx: int = 0
     ) -> Tensor:
-        """Compute the predicted class probabilities.
+        """Compute the predicted regression values.
 
         Args:
             batch: The output of your DataLoader.

--- a/torchgeo/trainers/regression.py
+++ b/torchgeo/trainers/regression.py
@@ -4,7 +4,7 @@
 """Trainers for regression."""
 
 import os
-from typing import Any, Optional, Union, cast
+from typing import Any, Optional, Union
 
 import matplotlib.pyplot as plt
 import segmentation_models_pytorch as smp
@@ -140,8 +140,8 @@ class RegressionTask(LightningModule):
         Returns:
             Output from the model.
         """
-        z = self.model(x)
-        return cast(Tensor, z)
+        z: Tensor = self.model(x)
+        return z
 
     def training_step(
         self, batch: Any, batch_idx: int, dataloader_idx: int = 0

--- a/torchgeo/trainers/regression.py
+++ b/torchgeo/trainers/regression.py
@@ -20,7 +20,7 @@ from torchvision.models._api import WeightsEnum
 
 from ..datasets import unbind_samples
 from ..models import FCN, get_weight
-from .utils import OptSched, extract_backbone, load_state_dict
+from .utils import extract_backbone, load_state_dict
 
 
 class RegressionTask(LightningModule):
@@ -254,7 +254,7 @@ class RegressionTask(LightningModule):
         y_hat: Tensor = self(x)
         return y_hat
 
-    def configure_optimizers(self) -> OptSched:
+    def configure_optimizers(self) -> dict[str, Any]:
         """Initialize the optimizer and learning rate scheduler.
 
         Returns:

--- a/torchgeo/trainers/regression.py
+++ b/torchgeo/trainers/regression.py
@@ -83,7 +83,7 @@ class RegressionTask(BaseTask):
         Raises:
             ValueError: If *loss* is invalid.
         """
-        loss = self.hparams["loss"]
+        loss: str = self.hparams["loss"]
         if loss == "mse":
             self.criterion: nn.Module = nn.MSELoss()
         elif loss == "mae":
@@ -110,7 +110,7 @@ class RegressionTask(BaseTask):
     def configure_models(self) -> None:
         """Initialize the model."""
         # Create model
-        weights = self.hparams["weights"]
+        weights: Optional[Union[WeightsEnum, str, bool]] = self.hparams["weights"]
         self.model = timm.create_model(
             self.hparams["model"],
             num_classes=self.hparams["num_outputs"],
@@ -251,7 +251,7 @@ class PixelwiseRegressionTask(RegressionTask):
 
     def configure_models(self) -> None:
         """Initialize the model."""
-        weights = self.hparams["weights"]
+        weights: Optional[Union[WeightsEnum, str, bool]] = self.hparams["weights"]
 
         if self.hparams["model"] == "unet":
             self.model = smp.Unet(

--- a/torchgeo/trainers/segmentation.py
+++ b/torchgeo/trainers/segmentation.py
@@ -101,7 +101,7 @@ class SemanticSegmentationTask(BaseTask):
         Raises:
             ValueError: If *loss* is invalid.
         """
-        loss = self.hparams["loss"]
+        loss: str = self.hparams["loss"]
         ignore_index = self.hparams["ignore_index"]
         if loss == "ce":
             ignore_value = -1000 if ignore_index is None else ignore_index
@@ -124,8 +124,8 @@ class SemanticSegmentationTask(BaseTask):
 
     def configure_metrics(self) -> None:
         """Initialize the performance metrics."""
-        num_classes = self.hparams["num_classes"]
-        ignore_index = self.hparams["ignore_index"]
+        num_classes: int = self.hparams["num_classes"]
+        ignore_index: Optional[int] = self.hparams["ignore_index"]
         metrics = MetricCollection(
             [
                 MulticlassAccuracy(
@@ -149,12 +149,12 @@ class SemanticSegmentationTask(BaseTask):
         Raises:
             ValueError: If *model* is invalid.
         """
-        model = self.hparams["model"]
-        backbone = self.hparams["backbone"]
-        weights = self.hparams["weights"]
-        in_channels = self.hparams["in_channels"]
-        num_classes = self.hparams["num_classes"]
-        num_filters = self.hparams["num_filters"]
+        model: str = self.hparams["model"]
+        backbone: str = self.hparams["backbone"]
+        weights: Optional[Union[WeightsEnum, str, bool]] = self.hparams["weights"]
+        in_channels: int = self.hparams["in_channels"]
+        num_classes: int = self.hparams["num_classes"]
+        num_filters: int = self.hparams["num_filters"]
 
         if model == "unet":
             self.model = smp.Unet(

--- a/torchgeo/trainers/segmentation.py
+++ b/torchgeo/trainers/segmentation.py
@@ -20,17 +20,11 @@ from torchvision.models._api import WeightsEnum
 
 from ..datasets.utils import unbind_samples
 from ..models import FCN, get_weight
-from .utils import extract_backbone
+from . import utils
 
 
 class SemanticSegmentationTask(LightningModule):
-    """Semantic Segmentation.
-
-    Supports `Segmentation Models Pytorch
-    <https://github.com/qubvel/segmentation_models.pytorch>`_
-    as an architecture choice in combination with any of these
-    `TIMM backbones <https://smp.readthedocs.io/en/latest/encoders_timm.html>`_.
-    """
+    """Semantic Segmentation."""
 
     def __init__(
         self,
@@ -51,8 +45,11 @@ class SemanticSegmentationTask(LightningModule):
         """Inititalize a new SemanticSegmentationTask instance.
 
         Args:
-            model: Name of the segmentation model type to use.
-            backbone: Name of the timm backbone to use.
+            model: Name of the
+                `smp <https://smp.readthedocs.io/en/latest/models.html>`__ model to use.
+            backbone: Name of the `timm
+                <https://smp.readthedocs.io/en/latest/encoders_timm.html>`__ or `smp
+                <https://smp.readthedocs.io/en/latest/encoders.html>`__ backbone to use.
             weights: Initial model weights. Either a weight enum, the string
                 representation of a weight enum, True for ImageNet weights, False or
                 None for random weights, or the path to a saved model state dict. FCN
@@ -81,16 +78,14 @@ class SemanticSegmentationTask(LightningModule):
             UserWarning: When loss='jaccard' and ignore_index is specified.
 
         .. versionchanged:: 0.3
-           The *ignore_zeros* parameter was renamed to *ignore_index*.
+           *ignore_zeros* was renamed to *ignore_index*.
 
         .. versionchanged:: 0.4
-           The *segmentation_model* parameter was renamed to *model*,
-           *encoder_name* renamed to *backbone*, and
-           *encoder_weights* to *weights*.
+           *segmentation_model*, *encoder_name*, and *encoder_weights*
+           were renamed to *model*, *backbone*, and *weights*.
 
         .. versionadded: 0.5
-            The *class_weights*, *freeze_backbone*,
-            and *freeze_decoder* parameters.
+            The *class_weights*, *freeze_backbone*, and *freeze_decoder* parameters.
 
         .. versionchanged:: 0.5
            The *weights* parameter now supports WeightEnums and checkpoint paths.
@@ -153,7 +148,7 @@ class SemanticSegmentationTask(LightningModule):
                 if isinstance(weights, WeightsEnum):
                     state_dict = weights.get_state_dict(progress=True)
                 elif os.path.exists(weights):
-                    _, state_dict = extract_backbone(weights)
+                    _, state_dict = utils.extract_backbone(weights)
                 else:
                     state_dict = get_weight(weights).get_state_dict(progress=True)
                 self.model.encoder.load_state_dict(state_dict)

--- a/torchgeo/trainers/segmentation.py
+++ b/torchgeo/trainers/segmentation.py
@@ -20,7 +20,7 @@ from torchvision.models._api import WeightsEnum
 
 from ..datasets.utils import unbind_samples
 from ..models import FCN, get_weight
-from .utils import OptSched, extract_backbone
+from .utils import extract_backbone
 
 
 class SemanticSegmentationTask(LightningModule):
@@ -299,7 +299,7 @@ class SemanticSegmentationTask(LightningModule):
         y_hat: Tensor = self(x).softmax(dim=1)
         return y_hat
 
-    def configure_optimizers(self) -> OptSched:
+    def configure_optimizers(self) -> dict[str, Any]:
         """Initialize the optimizer and learning rate scheduler.
 
         Returns:

--- a/torchgeo/trainers/segmentation.py
+++ b/torchgeo/trainers/segmentation.py
@@ -5,7 +5,7 @@
 
 import os
 import warnings
-from typing import Any, Optional, Union, cast
+from typing import Any, Optional, Union
 
 import matplotlib.pyplot as plt
 import segmentation_models_pytorch as smp
@@ -194,8 +194,8 @@ class SemanticSegmentationTask(LightningModule):
         Returns:
             Output from the model.
         """
-        z = self.model(x)
-        return cast(Tensor, z)
+        z: Tensor = self.model(x)
+        return z
 
     def training_step(
         self, batch: Any, batch_idx: int, dataloader_idx: int = 0
@@ -215,12 +215,12 @@ class SemanticSegmentationTask(LightningModule):
         y_hat = self(x)
         y_hat_hard = y_hat.argmax(dim=1)
 
-        loss = self.loss(y_hat, y)
+        loss: Tensor = self.loss(y_hat, y)
 
         self.log("train_loss", loss)
         self.train_metrics(y_hat_hard, y)
 
-        return cast(Tensor, loss)
+        return loss
 
     def validation_step(
         self, batch: Any, batch_idx: int, dataloader_idx: int = 0

--- a/torchgeo/trainers/segmentation.py
+++ b/torchgeo/trainers/segmentation.py
@@ -9,7 +9,6 @@ from typing import Any, Optional, Union, cast
 
 import matplotlib.pyplot as plt
 import segmentation_models_pytorch as smp
-import torch
 import torch.nn as nn
 from lightning.pytorch import LightningModule
 from torch import Tensor
@@ -134,12 +133,6 @@ class SemanticSegmentationTask(LightningModule):
 
         if loss == "ce":
             ignore_value = -1000 if ignore_index is None else ignore_index
-
-            if isinstance(class_weights, torch.Tensor):
-                class_weights = class_weights.to(dtype=torch.float32)
-            elif hasattr(class_weights, "__array__") or class_weights:
-                class_weights = torch.tensor(class_weights, dtype=torch.float32)
-
             self.loss = nn.CrossEntropyLoss(
                 ignore_index=ignore_value, weight=class_weights
             )

--- a/torchgeo/trainers/segmentation.py
+++ b/torchgeo/trainers/segmentation.py
@@ -1,11 +1,11 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-"""Segmentation tasks."""
+"""Trainers for semantic segmentation."""
 
 import os
 import warnings
-from typing import Any, cast
+from typing import Any, Optional, Union, cast
 
 import matplotlib.pyplot as plt
 import segmentation_models_pytorch as smp
@@ -13,6 +13,7 @@ import torch
 import torch.nn as nn
 from lightning.pytorch import LightningModule
 from torch import Tensor
+from torch.optim import Adam, Optimizer
 from torch.optim.lr_scheduler import ReduceLROnPlateau
 from torchmetrics import MetricCollection
 from torchmetrics.classification import MulticlassAccuracy, MulticlassJaccardIndex
@@ -24,7 +25,7 @@ from . import utils
 
 
 class SemanticSegmentationTask(LightningModule):
-    """LightningModule for semantic segmentation of images.
+    """Semantic Segmentation.
 
     Supports `Segmentation Models Pytorch
     <https://github.com/qubvel/segmentation_models.pytorch>`_
@@ -32,112 +33,53 @@ class SemanticSegmentationTask(LightningModule):
     `TIMM backbones <https://smp.readthedocs.io/en/latest/encoders_timm.html>`_.
     """
 
-    def config_task(self) -> None:
-        """Configures the task based on kwargs parameters passed to the constructor."""
-        weights = self.hyperparams["weights"]
+    def __init__(
+        self,
+        model: str = "unet",
+        backbone: str = "resnet50",
+        weights: Optional[Union[WeightsEnum, str, bool]] = None,
+        in_channels: int = 3,
+        num_classes: int = 1000,
+        num_filters: int = 3,
+        loss: str = "ce",
+        class_weights: Optional[Tensor] = None,
+        ignore_index: Optional[int] = None,
+        lr: float = 1e-3,
+        patience: int = 10,
+        freeze_backbone: bool = False,
+        freeze_decoder: bool = False,
+    ) -> None:
+        """Inititalize a new SemanticSegmentationTask instance.
 
-        if self.hyperparams["model"] == "unet":
-            self.model = smp.Unet(
-                encoder_name=self.hyperparams["backbone"],
-                encoder_weights="imagenet" if weights is True else None,
-                in_channels=self.hyperparams["in_channels"],
-                classes=self.hyperparams["num_classes"],
-            )
-        elif self.hyperparams["model"] == "deeplabv3+":
-            self.model = smp.DeepLabV3Plus(
-                encoder_name=self.hyperparams["backbone"],
-                encoder_weights="imagenet" if weights is True else None,
-                in_channels=self.hyperparams["in_channels"],
-                classes=self.hyperparams["num_classes"],
-            )
-        elif self.hyperparams["model"] == "fcn":
-            self.model = FCN(
-                in_channels=self.hyperparams["in_channels"],
-                classes=self.hyperparams["num_classes"],
-                num_filters=self.hyperparams["num_filters"],
-            )
-        else:
-            raise ValueError(
-                f"Model type '{self.hyperparams['model']}' is not valid. "
-                f"Currently, only supports 'unet', 'deeplabv3+' and 'fcn'."
-            )
-
-        if self.hyperparams["loss"] == "ce":
-            ignore_value = -1000 if self.ignore_index is None else self.ignore_index
-
-            class_weights = None
-            if isinstance(self.class_weights, torch.Tensor):
-                class_weights = self.class_weights.to(dtype=torch.float32)
-            elif hasattr(self.class_weights, "__array__") or self.class_weights:
-                class_weights = torch.tensor(self.class_weights, dtype=torch.float32)
-
-            self.loss = nn.CrossEntropyLoss(
-                ignore_index=ignore_value, weight=class_weights
-            )
-        elif self.hyperparams["loss"] == "jaccard":
-            self.loss = smp.losses.JaccardLoss(
-                mode="multiclass", classes=self.hyperparams["num_classes"]
-            )
-        elif self.hyperparams["loss"] == "focal":
-            self.loss = smp.losses.FocalLoss(
-                "multiclass", ignore_index=self.ignore_index, normalized=True
-            )
-        else:
-            raise ValueError(
-                f"Loss type '{self.hyperparams['loss']}' is not valid. "
-                f"Currently, supports 'ce', 'jaccard' or 'focal' loss."
-            )
-
-        if self.hyperparams["model"] != "fcn":
-            if weights and weights is not True:
-                if isinstance(weights, WeightsEnum):
-                    state_dict = weights.get_state_dict(progress=True)
-                elif os.path.exists(weights):
-                    _, state_dict = utils.extract_backbone(weights)
-                else:
-                    state_dict = get_weight(weights).get_state_dict(progress=True)
-                self.model.encoder.load_state_dict(state_dict)
-
-        # Freeze backbone
-        if self.hyperparams.get("freeze_backbone", False) and self.hyperparams[
-            "model"
-        ] in ["unet", "deeplabv3+"]:
-            for param in self.model.encoder.parameters():
-                param.requires_grad = False
-
-        # Freeze decoder
-        if self.hyperparams.get("freeze_decoder", False) and self.hyperparams[
-            "model"
-        ] in ["unet", "deeplabv3+"]:
-            for param in self.model.decoder.parameters():
-                param.requires_grad = False
-
-    def __init__(self, **kwargs: Any) -> None:
-        """Initialize the LightningModule with a model and loss function.
-
-        Keyword Args:
-            model: Name of the segmentation model type to use
-            backbone: Name of the timm backbone to use
-            weights: Either a weight enum, the string representation of a weight enum,
-                True for ImageNet weights, False or None for random weights,
-                or the path to a saved model state dict. FCN model does not support
-                pretrained weights. Pretrained ViT weight enums are not supported yet.
-            in_channels: Number of channels in input image
-            num_classes: Number of semantic classes to predict
+        Args:
+            model: Name of the segmentation model type to use.
+            backbone: Name of the timm backbone to use.
+            weights: Initial model weights. Either a weight enum, the string
+                representation of a weight enum, True for ImageNet weights, False or
+                None for random weights, or the path to a saved model state dict. FCN
+                model does not support pretrained weights. Pretrained ViT weight enums
+                are not supported yet.
+            in_channels: Number of input channels to model.
+            num_classes: Number of prediction classes.
+            num_filters: Number of filters. Only applicable when model='fcn'.
             loss: Name of the loss function, currently supports
-                'ce', 'jaccard' or 'focal' loss
+                'ce', 'jaccard' or 'focal' loss.
             class_weights: Optional rescaling weight given to each
-                class and used with 'ce' loss
-            ignore_index: Optional integer class index to ignore in the loss and metrics
-            learning_rate: Learning rate for optimizer
-            learning_rate_schedule_patience: Patience for learning rate scheduler
+                class and used with 'ce' loss.
+            ignore_index: Optional integer class index to ignore in the loss and
+                metrics.
+            lr: Learning rate for optimizer.
+            patience: Patience for learning rate scheduler.
             freeze_backbone: Freeze the backbone network to fine-tune the
-                decoder and segmentation head
+                decoder and segmentation head.
             freeze_decoder: Freeze the decoder network to linear probe
-                the segmentation head
+                the segmentation head.
 
         Raises:
-            ValueError: if kwargs arguments are invalid
+            ValueError: If any arguments are invalid.
+
+        Warns:
+            UserWarning: When loss='jaccard' and ignore_index is specified.
 
         .. versionchanged:: 0.3
            The *ignore_zeros* parameter was renamed to *ignore_index*.
@@ -153,38 +95,96 @@ class SemanticSegmentationTask(LightningModule):
 
         .. versionchanged:: 0.5
            The *weights* parameter now supports WeightEnums and checkpoint paths.
-
+           *learning_rate* and *learning_rate_schedule_patience* were renamed to
+           *lr* and *patience*.
         """
         super().__init__()
 
-        # Creates `self.hparams` from kwargs
         self.save_hyperparameters()
-        self.hyperparams = cast(dict[str, Any], self.hparams)
 
-        if not isinstance(kwargs["ignore_index"], (int, type(None))):
-            raise ValueError("ignore_index must be an int or None")
-        if (kwargs["ignore_index"] is not None) and (kwargs["loss"] == "jaccard"):
+        if ignore_index is not None and loss == "jaccard":
             warnings.warn(
                 "ignore_index has no effect on training when loss='jaccard'",
                 UserWarning,
             )
-        self.ignore_index = kwargs["ignore_index"]
-        self.class_weights = kwargs.get("class_weights", None)
 
-        self.config_task()
+        if model == "unet":
+            self.model = smp.Unet(
+                encoder_name=backbone,
+                encoder_weights="imagenet" if weights is True else None,
+                in_channels=in_channels,
+                classes=num_classes,
+            )
+        elif model == "deeplabv3+":
+            self.model = smp.DeepLabV3Plus(
+                encoder_name=backbone,
+                encoder_weights="imagenet" if weights is True else None,
+                in_channels=in_channels,
+                classes=num_classes,
+            )
+        elif model == "fcn":
+            self.model = FCN(
+                in_channels=in_channels, classes=num_classes, num_filters=num_filters
+            )
+        else:
+            raise ValueError(
+                f"Model type '{model}' is not valid. "
+                "Currently, only supports 'unet', 'deeplabv3+' and 'fcn'."
+            )
+
+        if loss == "ce":
+            ignore_value = -1000 if ignore_index is None else ignore_index
+
+            if isinstance(class_weights, torch.Tensor):
+                class_weights = class_weights.to(dtype=torch.float32)
+            elif hasattr(class_weights, "__array__") or class_weights:
+                class_weights = torch.tensor(class_weights, dtype=torch.float32)
+
+            self.loss = nn.CrossEntropyLoss(
+                ignore_index=ignore_value, weight=class_weights
+            )
+        elif loss == "jaccard":
+            self.loss = smp.losses.JaccardLoss(mode="multiclass", classes=num_classes)
+        elif loss == "focal":
+            self.loss = smp.losses.FocalLoss(
+                "multiclass", ignore_index=ignore_index, normalized=True
+            )
+        else:
+            raise ValueError(
+                f"Loss type '{loss}' is not valid. "
+                "Currently, supports 'ce', 'jaccard' or 'focal' loss."
+            )
+
+        if model != "fcn":
+            if weights and weights is not True:
+                if isinstance(weights, WeightsEnum):
+                    state_dict = weights.get_state_dict(progress=True)
+                elif os.path.exists(weights):
+                    _, state_dict = utils.extract_backbone(weights)
+                else:
+                    state_dict = get_weight(weights).get_state_dict(progress=True)
+                self.model.encoder.load_state_dict(state_dict)
+
+        # Freeze backbone
+        if freeze_backbone and model in ["unet", "deeplabv3+"]:
+            for param in self.model.encoder.parameters():
+                param.requires_grad = False
+
+        # Freeze decoder
+        if freeze_decoder and model in ["unet", "deeplabv3+"]:
+            for param in self.model.decoder.parameters():
+                param.requires_grad = False
 
         self.train_metrics = MetricCollection(
             [
                 MulticlassAccuracy(
-                    num_classes=self.hyperparams["num_classes"],
-                    ignore_index=self.ignore_index,
+                    num_classes=num_classes,
+                    ignore_index=ignore_index,
                     multidim_average="global",
                     average="micro",
                 ),
                 MulticlassJaccardIndex(
-                    num_classes=self.hyperparams["num_classes"],
-                    ignore_index=self.ignore_index,
-                    average="micro",
+                    num_classes=num_classes, ignore_index=ignore_index, average="micro"
                 ),
             ],
             prefix="train_",
@@ -192,27 +192,31 @@ class SemanticSegmentationTask(LightningModule):
         self.val_metrics = self.train_metrics.clone(prefix="val_")
         self.test_metrics = self.train_metrics.clone(prefix="test_")
 
-    def forward(self, *args: Any, **kwargs: Any) -> Any:
+    def forward(self, x: Tensor) -> Tensor:
         """Forward pass of the model.
 
         Args:
-            x: tensor of data to run through the model
+            x: Mini-batch of images.
 
         Returns:
-            output from the model
+            Output from the model.
         """
-        return self.model(*args, **kwargs)
+        z = self.model(x)
+        return cast(Tensor, z)
 
-    def training_step(self, *args: Any, **kwargs: Any) -> Tensor:
-        """Compute and return the training loss.
+    def training_step(
+        self, batch: Any, batch_idx: int, dataloader_idx: int = 0
+    ) -> Tensor:
+        """Compute the training loss and additional metrics.
 
         Args:
-            batch: the output of your DataLoader
+            batch: The output of your DataLoader.
+            batch_idx: Integer displaying index of this batch.
+            dataloader_idx: Index of the current dataloader.
 
         Returns:
-            training loss
+            The loss tensor.
         """
-        batch = args[0]
         x = batch["image"]
         y = batch["mask"]
         y_hat = self(x)
@@ -220,27 +224,21 @@ class SemanticSegmentationTask(LightningModule):
 
         loss = self.loss(y_hat, y)
 
-        # by default, the train step logs every `log_every_n_steps` steps where
-        # `log_every_n_steps` is a parameter to the `Trainer` object
-        self.log("train_loss", loss, on_step=True, on_epoch=False)
+        self.log("train_loss", loss)
         self.train_metrics(y_hat_hard, y)
 
         return cast(Tensor, loss)
 
-    def on_train_epoch_end(self) -> None:
-        """Logs epoch level training metrics."""
-        self.log_dict(self.train_metrics.compute())
-        self.train_metrics.reset()
-
-    def validation_step(self, *args: Any, **kwargs: Any) -> None:
-        """Compute validation loss and log example predictions.
+    def validation_step(
+        self, batch: Any, batch_idx: int, dataloader_idx: int = 0
+    ) -> None:
+        """Compute the validation loss and additional metrics.
 
         Args:
-            batch: the output of your DataLoader
-            batch_idx: the index of this batch
+            batch: The output of your DataLoader.
+            batch_idx: Integer displaying index of this batch.
+            dataloader_idx: Index of the current dataloader.
         """
-        batch = args[0]
-        batch_idx = args[1]
         x = batch["image"]
         y = batch["mask"]
         y_hat = self(x)
@@ -248,7 +246,7 @@ class SemanticSegmentationTask(LightningModule):
 
         loss = self.loss(y_hat, y)
 
-        self.log("val_loss", loss, on_step=False, on_epoch=True)
+        self.log("val_loss", loss)
         self.val_metrics(y_hat_hard, y)
 
         if (
@@ -273,18 +271,14 @@ class SemanticSegmentationTask(LightningModule):
             except ValueError:
                 pass
 
-    def on_validation_epoch_end(self) -> None:
-        """Logs epoch level validation metrics."""
-        self.log_dict(self.val_metrics.compute())
-        self.val_metrics.reset()
-
-    def test_step(self, *args: Any, **kwargs: Any) -> None:
-        """Compute test loss.
+    def test_step(self, batch: Any, batch_idx: int, dataloader_idx: int = 0) -> None:
+        """Compute the test loss and additional metrics.
 
         Args:
-            batch: the output of your DataLoader
+            batch: The output of your DataLoader.
+            batch_idx: Integer displaying index of this batch.
+            dataloader_idx: Index of the current dataloader.
         """
-        batch = args[0]
         x = batch["image"]
         y = batch["mask"]
         y_hat = self(x)
@@ -292,50 +286,32 @@ class SemanticSegmentationTask(LightningModule):
 
         loss = self.loss(y_hat, y)
 
-        # by default, the test and validation steps only log per *epoch*
-        self.log("test_loss", loss, on_step=False, on_epoch=True)
+        self.log("test_loss", loss)
         self.test_metrics(y_hat_hard, y)
 
-    def on_test_epoch_end(self) -> None:
-        """Logs epoch level test metrics."""
-        self.log_dict(self.test_metrics.compute())
-        self.test_metrics.reset()
-
-    def predict_step(self, *args: Any, **kwargs: Any) -> Tensor:
-        """Compute and return the predictions.
-
-        By default, this will loop over images in a dataloader and aggregate
-        predictions into a list. This may not be desirable if you have many images
-        or large images which could cause out of memory errors. In this case
-        it's recommended to override this with a custom predict_step.
+    def predict_step(
+        self, batch: Any, batch_idx: int, dataloader_idx: int = 0
+    ) -> Tensor:
+        """Compute the predicted class probabilities.
 
         Args:
-            batch: the output of your DataLoader
+            batch: The output of your DataLoader.
+            batch_idx: Integer displaying index of this batch.
+            dataloader_idx: Index of the current dataloader.
 
         Returns:
-            predicted softmax probabilities
+            Output predicted probabilities.
         """
-        batch = args[0]
         x = batch["image"]
         y_hat: Tensor = self(x).softmax(dim=1)
         return y_hat
 
-    def configure_optimizers(self) -> dict[str, Any]:
+    def configure_optimizers(self) -> tuple[list[Optimizer], list[ReduceLROnPlateau]]:
         """Initialize the optimizer and learning rate scheduler.
 
         Returns:
-            learning rate dictionary
+            Optimizer and learning rate scheduler.
         """
-        optimizer = torch.optim.Adam(
-            self.model.parameters(), lr=self.hyperparams["learning_rate"]
-        )
-        return {
-            "optimizer": optimizer,
-            "lr_scheduler": {
-                "scheduler": ReduceLROnPlateau(
-                    optimizer,
-                    patience=self.hyperparams["learning_rate_schedule_patience"],
-                ),
-                "monitor": "val_loss",
-            },
-        }
+        optimizer = Adam(self.parameters(), lr=self.hparams["lr"])
+        lr_scheduler = ReduceLROnPlateau(optimizer, patience=self.hparams["patience"])
+        return [optimizer], [lr_scheduler]

--- a/torchgeo/trainers/simclr.py
+++ b/torchgeo/trainers/simclr.py
@@ -150,9 +150,9 @@ class SimCLRTask(BaseTask):
 
     def configure_models(self) -> None:
         """Initialize the model."""
-        weights = self.hparams["weights"]
-        hidden_dim = self.hparams["hidden_dim"]
-        output_dim = self.hparams["output_dim"]
+        weights: Optional[Union[WeightsEnum, str, bool]] = self.hparams["weights"]
+        hidden_dim: int = self.hparams["hidden_dim"]
+        output_dim: int = self.hparams["output_dim"]
 
         # Create backbone
         self.backbone = timm.create_model(
@@ -221,7 +221,7 @@ class SimCLRTask(BaseTask):
         """
         x = batch["image"]
 
-        in_channels = self.hparams["in_channels"]
+        in_channels: int = self.hparams["in_channels"]
         assert x.size(1) == in_channels or x.size(1) == 2 * in_channels
 
         if x.size(1) == in_channels:

--- a/torchgeo/trainers/simclr.py
+++ b/torchgeo/trainers/simclr.py
@@ -205,6 +205,9 @@ class SimCLRTask(LightningModule):
 
         Returns:
             The loss tensor.
+
+        Raises:
+            AssertionError: If channel dimensions are incorrect.
         """
         x = batch["image"]
 

--- a/torchgeo/trainers/simclr.py
+++ b/torchgeo/trainers/simclr.py
@@ -133,12 +133,12 @@ class SimCLRTask(BaseTask):
             if memory_bank_size == 0:
                 warnings.warn("SimCLR v2 uses a memory bank")
 
+        super().__init__()
+
         grayscale_weights = grayscale_weights or torch.ones(in_channels)
         self.augmentations = augmentations or simclr_augmentations(
             size, grayscale_weights
         )
-
-        super().__init__()
 
     def configure_losses(self) -> None:
         """Initialize the loss criterion."""

--- a/torchgeo/trainers/simclr.py
+++ b/torchgeo/trainers/simclr.py
@@ -23,7 +23,7 @@ from torchvision.models._api import WeightsEnum
 import torchgeo.transforms as T
 
 from ..models import get_weight
-from .utils import OptSched, extract_backbone, load_state_dict
+from .utils import extract_backbone, load_state_dict
 
 
 def simclr_augmentations(size: int, weights: Tensor) -> nn.Module:
@@ -251,7 +251,7 @@ class SimCLRTask(LightningModule):
     def predict_step(self, batch: Any, batch_idx: int, dataloader_idx: int = 0) -> None:
         """No-op, does nothing."""
 
-    def configure_optimizers(self) -> OptSched:
+    def configure_optimizers(self) -> dict[str, Any]:
         """Initialize the optimizer and learning rate scheduler.
 
         Returns:

--- a/torchgeo/trainers/simclr.py
+++ b/torchgeo/trainers/simclr.py
@@ -23,7 +23,7 @@ from torchvision.models._api import WeightsEnum
 import torchgeo.transforms as T
 
 from ..models import get_weight
-from .utils import extract_backbone, load_state_dict
+from . import utils
 
 
 def simclr_augmentations(size: int, weights: Tensor) -> nn.Module:
@@ -88,7 +88,8 @@ class SimCLRTask(LightningModule):
         """Initialize a new SimCLRTask instance.
 
         Args:
-            model: Name of the timm model to use.
+            model: Name of the `timm
+                <https://huggingface.co/docs/timm/reference/models>`__ model to use.
             weights: Initial model weights. Either a weight enum, the string
                 representation of a weight enum, True for ImageNet weights, False
                 or None for random weights, or the path to a saved model state dict.
@@ -149,10 +150,10 @@ class SimCLRTask(LightningModule):
             if isinstance(weights, WeightsEnum):
                 state_dict = weights.get_state_dict(progress=True)
             elif os.path.exists(weights):
-                _, state_dict = extract_backbone(weights)
+                _, state_dict = utils.extract_backbone(weights)
             else:
                 state_dict = get_weight(weights).get_state_dict(progress=True)
-            self.backbone = load_state_dict(self.backbone, state_dict)
+            self.backbone = utils.load_state_dict(self.backbone, state_dict)
 
         # Create projection head
         input_dim = self.backbone.num_features

--- a/torchgeo/trainers/simclr.py
+++ b/torchgeo/trainers/simclr.py
@@ -5,7 +5,7 @@
 
 import os
 import warnings
-from typing import Any, Optional, Union, cast
+from typing import Any, Optional, Union
 
 import kornia.augmentation as K
 import timm
@@ -184,9 +184,9 @@ class SimCLRTask(LightningModule):
         Returns:
             Output from the model and backbone.
         """
-        h = self.backbone(x)  # shape of batch_size x num_features
+        h: Tensor = self.backbone(x)  # shape of batch_size x num_features
         z = self.projection_head(h)
-        return cast(Tensor, z), cast(Tensor, h)
+        return z, h
 
     def training_step(
         self, batch: Any, batch_idx: int, dataloader_idx: int = 0
@@ -223,7 +223,7 @@ class SimCLRTask(LightningModule):
         z1, h1 = self(x1)
         z2, h2 = self(x2)
 
-        loss = self.criterion(z1, z2)
+        loss: Tensor = self.criterion(z1, z2)
 
         # Calculate the mean normalized standard deviation over features dimensions.
         # If this is << 1 / sqrt(h1.shape[1]), then the model is not learning anything.
@@ -236,7 +236,7 @@ class SimCLRTask(LightningModule):
         self.log("train_ssl_std", self.avg_output_std)
         self.log("train_loss", loss)
 
-        return cast(Tensor, loss)
+        return loss
 
     def validation_step(
         self, batch: Any, batch_idx: int, dataloader_idx: int = 0

--- a/torchgeo/trainers/simclr.py
+++ b/torchgeo/trainers/simclr.py
@@ -281,5 +281,5 @@ class SimCLRTask(LightningModule):
         )
         return {
             "optimizer": optimizer,
-            "lr_scheduler": {"scheduler": scheduler, "monitor": "val_loss"},
+            "lr_scheduler": {"scheduler": scheduler, "monitor": "train_loss"},
         }

--- a/torchgeo/trainers/utils.py
+++ b/torchgeo/trainers/utils.py
@@ -5,28 +5,12 @@
 
 import warnings
 from collections import OrderedDict
-from typing import Optional, TypedDict, Union, cast
+from typing import Optional, Union, cast
 
 import torch
 import torch.nn as nn
 from torch import Tensor
 from torch.nn.modules import Conv2d, Module
-from torch.optim import Optimizer
-
-try:
-    from torch.optim.lr_scheduler import LRScheduler
-except ImportError:
-    from torch.optim.lr_scheduler import _LRScheduler as LRScheduler
-
-
-class Sched(TypedDict, total=False):
-    scheduler: LRScheduler
-    monitor: str
-
-
-class OptSched(TypedDict, total=False):
-    optimizer: Optimizer
-    lr_scheduler: Sched
 
 
 def extract_backbone(path: str) -> tuple[str, "OrderedDict[str, Tensor]"]:

--- a/torchgeo/trainers/utils.py
+++ b/torchgeo/trainers/utils.py
@@ -5,12 +5,28 @@
 
 import warnings
 from collections import OrderedDict
-from typing import Optional, Union, cast
+from typing import Optional, TypedDict, Union, cast
 
 import torch
 import torch.nn as nn
 from torch import Tensor
 from torch.nn.modules import Conv2d, Module
+from torch.optim import Optimizer
+
+try:
+    from torch.optim.lr_scheduler import LRScheduler
+except ImportError:
+    from torch.optim.lr_scheduler import _LRScheduler as LRScheduler
+
+
+class Sched(TypedDict, total=False):
+    scheduler: LRScheduler
+    monitor: str
+
+
+class OptSched(TypedDict, total=False):
+    optimizer: Optimizer
+    lr_scheduler: Sched
 
 
 def extract_backbone(path: str) -> tuple[str, "OrderedDict[str, Tensor]"]:


### PR DESCRIPTION
In #1195 we introduced a new structure for our trainers. This PR updates all existing trainers to match.

- [x] Add new base class (reduces code duplication)
- [x] No `*args` or `**kwargs` (prevents argument typos, adds default values and type hints, required for LightningCLI)
- [x] No `typing.cast` (declare type when initialized)
- [x] `__init__` first (should be first thing in docs)
- [x] Added `configure_(losses|metrics|models)` methods (easier to override in subclass)

This is a great time to bring #996 back up. At this point, our "trainers" are referred to as:

* tasks: they all have a `Task` suffix
* trainers: they live in `torchgeo.trainers`
* models: this is what Lightning refers to them as
* modules: our YAML config file list them as `module:` (this will go away in my next PR)

I would love it if we could decide on a single naming scheme and be consistent...

Closes #1393