### PR TITLE
Docs: fix trainer metric definitions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -121,6 +121,7 @@ intersphinx_mapping = {
     "sklearn": ("https://scikit-learn.org/stable/", None),
     "timm": ("https://huggingface.co/docs/timm/main/en/", None),
     "torch": ("https://pytorch.org/docs/stable", None),
+    "torchmetrics": ("https://lightning.ai/docs/torchmetrics/stable/", None),
     "torchvision": ("https://pytorch.org/vision/stable", None),
 }
 

--- a/torchgeo/trainers/classification.py
+++ b/torchgeo/trainers/classification.py
@@ -98,15 +98,15 @@ class ClassificationTask(BaseTask):
     def configure_metrics(self) -> None:
         """Initialize the performance metrics.
 
-        * Multiclass Overall Accuracy (OA): The number of true positives divided by
-          the dataset size. Uses 'micro' averaging. Higher values are better.
-        * Multiclass Average Accuracy (AA): The number of true positives divided by
-          the class size, averaged across all classes. Uses 'macro' averaging.
+        * :class:`~torchmetrics.classification.MulticlassAccuracy`: The number of
+          true positives divided by the dataset size. Both overall accuracy (OA)
+          using 'micro' averaging and average accuracy (AA) using 'macro' averaging
+          are reported. Higher values are better.
+        * :class:`~torchmetrics.classification.MulticlassJaccardIndex`: Intersection
+          over union (IoU). Uses 'macro' averaging. Higher valuers are better.
+        * :class:`~torchmetrics.classification.MulticlassFBetaScore`: F1 score.
+          The harmonic mean of precision and recall. Uses 'micro' averaging.
           Higher values are better.
-        * Multiclass Jaccard Index (IoU): Per-class overlap between predicted and
-          actual classes. Uses 'macro' averaging. Higher valuers are better.
-        * Multiclass F1 Score: The harmonic mean of precision and recall.
-          Uses 'micro' averaging. Higher values are better.
 
         .. note::
            * 'Micro' averaging suits overall performance evaluation but may not reflect
@@ -271,13 +271,13 @@ class MultiLabelClassificationTask(ClassificationTask):
     def configure_metrics(self) -> None:
         """Initialize the performance metrics.
 
-        * Multilabel Overall Accuracy (OA): The number of true positives divided by
-          the dataset size. Uses 'micro' averaging. Higher values are better.
-        * Multilabel Average Accuracy (AA): The number of true positives divided by
-          the class size, averaged across all classes. Uses 'macro' averaging.
+        * :class:`~torchmetrics.classification.MultilabelAccuracy`: The number of
+          true positives divided by the dataset size. Both overall accuracy (OA)
+          using 'micro' averaging and average accuracy (AA) using 'macro' averaging
+          are reported. Higher values are better.
+        * :class:`~torchmetrics.classification.MultilabelFBetaScore`: F1 score.
+          The harmonic mean of precision and recall. Uses 'micro' averaging.
           Higher values are better.
-        * Multiclass F1 Score: The harmonic mean of precision and recall.
-          Uses 'micro' averaging. Higher values are better.
 
         .. note::
            * 'Micro' averaging suits overall performance evaluation but may not

--- a/torchgeo/trainers/classification.py
+++ b/torchgeo/trainers/classification.py
@@ -98,10 +98,11 @@ class ClassificationTask(BaseTask):
     def configure_metrics(self) -> None:
         """Initialize the performance metrics.
 
-        * Multiclass Overall Accuracy (OA): Ratio of correctly classified pixels.
-          Uses 'micro' averaging. Higher values are better.
-        * Multiclass Average Accuracy (AA): Ratio of correctly classified classes.
-          Uses 'macro' averaging. Higher values are better.
+        * Multiclass Overall Accuracy (OA): The number of true positives divided by
+          the dataset size. Uses 'micro' averaging. Higher values are better.
+        * Multiclass Average Accuracy (AA): The number of true positives divided by
+          the class size, averaged across all classes. Uses 'macro' averaging.
+          Higher values are better.
         * Multiclass Jaccard Index (IoU): Per-class overlap between predicted and
           actual classes. Uses 'macro' averaging. Higher valuers are better.
         * Multiclass F1 Score: The harmonic mean of precision and recall.
@@ -270,10 +271,11 @@ class MultiLabelClassificationTask(ClassificationTask):
     def configure_metrics(self) -> None:
         """Initialize the performance metrics.
 
-        * Multiclass Overall Accuracy (OA): Ratio of correctly classified pixels.
-          Uses 'micro' averaging. Higher values are better.
-        * Multiclass Average Accuracy (AA): Ratio of correctly classified classes.
-          Uses 'macro' averaging. Higher values are better.
+        * Multilabel Overall Accuracy (OA): The number of true positives divided by
+          the dataset size. Uses 'micro' averaging. Higher values are better.
+        * Multilabel Average Accuracy (AA): The number of true positives divided by
+          the class size, averaged across all classes. Uses 'macro' averaging.
+          Higher values are better.
         * Multiclass F1 Score: The harmonic mean of precision and recall.
           Uses 'micro' averaging. Higher values are better.
 

