### PR TITLE
pytest: don't cast warnings to errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,9 +197,6 @@ match_dir = "(datamodules|datasets|losses|models|samplers|torchgeo|trainers|tran
 addopts = "-m 'not slow'"
 # https://docs.pytest.org/en/latest/how-to/capture-warnings.html
 filterwarnings = [
-    # Treat all warnings as errors
-    "error",
-
     # Warnings raised by dependencies of dependencies, out of our control
     # https://github.com/Cadene/pretrained-models.pytorch/issues/221
     "ignore:.* is deprecated and will be removed in Pillow 10:DeprecationWarning:pretrainedmodels.datasets.utils",


### PR DESCRIPTION
Previously, all warnings were cast to errors when running pytest. This helped uncover the use of deprecated features, allowing us to stay on top of deprecations and ensure support for future versions of dependencies.

However, this also meant that minor platform-specific or version-specific warning messages would cause pytest to fail. Although it's maintainable in CI, it's impossible to support all the platforms and versions our developers are using.

This PR disables the casting of warning messages to errors. We'll need to be careful to make sure the release branch is relatively warning-free before making a release, but this will make life much easier for our developers.

@yichiac