### PR TITLE
RtD: use stable dependency versions

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,10 +13,9 @@ build:
 # Configuration of the Python environment to be used
 python:
    install:
+   - requirements: requirements/required.txt
    - requirements: requirements/docs.txt
    - requirements: docs/requirements.txt
-   - method: pip
-     path: .
 
 # Configuration for Sphinx documentation
 sphinx:


### PR DESCRIPTION
At the moment, Read the Docs is using the latest version of all non-documentation dependencies, meaning that an incompatible version of lightly is installed, and CI is failing for all PRs. We should always use the stable tested dependency versions managed by dependabot. This also helps ensure that the docs for future releases build into the distant future, not just at time of release.