### PR TITLE
FireRisk HuggingFace Port

### DIFF
--- a/torchgeo/datasets/fire_risk.py
+++ b/torchgeo/datasets/fire_risk.py
@@ -50,7 +50,7 @@ class FireRisk(NonGeoClassificationDataset):
     .. versionadded:: 0.5
     """
 
-    url = "https://drive.google.com/file/d/1J5GrJJPLWkpuptfY_kgqkiDtcSNP88OP"
+    url = "https://hf.co/datasets/torchgeo/fire_risk/resolve/e6046a04350c6f1ab4ad791fb3a40bf8940be269/FireRisk.zip"
     md5 = "a77b9a100d51167992ae8c51d26198a6"
     filename = "FireRisk.zip"
     directory = "FireRisk"


### PR DESCRIPTION
The FireRisk dataset has been rehosted to HuggingFace. This PR updates the download url

Fixes #1996