### PR TITLE
CI: fix RAR backend installation

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -68,7 +68,7 @@ jobs:
       run: brew install rar
       if: ${{ runner.os == 'macOS' }}
     - name: Install choco dependencies (Windows)
-      run: choco install unrar
+      run: choco install 7zip
       if: ${{ runner.os == 'Windows' }}
     - name: Install pip dependencies
       if: steps.cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
CI is currently broken due to issues with `choco install unrar`. I informed the maintainers of that recipe. Until it gets fixed, we should consider using a different RAR backend. Rarfile supports many: https://pypi.org/project/rarfile/