### PR TITLE
Fix for Blank Images in plot due to Float Tensor Ranges

### DIFF
--- a/torchgeo/datasets/ucmerced.py
+++ b/torchgeo/datasets/ucmerced.py
@@ -214,6 +214,11 @@ class UCMerced(NonGeoClassificationDataset):
         .. versionadded:: 0.2
         """
         image = np.rollaxis(sample["image"].numpy(), 0, 3)
+
+        # Normalize the image if the max value is greater than 1
+        if image.max() > 1:
+            image = image.astype(np.float32) / 255.0 # Scale to [0, 1] 
+
         label = cast(int, sample["label"].item())
         label_class = self.classes[label]
 

--- a/torchgeo/datasets/ucmerced.py
+++ b/torchgeo/datasets/ucmerced.py
@@ -217,7 +217,7 @@ class UCMerced(NonGeoClassificationDataset):
 
         # Normalize the image if the max value is greater than 1
         if image.max() > 1:
-            image = image.astype(np.float32) / 255.0 # Scale to [0, 1] 
+            image = image.astype(np.float32) / 255.0  # Scale to [0, 1]
 
         label = cast(int, sample["label"].item())
         label_class = self.classes[label]


### PR DESCRIPTION
**Description:**
Encountered an issue where ucmerced dataset images would render as blank after using the plot function and matplotlib to show the image.

**Issue:**
The underlying cause is that Matplotlib expects float values to be normalized between 0 and 1. However, the float tensor representing our image data occasionally contained values in the 0 to 255 range, leading to unexpected behavior in the rendering process.

**Resolution:**
A conditional check has been introduced. When the maximum value in the image tensor exceeds 1, the tensor is normalized by scaling down to the 0 to 1 range. This ensures compatibility with Matplotlib's expected float value range and resolves the issue of blank images.

**Outcome:**
With the proposed changes, images are displayed correctly, regardless of whether their data originally spans 0 to 1 or 0 to 255. 

I invite the maintainers to review the changes. Please advise if further modifications are required or if the update can be merged.