### PR TITLE
Don't document param change for new datasets

### DIFF
--- a/torchgeo/datasets/l7irish.py
+++ b/torchgeo/datasets/l7irish.py
@@ -118,9 +118,6 @@ class L7Irish(RasterDataset):
         Raises:
             RuntimeError: if ``download=False`` and data is not found, or checksums
                 don't match
-
-        .. versionchanged:: 0.5
-           *root* was renamed to *paths*.
         """
         self.paths = paths
         self.download = download

--- a/torchgeo/datasets/l8biome.py
+++ b/torchgeo/datasets/l8biome.py
@@ -117,9 +117,6 @@ class L8Biome(RasterDataset):
         Raises:
             RuntimeError: if ``download=False`` and data is not found, or checksums
                 don't match
-
-        .. versionchanged:: 0.5
-           *root* was renamed to *paths*.
         """
         self.paths = paths
         self.download = download

--- a/torchgeo/datasets/nlcd.py
+++ b/torchgeo/datasets/nlcd.py
@@ -138,9 +138,6 @@ class NLCD(RasterDataset):
             AssertionError: if ``years`` or ``classes`` are invalid
             FileNotFoundError: if no files are found in ``paths``
             RuntimeError: if ``download=False`` but dataset is missing or checksum fails
-
-        .. versionchanged:: 0.5
-           *root* was renamed to *paths*.
         """
         assert set(years) <= self.md5s.keys(), (
             "NLCD data product only exists for the following years: "


### PR DESCRIPTION
These datasets are all new in 0.5.0, no reason to document the fact that the parameter name changed.