### PR TITLE
CI: minimize storage usage

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,9 @@ jobs:
         key: ${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}
     - name: Install pip dependencies
       if: steps.cache.outputs.cache-hit != 'true'
-      run: pip install .[tests]
+      run: |
+        pip install .[tests]
+        pip cache purge
     - name: List pip dependencies
       run: pip list
     - name: Run pytest checks
@@ -51,7 +53,9 @@ jobs:
         key: ${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}
     - name: Install pip dependencies
       if: steps.cache.outputs.cache-hit != 'true'
-      run: pip install .[datasets,tests]
+      run: |
+        pip install .[datasets,tests]
+        pip cache purge
     - name: List pip dependencies
       run: pip list
     - name: Run integration checks
@@ -77,7 +81,9 @@ jobs:
         key: ${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}
     - name: Install pip dependencies
       if: steps.cache.outputs.cache-hit != 'true'
-      run: pip install .[docs,tests] planetary_computer pystac
+      run: |
+        pip install .[docs,tests] planetary_computer pystac
+        pip cache purge
     - name: List pip dependencies
       run: pip list
     - name: Run notebook checks

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -27,7 +27,9 @@ jobs:
         key: ${{ env.pythonLocation }}-${{ hashFiles('requirements/style.txt') }}
     - name: Install pip dependencies
       if: steps.cache.outputs.cache-hit != 'true'
-      run: pip install -r requirements/style.txt
+      run: |
+        pip install -r requirements/style.txt
+        pip cache purge
     - name: List pip dependencies
       run: pip list
     - name: Run black checks
@@ -50,7 +52,9 @@ jobs:
         key: ${{ env.pythonLocation }}-${{ hashFiles('requirements/style.txt') }}
     - name: Install pip dependencies
       if: steps.cache.outputs.cache-hit != 'true'
-      run: pip install -r requirements/style.txt
+      run: |
+        pip install -r requirements/style.txt
+        pip cache purge
     - name: List pip dependencies
       run: pip list
     - name: Run flake8 checks
@@ -73,7 +77,9 @@ jobs:
         key: ${{ env.pythonLocation }}-${{ hashFiles('requirements/style.txt') }}
     - name: Install pip dependencies
       if: steps.cache.outputs.cache-hit != 'true'
-      run: pip install -r requirements/style.txt
+      run: |
+        pip install -r requirements/style.txt
+        pip cache purge
     - name: List pip dependencies
       run: pip list
     - name: Run isort checks
@@ -96,7 +102,9 @@ jobs:
         key: ${{ env.pythonLocation }}-${{ hashFiles('requirements/style.txt') }}
     - name: Install pip dependencies
       if: steps.cache.outputs.cache-hit != 'true'
-      run: pip install -r requirements/style.txt
+      run: |
+        pip install -r requirements/style.txt
+        pip cache purge
     - name: List pip dependencies
       run: pip list
     - name: Run pydocstyle checks
@@ -119,7 +127,9 @@ jobs:
         key: ${{ env.pythonLocation }}-${{ hashFiles('requirements/style.txt') }}
     - name: Install pip dependencies
       if: steps.cache.outputs.cache-hit != 'true'
-      run: pip install -r requirements/style.txt
+      run: |
+        pip install -r requirements/style.txt
+        pip cache purge
     - name: List pip dependencies
       run: pip list
     - name: Run pyupgrade checks

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -27,7 +27,9 @@ jobs:
         key: ${{ env.pythonLocation }}-${{ hashFiles('requirements/required.txt') }}-${{ hashFiles('requirements/datasets.txt') }}-${{ hashFiles('requirements/tests.txt') }}
     - name: Install pip dependencies
       if: steps.cache.outputs.cache-hit != 'true'
-      run: pip install -r requirements/required.txt -r requirements/datasets.txt -r requirements/tests.txt
+      run: |
+        pip install -r requirements/required.txt -r requirements/datasets.txt -r requirements/tests.txt
+        pip cache purge
     - name: List pip dependencies
       run: pip list
     - name: Run mypy checks
@@ -70,7 +72,9 @@ jobs:
       if: ${{ runner.os == 'Windows' }}
     - name: Install pip dependencies
       if: steps.cache.outputs.cache-hit != 'true'
-      run: pip install -r requirements/required.txt -r requirements/datasets.txt -r requirements/tests.txt
+      run: |
+        pip install -r requirements/required.txt -r requirements/datasets.txt -r requirements/tests.txt
+        pip cache purge
     - name: List pip dependencies
       run: pip list
     - name: Run pytest checks