--- a/torchgeo/trainers/detection.py
+++ b/torchgeo/trainers/detection.py
@@ -206,12 +206,11 @@ class ObjectDetectionTask(BaseTask):
     def configure_metrics(self) -> None:
         """Initialize the performance metrics.
 
-        * Mean Average Precision (mAP): Precision is the number of true positives
-          (as defined by intersection over union) divided by the number of true
-          positives + false positives. Uses 'macro' averaging. Higher values are better.
-        * Mean Average Recall (mAR): Recall is the number of true positives
-          (as defined by intersection over union) divived by the number of true
-          positives + false negatives. Uses 'macro' averaging. Higher values are better.
+        * :class:`~torchmetrics.detection.mean_ap.MeanAveragePrecision`: Mean average
+          precision (mAP) and mean average recall (mAR). Precision is the number of
+          true positives divided by the number of true positives + false positives.
+          Recall is the number of true positives divived by the number of true positives
+          + false negatives. Uses 'macro' averaging. Higher values are better.
 
         .. note::
            * 'Micro' averaging suits overall performance evaluation but may not
@@ -219,7 +218,7 @@ class ObjectDetectionTask(BaseTask):
            * 'Macro' averaging gives equal weight to each class, and is useful for
              balanced performance assessment across imbalanced classes.
         """
-        metrics = MetricCollection([MeanAveragePrecision()])
+        metrics = MetricCollection([MeanAveragePrecision(average="macro")])
         self.val_metrics = metrics.clone(prefix="val_")
         self.test_metrics = metrics.clone(prefix="test_")
 

--- a/torchgeo/trainers/detection.py
+++ b/torchgeo/trainers/detection.py
@@ -206,10 +206,12 @@ class ObjectDetectionTask(BaseTask):
     def configure_metrics(self) -> None:
         """Initialize the performance metrics.
 
-        * Mean Average Precision (mAP): Computes the Mean-Average-Precision (mAP) and
-          Mean-Average-Recall (mAR) for object detection. Prediction is based on the
-          intersection over union (IoU) between the predicted bounding boxes and the
-          ground truth bounding boxes. Uses 'macro' averaging. Higher values are better.
+        * Mean Average Precision (mAP): Precision is the number of true positives
+          (as defined by intersection over union) divided by the number of true
+          positives + false positives. Uses 'macro' averaging. Higher values are better.
+        * Mean Average Recall (mAR): Recall is the number of true positives
+          (as defined by intersection over union) divived by the number of true
+          positives + false negatives. Uses 'macro' averaging. Higher values are better.
 
         .. note::
            * 'Micro' averaging suits overall performance evaluation but may not

--- a/torchgeo/trainers/regression.py
+++ b/torchgeo/trainers/regression.py
@@ -99,12 +99,12 @@ class RegressionTask(BaseTask):
     def configure_metrics(self) -> None:
         """Initialize the performance metrics.
 
-        * Root Mean Squared Error (RMSE): The square root of the average of the squared
-          differences between the predicted and actual values. Lower values are better.
-        * Mean Squared Error (MSE): The average of the squared differences between the
-          predicted and actual values. Lower values are better.
-        * Mean Absolute Error (MAE): The average of the absolute differences between the
-          predicted and actual values. Lower values are better.
+        * :class:`~torchmetrics.MeanSquaredError`: The average of the squared
+          differences between the predicted and actual values (MSE) and its
+          square root (RMSE). Lower values are better.
+        * :class:`~torchmetrics.MeanAbsoluteError`: The average of the absolute
+          differences between the predicted and actual values (MAE).
+          Lower values are better.
         """
         metrics = MetricCollection(
             {

--- a/torchgeo/trainers/regression.py
+++ b/torchgeo/trainers/regression.py
@@ -105,12 +105,6 @@ class RegressionTask(BaseTask):
           predicted and actual values. Lower values are better.
         * Mean Absolute Error (MAE): The average of the absolute differences between the
           predicted and actual values. Lower values are better.
-
-        .. note::
-           * 'Micro' averaging suits overall performance evaluation but may not reflect
-             minority class accuracy.
-           * 'Macro' averaging gives equal weight to each class, and is useful for
-             balanced performance assessment across imbalanced classes.
         """
         metrics = MetricCollection(
             {

--- a/torchgeo/trainers/segmentation.py
+++ b/torchgeo/trainers/segmentation.py
@@ -127,7 +127,7 @@ class SemanticSegmentationTask(BaseTask):
         * Multiclass Pixel Accuracy: Ratio of correctly classified pixels.
           Uses 'micro' averaging. Higher values are better.
         * Multiclass Jaccard Index (IoU): Per-pixel overlap between predicted and
-          actual segments. Uses 'macro' averaging. Higher values are better.
+          actual segments. Uses 'micro' averaging. Higher values are better.
 
         .. note::
            * 'Micro' averaging suits overall performance evaluation but may not reflect

--- a/torchgeo/trainers/segmentation.py
+++ b/torchgeo/trainers/segmentation.py
@@ -124,10 +124,11 @@ class SemanticSegmentationTask(BaseTask):
     def configure_metrics(self) -> None:
         """Initialize the performance metrics.
 
-        * Multiclass Pixel Accuracy: Ratio of correctly classified pixels.
-          Uses 'micro' averaging. Higher values are better.
-        * Multiclass Jaccard Index (IoU): Per-pixel overlap between predicted and
-          actual segments. Uses 'micro' averaging. Higher values are better.
+        * :class:`~torchmetrics.classification.MulticlassAccuracy`: Overall accuracy
+          (OA) using 'micro' averaging. The number of true positives divided by the
+          dataset size. Higher values are better.
+        * :class:`~torchmetrics.classification.MulticlassJaccardIndex`: Intersection
+          over union (IoU). Uses 'micro' averaging. Higher valuers are better.
 
         .. note::
            * 'Micro' averaging suits overall performance evaluation but may not reflect


### PR DESCRIPTION
Closes #1923 

We are nowhere near the limit of how much detail we could have. We can always start adding mathematical equations.

Alternative: why don't we just list the metrics and link to the torchmetrics docs? If a metric isn't properly explained, we can always improve the torchmetrics docs.

@robmarkcole @jdilger