### PR TITLE
Test Python 3.12

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v5.0.0
       with:
-        python-version: '3.11'
+        python-version: '3.12'
     - name: Cache dependencies
       uses: actions/cache@v4.0.0
       id: cache
@@ -44,7 +44,7 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v5.0.0
       with:
-        python-version: '3.11'
+        python-version: '3.12'
     - name: Cache dependencies
       uses: actions/cache@v4.0.0
       id: cache
@@ -72,7 +72,7 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v5.0.0
       with:
-        python-version: '3.11'
+        python-version: '3.12'
     - name: Cache dependencies
       uses: actions/cache@v4.0.0
       id: cache

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v5.0.0
       with:
-        python-version: '3.11'
+        python-version: '3.12'
     - name: Cache dependencies
       uses: actions/cache@v4.0.0
       id: cache
@@ -43,7 +43,7 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v5.0.0
       with:
-        python-version: '3.11'
+        python-version: '3.12'
     - name: Cache dependencies
       uses: actions/cache@v4.0.0
       id: cache
@@ -68,7 +68,7 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v5.0.0
       with:
-        python-version: '3.11'
+        python-version: '3.12'
     - name: Cache dependencies
       uses: actions/cache@v4.0.0
       id: cache
@@ -93,7 +93,7 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v5.0.0
       with:
-        python-version: '3.11'
+        python-version: '3.12'
     - name: Cache dependencies
       uses: actions/cache@v4.0.0
       id: cache
@@ -118,7 +118,7 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v5.0.0
       with:
-        python-version: '3.11'
+        python-version: '3.12'
     - name: Cache dependencies
       uses: actions/cache@v4.0.0
       id: cache
@@ -143,7 +143,7 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v5.0.0
       with:
-        python-version: '3.11'
+        python-version: '3.12'
     - name: Cache dependencies
       uses: actions/cache@v4.0.0
       id: cache

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
     steps:
     - name: Clone repo
       uses: actions/checkout@v4.1.1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,7 +31,7 @@ jobs:
       with:
         path: ${{ env.pythonLocation }}
         key: ${{ env.pythonLocation }}-${{ hashFiles('requirements/required.txt') }}-${{ hashFiles('requirements/datasets.txt') }}-${{ hashFiles('requirements/tests.txt') }}
-      if: ${{ ! (runner.os == 'macOS' && matrix.python-version == '3.11') }}
+      if: ${{ ! (runner.os == 'macOS' && (matrix.python-version == '3.11' || matrix.python-version == '3.12')) }}
     - name: Setup headless display for pyvista
       uses: pyvista/setup-headless-display-action@v2
     - name: Install apt dependencies (Linux)

--- a/.github/workflows/tutorials.yaml
+++ b/.github/workflows/tutorials.yaml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v5.0.0
       with:
-        python-version: '3.11'
+        python-version: '3.12'
     - name: Cache dependencies
       uses: actions/cache@v4.0.0
       id: cache

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.12"
 
 # Configuration of the Python environment to be used
 python:

--- a/experiments/torchgeo/run_resisc45_experiments.py
+++ b/experiments/torchgeo/run_resisc45_experiments.py
@@ -37,7 +37,7 @@ if __name__ == "__main__":
     for model, lr, loss, weights in itertools.product(
         model_options, lr_options, loss_options, weight_options
     ):
-        experiment_name = f"{model}_{lr}_{loss}_{weights.replace('_','-')}"
+        experiment_name = f"{model}_{lr}_{loss}_{weights.replace('_', '-')}"
 
         output_dir = os.path.join("output", "resisc45_experiments")
         log_dir = os.path.join(output_dir, "logs")

--- a/experiments/torchgeo/run_so2sat_experiments.py
+++ b/experiments/torchgeo/run_so2sat_experiments.py
@@ -37,7 +37,7 @@ if __name__ == "__main__":
     for model, lr, loss, weights in itertools.product(
         model_options, lr_options, loss_options, weight_options
     ):
-        experiment_name = f"{model}_{lr}_{loss}_{weights.replace('_','-')}"
+        experiment_name = f"{model}_{lr}_{loss}_{weights.replace('_', '-')}"
 
         output_dir = os.path.join("output", "so2sat_experiments")
         log_dir = os.path.join(output_dir, "logs")

--- a/experiments/torchgeo/run_so2sat_seed_experiments.py
+++ b/experiments/torchgeo/run_so2sat_seed_experiments.py
@@ -38,7 +38,7 @@ if __name__ == "__main__":
     for model, lr, loss, weights, seed in itertools.product(
         model_options, lr_options, loss_options, weight_options, seeds
     ):
-        experiment_name = f"{model}_{lr}_{loss}_{weights.replace('_','-')}_{seed}"
+        experiment_name = f"{model}_{lr}_{loss}_{weights.replace('_', '-')}_{seed}"
 
         output_dir = os.path.join("output", "so2sat_seed_experiments")
         log_dir = os.path.join(output_dir, "logs")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Scientific/Engineering :: GIS",
 ]


### PR DESCRIPTION
Now that PyTorch 2.2 is out, which adds Python 3.12 support, we should see how many of our other dependencies support Python 3.12 and make sure TorchGeo supports it as well. This PR adds Python 3.12 to our unit tests.