@@ -107,7 +111,9 @@ jobs:
         sudo apt-get install unrar
     - name: Install pip dependencies
       if: steps.cache.outputs.cache-hit != 'true'
-      run: pip install -r requirements/min-reqs.old -c requirements/min-cons.old
+      run: |
+        pip install -r requirements/min-reqs.old -c requirements/min-cons.old
+        pip cache purge
     - name: List pip dependencies
       run: pip list
     - name: Run pytest checks

--- a/.github/workflows/tutorials.yaml
+++ b/.github/workflows/tutorials.yaml
@@ -29,7 +29,9 @@ jobs:
         key: ${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}
     - name: Install pip dependencies
       if: steps.cache.outputs.cache-hit != 'true'
-      run: pip install .[docs,tests] planetary_computer pystac
+      run: |
+        pip install .[docs,tests] planetary_computer pystac
+        pip cache purge
     - name: List pip dependencies
       run: pip list
     - name: Run notebook checks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,6 +257,8 @@ filterwarnings = [
     "ignore:`ColorJitter` is now following Torchvision implementation.:DeprecationWarning:kornia.augmentation._2d.intensity.color_jitter",
     # https://github.com/kornia/kornia/pull/1663
     "ignore:`RandomGaussianBlur` has changed its behavior and now randomly sample sigma for both axes.:DeprecationWarning:kornia.augmentation._2d.intensity.gaussian_blur",
+    # We are explicitly requesting pytest not to save temporary directories
+    "ignore:Implicitly cleaning up <TemporaryDirectory:ResourceWarning:tempfile",
 
     # Unexpected warnings, worth investigating
     # Lightning is having trouble inferring the batch size for ChesapeakeCVPRDataModule and CycloneDataModule for some reason

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,8 +133,8 @@ tests = [
     "nbmake>=1.3.3",
     # pytest 7.3+ required for tmp_path_retention_policy
     "pytest>=7.3",
-    # pytest-cov 2.4+ required for pytest --cov flags
-    "pytest-cov>=2.4",
+    # pytest-cov 4+ required for pytest 7.2+ compatibility
+    "pytest-cov>=4",
 ]
 all = [
     "torchgeo[datasets,docs,style,tests]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,8 +131,8 @@ tests = [
     "mypy>=0.900",
     # nbmake 1.3.3+ required for variable mocking
     "nbmake>=1.3.3",
-    # pytest 6.2+ required for pytest.MonkeyPatch
-    "pytest>=6.2",
+    # pytest 7.3+ required for tmp_path_retention_policy
+    "pytest>=7.3",
     # pytest-cov 2.4+ required for pytest --cov flags
     "pytest-cov>=2.4",
 ]
@@ -257,8 +257,6 @@ filterwarnings = [
     "ignore:`ColorJitter` is now following Torchvision implementation.:DeprecationWarning:kornia.augmentation._2d.intensity.color_jitter",
     # https://github.com/kornia/kornia/pull/1663
     "ignore:`RandomGaussianBlur` has changed its behavior and now randomly sample sigma for both axes.:DeprecationWarning:kornia.augmentation._2d.intensity.gaussian_blur",
-    # We are explicitly requesting pytest not to save temporary directories
-    "ignore:Implicitly cleaning up <TemporaryDirectory:ResourceWarning:tempfile",
 
     # Unexpected warnings, worth investigating
     # Lightning is having trouble inferring the batch size for ChesapeakeCVPRDataModule and CycloneDataModule for some reason

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -276,6 +276,7 @@ testpaths = [
     "tests",
     "docs/tutorials",
 ]
+tmp_path_retention_policy = "failed"
 
 # https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html
 [tool.setuptools.dynamic]

--- a/requirements/min-reqs.old
+++ b/requirements/min-reqs.old
@@ -49,4 +49,4 @@ pyupgrade==2.8.0
 mypy==0.900
 nbmake==1.3.3
 pytest==7.3.0
-pytest-cov==2.4.0
+pytest-cov==4.0.0

--- a/requirements/min-reqs.old
+++ b/requirements/min-reqs.old
@@ -48,5 +48,5 @@ pyupgrade==2.8.0
 # tests
 mypy==0.900
 nbmake==1.3.3
-pytest==6.2.0
+pytest==7.3.0
 pytest-cov==2.4.0


### PR DESCRIPTION
Our CI has been dead in the water for the last 4 days. This PR fixes that. Specifically, this includes the following changes:

- [x] Purge pip's download cache (-2.7G)
- [x] Don't save tmp path if tests pass (-10.6G)

The result is that we're no longer MBs away from running out of space in any given PR.