### PR TITLE
Remov Argmax Computation for torchmetrics in Classification and Segmentation

### DIFF
--- a/torchgeo/trainers/classification.py
+++ b/torchgeo/trainers/classification.py
@@ -196,7 +196,7 @@ class ClassificationTask(BaseTask):
             and hasattr(self.logger.experiment, "add_figure")
         ):
             datamodule = self.trainer.datamodule
-            batch["prediction"] = y_hat.softmax(dim=-1)
+            batch["prediction"] = y_hat.argmax(dim=-1)
             for key in ["image", "label", "prediction"]:
                 batch[key] = batch[key].cpu()
             sample = unbind_samples(batch)[0]

--- a/torchgeo/trainers/classification.py
+++ b/torchgeo/trainers/classification.py
@@ -162,10 +162,9 @@ class ClassificationTask(BaseTask):
         x = batch["image"]
         y = batch["label"]
         y_hat = self(x)
-        y_hat_hard = y_hat.argmax(dim=1)
         loss: Tensor = self.criterion(y_hat, y)
         self.log("train_loss", loss)
-        self.train_metrics(y_hat_hard, y)
+        self.train_metrics(y_hat, y)
         self.log_dict(self.train_metrics)
 
         return loss
@@ -183,10 +182,9 @@ class ClassificationTask(BaseTask):
         x = batch["image"]
         y = batch["label"]
         y_hat = self(x)
-        y_hat_hard = y_hat.argmax(dim=1)
         loss = self.criterion(y_hat, y)
         self.log("val_loss", loss)
-        self.val_metrics(y_hat_hard, y)
+        self.val_metrics(y_hat, y)
         self.log_dict(self.val_metrics)
 
         if (
@@ -198,7 +196,7 @@ class ClassificationTask(BaseTask):
             and hasattr(self.logger.experiment, "add_figure")
         ):
             datamodule = self.trainer.datamodule
-            batch["prediction"] = y_hat_hard
+            batch["prediction"] = y_hat.softmax(dim=-1)
             for key in ["image", "label", "prediction"]:
                 batch[key] = batch[key].cpu()
             sample = unbind_samples(batch)[0]
@@ -227,10 +225,9 @@ class ClassificationTask(BaseTask):
         x = batch["image"]
         y = batch["label"]
         y_hat = self(x)
-        y_hat_hard = y_hat.argmax(dim=1)
         loss = self.criterion(y_hat, y)
         self.log("test_loss", loss)
-        self.test_metrics(y_hat_hard, y)
+        self.test_metrics(y_hat, y)
         self.log_dict(self.test_metrics)
 
     def predict_step(

--- a/torchgeo/trainers/segmentation.py
+++ b/torchgeo/trainers/segmentation.py
@@ -251,7 +251,7 @@ class SemanticSegmentationTask(BaseTask):
             and hasattr(self.logger.experiment, "add_figure")
         ):
             datamodule = self.trainer.datamodule
-            batch["prediction"] = y_hat.softmax(dim=1)
+            batch["prediction"] = y_hat.argmax(dim=1)
             for key in ["image", "mask", "prediction"]:
                 batch[key] = batch[key].cpu()
             sample = unbind_samples(batch)[0]

--- a/torchgeo/trainers/segmentation.py
+++ b/torchgeo/trainers/segmentation.py
@@ -218,10 +218,9 @@ class SemanticSegmentationTask(BaseTask):
         x = batch["image"]
         y = batch["mask"]
         y_hat = self(x)
-        y_hat_hard = y_hat.argmax(dim=1)
         loss: Tensor = self.criterion(y_hat, y)
         self.log("train_loss", loss)
-        self.train_metrics(y_hat_hard, y)
+        self.train_metrics(y_hat, y)
         self.log_dict(self.train_metrics)
         return loss
 
@@ -238,10 +237,9 @@ class SemanticSegmentationTask(BaseTask):
         x = batch["image"]
         y = batch["mask"]
         y_hat = self(x)
-        y_hat_hard = y_hat.argmax(dim=1)
         loss = self.criterion(y_hat, y)
         self.log("val_loss", loss)
-        self.val_metrics(y_hat_hard, y)
+        self.val_metrics(y_hat, y)
         self.log_dict(self.val_metrics)
 
         if (
@@ -253,7 +251,7 @@ class SemanticSegmentationTask(BaseTask):
             and hasattr(self.logger.experiment, "add_figure")
         ):
             datamodule = self.trainer.datamodule
-            batch["prediction"] = y_hat_hard
+            batch["prediction"] = y_hat.softmax(dim=1)
             for key in ["image", "mask", "prediction"]:
                 batch[key] = batch[key].cpu()
             sample = unbind_samples(batch)[0]
@@ -282,10 +280,9 @@ class SemanticSegmentationTask(BaseTask):
         x = batch["image"]
         y = batch["mask"]
         y_hat = self(x)
-        y_hat_hard = y_hat.argmax(dim=1)
         loss = self.criterion(y_hat, y)
         self.log("test_loss", loss)
-        self.test_metrics(y_hat_hard, y)
+        self.test_metrics(y_hat, y)
         self.log_dict(self.test_metrics)
 
     def predict_step(


### PR DESCRIPTION
Torchmetrics automatically applies the argmax on logits already if the datatype is float (so the logits) for the Classification Metrics https://lightning.ai/docs/torchmetrics/stable/classification/accuracy.html#multiclassaccuracy.

However, some metrics like [Calibration Error](https://lightning.ai/docs/torchmetrics/stable/classification/calibration_error.html#multiclasscalibrationerror) expect the logits. So in order to overwrite the configuration of metrics without having to change the train, val , test steps, this PR removes the argmax computation. 