### PR TITLE
Automatically generate release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,41 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot[bot]
+  categories:
+    - title: Backwards-incompatible changes
+      labels:
+        - backwards-incompatible
+    - title: Dependencies
+      labels:
+        - dependencies
+    - title: Datamodules
+      labels:
+        - datamodules
+    - title: Datasets
+      labels:
+        - datasets
+    - title: Losses
+      labels:
+        - losses
+    - title: Models
+      labels:
+        - models
+    - title: Samplers
+      labels:
+        - samplers
+    - title: Trainers
+      labels:
+        - trainers
+    - title: Transforms
+      labels:
+        - transforms
+    - title: Scripts
+      labels:
+        - scripts
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Testing
+      labels:
+        - testing


### PR DESCRIPTION
See https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes for documentation.

This file lets us automatically generate Release Notes based on PR labels. In combination with the Labeler action, it ensures that all PRs make it into the Release Notes.

It's not perfect, and there will be many times when we have to edit things, but it gives us a start and saves us a lot time.