### PR TITLE
RtD: use latest Ubuntu

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -33,6 +33,7 @@ documentation:
     - "docs/**"
     - "*.md"
     - ".github/*.md"
+    - ".readthedocs.yaml"
 scripts:
 - changed-files:
   - any-glob-to-any-file:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,8 +6,6 @@ version: 2
 
 # Set the version of Python
 build:
-  apt_packages:
-  - pandoc
   os: ubuntu-lts-latest
   tools:
     python: "3.12"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,9 @@ version: 2
 
 # Set the version of Python
 build:
-  os: ubuntu-22.04
+  apt-packages:
+  - pandoc
+  os: ubuntu-lts-latest
   tools:
     python: "3.12"
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ version: 2
 
 # Set the version of Python
 build:
-  apt-packages:
+  apt_packages:
   - pandoc
   os: ubuntu-lts-latest
   tools:


### PR DESCRIPTION
Attempting to resolve the following warning message:
```
/home/docs/checkouts/readthedocs.org/user_builds/torchgeo/envs/1903/lib/python3.12/site-packages/nbsphinx/__init__.py:1058: RuntimeWarning: You are using an unsupported version of pandoc (2.9.2.1).
Your version must be at least (2.14.2) but less than (4.0.0).
Refer to https://pandoc.org/installing.html.
Continuing with doubts...
  nbconvert.utils.pandoc.check_pandoc_version()
```