### PR TITLE
Fix for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,5 +34,5 @@ repos:
         hooks:
         -   id: mypy
             args: [--strict, --ignore-missing-imports, --show-error-codes]
-            additional_dependencies: [kornia>=0.6.5, lightning>=2.0.9, matplotlib>=3.8.1, numpy>=1.22, pytest>=6.1.2, pyvista>=0.34.2, torch>=2, torchmetrics>=0.10]
+            additional_dependencies: [kornia>=0.6.9, lightning>=2.0.9, matplotlib>=3.8.1, numpy>=1.22, pytest>=6.1.2, pyvista>=0.34.2, scikit-image>=0.18.0, torch>=2, torchmetrics>=0.10]
             exclude: (build|data|dist|logo|logs|output)/


### PR DESCRIPTION
Type ignores added in 135f564837655ebf0146325e973d9336a998073e were not reflected in the pre-commit environment since `scikit-image` was not declared a dependency. This caused the `mypy` hook to fail with the following message:

```
pyupgrade................................................................Passed
isort....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pydocstyle...............................................................Passed
mypy.....................................................................Failed
- hook id: mypy
- exit code: 1

torchgeo/datasets/vhr10.py:476: error: Unused "type: ignore" comment  [unused-ignore]
torchgeo/datasets/vhr10.py:528: error: Unused "type: ignore" comment  [unused-ignore]
Found 2 errors in 1 file (checked 292 source files)
```

