### PR TITLE
Docs: allow horizontal scrolling of wide tables

### DIFF
--- a/docs/_static/table-scroll.css
+++ b/docs/_static/table-scroll.css
@@ -1,0 +1,5 @@
+table {
+  border-collapse: collapse;
+  display: block;
+  overflow-x: auto;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -93,7 +93,7 @@ html_theme_options = {
 html_favicon = os.path.join("..", "logo", "favicon.ico")
 
 html_static_path = ["_static"]
-html_css_files = ["button-width.css", "notebook-prompt.css"]
+html_css_files = ["button-width.css", "notebook-prompt.css", "table-scroll.css"]
 
 # -- Extension configuration -------------------------------------------------
 


### PR DESCRIPTION
Also submitted upstream to https://github.com/pytorch/pytorch_sphinx_theme/pull/192, can be removed once that PR is accepted.

### Before

https://torchgeo.readthedocs.io/en/latest/api/models.html#sensor-agnostic

### After

https://torchgeo--1958.org.readthedocs.build/en/1958/api/models.html#sensor-agnostic