### PR TITLE
Fix all Trainers to support PyTorch DataLoaders

### DIFF
--- a/torchgeo/trainers/classification.py
+++ b/torchgeo/trainers/classification.py
@@ -314,6 +314,7 @@ class MultiLabelClassificationTask(ClassificationTask):
         if (
             batch_idx < 10
             and hasattr(self.trainer, "datamodule")
+            and hasattr(self.trainer.datamodule, "plot")
             and self.logger
             and hasattr(self.logger, "experiment")
             and hasattr(self.logger.experiment, "add_figure")

--- a/torchgeo/trainers/classification.py
+++ b/torchgeo/trainers/classification.py
@@ -190,6 +190,7 @@ class ClassificationTask(BaseTask):
         if (
             batch_idx < 10
             and hasattr(self.trainer, "datamodule")
+            and hasattr(self.trainer.datamodule, "plot")
             and self.logger
             and hasattr(self.logger, "experiment")
             and hasattr(self.logger.experiment, "add_figure")

--- a/torchgeo/trainers/detection.py
+++ b/torchgeo/trainers/detection.py
@@ -259,6 +259,7 @@ class ObjectDetectionTask(BaseTask):
         if (
             batch_idx < 10
             and hasattr(self.trainer, "datamodule")
+            and hasattr(self.trainer.datamodule, "plot")
             and self.logger
             and hasattr(self.logger, "experiment")
             and hasattr(self.logger.experiment, "add_figure")

--- a/torchgeo/trainers/regression.py
+++ b/torchgeo/trainers/regression.py
@@ -185,6 +185,7 @@ class RegressionTask(BaseTask):
         if (
             batch_idx < 10
             and hasattr(self.trainer, "datamodule")
+            and hasattr(self.trainer.datamodule, "plot")
             and self.logger
             and hasattr(self.logger, "experiment")
             and hasattr(self.logger.experiment, "add_figure")

--- a/torchgeo/trainers/segmentation.py
+++ b/torchgeo/trainers/segmentation.py
@@ -245,6 +245,7 @@ class SemanticSegmentationTask(BaseTask):
         if (
             batch_idx < 10
             and hasattr(self.trainer, "datamodule")
+            and hasattr(self.trainer.datamodule, "plot")
             and self.logger
             and hasattr(self.logger, "experiment")
             and hasattr(self.logger.experiment, "add_figure")


### PR DESCRIPTION
Fixes an error that occurred when using Trainers with PyTorch DataLoaders instead of a Lightning DataModule.
-> as discussed in #1598 