### PR TITLE
Promote pandas to a required dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,8 @@ dependencies = [
     "matplotlib>=3.3.3",
     # numpy 1.19.3+ required by Python 3.9 wheels
     "numpy>=1.19.3",
+    # pandas 1.1.3+ required for Python 3.9 wheels
+    "pandas>=1.1.3",
     # pillow 8+ required for Python 3.9 wheels
     "pillow>=8",
     # pyproj 3+ required for Python 3.9 wheels
@@ -82,8 +84,6 @@ datasets = [
     "laspy>=2",
     # opencv-python 4.4.0.46+ required for Python 3.9 wheels
     "opencv-python>=4.4.0.46",
-    # pandas 1.1.3+ required for Python 3.9 wheels
-    "pandas>=1.1.3",
     # pycocotools 2.0.5+ required for cython 3+ support
     "pycocotools>=2.0.5",
     # pyvista 0.29+ required for to avoid segfault during testing

--- a/requirements/datasets.txt
+++ b/requirements/datasets.txt
@@ -2,7 +2,6 @@
 h5py==3.9.0
 laspy==2.5.1
 opencv-python==4.8.0.76
-pandas==2.1.1
 pycocotools==2.0.7
 pyvista==0.42.2
 radiant-mlhub==0.4.1

--- a/requirements/min-reqs.old
+++ b/requirements/min-reqs.old
@@ -9,6 +9,7 @@ lightly==1.4.4
 lightning==1.8.0
 matplotlib==3.3.3
 numpy==1.19.3
+pandas==1.1.3
 pillow==8.0.0
 pyproj==3.0.0
 rasterio==1.2.0
@@ -24,7 +25,6 @@ torchvision==0.13.0
 h5py==3.0.0
 laspy==2.0.0
 opencv-python==4.4.0.46
-pandas==1.1.3
 pycocotools==2.0.5
 pyvista==0.29.0
 radiant-mlhub==0.3.0

--- a/requirements/required.txt
+++ b/requirements/required.txt
@@ -9,6 +9,7 @@ lightly==1.4.19
 lightning==2.0.9
 matplotlib==3.8.0
 numpy==1.26.0
+pandas==2.1.1
 pillow==10.0.1
 pyproj==3.6.1
 rasterio==1.3.8

--- a/tests/datasets/test_eddmaps.py
+++ b/tests/datasets/test_eddmaps.py
@@ -11,8 +11,6 @@ from pytest import MonkeyPatch
 
 from torchgeo.datasets import BoundingBox, EDDMapS, IntersectionDataset, UnionDataset
 
-pytest.importorskip("pandas", minversion="1.1.3")
-
 
 class TestEDDMapS:
     @pytest.fixture(scope="class")
@@ -38,26 +36,6 @@ class TestEDDMapS:
     def test_no_data(self, tmp_path: Path) -> None:
         with pytest.raises(FileNotFoundError, match="Dataset not found"):
             EDDMapS(str(tmp_path))
-
-    @pytest.fixture
-    def mock_missing_module(self, monkeypatch: MonkeyPatch) -> None:
-        import_orig = builtins.__import__
-
-        def mocked_import(name: str, *args: Any, **kwargs: Any) -> Any:
-            if name == "pandas":
-                raise ImportError()
-            return import_orig(name, *args, **kwargs)
-
-        monkeypatch.setattr(builtins, "__import__", mocked_import)
-
-    def test_mock_missing_module(
-        self, dataset: EDDMapS, mock_missing_module: None
-    ) -> None:
-        with pytest.raises(
-            ImportError,
-            match="pandas is not installed and is required to use this dataset",
-        ):
-            EDDMapS(dataset.root)
 
     def test_invalid_query(self, dataset: EDDMapS) -> None:
         query = BoundingBox(0, 0, 0, 0, 0, 0)

--- a/tests/datasets/test_eddmaps.py
+++ b/tests/datasets/test_eddmaps.py
@@ -1,13 +1,10 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-import builtins
 import os
 from pathlib import Path
-from typing import Any
 
 import pytest
-from pytest import MonkeyPatch
 
 from torchgeo.datasets import BoundingBox, EDDMapS, IntersectionDataset, UnionDataset
 

--- a/tests/datasets/test_gbif.py
+++ b/tests/datasets/test_gbif.py
@@ -1,13 +1,10 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-import builtins
 import os
 from pathlib import Path
-from typing import Any
 
 import pytest
-from pytest import MonkeyPatch
 
 from torchgeo.datasets import GBIF, BoundingBox, IntersectionDataset, UnionDataset
 

--- a/tests/datasets/test_gbif.py
+++ b/tests/datasets/test_gbif.py
@@ -11,8 +11,6 @@ from pytest import MonkeyPatch
 
 from torchgeo.datasets import GBIF, BoundingBox, IntersectionDataset, UnionDataset
 
-pytest.importorskip("pandas", minversion="1.1.3")
-
 
 class TestGBIF:
     @pytest.fixture(scope="class")
@@ -38,26 +36,6 @@ class TestGBIF:
     def test_no_data(self, tmp_path: Path) -> None:
         with pytest.raises(FileNotFoundError, match="Dataset not found"):
             GBIF(str(tmp_path))
-
-    @pytest.fixture
-    def mock_missing_module(self, monkeypatch: MonkeyPatch) -> None:
-        import_orig = builtins.__import__
-
-        def mocked_import(name: str, *args: Any, **kwargs: Any) -> Any:
-            if name == "pandas":
-                raise ImportError()
-            return import_orig(name, *args, **kwargs)
-
-        monkeypatch.setattr(builtins, "__import__", mocked_import)
-
-    def test_mock_missing_module(
-        self, dataset: GBIF, mock_missing_module: None
-    ) -> None:
-        with pytest.raises(
-            ImportError,
-            match="pandas is not installed and is required to use this dataset",
-        ):
-            GBIF(dataset.root)
 
     def test_invalid_query(self, dataset: GBIF) -> None:
         query = BoundingBox(0, 0, 0, 0, 0, 0)

--- a/tests/datasets/test_idtrees.py
+++ b/tests/datasets/test_idtrees.py
@@ -18,7 +18,6 @@ from pytest import MonkeyPatch
 import torchgeo.datasets.utils
 from torchgeo.datasets import IDTReeS
 
-pytest.importorskip("pandas", minversion="1.1.3")
 pytest.importorskip("laspy", minversion="2")
 
 
@@ -51,7 +50,7 @@ class TestIDTReeS:
         transforms = nn.Identity()
         return IDTReeS(root, split, task, transforms, download=True, checksum=True)
 
-    @pytest.fixture(params=["pandas", "laspy", "pyvista"])
+    @pytest.fixture(params=["laspy", "pyvista"])
     def mock_missing_module(self, monkeypatch: MonkeyPatch, request: SubRequest) -> str:
         import_orig = builtins.__import__
         package = str(request.param)
@@ -110,13 +109,13 @@ class TestIDTReeS:
     ) -> None:
         package = mock_missing_module
 
-        if package in ["pandas", "laspy"]:
+        if package == "laspy":
             with pytest.raises(
                 ImportError,
                 match=f"{package} is not installed and is required to use this dataset",
             ):
                 IDTReeS(dataset.root, dataset.split, dataset.task)
-        elif package in ["pyvista"]:
+        elif package == "pyvista":
             with pytest.raises(
                 ImportError,
                 match=f"{package} is not installed and is required to plot point cloud",

--- a/tests/datasets/test_inaturalist.py
+++ b/tests/datasets/test_inaturalist.py
@@ -1,13 +1,10 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-import builtins
 import os
 from pathlib import Path
-from typing import Any
 
 import pytest
-from pytest import MonkeyPatch
 
 from torchgeo.datasets import (
     BoundingBox,

--- a/tests/datasets/test_inaturalist.py
+++ b/tests/datasets/test_inaturalist.py
@@ -16,8 +16,6 @@ from torchgeo.datasets import (
     UnionDataset,
 )
 
-pytest.importorskip("pandas", minversion="1.1.3")
-
 
 class TestINaturalist:
     @pytest.fixture(scope="class")
@@ -43,26 +41,6 @@ class TestINaturalist:
     def test_no_data(self, tmp_path: Path) -> None:
         with pytest.raises(FileNotFoundError, match="Dataset not found"):
             INaturalist(str(tmp_path))
-
-    @pytest.fixture
-    def mock_missing_module(self, monkeypatch: MonkeyPatch) -> None:
-        import_orig = builtins.__import__
-
-        def mocked_import(name: str, *args: Any, **kwargs: Any) -> Any:
-            if name == "pandas":
-                raise ImportError()
-            return import_orig(name, *args, **kwargs)
-
-        monkeypatch.setattr(builtins, "__import__", mocked_import)
-
-    def test_mock_missing_module(
-        self, dataset: INaturalist, mock_missing_module: None
-    ) -> None:
-        with pytest.raises(
-            ImportError,
-            match="pandas is not installed and is required to use this dataset",
-        ):
-            INaturalist(dataset.root)
 
     def test_invalid_query(self, dataset: INaturalist) -> None:
         query = BoundingBox(0, 0, 0, 0, 0, 0)

--- a/tests/datasets/test_openbuildings.py
+++ b/tests/datasets/test_openbuildings.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 import matplotlib.pyplot as plt
+import pandas as pd
 import pytest
 import torch
 import torch.nn as nn
@@ -22,8 +23,6 @@ from torchgeo.datasets import (
     OpenBuildings,
     UnionDataset,
 )
-
-pd = pytest.importorskip("pandas", minversion="1.1.3")
 
 
 class TestOpenBuildings:
@@ -42,30 +41,6 @@ class TestOpenBuildings:
         monkeypatch.setattr(OpenBuildings, "md5s", md5s)
         transforms = nn.Identity()
         return OpenBuildings(root=root, transforms=transforms)
-
-    @pytest.fixture(params=["pandas"])
-    def mock_missing_module(self, monkeypatch: MonkeyPatch, request: SubRequest) -> str:
-        import_orig = builtins.__import__
-        package = str(request.param)
-
-        def mocked_import(name: str, *args: Any, **kwargs: Any) -> Any:
-            if name == package:
-                raise ImportError()
-            return import_orig(name, *args, **kwargs)
-
-        monkeypatch.setattr(builtins, "__import__", mocked_import)
-        return package
-
-    def test_mock_missing_module(
-        self, dataset: OpenBuildings, mock_missing_module: str
-    ) -> None:
-        package = mock_missing_module
-
-        with pytest.raises(
-            ImportError,
-            match=f"{package} is not installed and is required to use this dataset",
-        ):
-            OpenBuildings(root=dataset.root)
 
     def test_no_shapes_to_rasterize(
         self, dataset: OpenBuildings, tmp_path: Path

--- a/tests/datasets/test_openbuildings.py
+++ b/tests/datasets/test_openbuildings.py
@@ -1,19 +1,16 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-import builtins
 import json
 import os
 import shutil
 from pathlib import Path
-from typing import Any
 
 import matplotlib.pyplot as plt
 import pandas as pd
 import pytest
 import torch
 import torch.nn as nn
-from _pytest.fixtures import SubRequest
 from pytest import MonkeyPatch
 from rasterio.crs import CRS
 

--- a/tests/datasets/test_reforestree.py
+++ b/tests/datasets/test_reforestree.py
@@ -24,7 +24,6 @@ def download_url(url: str, root: str, *args: str) -> None:
 class TestReforesTree:
     @pytest.fixture
     def dataset(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> ReforesTree:
-        pytest.importorskip("pandas", minversion="1.1.3")
         monkeypatch.setattr(torchgeo.datasets.utils, "download_url", download_url)
         data_dir = os.path.join("tests", "data", "reforestree")
 
@@ -54,32 +53,10 @@ class TestReforesTree:
         assert x["image"].ndim == 3
         assert len(x["boxes"]) == 2
 
-    @pytest.fixture
-    def mock_missing_module(self, monkeypatch: MonkeyPatch) -> None:
-        import_orig = builtins.__import__
-        package = "pandas"
-
-        def mocked_import(name: str, *args: Any, **kwargs: Any) -> Any:
-            if name == package:
-                raise ImportError()
-            return import_orig(name, *args, **kwargs)
-
-        monkeypatch.setattr(builtins, "__import__", mocked_import)
-
-    def test_mock_missing_module(
-        self, dataset: ReforesTree, mock_missing_module: None
-    ) -> None:
-        with pytest.raises(
-            ImportError,
-            match="pandas is not installed and is required to use this dataset",
-        ):
-            ReforesTree(root=dataset.root)
-
     def test_len(self, dataset: ReforesTree) -> None:
         assert len(dataset) == 2
 
     def test_not_extracted(self, tmp_path: Path) -> None:
-        pytest.importorskip("pandas", minversion="1.1.3")
         url = os.path.join("tests", "data", "reforestree", "reforesTree.zip")
         shutil.copy(url, tmp_path)
         ReforesTree(root=str(tmp_path))

--- a/tests/datasets/test_reforestree.py
+++ b/tests/datasets/test_reforestree.py
@@ -1,11 +1,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-import builtins
 import os
 import shutil
 from pathlib import Path
-from typing import Any
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/datasets/test_seasonet.py
+++ b/tests/datasets/test_seasonet.py
@@ -19,8 +19,6 @@ from torch.utils.data import ConcatDataset
 import torchgeo.datasets.utils
 from torchgeo.datasets import SeasoNet
 
-pytest.importorskip("pandas", minversion="1.1.3")
-
 
 def download_url(url: str, root: str, md5: str, *args: str, **kwargs: str) -> None:
     shutil.copy(url, root)
@@ -153,25 +151,6 @@ class TestSeasoNet:
     def test_not_downloaded(self, tmp_path: Path) -> None:
         with pytest.raises(RuntimeError, match="not found in"):
             SeasoNet(str(tmp_path), download=False)
-
-    @pytest.fixture
-    def mock_missing_module(self, monkeypatch: MonkeyPatch) -> None:
-        import_orig = builtins.__import__
-
-        def mocked_import(name: str, *args: Any, **kwargs: Any) -> Any:
-            if name == "pandas":
-                raise ImportError()
-            return import_orig(name, *args, **kwargs)
-
-        monkeypatch.setattr(builtins, "__import__", mocked_import)
-
-    def test_mock_missing_module(
-        self, dataset: SeasoNet, mock_missing_module: None
-    ) -> None:
-        with pytest.raises(
-            ImportError, match="pandas is not installed and is required"
-        ):
-            SeasoNet(dataset.root)
 
     def test_out_of_bounds(self, dataset: SeasoNet) -> None:
         with pytest.raises(IndexError):

--- a/tests/datasets/test_seasonet.py
+++ b/tests/datasets/test_seasonet.py
@@ -1,12 +1,10 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-import builtins
 import glob
 import os
 import shutil
 from pathlib import Path
-from typing import Any
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/datasets/test_usavars.py
+++ b/tests/datasets/test_usavars.py
@@ -1,11 +1,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-import builtins
 import os
 import shutil
 from pathlib import Path
-from typing import Any
 
 import pytest
 import torch

--- a/tests/datasets/test_usavars.py
+++ b/tests/datasets/test_usavars.py
@@ -18,8 +18,6 @@ from torch.utils.data import ConcatDataset
 import torchgeo.datasets.utils
 from torchgeo.datasets import USAVars
 
-pytest.importorskip("pandas", minversion="1.1.3")
-
 
 def download_url(url: str, root: str, *args: str, **kwargs: str) -> None:
     shutil.copy(url, root)
@@ -135,30 +133,6 @@ class TestUSAVars:
     def test_not_downloaded(self, tmp_path: Path) -> None:
         with pytest.raises(RuntimeError, match="Dataset not found"):
             USAVars(str(tmp_path))
-
-    @pytest.fixture(params=["pandas"])
-    def mock_missing_module(self, monkeypatch: MonkeyPatch, request: SubRequest) -> str:
-        import_orig = builtins.__import__
-        package = str(request.param)
-
-        def mocked_import(name: str, *args: Any, **kwargs: Any) -> Any:
-            if name == package:
-                raise ImportError()
-            return import_orig(name, *args, **kwargs)
-
-        monkeypatch.setattr(builtins, "__import__", mocked_import)
-        return package
-
-    def test_mock_missing_module(
-        self, dataset: USAVars, mock_missing_module: str
-    ) -> None:
-        package = mock_missing_module
-        if package == "pandas":
-            with pytest.raises(
-                ImportError,
-                match=f"{package} is not installed and is required to use this dataset",
-            ):
-                USAVars(dataset.root)
 
     def test_plot(self, dataset: USAVars) -> None:
         dataset.plot(dataset[0], suptitle="Test")

--- a/tests/datasets/test_western_usa_live_fuel_moisture.py
+++ b/tests/datasets/test_western_usa_live_fuel_moisture.py
@@ -74,27 +74,3 @@ class TestWesternUSALiveFuelMoisture:
     def test_invalid_features(self, dataset: WesternUSALiveFuelMoisture) -> None:
         with pytest.raises(AssertionError, match="Invalid input variable name."):
             WesternUSALiveFuelMoisture(dataset.root, input_features=["foo"])
-
-    @pytest.fixture(params=["pandas"])
-    def mock_missing_module(self, monkeypatch: MonkeyPatch, request: SubRequest) -> str:
-        import_orig = builtins.__import__
-        package = str(request.param)
-
-        def mocked_import(name: str, *args: Any, **kwargs: Any) -> Any:
-            if name == package:
-                raise ImportError()
-            return import_orig(name, *args, **kwargs)
-
-        monkeypatch.setattr(builtins, "__import__", mocked_import)
-        return package
-
-    def test_mock_missing_module(
-        self, dataset: WesternUSALiveFuelMoisture, mock_missing_module: str
-    ) -> None:
-        package = mock_missing_module
-        if package == "pandas":
-            with pytest.raises(
-                ImportError,
-                match=f"{package} is not installed and is required to use this dataset",
-            ):
-                WesternUSALiveFuelMoisture(dataset.root)

--- a/tests/datasets/test_western_usa_live_fuel_moisture.py
+++ b/tests/datasets/test_western_usa_live_fuel_moisture.py
@@ -1,16 +1,13 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-import builtins
 import os
 import shutil
 from pathlib import Path
-from typing import Any
 
 import pytest
 import torch
 import torch.nn as nn
-from _pytest.fixtures import SubRequest
 from pytest import MonkeyPatch
 
 from torchgeo.datasets import WesternUSALiveFuelMoisture

--- a/torchgeo/datasets/eddmaps.py
+++ b/torchgeo/datasets/eddmaps.py
@@ -8,6 +8,7 @@ import sys
 from typing import Any
 
 import numpy as np
+import pandas as pd
 from rasterio.crs import CRS
 
 from .geo import GeoDataset
@@ -34,11 +35,6 @@ class EDDMapS(GeoDataset):
       Georgia - Center for Invasive Species and Ecosystem Health. Available online at
       https://www.eddmaps.org/; last accessed *DATE*.
 
-    .. note::
-       This dataset requires the following additional library to be installed:
-
-       * `pandas <https://pypi.org/project/pandas/>`_ to load CSV files
-
     .. versionadded:: 0.3
     """
 
@@ -53,7 +49,6 @@ class EDDMapS(GeoDataset):
 
         Raises:
             FileNotFoundError: if no files are found in ``root``
-            ImportError: if pandas is not installed
         """
         super().__init__()
 
@@ -62,13 +57,6 @@ class EDDMapS(GeoDataset):
         filepath = os.path.join(root, "mappings.csv")
         if not os.path.exists(filepath):
             raise FileNotFoundError(f"Dataset not found in `root={self.root}`")
-
-        try:
-            import pandas as pd  # noqa: F401
-        except ImportError:
-            raise ImportError(
-                "pandas is not installed and is required to use this dataset"
-            )
 
         # Read CSV file
         data = pd.read_csv(

--- a/torchgeo/datasets/gbif.py
+++ b/torchgeo/datasets/gbif.py
@@ -10,6 +10,7 @@ from datetime import datetime, timedelta
 from typing import Any
 
 import numpy as np
+import pandas as pd
 from rasterio.crs import CRS
 
 from .geo import GeoDataset
@@ -72,11 +73,6 @@ class GBIF(GeoDataset):
 
     * https://www.gbif.org/citation-guidelines
 
-    .. note::
-       This dataset requires the following additional library to be installed:
-
-       * `pandas <https://pypi.org/project/pandas/>`_ to load CSV files
-
     .. versionadded:: 0.3
     """
 
@@ -91,7 +87,6 @@ class GBIF(GeoDataset):
 
         Raises:
             FileNotFoundError: if no files are found in ``root``
-            ImportError: if pandas is not installed
         """
         super().__init__()
 
@@ -100,13 +95,6 @@ class GBIF(GeoDataset):
         files = glob.glob(os.path.join(root, "**.csv"))
         if not files:
             raise FileNotFoundError(f"Dataset not found in `root={self.root}`")
-
-        try:
-            import pandas as pd  # noqa: F401
-        except ImportError:
-            raise ImportError(
-                "pandas is not installed and is required to use this dataset"
-            )
 
         # Read tab-delimited CSV file
         data = pd.read_table(

--- a/torchgeo/datasets/idtrees.py
+++ b/torchgeo/datasets/idtrees.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, Optional, cast, overload
 import fiona
 import matplotlib.pyplot as plt
 import numpy as np
+import pandas as pd
 import rasterio
 import torch
 from matplotlib.figure import Figure
@@ -164,7 +165,7 @@ class IDTReeS(NonGeoDataset):
             checksum: if True, check the MD5 of the downloaded files (may be slow)
 
         Raises:
-            ImportError: if laspy or pandas are are not installed
+            ImportError: if laspy is not installed
         """
         assert split in ["train", "test"]
         assert task in ["task1", "task2"]
@@ -179,12 +180,6 @@ class IDTReeS(NonGeoDataset):
         self.num_classes = len(self.classes)
         self._verify()
 
-        try:
-            import pandas as pd  # noqa: F401
-        except ImportError:
-            raise ImportError(
-                "pandas is not installed and is required to use this dataset"
-            )
         try:
             import laspy  # noqa: F401
         except ImportError:
@@ -346,8 +341,6 @@ class IDTReeS(NonGeoDataset):
         Returns:
             the image path, geometries, and labels
         """
-        import pandas as pd
-
         if self.split == "train":
             directory = os.path.join(root, self.directories[self.split][0])
             labels: pd.DataFrame = self._load_labels(directory)
@@ -374,8 +367,6 @@ class IDTReeS(NonGeoDataset):
         Returns:
             a pandas DataFrame containing the labels for each image
         """
-        import pandas as pd
-
         path_mapping = os.path.join(directory, "Field", "itc_rsFile.csv")
         path_labels = os.path.join(directory, "Field", "train_data.csv")
         df_mapping = pd.read_csv(path_mapping)

--- a/torchgeo/datasets/inaturalist.py
+++ b/torchgeo/datasets/inaturalist.py
@@ -8,6 +8,7 @@ import os
 import sys
 from typing import Any
 
+import pandas as pd
 from rasterio.crs import CRS
 
 from .geo import GeoDataset
@@ -26,11 +27,6 @@ class INaturalist(GeoDataset):
 
     * https://www.inaturalist.org/pages/help#cite
 
-    .. note::
-       This dataset requires the following additional library to be installed:
-
-       * `pandas <https://pypi.org/project/pandas/>`_ to load CSV files
-
     .. versionadded:: 0.3
     """
 
@@ -45,7 +41,6 @@ class INaturalist(GeoDataset):
 
         Raises:
             FileNotFoundError: if no files are found in ``root``
-            ImportError: if pandas is not installed
         """
         super().__init__()
 
@@ -54,13 +49,6 @@ class INaturalist(GeoDataset):
         files = glob.glob(os.path.join(root, "**.csv"))
         if not files:
             raise FileNotFoundError(f"Dataset not found in `root={self.root}`")
-
-        try:
-            import pandas as pd  # noqa: F401
-        except ImportError:
-            raise ImportError(
-                "pandas is not installed and is required to use this dataset"
-            )
 
         # Read CSV file
         data = pd.read_csv(

--- a/torchgeo/datasets/openbuildings.py
+++ b/torchgeo/datasets/openbuildings.py
@@ -12,6 +12,7 @@ from typing import Any, Callable, Optional, cast
 import fiona
 import fiona.transform
 import matplotlib.pyplot as plt
+import pandas as pd
 import rasterio
 import shapely
 import shapely.wkt as wkt
@@ -233,13 +234,6 @@ class OpenBuildings(VectorDataset):
 
         self._verify()
 
-        try:
-            import pandas as pd  # noqa: F401
-        except ImportError:
-            raise ImportError(
-                "pandas is not installed and is required to use this dataset"
-            )
-
         # Create an R-tree to index the dataset using the polygon centroid as bounds
         self.index = Index(interleaved=False, properties=Property(dimension=3))
 
@@ -350,8 +344,6 @@ class OpenBuildings(VectorDataset):
             List with all polygons from all hit filepaths
 
         """
-        import pandas as pd
-
         # We need to know the bounding box of the query in the source CRS
         (minx, maxx), (miny, maxy) = fiona.transform.transform(
             self._crs.to_dict(),

--- a/torchgeo/datasets/reforestree.py
+++ b/torchgeo/datasets/reforestree.py
@@ -10,6 +10,7 @@ from typing import Callable, Optional
 import matplotlib.patches as patches
 import matplotlib.pyplot as plt
 import numpy as np
+import pandas as pd
 import torch
 from matplotlib.figure import Figure
 from PIL import Image
@@ -86,13 +87,6 @@ class ReforesTree(NonGeoDataset):
         self.download = download
 
         self._verify()
-
-        try:
-            import pandas as pd  # noqa: F401
-        except ImportError:
-            raise ImportError(
-                "pandas is not installed and is required to use this dataset"
-            )
 
         self.files = self._load_files(self.root)
 

--- a/torchgeo/datasets/seasonet.py
+++ b/torchgeo/datasets/seasonet.py
@@ -11,6 +11,7 @@ from typing import Optional
 import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
 import numpy as np
+import pandas as pd
 import rasterio
 import torch
 from matplotlib.colors import ListedColormap
@@ -80,11 +81,6 @@ class SeasoNet(NonGeoDataset):
     If you use this dataset in your research, please cite the following paper:
 
     * https://doi.org/10.1109/IGARSS46834.2022.9884079
-
-    .. note::
-       This dataset requires the following additional library to be installed:
-
-       * `pandas <https://pypi.org/project/pandas/>`_ to load CSV files
 
     .. versionadded:: 0.5
     """
@@ -237,9 +233,6 @@ class SeasoNet(NonGeoDataset):
                 entry and returns a transformed version
             download: if True, download dataset and store it in the root directory
             checksum: if True, check the MD5 of the downloaded files (may be slow)
-
-        Raises:
-            ImportError: if pandas is not installed
         """
         assert split in self.splits
         assert set(seasons) <= self.all_seasons
@@ -259,13 +252,6 @@ class SeasoNet(NonGeoDataset):
         self.channels = 0
         for b in bands:
             self.channels += self.band_nums[b]
-
-        try:
-            import pandas as pd  # noqa: F401
-        except ImportError:
-            raise ImportError(
-                "pandas is not installed and is required to use this dataset"
-            )
 
         csv = pd.read_csv(os.path.join(self.root, "meta.csv"), index_col="Index")
 

--- a/torchgeo/datasets/usavars.py
+++ b/torchgeo/datasets/usavars.py
@@ -10,6 +10,7 @@ from typing import Callable, Optional
 
 import matplotlib.pyplot as plt
 import numpy as np
+import pandas as pd
 import rasterio
 import torch
 from matplotlib.figure import Figure
@@ -105,7 +106,6 @@ class USAVars(NonGeoDataset):
 
         Raises:
             AssertionError: if invalid labels are provided
-            ImportError: if pandas is not installed
             RuntimeError: if ``download=False`` and data is not found, or checksums
                 don't match
         """
@@ -123,13 +123,6 @@ class USAVars(NonGeoDataset):
         self.checksum = checksum
 
         self._verify()
-
-        try:
-            import pandas as pd  # noqa: F401
-        except ImportError:
-            raise ImportError(
-                "pandas is not installed and is required to use this dataset"
-            )
 
         self.files = self._load_files()
 

--- a/torchgeo/datasets/western_usa_live_fuel_moisture.py
+++ b/torchgeo/datasets/western_usa_live_fuel_moisture.py
@@ -8,6 +8,7 @@ import json
 import os
 from typing import Any, Callable, Optional
 
+import pandas as pd
 import torch
 from torch import Tensor
 
@@ -217,7 +218,6 @@ class WesternUSALiveFuelMoisture(NonGeoDataset):
 
         Raises:
             AssertionError: if ``input_features`` contains invalid variable names
-            ImportError: if pandas is not installed
             RuntimeError: if ``download=False`` but dataset is missing or checksum fails
         """
         super().__init__()
@@ -229,13 +229,6 @@ class WesternUSALiveFuelMoisture(NonGeoDataset):
         self.api_key = api_key
 
         self._verify()
-
-        try:
-            import pandas as pd  # noqa: F401
-        except ImportError:
-            raise ImportError(
-                "pandas is not installed and is required to use this dataset"
-            )
 
         assert all(
             input in self.all_variable_names for input in input_features
@@ -287,14 +280,12 @@ class WesternUSALiveFuelMoisture(NonGeoDataset):
 
         return sample
 
-    def _load_data(self) -> "pd.DataFrame":  # type: ignore[name-defined] # noqa: F821
+    def _load_data(self) -> pd.DataFrame:
         """Load data from individual files into pandas dataframe.
 
         Returns:
             the features and label
         """
-        import pandas as pd
-
         data_rows = []
         for path in self.collection:
             with open(path) as f:


### PR DESCRIPTION
Pandas is now used in 9 of our datasets, and 2 other datasets use csv but could use pandas instead. I think it's worth making pandas a required dependency. Also see discussion in #662. This lets us shave off 300 lines of code.