### PR TITLE
README: add OSGeo badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ The goal of this library is to make it simple:
 2. for remote sensing experts to explore machine learning solutions.
 
 Community:
-[![slack](https://img.shields.io/badge/slack-join-purple?logo=slack)](https://join.slack.com/t/torchgeo/shared_invite/zt-22rse667m-eqtCeNW0yI000Tl4B~2PIw)
+[![slack](https://img.shields.io/badge/slack-join-7C0385?logo=slack)](https://join.slack.com/t/torchgeo/shared_invite/zt-22rse667m-eqtCeNW0yI000Tl4B~2PIw)
+[![osgeo](https://img.shields.io/badge/OSGeo-join-4CB05B?logo=osgeo)](https://www.osgeo.org/community/getting-started-osgeo/)
 
 Packaging:
 [![pypi](https://badge.fury.io/py/torchgeo.svg)](https://pypi.org/project/torchgeo/)


### PR DESCRIPTION
Used the link to join OSGeo, not the link to our OSGeo project page. Can change if preferred.

Also changed the color of the Slack button to match the official branding guide.

Preview: https://github.com/adamjstewart/torchgeo/tree/readme/osgeo