### PR TITLE
Minor typo in notebook

### DIFF
--- a/docs/tutorials/custom_raster_dataset.ipynb
+++ b/docs/tutorials/custom_raster_dataset.ipynb
@@ -345,7 +345,7 @@
     "\n",
     "### `rgb_bands`\n",
     "\n",
-    "If your data is a multispectral iamge, you can define which bands correspond to the red, green, and blue channels. In the case of Sentinel-2, this corresponds to B04, B03, and B02, in that order.\n",
+    "If your data is a multispectral image, you can define which bands correspond to the red, green, and blue channels. In the case of Sentinel-2, this corresponds to B04, B03, and B02, in that order.\n",
     "\n",
     "Putting this all together into a single class, we get:"
    ]


### PR DESCRIPTION
Spotted a tiny typo in `custom_raster_dataset.ipynb` --my inner nitpicker couldn't resist pointing it out.