### PR TITLE
CI: fix lightning-utilities deprecation warning

### DIFF
--- a/requirements/min-cons.old
+++ b/requirements/min-cons.old
@@ -1,3 +1,5 @@
+# https://github.com/Lightning-AI/utilities/pull/147
+lightning-utilities<0.10
 # https://github.com/pypa/pip/issues/11760
 nbconvert<6
 # https://github.com/fatiando/pooch/issues/252


### PR DESCRIPTION
The latest lightning-utilities release deprecates a feature that was used in old versions of lightning. Instead of ignoring it, let's prevent newer versions of lightning-utilities from being used in CI. Otherwise, it will eventually be removed and things will start to break.

Released [2 days ago](https://pypi.org/project/lightning-utilities/), which explains why our tests just started to break.