### PR TITLE
RandomGeoSampler: optional length is optional

### DIFF
--- a/torchgeo/samplers/single.py
+++ b/torchgeo/samplers/single.py
@@ -70,7 +70,7 @@ class RandomGeoSampler(GeoSampler):
         self,
         dataset: GeoDataset,
         size: Union[tuple[float, float], float],
-        length: Optional[int],
+        length: Optional[int] = None,
         roi: Optional[BoundingBox] = None,
         units: Units = Units.PIXELS,
     ) -> None:


### PR DESCRIPTION
Not sure how no one noticed this bug in the past 2 years...

#755 made `length` optional for all samplers. We provided a default value of None for RandomBatchGeoSampler, but not RandomGeoSampler. This PR fixes it so the optional length is _actually_ optional.