### PR TITLE
Fix plotting in datamodules when dataset is a Subset

### DIFF
--- a/torchgeo/datamodules/geo.py
+++ b/torchgeo/datamodules/geo.py
@@ -11,7 +11,7 @@ import torch
 from lightning.pytorch import LightningDataModule
 from matplotlib.figure import Figure
 from torch import Tensor
-from torch.utils.data import DataLoader, Dataset, default_collate, Subset
+from torch.utils.data import DataLoader, Dataset, Subset, default_collate
 
 from ..datasets import GeoDataset, NonGeoDataset, stack_samples
 from ..samplers import (

--- a/torchgeo/datamodules/geo.py
+++ b/torchgeo/datamodules/geo.py
@@ -11,7 +11,7 @@ import torch
 from lightning.pytorch import LightningDataModule
 from matplotlib.figure import Figure
 from torch import Tensor
-from torch.utils.data import DataLoader, Dataset, default_collate
+from torch.utils.data import DataLoader, Dataset, default_collate, Subset
 
 from ..datasets import GeoDataset, NonGeoDataset, stack_samples
 from ..samplers import (
@@ -157,6 +157,8 @@ class BaseDataModule(LightningDataModule):
         """
         fig: Figure | None = None
         dataset = self.dataset or self.val_dataset
+        if isinstance(dataset, Subset):
+            dataset = dataset.dataset
         if dataset is not None:
             if hasattr(dataset, "plot"):
                 fig = dataset.plot(*args, **kwargs)


### PR DESCRIPTION
We have a `.plot(...)` method in our `BaseDataModule` that routes plot requests from the trainers through to the dataset object's `.plot(...)` method. This currently only works if `trainer.dataset` or `trainer.val_dataset` has a plot method. However, when you call `torch.utils.data.random_split` to get a train/val split, your dataset objects are `Subsets` which don't have a plot method.  