### PR TITLE
Add methods for extracting true footprint for sampling valid data only

### DIFF
--- a/torchgeo/samplers/single.py
+++ b/torchgeo/samplers/single.py
@@ -13,7 +13,7 @@ from torch.utils.data import Sampler
 
 from ..datasets import BoundingBox, GeoDataset
 from .constants import Units
-from .utils import _to_tuple, get_random_bounding_box, tile_to_chips
+from .utils import _to_tuple, get_random_bounding_box_check_valid_overlap, tile_to_chips
 
 
 class GeoSampler(Sampler[BoundingBox], abc.ABC):
@@ -142,10 +142,9 @@ class RandomGeoSampler(GeoSampler):
             hit = self.hits[idx]
             bounds = BoundingBox(*hit.bounds)
 
-            # Choose a random index within that tile
-            bounding_box = get_random_bounding_box(bounds, self.size, self.res)
-
-            yield bounding_box
+            yield get_random_bounding_box_check_valid_overlap(
+                bounds, self.size, self.res, hit.object
+            )
 
     def __len__(self) -> int:
         """Return the number of samples in a single epoch.

--- a/torchgeo/samplers/utils.py
+++ b/torchgeo/samplers/utils.py
@@ -6,6 +6,7 @@
 import math
 from typing import Optional, Union, overload
 
+import shapely
 import torch
 
 from ..datasets import BoundingBox
@@ -75,6 +76,43 @@ def get_random_bounding_box(
 
     query = BoundingBox(minx, maxx, miny, maxy, mint, maxt)
     return query
+
+
+def get_random_bounding_box_check_valid_overlap(
+    bounds: BoundingBox,
+    size: Union[tuple[float, float], float],
+    res: float,
+    valid_footprint: shapely.geometry.Polygon,
+) -> BoundingBox:
+    """Returns a random bounding box within a given bounding box.
+
+    Extends `get_random_bounding_box`by guaranteeing that
+    the bounding box overlaps spatially with the valid_footprint of the raster.
+
+    The ``size`` argument can either be:
+
+        * a single ``float`` - in which case the same value is used for the height and
+          width dimension
+        * a ``tuple`` of two floats - in which case, the first *float* is used for the
+          height dimension, and the second *float* for the width dimension
+
+    Args:
+        bounds: the larger bounding box to sample from
+        size: the size of the bounding box to sample
+        valid_footprint: a Polygon in the common CRS of the originating RasterDataset
+
+    Returns:
+        randomly sampled bounding box from the extent of the input
+    """
+    # We should be able to trust that torchgeo/rtree
+    # can guarantee that there are valid pixels within the bounds
+    while True:
+        bounding_box = get_random_bounding_box(bounds, size, res)
+        bbox = shapely.geometry.box(
+            bounding_box.minx, bounding_box.miny, bounding_box.maxx, bounding_box.maxy
+        )
+        if shapely.overlaps(bbox, valid_footprint):
+            return bounding_box
 
 
 def tile_to_chips(


### PR DESCRIPTION
Fix #1330 

RasterDatasets may contain nodata regions due to projecting all file to the same CRS, and due to eventual inherit nodata regions in the images.
When IntersectionDataset joins this with VectorDataset, this may yield 
1. false positive samples (bad for learning)
2. empty negative samples (may be bad for learning)

The solution can be summarised as:
- [ ] In RasterDataset, when opening each file, extract footprint and add to rtree index object
- [ ] In IntersectionDataset._merge_dataset_indices copy over the footprint to the new index. 
- [ ] In the same method, could optimise by minimizing bbox to cover only actual intersection of valid data.
- [ ] In RandomGeoSampler.__iter__, use this footprint to validate that sample bbox actually overlaps, and don't yield until a valid box is found. 
- [ ] Enable the same for GridGeoSampler **(probably other PR)**
- [ ] Remove label mask for eventual nodata-regions that  outside regions in boundary. (As the criteria above is `overlaps` and not `contains`, corners of the resulting sample may still contain nodata, while the label mask still may cover this.) **(probably other PR)**
- [ ] Add ability to balance positive and negative samples. The VectorData can be intersected with the raster valid data footprint in the GeoSampler to facilitate ballancing positives and negatives. Right now torchgeo gives the user no control of this. **(probably other PR)**

Useful resources:
Rasterio nodata masks:
https://rasterio.readthedocs.io/en/latest/topics/masks.html#nodata-masks

Extract valid data footprint as vector
https://gist.github.com/sgillies/9713809

Reproject valid data footprint with rasterio
https://geopandas.org/en/stable/docs/user_guide/reproject_fiona.html#rasterio-example