### PR TITLE
IntersectionDataset: ignore 0 area overlap

### DIFF
--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -543,9 +543,25 @@ class TestIntersectionDataset:
         assert len(ds1) == len(ds2) == len(ds3) == len(ds) == 1
         assert isinstance(sample["image"], torch.Tensor)
 
+    def test_point_dataset(self) -> None:
+        ds1 = CustomGeoDataset(BoundingBox(0, 2, 2, 4, 4, 6))
+        ds2 = CustomGeoDataset(BoundingBox(1, 1, 3, 3, 5, 5))
+        ds = IntersectionDataset(ds1, ds2)
+        sample = ds[ds.bounds]
+        assert ds1.crs == ds2.crs == ds.crs == CRS.from_epsg(4087)
+        assert ds1.res == ds2.res == ds.res == 1
+        assert len(ds1) == len(ds2) == len(ds) == 1
+
     def test_no_overlap(self) -> None:
         ds1 = CustomGeoDataset(BoundingBox(0, 1, 2, 3, 4, 5))
         ds2 = CustomGeoDataset(BoundingBox(6, 7, 8, 9, 10, 11))
+        msg = "Datasets have no spatiotemporal intersection"
+        with pytest.raises(RuntimeError, match=msg):
+            IntersectionDataset(ds1, ds2)
+
+    def test_grid_overlap(self) -> None:
+        ds1 = CustomGeoDataset(BoundingBox(0, 1, 2, 3, 4, 5))
+        ds2 = CustomGeoDataset(BoundingBox(1, 2, 3, 4, 5, 6))
         msg = "Datasets have no spatiotemporal intersection"
         with pytest.raises(RuntimeError, match=msg):
             IntersectionDataset(ds1, ds2)

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -952,8 +952,11 @@ class IntersectionDataset(GeoDataset):
             for hit2 in ds2.index.intersection(hit1.bounds, objects=True):
                 box1 = BoundingBox(*hit1.bounds)
                 box2 = BoundingBox(*hit2.bounds)
-                self.index.insert(i, tuple(box1 & box2))
-                i += 1
+                box3 = box1 & box2
+                # Skip 0 area overlap (unless 0 area dataset)
+                if box3.area > 0 or box1.area == 0 or box2.area == 0:
+                    self.index.insert(i, tuple(box1 & box2))
+                    i += 1
 
         if i == 0:
             raise RuntimeError("Datasets have no spatiotemporal intersection")


### PR DESCRIPTION
R-tree considers two bounding boxes to intersect if they share a line or corner, even if they have zero area of overlap. For example, given two datasets (e.g., NAIP) organized in a grid:
```
+---+---+
| A | B |
+---+---+
| C | D |
+---+---+
```
The intersection will actually have length 16, not 4, because A intersects with B, C, and D (A shares a boundary with B and C and a corner with D).

This PR ignores the additional 12 bounding boxes with 0 area. It takes care to add special consideration for point datasets where the original dataset also has 0 area.

Question: should we check volume instead of area? What if two tiles share a time border? Currently we subtract a microsecond from the bounds, so this probably shouldn't happen...

Fixes #547 @Modexus
Fixes #1270 @calebrob6
@yichiac also reported this issue