### PR TITLE
NCCM: fix timestamp extraction

### DIFF
--- a/torchgeo/datasets/nccm.py
+++ b/torchgeo/datasets/nccm.py
@@ -51,7 +51,7 @@ class NCCM(RasterDataset):
     .. versionadded:: 0.6
     """
 
-    filename_regex = r"CDL(?P<year>\d{4})_clip"
+    filename_regex = r"CDL(?P<date>\d{4})_clip"
     filename_glob = "CDL*.*"
 
     date_format = "%Y"


### PR DESCRIPTION
We weren't properly extracting the timestamp from the filename, we were just using the default `0` and `sys.maxsize`.

### Before

```console
> python3 -c 'from torchgeo.datasets import NCCM; print(NCCM("tests/data/nccm"))'
NCCM Dataset
    type: GeoDataset
    bbox: BoundingBox(minx=115.483402043364, maxx=115.48627665227318, miny=53.528522711204424, maxy=53.531397320113605, mint=0.0, maxt=9.223372036854776e+18)
    size: 3
```

### After

```console
> python3 -c 'from torchgeo.datasets import NCCM; print(NCCM("tests/data/nccm"))'
NCCM Dataset
    type: GeoDataset
    bbox: BoundingBox(minx=115.483402043364, maxx=115.48627665227318, miny=53.528522711204424, maxy=53.531397320113605, mint=1483225200.0, maxt=1577833199.999999)
    size: 3
```

@shreyakannan1205 @yichiac