### PR TITLE
Resolve multiple SimCLR and MoCo lightly warnings

### DIFF
--- a/tests/trainers/test_simclr.py
+++ b/tests/trainers/test_simclr.py
@@ -73,13 +73,13 @@ class TestSimCLRTask:
 
     def test_version_warnings(self) -> None:
         with pytest.warns(UserWarning, match="SimCLR v1 only uses 2 layers"):
-            SimCLRTask(version=1, layers=3)
+            SimCLRTask(version=1, layers=3, memory_bank_size=0)
         with pytest.warns(UserWarning, match="SimCLR v1 does not use a memory bank"):
-            SimCLRTask(version=1, memory_bank_size=10)
+            SimCLRTask(version=1, layers=2, memory_bank_size=10)
         with pytest.warns(UserWarning, match=r"SimCLR v2 uses 3\+ layers"):
-            SimCLRTask(version=2, layers=2)
+            SimCLRTask(version=2, layers=2, memory_bank_size=10)
         with pytest.warns(UserWarning, match="SimCLR v2 uses a memory bank"):
-            SimCLRTask(version=2, memory_bank_size=0)
+            SimCLRTask(version=2, layers=3, memory_bank_size=0)
 
     @pytest.fixture
     def weights(self) -> WeightsEnum:

--- a/torchgeo/trainers/base.py
+++ b/torchgeo/trainers/base.py
@@ -36,19 +36,19 @@ class BaseTask(LightningModule, ABC):
         """
         super().__init__()
         self.save_hyperparameters(ignore=ignore)
+        self.configure_models()
         self.configure_losses()
         self.configure_metrics()
-        self.configure_models()
+
+    @abstractmethod
+    def configure_models(self) -> None:
+        """Initialize the model."""
 
     def configure_losses(self) -> None:
         """Initialize the loss criterion."""
 
     def configure_metrics(self) -> None:
         """Initialize the performance metrics."""
-
-    @abstractmethod
-    def configure_models(self) -> None:
-        """Initialize the model."""
 
     def configure_optimizers(
         self,

--- a/torchgeo/trainers/classification.py
+++ b/torchgeo/trainers/classification.py
@@ -75,6 +75,35 @@ class ClassificationTask(BaseTask):
         self.weights = weights
         super().__init__(ignore="weights")
 
+    def configure_models(self) -> None:
+        """Initialize the model."""
+        weights = self.weights
+
+        # Create model
+        self.model = timm.create_model(
+            self.hparams["model"],
+            num_classes=self.hparams["num_classes"],
+            in_chans=self.hparams["in_channels"],
+            pretrained=weights is True,
+        )
+
+        # Load weights
+        if weights and weights is not True:
+            if isinstance(weights, WeightsEnum):
+                state_dict = weights.get_state_dict(progress=True)
+            elif os.path.exists(weights):
+                _, state_dict = utils.extract_backbone(weights)
+            else:
+                state_dict = get_weight(weights).get_state_dict(progress=True)
+            utils.load_state_dict(self.model, state_dict)
+
+        # Freeze backbone and unfreeze classifier head
+        if self.hparams["freeze_backbone"]:
+            for param in self.model.parameters():
+                param.requires_grad = False
+            for param in self.model.get_classifier().parameters():
+                param.requires_grad = True
+
     def configure_losses(self) -> None:
         """Initialize the loss criterion.
 
@@ -132,35 +161,6 @@ class ClassificationTask(BaseTask):
         self.train_metrics = metrics.clone(prefix="train_")
         self.val_metrics = metrics.clone(prefix="val_")
         self.test_metrics = metrics.clone(prefix="test_")
