### PR TITLE
LEVIR-CD+ bug fixes

### DIFF
--- a/tests/datamodules/test_levircd.py
+++ b/tests/datamodules/test_levircd.py
@@ -86,8 +86,6 @@ class TestLEVIRCDPlusDataModule:
         batch = next(iter(datamodule.val_dataloader()))
         batch = datamodule.on_after_batch_transfer(batch, 0)
         if datamodule.val_split_pct > 0.0:
-            for k, v in batch.items():
-                print(k, v.shape, v.dtype)
             assert (
                 batch["image1"].shape[-2:] == batch["mask"].shape[-2:] == (1024, 1024)
             )

--- a/tests/datamodules/test_levircd.py
+++ b/tests/datamodules/test_levircd.py
@@ -6,8 +6,11 @@ import shutil
 from pathlib import Path
 
 import pytest
+import torchvision.transforms.functional as F
 from lightning.pytorch import Trainer
 from pytest import MonkeyPatch
+from torch import Tensor
+from torchvision.transforms import InterpolationMode
 
 import torchgeo.datasets.utils
 from torchgeo.datamodules import LEVIRCDPlusDataModule
@@ -16,6 +19,27 @@ from torchgeo.datasets import LEVIRCDPlus
 
 def download_url(url: str, root: str, *args: str) -> None:
     shutil.copy(url, root)
+
+
+def transforms(sample: dict[str, Tensor]) -> dict[str, Tensor]:
+    sample["image1"] = F.resize(
+        sample["image1"],
+        size=[1024, 1024],
+        antialias=True,
+        interpolation=InterpolationMode.BILINEAR,
+    )
+    sample["image2"] = F.resize(
+        sample["image2"],
+        size=[1024, 1024],
+        antialias=True,
+        interpolation=InterpolationMode.BILINEAR,
+    )
+    sample["mask"] = F.resize(
+        sample["mask"].unsqueeze(dim=0),
+        size=[1024, 1024],
+        interpolation=InterpolationMode.NEAREST,
+    )
+    return sample
 
 
 class TestLEVIRCDPlusDataModule:
@@ -31,7 +55,12 @@ class TestLEVIRCDPlusDataModule:
 
         root = str(tmp_path)
         dm = LEVIRCDPlusDataModule(
-            root=root, download=True, num_workers=0, checksum=True, val_split_pct=0.5
+            root=root,
+            download=True,
+            num_workers=0,
+            checksum=True,
+            val_split_pct=0.5,
+            transforms=transforms,
         )
         dm.prepare_data()
         dm.trainer = Trainer(accelerator="cpu", max_epochs=1)
@@ -57,10 +86,16 @@ class TestLEVIRCDPlusDataModule:
         batch = next(iter(datamodule.val_dataloader()))
         batch = datamodule.on_after_batch_transfer(batch, 0)
         if datamodule.val_split_pct > 0.0:
-            assert batch["image1"].shape[-2:] == batch["mask"].shape[-2:] == (256, 256)
-            assert batch["image1"].shape[0] == batch["mask"].shape[0] == 8
-            assert batch["image2"].shape[-2:] == batch["mask"].shape[-2:] == (256, 256)
-            assert batch["image2"].shape[0] == batch["mask"].shape[0] == 8
+            for k, v in batch.items():
+                print(k, v.shape, v.dtype)
+            assert (
+                batch["image1"].shape[-2:] == batch["mask"].shape[-2:] == (1024, 1024)
+            )
+            assert batch["image1"].shape[0] == batch["mask"].shape[0] == 1
+            assert (
+                batch["image2"].shape[-2:] == batch["mask"].shape[-2:] == (1024, 1024)
+            )
+            assert batch["image2"].shape[0] == batch["mask"].shape[0] == 1
             assert batch["image1"].shape[1] == 3
             assert batch["image2"].shape[1] == 3
 
@@ -70,9 +105,9 @@ class TestLEVIRCDPlusDataModule:
             datamodule.trainer.testing = True
         batch = next(iter(datamodule.test_dataloader()))
         batch = datamodule.on_after_batch_transfer(batch, 0)
-        assert batch["image1"].shape[-2:] == batch["mask"].shape[-2:] == (256, 256)
-        assert batch["image1"].shape[0] == batch["mask"].shape[0] == 8
-        assert batch["image2"].shape[-2:] == batch["mask"].shape[-2:] == (256, 256)
-        assert batch["image2"].shape[0] == batch["mask"].shape[0] == 8
+        assert batch["image1"].shape[-2:] == batch["mask"].shape[-2:] == (1024, 1024)
+        assert batch["image1"].shape[0] == batch["mask"].shape[0] == 1
+        assert batch["image2"].shape[-2:] == batch["mask"].shape[-2:] == (1024, 1024)
+        assert batch["image2"].shape[0] == batch["mask"].shape[0] == 1
         assert batch["image1"].shape[1] == 3
         assert batch["image2"].shape[1] == 3

--- a/torchgeo/datamodules/levircd.py
+++ b/torchgeo/datamodules/levircd.py
@@ -49,9 +49,17 @@ class LEVIRCDPlusDataModule(NonGeoDataModule):
         self.patch_size = _to_tuple(patch_size)
         self.val_split_pct = val_split_pct
 
-        self.aug = AugmentationSequential(
+        self.train_aug = AugmentationSequential(
             K.Normalize(mean=self.mean, std=self.std),
             _RandomNCrop(self.patch_size, batch_size),
+            data_keys=["image1", "image2", "mask"],
+        )
+        self.val_aug = AugmentationSequential(
+            K.Normalize(mean=self.mean, std=self.std),
+            data_keys=["image1", "image2", "mask"],
+        )
+        self.test_aug = AugmentationSequential(
+            K.Normalize(mean=self.mean, std=self.std),
             data_keys=["image1", "image2", "mask"],
         )
 

--- a/torchgeo/datasets/levircd.py
+++ b/torchgeo/datasets/levircd.py
@@ -223,10 +223,10 @@ class LEVIRCDPlus(NonGeoDataset):
         """
         ncols = 3
 
-        image1 = sample["image1"].permute(1, 2, 0)
+        image1 = sample["image1"].permute(1, 2, 0).numpy()
         image1 = percentile_normalization(image1, axis=(0, 1))
 
-        image2 = sample["image2"].permute(1, 2, 0)
+        image2 = sample["image2"].permute(1, 2, 0).numpy()
         image2 = percentile_normalization(image2, axis=(0, 1))
 
         if "prediction" in sample:


### PR DESCRIPTION
This PR fixes the following bugs in the LEVIR-CD+ dataset and datamodule.

- The plot method plots the ground truth in a different cmap than a predicted mask
- Cleaned up some image normalization code which basically replicates `torchgeo.datasets.utils.percentile_normalization`
- Added `val_augs` and `test_augs` to the LEVIR-CD+ datamodule so random cropping isn't used for computing evaluation metrics

New example plot:

![output](https://github.com/microsoft/torchgeo/assets/22203655/74afc380-abdb-4ff4-9f81-03afd0872170)
