### PR TITLE
Ensure that all files have the license header at the top

### DIFF
--- a/experiments/torchgeo/benchmark.py
+++ b/experiments/torchgeo/benchmark.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
 """dataset and sampler benchmarking script."""
 
 import argparse

--- a/tests/data/vhr10/data.py
+++ b/tests/data/vhr10/data.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
 import json
 import os
 import shutil

--- a/torchgeo/losses/qr.py
+++ b/torchgeo/losses/qr.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
 """Loss functions for learing on the prior."""
 
 import torch


### PR DESCRIPTION
Discovered some files that were missing a license header.

The command I used to find these was:
```console
> grep -RL --include '*.py' --include '*.sh' '^# Copyright (c) Microsoft Corporation' .
```

Not sure if there is an easy way to add a test for this, or whether or not it's worth testing in CI.