### PR TITLE
Ensure that none of our minimum version tests are skipped

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,5 +34,5 @@ repos:
         hooks:
         -   id: mypy
             args: [--strict, --ignore-missing-imports, --show-error-codes]
-            additional_dependencies: [torch>=2, torchmetrics>=0.10, lightning>=2.0.9, pytest>=6.1.2, pyvista>=0.29, omegaconf>=2.0.1, hydra-core>=1, kornia>=0.6.5, numpy>=1.22]
+            additional_dependencies: [torch>=2, torchmetrics>=0.10, lightning>=2.0.9, pytest>=6.1.2, pyvista>=0.34.2, omegaconf>=2.0.1, hydra-core>=1, kornia>=0.6.5, numpy>=1.22]
             exclude: (build|data|dist|logo|logs|output)/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,8 +86,8 @@ datasets = [
     "pandas>=1.1.3",
     # pycocotools 2.0.5+ required for cython 3+ support
     "pycocotools>=2.0.5",
-    # pyvista 0.29+ required for to avoid segfault during testing
-    "pyvista>=0.29",
+    # pyvista 0.34.2+ required to avoid ImportError in CI
+    "pyvista>=0.34.2",
     # radiant-mlhub 0.3+ required for newer tqdm support required by lightning
     "radiant-mlhub>=0.3",
     # rarfile 4+ required for wheels

--- a/requirements/min-reqs.old
+++ b/requirements/min-reqs.old
@@ -26,7 +26,7 @@ laspy==2.0.0
 opencv-python==4.4.0.46
 pandas==1.1.3
 pycocotools==2.0.5
-pyvista==0.34.0
+pyvista==0.34.2
 radiant-mlhub==0.3.0
 rarfile==4.0
 scikit-image==0.18.0

--- a/requirements/min-reqs.old
+++ b/requirements/min-reqs.old
@@ -26,7 +26,7 @@ laspy==2.0.0
 opencv-python==4.4.0.46
 pandas==1.1.3
 pycocotools==2.0.5
-pyvista==0.34.1
+pyvista==0.34.2
 radiant-mlhub==0.3.0
 rarfile==4.0
 scikit-image==0.18.0

--- a/requirements/min-reqs.old
+++ b/requirements/min-reqs.old
@@ -26,7 +26,7 @@ laspy==2.0.0
 opencv-python==4.4.0.46
 pandas==1.1.3
 pycocotools==2.0.5
-pyvista==0.35.0
+pyvista==0.35.1
 radiant-mlhub==0.3.0
 rarfile==4.0
 scikit-image==0.18.0

--- a/requirements/min-reqs.old
+++ b/requirements/min-reqs.old
@@ -26,7 +26,7 @@ laspy==2.0.0
 opencv-python==4.4.0.46
 pandas==1.1.3
 pycocotools==2.0.5
-pyvista==0.32.0
+pyvista==0.35.0
 radiant-mlhub==0.3.0
 rarfile==4.0
 scikit-image==0.18.0

--- a/requirements/min-reqs.old
+++ b/requirements/min-reqs.old
@@ -26,7 +26,7 @@ laspy==2.0.0
 opencv-python==4.4.0.46
 pandas==1.1.3
 pycocotools==2.0.5
-pyvista==0.34.2
+pyvista==0.34.1
 radiant-mlhub==0.3.0
 rarfile==4.0
 scikit-image==0.18.0

--- a/requirements/min-reqs.old
+++ b/requirements/min-reqs.old
@@ -26,7 +26,7 @@ laspy==2.0.0
 opencv-python==4.4.0.46
 pandas==1.1.3
 pycocotools==2.0.5
-pyvista==0.35.1
+pyvista==0.34.0
 radiant-mlhub==0.3.0
 rarfile==4.0
 scikit-image==0.18.0

--- a/requirements/min-reqs.old
+++ b/requirements/min-reqs.old
@@ -26,7 +26,7 @@ laspy==2.0.0
 opencv-python==4.4.0.46
 pandas==1.1.3
 pycocotools==2.0.5
-pyvista==0.29.0
+pyvista==0.32.0
 radiant-mlhub==0.3.0
 rarfile==4.0
 scikit-image==0.18.0

--- a/tests/datasets/test_idtrees.py
+++ b/tests/datasets/test_idtrees.py
@@ -140,7 +140,7 @@ class TestIDTReeS:
             plt.close()
 
     def test_plot_las(self, dataset: IDTReeS) -> None:
-        pyvista = pytest.importorskip("pyvista", minversion="0.29.0")
+        pyvista = pytest.importorskip("pyvista")
 
         # Test point cloud without colors
         point_cloud = dataset.plot_las(index=0)

--- a/tests/datasets/test_idtrees.py
+++ b/tests/datasets/test_idtrees.py
@@ -19,7 +19,7 @@ import torchgeo.datasets.utils
 from torchgeo.datasets import IDTReeS
 
 pytest.importorskip("pandas", minversion="1.1.3")
-pytest.importorskip("laspy", minversion="2")
+pytest.importorskip("laspy", minversion="2.0.0")
 
 
 def download_url(url: str, root: str, *args: str, **kwargs: str) -> None:

--- a/tests/datasets/test_idtrees.py
+++ b/tests/datasets/test_idtrees.py
@@ -140,7 +140,7 @@ class TestIDTReeS:
             plt.close()
 
     def test_plot_las(self, dataset: IDTReeS) -> None:
-        import pyvista
+        pyvista = pytest.importorskip("pyvista", minversion="0.34.2")
 
         # Test point cloud without colors
         point_cloud = dataset.plot_las(index=0)

--- a/tests/datasets/test_idtrees.py
+++ b/tests/datasets/test_idtrees.py
@@ -19,7 +19,7 @@ import torchgeo.datasets.utils
 from torchgeo.datasets import IDTReeS
 
 pytest.importorskip("pandas", minversion="1.1.3")
-pytest.importorskip("laspy", minversion="2.0.0")
+pytest.importorskip("laspy", minversion="2")
 
 
 def download_url(url: str, root: str, *args: str, **kwargs: str) -> None:
@@ -140,7 +140,7 @@ class TestIDTReeS:
             plt.close()
 
     def test_plot_las(self, dataset: IDTReeS) -> None:
-        pyvista = pytest.importorskip("pyvista", minversion="0.29")
+        pyvista = pytest.importorskip("pyvista", minversion="0.29.0")
 
         # Test point cloud without colors
         point_cloud = dataset.plot_las(index=0)

--- a/tests/datasets/test_idtrees.py
+++ b/tests/datasets/test_idtrees.py
@@ -140,7 +140,7 @@ class TestIDTReeS:
             plt.close()
 
     def test_plot_las(self, dataset: IDTReeS) -> None:
-        pyvista = pytest.importorskip("pyvista")
+        import pyvista
 
         # Test point cloud without colors
         point_cloud = dataset.plot_las(index=0)

--- a/tests/datasets/test_landcoverai.py
+++ b/tests/datasets/test_landcoverai.py
@@ -75,7 +75,7 @@ class TestLandCoverAI:
     def dataset(
         self, monkeypatch: MonkeyPatch, tmp_path: Path, request: SubRequest
     ) -> LandCoverAI:
-        pytest.importorskip("cv2", minversion="4.4.0.46")
+        pytest.importorskip("cv2", minversion="4.4.0")
         monkeypatch.setattr(torchgeo.datasets.landcoverai, "download_url", download_url)
         md5 = "ff8998857cc8511f644d3f7d0f3688d0"
         monkeypatch.setattr(LandCoverAI, "md5", md5)
@@ -106,7 +106,7 @@ class TestLandCoverAI:
         LandCoverAI(root=dataset.root, download=True)
 
     def test_already_downloaded(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
-        pytest.importorskip("cv2", minversion="4.4.0.46")
+        pytest.importorskip("cv2", minversion="4.4.0")
         sha256 = "ecec8e871faf1bbd8ca525ca95ddc1c1f5213f40afb94599884bd85f990ebd6b"
         monkeypatch.setattr(LandCoverAI, "sha256", sha256)
         url = os.path.join("tests", "data", "landcoverai", "landcover.ai.v1.zip")


### PR DESCRIPTION
Some of our minimum version tests are being skipped. This doesn't ensure that our minimum versions actually work. Let's fix that.