### PR TITLE
Add SSL4EO-L Benchmark to docs

### DIFF
--- a/docs/api/datamodules.rst
+++ b/docs/api/datamodules.rst
@@ -131,8 +131,8 @@ SSL4EO
 .. autoclass:: SSL4EOLDataModule
 .. autoclass:: SSL4EOS12DataModule
 
-SSL4EOLBenchmarkDataModule
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+SSL4EO-L Benchmark
+^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: SSL4EOLBenchmarkDataModule
 

--- a/docs/api/datamodules.rst
+++ b/docs/api/datamodules.rst
@@ -131,6 +131,11 @@ SSL4EO
 .. autoclass:: SSL4EOLDataModule
 .. autoclass:: SSL4EOS12DataModule
 
+SSL4EOLBenchmarkDataModule
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autoclass:: SSL4EOLBenchmarkDataModule
+
 SustainBench Crop Yield
 ^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/api/datasets.rst
+++ b/docs/api/datasets.rst
@@ -356,8 +356,8 @@ SSL4EO
 .. autoclass:: SSL4EOL
 .. autoclass:: SSL4EOS12
 
-SSL4EOLBenchmark
-^^^^^^^^^^^^^^^^
+SSL4EO-L Benchmark
+^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: SSL4EOLBenchmark
 

--- a/docs/api/datasets.rst
+++ b/docs/api/datasets.rst
@@ -356,6 +356,11 @@ SSL4EO
 .. autoclass:: SSL4EOL
 .. autoclass:: SSL4EOS12
 
+SSL4EOLBenchmark
+^^^^^^^^^^^^^^^^
+
+.. autoclass:: SSL4EOLBenchmark
+
 SustainBench Crop Yield
 ^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/api/non_geo_datasets.csv
+++ b/docs/api/non_geo_datasets.csv
@@ -37,6 +37,8 @@ Dataset,Task,Source,# Samples,# Classes,Size (px),Resolution (m),Bands
 `SpaceNet`_,I,WorldView-2/3 Planet Lab Dove,"1,889--28,728",2,102--900,0.5--4,MSI
 `SSL4EO`_-L,T,Landsat,1M,-,264x264,30,MSI
 `SSL4EO`_-S12,T,Sentinel-1/2,1M,-,264x264,10,"SAR, MSI"
+`SSL4EOLBenchmark`_-TM-TOA & CDL, S, Lansat, 25k,18,264x264,30,MSI
+`SSL4EOLBenchmark`_-TM-TOA & NLCD, S, Lansat, 25k,14,264x264,30,MSI
 `SustainBench Crop Yield`_,R,MODIS,11k,-,32x32,-,MSI
 `Tropical Cyclone`_,R,GOES 8--16,"108,110",-,256x256,4K--8K,MSI
 `UC Merced`_,C,USGS National Map,"2,100",21,256x256,0.3,RGB

--- a/docs/api/non_geo_datasets.csv
+++ b/docs/api/non_geo_datasets.csv
@@ -37,8 +37,8 @@ Dataset,Task,Source,# Samples,# Classes,Size (px),Resolution (m),Bands
 `SpaceNet`_,I,WorldView-2/3 Planet Lab Dove,"1,889--28,728",2,102--900,0.5--4,MSI
 `SSL4EO`_-L,T,Landsat,1M,-,264x264,30,MSI
 `SSL4EO`_-S12,T,Sentinel-1/2,1M,-,264x264,10,"SAR, MSI"
-`SSL4EO-L Benchmark`_, S, Lansat & CDL, 25k,18,264x264,30,MSI
-`SSL4EO-L Benchmark`_, S, Lansat & NLCD, 25k,14,264x264,30,MSI
+`SSL4EO-L Benchmark`_,S,Lansat & CDL,25K,134,264x264,30,MSI
+`SSL4EO-L Benchmark`_,S,Lansat & NLCD,25K,17,264x264,30,MSI
 `SustainBench Crop Yield`_,R,MODIS,11k,-,32x32,-,MSI
 `Tropical Cyclone`_,R,GOES 8--16,"108,110",-,256x256,4K--8K,MSI
 `UC Merced`_,C,USGS National Map,"2,100",21,256x256,0.3,RGB

--- a/docs/api/non_geo_datasets.csv
+++ b/docs/api/non_geo_datasets.csv
@@ -37,8 +37,8 @@ Dataset,Task,Source,# Samples,# Classes,Size (px),Resolution (m),Bands
 `SpaceNet`_,I,WorldView-2/3 Planet Lab Dove,"1,889--28,728",2,102--900,0.5--4,MSI
 `SSL4EO`_-L,T,Landsat,1M,-,264x264,30,MSI
 `SSL4EO`_-S12,T,Sentinel-1/2,1M,-,264x264,10,"SAR, MSI"
-`SSL4EOLBenchmark`_-TM-TOA & CDL, S, Lansat, 25k,18,264x264,30,MSI
-`SSL4EOLBenchmark`_-TM-TOA & NLCD, S, Lansat, 25k,14,264x264,30,MSI
+`SSL4EO-L Benchmark`_, S, Lansat & CDL, 25k,18,264x264,30,MSI
+`SSL4EO-L Benchmark`_, S, Lansat & NLCD, 25k,14,264x264,30,MSI
 `SustainBench Crop Yield`_,R,MODIS,11k,-,32x32,-,MSI
 `Tropical Cyclone`_,R,GOES 8--16,"108,110",-,256x256,4K--8K,MSI
 `UC Merced`_,C,USGS National Map,"2,100",21,256x256,0.3,RGB


### PR DESCRIPTION
I think we forgot to add the SSL4EO Benchmark Dataset/Datamodule to the Docs. Do you want to put entries for all possible constillations in the csv file?