### PR TITLE
Add CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contributing
+
+TorchGeo is an open-source project built by contributors like you from around the world. If you find a bug or would like to add a new feature, please open a pull request. For further information on how to contribute, including topics like:
+
+* using git,
+* licensing requirements,
+* writing and running unit tests,
+* running linters,
+* building the documentation, and
+* adding new datasets,
+
+please see our [Contributing Guide](https://torchgeo.readthedocs.io/en/stable/user/contributing.html).
+
+You can find a curated list of issues that we believe are easy for new contributors to tackle at https://github.com/microsoft/torchgeo/contribute.


### PR DESCRIPTION
A link to this file will be displayed when opening a new PR and on https://github.com/microsoft/torchgeo/contribute.

### Alternatives

We could also move the contents of https://torchgeo.readthedocs.io/en/stable/user/contributing.html into this file instead.

### Docs

https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors