### PR TITLE
GitLab: use stable download URLs

### DIFF
--- a/torchgeo/datasets/bigearthnet.py
+++ b/torchgeo/datasets/bigearthnet.py
@@ -238,17 +238,17 @@ class BigEarthNet(NonGeoDataset):
 
     splits_metadata = {
         "train": {
-            "url": "https://git.tu-berlin.de/rsim/BigEarthNet-MM_19-classes_models/-/raw/master/splits/train.csv?inline=false",  # noqa: E501
+            "url": "https://git.tu-berlin.de/rsim/BigEarthNet-MM_19-classes_models/-/raw/9a5be07346ab0884b2d9517475c27ef9db9b5104/splits/train.csv?inline=false",  # noqa: E501
             "filename": "bigearthnet-train.csv",
             "md5": "623e501b38ab7b12fe44f0083c00986d",
         },
         "val": {
-            "url": "https://git.tu-berlin.de/rsim/BigEarthNet-MM_19-classes_models/-/raw/master/splits/val.csv?inline=false",  # noqa: E501
+            "url": "https://git.tu-berlin.de/rsim/BigEarthNet-MM_19-classes_models/-/raw/9a5be07346ab0884b2d9517475c27ef9db9b5104/splits/val.csv?inline=false",  # noqa: E501
             "filename": "bigearthnet-val.csv",
             "md5": "22efe8ed9cbd71fa10742ff7df2b7978",
         },
         "test": {
-            "url": "https://git.tu-berlin.de/rsim/BigEarthNet-MM_19-classes_models/-/raw/master/splits/test.csv?inline=false",  # noqa: E501
+            "url": "https://git.tu-berlin.de/rsim/BigEarthNet-MM_19-classes_models/-/raw/9a5be07346ab0884b2d9517475c27ef9db9b5104/splits/test.csv?inline=false",  # noqa: E501
             "filename": "bigearthnet-test.csv",
             "md5": "697fb90677e30571b9ac7699b7e5b432",
         },


### PR DESCRIPTION
Same as #1916 but for other git repos. We already do this for all GitHub repos.