### PR TITLE
Workaround for codecov rate limits

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -131,6 +131,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [pytest, minimum]
     steps:
+    - name: Clone repo
+      uses: actions/checkout@v4.1.1
     - name: Download coverage artifacts
       uses: actions/download-artifact@v4.1.1
     - name: Report coverage

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -134,7 +134,7 @@ jobs:
     - name: Download coverage artifacts
       uses: actions/download-artifact@v4.1.1
     - name: Report coverage
-      uses: codecov/codecov-action@v4.0.1
+      uses: codecov/codecov-action@v3.1.6
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -81,10 +81,11 @@ jobs:
       run: |
         pytest --cov=torchgeo --cov-report=xml --durations=10
         python3 -m torchgeo --help
-    - name: Report coverage
-      uses: codecov/codecov-action@v3.1.5
+    - name: Upload coverage artifact
+      uses: actions/upload-artifact@v4.3.0
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+        name: coverage_${{ matrix.os }}_py-${{ matrix.python-version }}
+        path: coverage.xml
   minimum:
     name: minimum
     runs-on: ubuntu-latest
@@ -120,10 +121,23 @@ jobs:
       run: |
         pytest --cov=torchgeo --cov-report=xml --durations=10
         python3 -m torchgeo --help
+    - name: Upload coverage artifact
+      uses: actions/upload-artifact@v4.3.0
+      with:
+        name: coverage_minimum
+        path: coverage.xml
+  codecov:
+    name: codecov
+    runs-on: ubuntu-latest
+    needs: [pytest, minimum]
+    steps:
+    - name: Download coverage artifacts
+      uses: actions/download-artifact@v4.1.1
     - name: Report coverage
-      uses: codecov/codecov-action@v3.1.5
+      uses: codecov/codecov-action@v4.0.1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: true
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.head.label || github.head_ref || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Workaround for https://github.com/codecov/feedback/issues/126

### Problem

The GitHub API has a strict rate limit. For PRs originating from https://github.com/microsoft/torchgeo, we use our own upload token. However, PRs originating from forks do not have access to repository secrets, and must instead use the same generic Codecov token as every other repository. The popularity of Codecov means that this generic token frequently exceeds the rate limit, resulting in the type of intermittent errors reported in https://github.com/codecov/codecov-action/issues/903. This error is usually tolerable since most of our test coverage is redundant, but the minimum tests hit a different code path. If the minimum tests encounter this issue, the total coverage of the PR will decrease, through no fault of the PR contributor. This causes much confusion, and requires an "expert" (me) to re-run the minimum tests from the beginning until the upload succeeds.

### Workaround

One workaround is to use the following two-step process:

1. Upload coverage.xml as an artifact after each individual test
2. Download all coverage artifacts and upload a single time to Codecov

Based on:

* https://github.com/cylc/cylc-flow/pull/5459

### Rationale

This has the following benefits:

* Reduces how hard we hit the Codecov API
* Allows easy re-attempts to upload
* Makes clear the separation between test status and Codecov upload failures
* Waits until all tests pass before reporting coverage, no initially failing coverage metrics

This doesn't "solve" the issue, but makes it much less likely to occur and easier to understand when it does occur.