-
-    def configure_models(self) -> None:
-        """Initialize the model."""
-        weights = self.weights
-
-        # Create model
-        self.model = timm.create_model(
-            self.hparams["model"],
-            num_classes=self.hparams["num_classes"],
-            in_chans=self.hparams["in_channels"],
-            pretrained=weights is True,
-        )
-
-        # Load weights
-        if weights and weights is not True:
-            if isinstance(weights, WeightsEnum):
-                state_dict = weights.get_state_dict(progress=True)
-            elif os.path.exists(weights):
-                _, state_dict = utils.extract_backbone(weights)
-            else:
-                state_dict = get_weight(weights).get_state_dict(progress=True)
-            utils.load_state_dict(self.model, state_dict)
-
-        # Freeze backbone and unfreeze classifier head
-        if self.hparams["freeze_backbone"]:
-            for param in self.model.parameters():
-                param.requires_grad = False
-            for param in self.model.get_classifier().parameters():
-                param.requires_grad = True
 
     def training_step(
         self, batch: Any, batch_idx: int, dataloader_idx: int = 0

--- a/torchgeo/trainers/moco.py
+++ b/torchgeo/trainers/moco.py
@@ -226,14 +226,6 @@ class MoCoTask(BaseTask):
         self.augmentation1 = augmentation1 or aug1
         self.augmentation2 = augmentation2 or aug2
 
-    def configure_losses(self) -> None:
-        """Initialize the loss criterion."""
-        self.criterion = NTXentLoss(
-            self.hparams["temperature"],
-            self.hparams["memory_bank_size"],
-            self.hparams["gather_distributed"],
-        )
-
     def configure_models(self) -> None:
         """Initialize the model."""
         model: str = self.hparams["model"]
@@ -281,6 +273,14 @@ class MoCoTask(BaseTask):
 
         # Initialize moving average of output
         self.avg_output_std = 0.0
+
+    def configure_losses(self) -> None:
+        """Initialize the loss criterion."""
+        self.criterion = NTXentLoss(
+            self.hparams["temperature"],
+            self.hparams["memory_bank_size"],
+            self.hparams["gather_distributed"],
+        )
 
     def configure_optimizers(
         self,

--- a/torchgeo/trainers/moco.py
+++ b/torchgeo/trainers/moco.py
@@ -278,7 +278,7 @@ class MoCoTask(BaseTask):
         """Initialize the loss criterion."""
         self.criterion = NTXentLoss(
             self.hparams["temperature"],
-            self.hparams["memory_bank_size"],
+            (self.hparams["memory_bank_size"], self.hparams["output_dim"]),
             self.hparams["gather_distributed"],
         )
 

--- a/torchgeo/trainers/regression.py
+++ b/torchgeo/trainers/regression.py
@@ -79,6 +79,34 @@ class RegressionTask(BaseTask):
         self.weights = weights
         super().__init__(ignore="weights")
 
+    def configure_models(self) -> None:
+        """Initialize the model."""
+        # Create model
+        weights = self.weights
+        self.model = timm.create_model(
+            self.hparams["model"],
+            num_classes=self.hparams["num_outputs"],
+            in_chans=self.hparams["in_channels"],
+            pretrained=weights is True,
+        )
+
+        # Load weights
+        if weights and weights is not True:
+            if isinstance(weights, WeightsEnum):
+                state_dict = weights.get_state_dict(progress=True)
+            elif os.path.exists(weights):
+                _, state_dict = utils.extract_backbone(weights)
+            else:
+                state_dict = get_weight(weights).get_state_dict(progress=True)
+            utils.load_state_dict(self.model, state_dict)
+
+        # Freeze backbone and unfreeze classifier head
+        if self.hparams["freeze_backbone"]:
+            for param in self.model.parameters():
+                param.requires_grad = False
+            for param in self.model.get_classifier().parameters():
+                param.requires_grad = True
+
     def configure_losses(self) -> None:
         """Initialize the loss criterion.
 
@@ -122,34 +150,6 @@ class RegressionTask(BaseTask):
         self.train_metrics = metrics.clone(prefix="train_")
         self.val_metrics = metrics.clone(prefix="val_")
         self.test_metrics = metrics.clone(prefix="test_")
-
-    def configure_models(self) -> None:
-        """Initialize the model."""
-        # Create model
-        weights = self.weights
-        self.model = timm.create_model(
-            self.hparams["model"],
-            num_classes=self.hparams["num_outputs"],
-            in_chans=self.hparams["in_channels"],
-            pretrained=weights is True,
-        )
-
-        # Load weights
-        if weights and weights is not True:
-            if isinstance(weights, WeightsEnum):
-                state_dict = weights.get_state_dict(progress=True)
-            elif os.path.exists(weights):
-                _, state_dict = utils.extract_backbone(weights)
-            else:
-                state_dict = get_weight(weights).get_state_dict(progress=True)
-            utils.load_state_dict(self.model, state_dict)
-
-        # Freeze backbone and unfreeze classifier head
-        if self.hparams["freeze_backbone"]:
-            for param in self.model.parameters():
-                param.requires_grad = False
-            for param in self.model.get_classifier().parameters():
-                param.requires_grad = True
 
     def training_step(
         self, batch: Any, batch_idx: int, dataloader_idx: int = 0

--- a/torchgeo/trainers/segmentation.py
+++ b/torchgeo/trainers/segmentation.py
@@ -90,6 +90,63 @@ class SemanticSegmentationTask(BaseTask):
         self.weights = weights
         super().__init__(ignore="weights")
 
+    def configure_models(self) -> None:
+        """Initialize the model.
+
+        Raises:
+            ValueError: If *model* is invalid.
+        """
+        model: str = self.hparams["model"]
+        backbone: str = self.hparams["backbone"]
+        weights = self.weights
+        in_channels: int = self.hparams["in_channels"]
+        num_classes: int = self.hparams["num_classes"]
+        num_filters: int = self.hparams["num_filters"]
+
+        if model == "unet":
+            self.model = smp.Unet(
+                encoder_name=backbone,
+                encoder_weights="imagenet" if weights is True else None,
+                in_channels=in_channels,
+                classes=num_classes,
+            )
+        elif model == "deeplabv3+":
+            self.model = smp.DeepLabV3Plus(
+                encoder_name=backbone,
+                encoder_weights="imagenet" if weights is True else None,
+                in_channels=in_channels,
+                classes=num_classes,
+            )
+        elif model == "fcn":
+            self.model = FCN(
+                in_channels=in_channels, classes=num_classes, num_filters=num_filters
+            )
+        else:
+            raise ValueError(
+                f"Model type '{model}' is not valid. "
+                "Currently, only supports 'unet', 'deeplabv3+' and 'fcn'."
+            )
+
+        if model != "fcn":
+            if weights and weights is not True:
+                if isinstance(weights, WeightsEnum):
+                    state_dict = weights.get_state_dict(progress=True)
+                elif os.path.exists(weights):
+                    _, state_dict = utils.extract_backbone(weights)
+                else:
+                    state_dict = get_weight(weights).get_state_dict(progress=True)
+                self.model.encoder.load_state_dict(state_dict)
+
+        # Freeze backbone
+        if self.hparams["freeze_backbone"] and model in ["unet", "deeplabv3+"]:
+            for param in self.model.encoder.parameters():
+                param.requires_grad = False
+
+        # Freeze decoder
+        if self.hparams["freeze_decoder"] and model in ["unet", "deeplabv3+"]:
+            for param in self.model.decoder.parameters():
+                param.requires_grad = False
+
     def configure_losses(self) -> None:
         """Initialize the loss criterion.
 
@@ -153,63 +210,6 @@ class SemanticSegmentationTask(BaseTask):
         self.train_metrics = metrics.clone(prefix="train_")
         self.val_metrics = metrics.clone(prefix="val_")
         self.test_metrics = metrics.clone(prefix="test_")
-
-    def configure_models(self) -> None:
-        """Initialize the model.
-
-        Raises:
-            ValueError: If *model* is invalid.
-        """
-        model: str = self.hparams["model"]
-        backbone: str = self.hparams["backbone"]
-        weights = self.weights
-        in_channels: int = self.hparams["in_channels"]
-        num_classes: int = self.hparams["num_classes"]
-        num_filters: int = self.hparams["num_filters"]
-
-        if model == "unet":
-            self.model = smp.Unet(
-                encoder_name=backbone,
-                encoder_weights="imagenet" if weights is True else None,
-                in_channels=in_channels,
-                classes=num_classes,
-            )
-        elif model == "deeplabv3+":
-            self.model = smp.DeepLabV3Plus(
-                encoder_name=backbone,
-                encoder_weights="imagenet" if weights is True else None,
-                in_channels=in_channels,
-                classes=num_classes,
-            )
-        elif model == "fcn":
-            self.model = FCN(
-                in_channels=in_channels, classes=num_classes, num_filters=num_filters
-            )
-        else:
-            raise ValueError(
-                f"Model type '{model}' is not valid. "
-                "Currently, only supports 'unet', 'deeplabv3+' and 'fcn'."
-            )
-
-        if model != "fcn":
-            if weights and weights is not True:
-                if isinstance(weights, WeightsEnum):
-                    state_dict = weights.get_state_dict(progress=True)
-                elif os.path.exists(weights):
-                    _, state_dict = utils.extract_backbone(weights)
-                else:
-                    state_dict = get_weight(weights).get_state_dict(progress=True)
-                self.model.encoder.load_state_dict(state_dict)
-
-        # Freeze backbone
-        if self.hparams["freeze_backbone"] and model in ["unet", "deeplabv3+"]:
-            for param in self.model.encoder.parameters():
-                param.requires_grad = False
-
-        # Freeze decoder
-        if self.hparams["freeze_decoder"] and model in ["unet", "deeplabv3+"]:
-            for param in self.model.decoder.parameters():
-                param.requires_grad = False
 
     def training_step(
         self, batch: Any, batch_idx: int, dataloader_idx: int = 0

--- a/torchgeo/trainers/simclr.py
+++ b/torchgeo/trainers/simclr.py
@@ -142,14 +142,6 @@ class SimCLRTask(BaseTask):
             size, grayscale_weights
         )
 
-    def configure_losses(self) -> None:
-        """Initialize the loss criterion."""
-        self.criterion = NTXentLoss(
-            self.hparams["temperature"],
-            self.hparams["memory_bank_size"],
-            self.hparams["gather_distributed"],
-        )
-
     def configure_models(self) -> None:
         """Initialize the model."""
         weights = self.weights
@@ -191,6 +183,14 @@ class SimCLRTask(BaseTask):
         # TODO
         # v1+: add global batch norm
         # v2: add selective kernels, channel-wise attention mechanism
+
+    def configure_losses(self) -> None:
+        """Initialize the loss criterion."""
+        self.criterion = NTXentLoss(
+            self.hparams["temperature"],
+            self.hparams["memory_bank_size"],
+            self.hparams["gather_distributed"],
+        )
 
     def forward(self, x: Tensor) -> tuple[Tensor, Tensor]:
         """Forward pass of the model.

--- a/torchgeo/trainers/simclr.py
+++ b/torchgeo/trainers/simclr.py
@@ -145,8 +145,6 @@ class SimCLRTask(BaseTask):
     def configure_models(self) -> None:
         """Initialize the model."""
         weights = self.weights
-        hidden_dim: int = self.hparams["hidden_dim"]
-        output_dim: int = self.hparams["output_dim"]
 
         # Create backbone
         self.backbone = timm.create_model(
@@ -168,13 +166,13 @@ class SimCLRTask(BaseTask):
 
         # Create projection head
         input_dim = self.backbone.num_features
-        if hidden_dim is None:
-            hidden_dim = input_dim
-        if output_dim is None:
-            output_dim = input_dim
+        if self.hparams["hidden_dim"] is None:
+            self.hparams["hidden_dim"] = input_dim
+        if self.hparams["output_dim"] is None:
+            self.hparams["output_dim"] = input_dim
 
         self.projection_head = SimCLRProjectionHead(
-            input_dim, hidden_dim, output_dim, self.hparams["layers"]
+            input_dim, self.hparams["hidden_dim"], self.hparams["output_dim"], self.hparams["layers"]
         )
 
         # Initialize moving average of output
@@ -188,7 +186,7 @@ class SimCLRTask(BaseTask):
         """Initialize the loss criterion."""
         self.criterion = NTXentLoss(
             self.hparams["temperature"],
-            self.hparams["memory_bank_size"],
+            (self.hparams["memory_bank_size"], self.hparams["output_dim"]),
             self.hparams["gather_distributed"],
         )
 


### PR DESCRIPTION
This PR consists of 3 commits:

1. Configure the model first
2. Specify the feature dimension of the memory bank
3. Only test one warning at a time

1 is only needed for 2. The alternative would be to make `hidden_dim` and `output_dim` non-optional. This is already the case in MoCo, but not yet the case in SimCLR. I'm open to this change, let me know what you think. I kinda think 1 is the right way to go regardless, but I wonder if we should make them non-optional too just so SimCLR and MoCo match. Can't remember why I did it this way in the first place...

2 is needed to resolve the following warning:
```
lib/python3.12/site-packages/lightly/models/modules/memory_bank.py:88: UserWarning: Memory bank size 'size=10' does not specify feature dimension. It is recommended to set the feature dimension with 'size=(n, dim)' when creating the memory bank. Distributed training might fail if the feature dimension is not set.
```
We might want to consider backporting this for distributed training support.