### PR TITLE
lightly v1.4.26 is incompatible with smp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,9 @@ dependencies = [
     # kornia 0.6.9+ required for kornia.augmentation.RandomBrightness
     "kornia>=0.6.9",
     # lightly 1.4.4+ required for MoCo v3 support
-    "lightly>=1.4.4",
+    # lightly 1.4.26 is incompatible with the version of timm required by smp
+    # https://github.com/microsoft/torchgeo/issues/1824
+    "lightly>=1.4.4,!=1.4.26",
     # lightning 2+ required for LightningCLI args + sys.argv support
     "lightning[pytorch-extra]>=2",
     # matplotlib 3.3.3+ required for Python 3.9 wheels


### PR DESCRIPTION
Fixes #1824

Hopefully smp will bump timm or lightly will check the timm version before use. Then we can unpin lightly.