### PR TITLE
Fix CITATION.cff format

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,4 +1,18 @@
 # https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md
+# Can be validated using `cffconvert --validate`
+authors:
+- family-names: "Stewart"
+  given-names: "Adam J."
+- family-names: "Robinson"
+  given-names: "Caleb"
+- family-names: "Corley"
+  given-names: "Isaac A."
+- family-names: "Ortiz"
+  given-names: "Anthony"
+- family-names: "Lavista Ferres"
+  given-names: "Juan M."
+- family-names: "Banerjee"
+  given-names: "Arindam"
 cff-version: "1.2.0"
 message: "If you use this software, please cite it using the metadata from this file."
 preferred-citation:
@@ -26,9 +40,11 @@ preferred-citation:
   isbn: "9781450395298"
   month: 11
   number: 19
-  publisher: "Association for Computing Machinery"
+  publisher:
+    name: "Association for Computing Machinery"
   start: 1
   title: "TorchGeo: Deep Learning With Geospatial Data"
   type: "conference-paper"
   url: "https://dl.acm.org/doi/10.1145/3557915.3560953"
   year: 2022
+title: "TorchGeo: Deep Learning With Geospatial Data"

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ If you use this software in your work, please cite our [paper](https://dl.acm.or
     author = {Stewart, Adam J. and Robinson, Caleb and Corley, Isaac A. and Ortiz, Anthony and Lavista Ferres, Juan M. and Banerjee, Arindam},
     booktitle = {Proceedings of the 30th International Conference on Advances in Geographic Information Systems},
     doi = {10.1145/3557915.3560953},
-    month = {11},
+    month = nov,
     pages = {1--12},
     publisher = {Association for Computing Machinery},
     series = {SIGSPATIAL '22},


### PR DESCRIPTION
When running `cffconvert --validate`, we see a bunch of issues. They don't cause issues when rendering the citation, but might as well fix them.