### PR TITLE
ExtractPatches augmentation

### DIFF
--- a/torchgeo/transforms/transforms.py
+++ b/torchgeo/transforms/transforms.py
@@ -201,7 +201,7 @@ class _ExtractPatches(K.GeometricAugmentationBase2D):
             padding: zero padding added to the height and width dimensions
             keepdim: Combine the patch dimension into the batch dimension
         """
-        super().__init__()
+        super().__init__(p=1)
         self.flags = {
             "window_size": window_size,
             "stride": stride if stride is not None else window_size,

--- a/torchgeo/transforms/transforms.py
+++ b/torchgeo/transforms/transforms.py
@@ -188,7 +188,7 @@ class _ExtractPatches(K.GeometricAugmentationBase2D):
     def __init__(
         self,
         window_size: Union[int, tuple[int, int]],
-        stride: Optional[Union[int, tuple[int, int]]] = 1,
+        stride: Optional[Union[int, tuple[int, int]]] = None,
         padding: Optional[Union[int, tuple[int, int]]] = 0,
         keepdim: bool = True,
     ) -> None:
@@ -196,15 +196,15 @@ class _ExtractPatches(K.GeometricAugmentationBase2D):
 
         Args:
             window_size: desired output size (out_h, out_w) of the crop
-            stride: stride of window to extract patches
-                (nonoverlapping windows occur when stride=window_size)
+            stride: stride of window to extract patches. Defaults to non-overlapping
+                patches (stride=window_size)
             padding: zero padding added to the height and width dimensions
             keepdim: Combine the patch dimension into the batch dimension
         """
         super().__init__()
         self.flags = {
             "window_size": window_size,
-            "stride": stride,
+            "stride": stride if stride is not None else window_size,
             "padding": padding,
             "keepdim": keepdim,
         }

--- a/torchgeo/transforms/transforms.py
+++ b/torchgeo/transforms/transforms.py
@@ -8,6 +8,7 @@ from typing import Any, Optional, Union
 import kornia.augmentation as K
 import torch
 from einops import rearrange
+from kornia.contrib import extract_tensor_patches
 from kornia.geometry import crop_by_indices
 from torch import Tensor
 from torch.nn.modules import Module
@@ -179,3 +180,77 @@ class _NCropGenerator(K.random_generator.CropGenerator):
             "input_size": out[0]["input_size"],
             "output_size": out[0]["output_size"],
         }
+
+
+class _ExtractPatches(K.GeometricAugmentationBase2D):
+    """Extract patches from an image or mask."""
+
+    def __init__(
+        self,
+        window_size: Union[int, tuple[int, int]],
+        stride: Optional[Union[int, tuple[int, int]]] = 1,
+        padding: Optional[Union[int, tuple[int, int]]] = 0,
+        keepdim: bool = True,
+    ) -> None:
+        """Initialize a new _ExtractPatches instance.
+
+        Args:
+            window_size: desired output size (out_h, out_w) of the crop
+            stride: stride of window to extract patches
+                (nonoverlapping windows occur when stride=window_size)
+            padding: zero padding added to the height and width dimensions
+            keepdim: Combine the patch dimension into the batch dimension
+        """
+        super().__init__()
+        self.flags = {
+            "window_size": window_size,
+            "stride": stride,
+            "padding": padding,
+            "keepdim": keepdim,
+        }
+
+    def compute_transformation(
+        self, input: Tensor, params: dict[str, Tensor], flags: dict[str, Any]
+    ) -> Tensor:
+        """Compute the transformation.
+
+        Args:
+            input: the input tensor
+            params: generated parameters
+            flags: static parameters
+
+        Returns:
+            the transformation
+        """
+        out: Tensor = self.identity_matrix(input)
+        return out
+
+    def apply_transform(
+        self,
+        input: Tensor,
+        params: dict[str, Tensor],
+        flags: dict[str, Any],
+        transform: Optional[Tensor] = None,
+    ) -> Tensor:
+        """Apply the transform.
+
+        Args:
+            input: the input tensor
+            params: generated parameters
+            flags: static parameters
+            transform: the geometric transformation tensor
+
+        Returns:
+            the augmented input
+        """
+        out = extract_tensor_patches(
+            input,
+            window_size=flags["window_size"],
+            stride=flags["stride"],
+            padding=flags["padding"],
+        )
+
+        if flags["keepdim"]:
+            out = rearrange(out, "b t c h w -> (b t) c h w")
+
+        return out


### PR DESCRIPTION
When using the `_RandomNCrop` transform during training as an augmentation we need to be able to perform evaluation on the val and test sets on non overlapping patches of the same crop size.

While kornia.contrib contains an `ExtractPatches` transform, it unfortunately is not an augmentation therefore it a) doesn't work on masks in `K.AugmentationSequential` and b) has no option to combine the resulting patch dimension back into the batch dimensions for inference e.g. `b p c h w -> (b p) c h w` which breaks any downstream processing after the augmentation.

This PR adds the `_ExtractPatches` transform which can be used in the `test_aug` and `val_aug` augmentations in datamodules for evaluation on patches of images which aren't geotiffs (jpg, png, etc.), e.g. LEVIR-CD. 

Example:
```python
import kornia.augmentation as K
from torchgeo.transforms import AugmentationSequential
from torchgeo.transforms.transforms import _ExtractPatches`

augs = AugmentationSequential(
   K.Normalize(mean=0.0, std=255.0),
   _ExtractPatches(window_size=256, stride=256, padding=0, keepdim=True),
   same_on_batch=True
   data_keys=["image1", "image2", "mask"]
)
```
One thing that's important is to use the `same_on_batch=True` option in `AugmentationSequential` which will allow the batch dimension to be combined.


I've opened another PR https://github.com/kornia/kornia/pull/2685 in kornia but not sure how long that will take to get merged.


