### PR TITLE
CI: pip list even if restoring from cache

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,9 +25,9 @@ jobs:
         key: ${{ env.pythonLocation }}-${{ hashFiles('setup.cfg') }}
     - name: Install pip dependencies
       if: steps.cache.outputs.cache-hit != 'true'
-      run: |
-        pip install .[tests]
-        pip list
+      run: pip install .[tests]
+    - name: List pip dependencies
+      run: pip list
     - name: Run pytest checks
       run: pytest --cov=torchgeo --cov-report=xml --durations=10
   integration:
@@ -48,9 +48,9 @@ jobs:
         key: ${{ env.pythonLocation }}-${{ hashFiles('setup.cfg') }}
     - name: Install pip dependencies
       if: steps.cache.outputs.cache-hit != 'true'
-      run: |
-        pip install .[datasets,tests]
-        pip list
+      run: pip install .[datasets,tests]
+    - name: List pip dependencies
+      run: pip list
     - name: Run integration checks
       run: pytest -m slow --durations=10
   notebooks:
@@ -71,9 +71,9 @@ jobs:
         key: ${{ env.pythonLocation }}-${{ hashFiles('setup.cfg') }}
     - name: Install pip dependencies
       if: steps.cache.outputs.cache-hit != 'true'
-      run: |
-        pip install .[docs,tests] planetary_computer pystac
-        pip list
+      run: pip install .[docs,tests] planetary_computer pystac
+    - name: List pip dependencies
+      run: pip list
     - name: Run notebook checks
       run: pytest --nbmake --durations=10 docs/tutorials
 concurrency:

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -27,9 +27,9 @@ jobs:
         key: ${{ env.pythonLocation }}-${{ hashFiles('requirements/style.txt') }}
     - name: Install pip dependencies
       if: steps.cache.outputs.cache-hit != 'true'
-      run: |
-        pip install -r requirements/style.txt
-        pip list
+      run: pip install -r requirements/style.txt
+    - name: List pip dependencies
+      run: pip list
     - name: Run black checks
       run: black . --check --diff
   flake8:
@@ -50,9 +50,9 @@ jobs:
         key: ${{ env.pythonLocation }}-${{ hashFiles('requirements/style.txt') }}
     - name: Install pip dependencies
       if: steps.cache.outputs.cache-hit != 'true'
-      run: |
-        pip install -r requirements/style.txt
-        pip list
+      run: pip install -r requirements/style.txt
+    - name: List pip dependencies
+      run: pip list
     - name: Run flake8 checks
       run: flake8
   isort:
@@ -73,9 +73,9 @@ jobs:
         key: ${{ env.pythonLocation }}-${{ hashFiles('requirements/style.txt') }}
     - name: Install pip dependencies
       if: steps.cache.outputs.cache-hit != 'true'
-      run: |
-        pip install -r requirements/style.txt
-        pip list
+      run: pip install -r requirements/style.txt
+    - name: List pip dependencies
+      run: pip list
     - name: Run isort checks
       run: isort . --check --diff
   pydocstyle:
@@ -96,9 +96,9 @@ jobs:
         key: ${{ env.pythonLocation }}-${{ hashFiles('requirements/style.txt') }}
     - name: Install pip dependencies
       if: steps.cache.outputs.cache-hit != 'true'
-      run: |
-        pip install -r requirements/style.txt
-        pip list
+      run: pip install -r requirements/style.txt
+    - name: List pip dependencies
+      run: pip list
     - name: Run pydocstyle checks
       run: pydocstyle
   pyupgrade:
@@ -119,9 +119,9 @@ jobs:
         key: ${{ env.pythonLocation }}-${{ hashFiles('requirements/style.txt') }}
     - name: Install pip dependencies
       if: steps.cache.outputs.cache-hit != 'true'
-      run: |
-        pip install -r requirements/style.txt
-        pip list
+      run: pip install -r requirements/style.txt
+    - name: List pip dependencies
+      run: pip list
     - name: Run pyupgrade checks
       run: pyupgrade --py39-plus $(find . -path ./docs/src -prune -o -name "*.py" -print)
 concurrency:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -27,9 +27,9 @@ jobs:
         key: ${{ env.pythonLocation }}-${{ hashFiles('requirements/required.txt') }}-${{ hashFiles('requirements/datasets.txt') }}-${{ hashFiles('requirements/tests.txt') }}
     - name: Install pip dependencies
       if: steps.cache.outputs.cache-hit != 'true'
-      run: |
-        pip install -r requirements/required.txt -r requirements/datasets.txt -r requirements/tests.txt
-        pip list
+      run: pip install -r requirements/required.txt -r requirements/datasets.txt -r requirements/tests.txt
+    - name: List pip dependencies
+      run: pip list
     - name: Run mypy checks
       run: mypy .
   pytest:
@@ -70,9 +70,9 @@ jobs:
       if: ${{ runner.os == 'Windows' }}
     - name: Install pip dependencies
       if: steps.cache.outputs.cache-hit != 'true'
-      run: |
-        pip install -r requirements/required.txt -r requirements/datasets.txt -r requirements/tests.txt
-        pip list
+      run: pip install -r requirements/required.txt -r requirements/datasets.txt -r requirements/tests.txt
+    - name: List pip dependencies
+      run: pip list
     - name: Run pytest checks
       run: pytest --cov=torchgeo --cov-report=xml --durations=10
     - name: Report coverage
@@ -105,9 +105,9 @@ jobs:
         sudo apt-get install unrar
     - name: Install pip dependencies
       if: steps.cache.outputs.cache-hit != 'true'
-      run: |
-        pip install -r requirements/min-reqs.old -c requirements/min-cons.old
-        pip list
+      run: pip install -r requirements/min-reqs.old -c requirements/min-cons.old
+    - name: List pip dependencies
+      run: pip list
     - name: Run pytest checks
       run: pytest --cov=torchgeo --cov-report=xml --durations=10
     - name: Report coverage

--- a/.github/workflows/tutorials.yaml
+++ b/.github/workflows/tutorials.yaml
@@ -29,9 +29,9 @@ jobs:
         key: ${{ env.pythonLocation }}-${{ hashFiles('setup.cfg') }}
     - name: Install pip dependencies
       if: steps.cache.outputs.cache-hit != 'true'
-      run: |
-        pip install .[docs,tests] planetary_computer pystac
-        pip list
+      run: pip install .[docs,tests] planetary_computer pystac
+    - name: List pip dependencies
+      run: pip list
     - name: Run notebook checks
       run: pytest --nbmake --durations=10 docs/tutorials
 concurrency:


### PR DESCRIPTION
We don't run `pip list` if we restore from cache, making it difficult to report and debug version issues. This PR fixes that.