### PR TITLE
ObjectDetectionTask: explicit batch size

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -267,8 +267,6 @@ filterwarnings = [
     "ignore:Skipping device Apple Paravirtual device that does not support Metal 2.0:UserWarning",
 
     # Unexpected warnings, worth investigating
-    # Lightning is having trouble inferring the batch size for ChesapeakeCVPRDataModule and CycloneDataModule for some reason
-    "ignore:Trying to infer the `batch_size` from an ambiguous collection:UserWarning",
     # https://github.com/pytest-dev/pytest/issues/11461
     "ignore::pytest.PytestUnraisableExceptionWarning",
 ]

--- a/torchgeo/trainers/detection.py
+++ b/torchgeo/trainers/detection.py
@@ -242,7 +242,7 @@ class ObjectDetectionTask(BaseTask):
         ]
         loss_dict = self(x, y)
         train_loss: Tensor = sum(loss_dict.values())
-        self.log_dict(loss_dict)
+        self.log_dict(loss_dict, batch_size=batch_size)
         return train_loss
 
     def validation_step(
@@ -267,7 +267,7 @@ class ObjectDetectionTask(BaseTask):
         # https://github.com/Lightning-AI/torchmetrics/pull/1832#issuecomment-1623890714
         metrics.pop("val_classes", None)
 
-        self.log_dict(metrics)
+        self.log_dict(metrics, batch_size=batch_size)
 
         if (
             batch_idx < 10
@@ -321,7 +321,7 @@ class ObjectDetectionTask(BaseTask):
         # https://github.com/Lightning-AI/torchmetrics/pull/1832#issuecomment-1623890714
         metrics.pop("test_classes", None)
 
-        self.log_dict(metrics)
+        self.log_dict(metrics, batch_size=batch_size)
 
     def predict_step(
         self, batch: Any, batch_idx: int, dataloader_idx: int = 0


### PR DESCRIPTION
Just following the instructions from the error message:
```
tests/trainers/test_detection.py::TestObjectDetectionTask::test_trainer[True-faster-rcnn-nasa_marine_debris]
  lib/python3.11/site-packages/lightning/pytorch/utilities/data.py:77: Trying to infer the `batch_size` from an ambiguous collection. The batch size we found is 1. To avoid any miscalculations, use `self.log(..., batch_size=batch_size)`.
```