### PR TITLE
Labeler: additional doc locations

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -29,7 +29,10 @@ dependencies:
     - "requirements/**"
 documentation:
 - changed-files:
-  - any-glob-to-any-file: "docs/**"
+  - any-glob-to-any-file:
+    - "docs/**"
+    - "*.md"
+    - ".github/*.md"
 scripts:
 - changed-files:
   - any-glob-to-any-file:


### PR DESCRIPTION
Files like README.md and CONTRIBUTING.md should also be considered documentation when adding PR labels.