### PR TITLE
Solution for codecov rate limits

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,0 +1,20 @@
+name: coverage
+on:
+  workflow_run:
+    workflows: [tests, minimum]
+    types: [completed]
+jobs:
+  codecov:
+    name: codecov
+    runs-on: ubuntu-latest
+    needs: [pytest, minimum]
+    steps:
+    - name: Clone repo
+      uses: actions/checkout@v4.1.1
+    - name: Download coverage artifacts
+      uses: actions/download-artifact@v4.1.1
+    - name: Report coverage
+      uses: codecov/codecov-action@v4.0.1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -81,10 +81,11 @@ jobs:
       run: |
         pytest --cov=torchgeo --cov-report=xml --durations=10
         python3 -m torchgeo --help
-    - name: Report coverage
-      uses: codecov/codecov-action@v3.1.5
+    - name: Upload coverage artifact
+      uses: actions/upload-artifact@v4.3.0
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+        name: coverage_${{ matrix.os }}_py-${{ matrix.python-version }}
+        path: coverage.xml
   minimum:
     name: minimum
     runs-on: ubuntu-latest
@@ -120,10 +121,11 @@ jobs:
       run: |
         pytest --cov=torchgeo --cov-report=xml --durations=10
         python3 -m torchgeo --help
-    - name: Report coverage
-      uses: codecov/codecov-action@v3.1.5
+    - name: Upload coverage artifact
+      uses: actions/upload-artifact@v4.3.0
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+        name: coverage_minimum
+        path: coverage.xml
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.head.label || github.head_ref || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Solution for https://github.com/codecov/feedback/issues/126

Alternative to https://github.com/microsoft/torchgeo/pull/1845

### Problem

The GitHub API has a strict rate limit. For PRs originating from https://github.com/microsoft/torchgeo, we use our own upload token. However, PRs originating from forks do not have access to repository secrets, and must instead use the same generic Codecov token as every other repository. The popularity of Codecov means that this generic token frequently exceeds the rate limit, resulting in the type of intermittent errors reported in https://github.com/codecov/codecov-action/issues/903. This error is usually tolerable since most of our test coverage is redundant, but the minimum tests hit a different code path. If the minimum tests encounter this issue, the total coverage of the PR will decrease, through no fault of the PR contributor. This causes much confusion, and requires an "expert" (me) to re-run the minimum tests from the beginning until the upload succeeds.

### Solution

One solution is to use two different workflows:

1. `on.pull_request`: upload coverage.xml as an artifact after each individual test
2. `on.workflow_run`: download all coverage artifacts and upload a single time to Codecov

Although the `pull_request` trigger does not have access to GitHub secrets, the `workflow_run` trigger does.

Based on:

* https://github.com/google/mdbook-i18n-helpers/pull/162
* https://github.com/google/mdbook-i18n-helpers/pull/168
* https://github.com/cylc/cylc-flow/pull/5459

### Rationale

This has the following benefits:

* Reduces how hard we hit the Codecov API
* Waits until all tests pass before reporting coverage, no initially failing coverage metrics
* Uses our upload token, even for PRs contributed from forks, no more issues!
* Allows us to update to codecov-action@v4, which doesn't support tokenless uploads