### PR TITLE
MapInWild: prevent download during testing

### DIFF
--- a/tests/datasets/test_mapinwild.py
+++ b/tests/datasets/test_mapinwild.py
@@ -101,12 +101,12 @@ class TestMapInWild:
             MapInWild(root=str(tmp_path))
 
     def test_downloaded_not_extracted(self, tmp_path: Path) -> None:
-        pathname = os.path.join("tests", "data", "mapinwild", "**", "*.zip")
-        pathname_glob = glob.glob(pathname, recursive=True)
+        pathname = os.path.join("tests", "data", "mapinwild", "*", "*")
+        pathname_glob = glob.glob(pathname)
         root = str(tmp_path)
         for zipfile in pathname_glob:
             shutil.copy(zipfile, root)
-        MapInWild(root, download=True)
+        MapInWild(root, download=False)
 
     def test_corrupted(self, tmp_path: Path) -> None:
         pathname = os.path.join("tests", "data", "mapinwild", "**", "*.zip")


### PR DESCRIPTION
We were only copying .zip files but we also need to copy .csv files. Without this, the tests were downloading an extra CSV file.

Relates to #1088, wish we had a better way to test this.

@burakekim