### PR TITLE
Remove torchgeo.datamodules.dataset_split

### DIFF
--- a/tests/conf/skippd.yaml
+++ b/tests/conf/skippd.yaml
@@ -9,6 +9,7 @@ data:
   class_path: SKIPPDDataModule
   init_args:
     batch_size: 1
+    val_split_pct: 0.4
   dict_kwargs:
     root: "tests/data/skippd"
     download: true

--- a/tests/datamodules/test_utils.py
+++ b/tests/datamodules/test_utils.py
@@ -5,8 +5,6 @@ import re
 
 import numpy as np
 import pytest
-import torch
-from torch.utils.data import TensorDataset
 
 from torchgeo.datamodules.utils import group_shuffle_split
 

--- a/tests/datamodules/test_utils.py
+++ b/tests/datamodules/test_utils.py
@@ -8,25 +8,7 @@ import pytest
 import torch
 from torch.utils.data import TensorDataset
 
-from torchgeo.datamodules.utils import dataset_split, group_shuffle_split
-
-
-def test_dataset_split() -> None:
-    num_samples = 24
-    x = torch.ones(num_samples, 5)
-    y = torch.randint(low=0, high=2, size=(num_samples,))
-    ds = TensorDataset(x, y)
-
-    # Test only train/val set split
-    train_ds, val_ds = dataset_split(ds, val_pct=1 / 2)
-    assert len(train_ds) == round(num_samples / 2)
-    assert len(val_ds) == round(num_samples / 2)
-
-    # Test train/val/test set split
-    train_ds, val_ds, test_ds = dataset_split(ds, val_pct=1 / 3, test_pct=1 / 3)
-    assert len(train_ds) == round(num_samples / 3)
-    assert len(val_ds) == round(num_samples / 3)
-    assert len(test_ds) == round(num_samples / 3)
+from torchgeo.datamodules.utils import group_shuffle_split
 
 
 def test_group_shuffle_split() -> None:

--- a/torchgeo/datamodules/deepglobelandcover.py
+++ b/torchgeo/datamodules/deepglobelandcover.py
@@ -6,13 +6,13 @@
 from typing import Any
 
 import kornia.augmentation as K
+from torch.utils.data import dataset_split
 
 from ..datasets import DeepGlobeLandCover
 from ..samplers.utils import _to_tuple
 from ..transforms import AugmentationSequential
 from ..transforms.transforms import _RandomNCrop
 from .geo import NonGeoDataModule
-from .utils import dataset_split
 
 
 class DeepGlobeLandCoverDataModule(NonGeoDataModule):

--- a/torchgeo/datamodules/deepglobelandcover.py
+++ b/torchgeo/datamodules/deepglobelandcover.py
@@ -6,7 +6,7 @@
 from typing import Any
 
 import kornia.augmentation as K
-from torch.utils.data import dataset_split
+from torch.utils.data import random_split
 
 from ..datasets import DeepGlobeLandCover
 from ..samplers.utils import _to_tuple
@@ -59,7 +59,7 @@ class DeepGlobeLandCoverDataModule(NonGeoDataModule):
         """
         if stage in ["fit", "validate"]:
             self.dataset = DeepGlobeLandCover(split="train", **self.kwargs)
-            self.train_dataset, self.val_dataset = dataset_split(
+            self.train_dataset, self.val_dataset = random_split(
                 self.dataset, self.val_split_pct
             )
         if stage in ["test"]:

--- a/torchgeo/datamodules/deepglobelandcover.py
+++ b/torchgeo/datamodules/deepglobelandcover.py
@@ -6,6 +6,7 @@
 from typing import Any
 
 import kornia.augmentation as K
+import torch
 from torch.utils.data import random_split
 
 from ..datasets import DeepGlobeLandCover
@@ -59,8 +60,9 @@ class DeepGlobeLandCoverDataModule(NonGeoDataModule):
         """
         if stage in ["fit", "validate"]:
             self.dataset = DeepGlobeLandCover(split="train", **self.kwargs)
+            generator = torch.Generator().manual_seed(0)
             self.train_dataset, self.val_dataset = random_split(
-                self.dataset, self.val_split_pct
+                self.dataset, [1 - self.val_split_pct, self.val_split_pct], generator
             )
         if stage in ["test"]:
             self.test_dataset = DeepGlobeLandCover(split="test", **self.kwargs)

--- a/torchgeo/datamodules/gid15.py
+++ b/torchgeo/datamodules/gid15.py
@@ -6,13 +6,13 @@
 from typing import Any
 
 import kornia.augmentation as K
+from torch.utils.data import dataset_split
 
 from ..datasets import GID15
 from ..samplers.utils import _to_tuple
 from ..transforms import AugmentationSequential
 from ..transforms.transforms import _RandomNCrop
 from .geo import NonGeoDataModule
-from .utils import dataset_split
 
 
 class GID15DataModule(NonGeoDataModule):

--- a/torchgeo/datamodules/gid15.py
+++ b/torchgeo/datamodules/gid15.py
@@ -6,6 +6,7 @@
 from typing import Any
 
 import kornia.augmentation as K
+import torch
 from torch.utils.data import random_split
 
 from ..datasets import GID15
@@ -66,8 +67,9 @@ class GID15DataModule(NonGeoDataModule):
         """
         if stage in ["fit", "validate"]:
             self.dataset = GID15(split="train", **self.kwargs)
+            generator = torch.Generator().manual_seed(0)
             self.train_dataset, self.val_dataset = random_split(
-                self.dataset, self.val_split_pct
+                self.dataset, [1 - self.val_split_pct, self.val_split_pct], generator
             )
         if stage in ["test"]:
             # Test set masks are not public, use for prediction instead

--- a/torchgeo/datamodules/gid15.py
+++ b/torchgeo/datamodules/gid15.py
@@ -6,7 +6,7 @@
 from typing import Any
 
 import kornia.augmentation as K
-from torch.utils.data import dataset_split
+from torch.utils.data import random_split
 
 from ..datasets import GID15
 from ..samplers.utils import _to_tuple
@@ -66,7 +66,7 @@ class GID15DataModule(NonGeoDataModule):
         """
         if stage in ["fit", "validate"]:
             self.dataset = GID15(split="train", **self.kwargs)
-            self.train_dataset, self.val_dataset = dataset_split(
+            self.train_dataset, self.val_dataset = random_split(
                 self.dataset, self.val_split_pct
             )
         if stage in ["test"]:

--- a/torchgeo/datamodules/levircd.py
+++ b/torchgeo/datamodules/levircd.py
@@ -6,7 +6,7 @@
 from typing import Any
 
 import kornia.augmentation as K
-from torch.utils.data import dataset_split
+from torch.utils.data import random_split
 
 from torchgeo.samplers.utils import _to_tuple
 
@@ -113,7 +113,7 @@ class LEVIRCDPlusDataModule(NonGeoDataModule):
         """
         if stage in ["fit", "validate"]:
             self.dataset = LEVIRCDPlus(split="train", **self.kwargs)
-            self.train_dataset, self.val_dataset = dataset_split(
+            self.train_dataset, self.val_dataset = random_split(
                 self.dataset, val_pct=self.val_split_pct
             )
         if stage in ["test"]:

--- a/torchgeo/datamodules/levircd.py
+++ b/torchgeo/datamodules/levircd.py
@@ -6,6 +6,7 @@
 from typing import Any
 
 import kornia.augmentation as K
+import torch
 from torch.utils.data import random_split
 
 from torchgeo.samplers.utils import _to_tuple
@@ -113,8 +114,9 @@ class LEVIRCDPlusDataModule(NonGeoDataModule):
         """
         if stage in ["fit", "validate"]:
             self.dataset = LEVIRCDPlus(split="train", **self.kwargs)
+            generator = torch.Generator().manual_seed(0)
             self.train_dataset, self.val_dataset = random_split(
-                self.dataset, val_pct=self.val_split_pct
+                self.dataset, [1 - self.val_split_pct, self.val_split_pct], generator
             )
         if stage in ["test"]:
             self.test_dataset = LEVIRCDPlus(split="test", **self.kwargs)

--- a/torchgeo/datamodules/levircd.py
+++ b/torchgeo/datamodules/levircd.py
@@ -6,8 +6,8 @@
 from typing import Any
 
 import kornia.augmentation as K
+from torch.utils.data import dataset_split
 
-from torchgeo.datamodules.utils import dataset_split
 from torchgeo.samplers.utils import _to_tuple
 
 from ..datasets import LEVIRCD, LEVIRCDPlus

--- a/torchgeo/datamodules/nasa_marine_debris.py
+++ b/torchgeo/datamodules/nasa_marine_debris.py
@@ -7,11 +7,12 @@ from typing import Any
 
 import kornia.augmentation as K
 import torch
+from torch.utils.data import dataset_split
 
 from ..datasets import NASAMarineDebris
 from ..transforms import AugmentationSequential
 from .geo import NonGeoDataModule
-from .utils import AugPipe, collate_fn_detection, dataset_split
+from .utils import AugPipe, collate_fn_detection
 
 
 class NASAMarineDebrisDataModule(NonGeoDataModule):

--- a/torchgeo/datamodules/nasa_marine_debris.py
+++ b/torchgeo/datamodules/nasa_marine_debris.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import kornia.augmentation as K
 import torch
-from torch.utils.data import dataset_split
+from torch.utils.data import random_split
 
 from ..datasets import NASAMarineDebris
 from ..transforms import AugmentationSequential
@@ -62,6 +62,6 @@ class NASAMarineDebrisDataModule(NonGeoDataModule):
             stage: Either 'fit', 'validate', 'test', or 'predict'.
         """
         self.dataset = NASAMarineDebris(**self.kwargs)
-        self.train_dataset, self.val_dataset, self.test_dataset = dataset_split(
+        self.train_dataset, self.val_dataset, self.test_dataset = random_split(
             self.dataset, val_pct=self.val_split_pct, test_pct=self.test_split_pct
         )

--- a/torchgeo/datamodules/nasa_marine_debris.py
+++ b/torchgeo/datamodules/nasa_marine_debris.py
@@ -62,6 +62,13 @@ class NASAMarineDebrisDataModule(NonGeoDataModule):
             stage: Either 'fit', 'validate', 'test', or 'predict'.
         """
         self.dataset = NASAMarineDebris(**self.kwargs)
+        generator = torch.Generator().manual_seed(0)
         self.train_dataset, self.val_dataset, self.test_dataset = random_split(
-            self.dataset, val_pct=self.val_split_pct, test_pct=self.test_split_pct
+            self.dataset,
+            [
+                1 - self.val_split_pct - self.test_split_pct,
+                self.val_split_pct,
+                self.test_split_pct,
+            ],
+            generator,
         )

--- a/torchgeo/datamodules/oscd.py
+++ b/torchgeo/datamodules/oscd.py
@@ -7,13 +7,13 @@ from typing import Any
 
 import kornia.augmentation as K
 import torch
+from torch.utils.data import dataset_split
 
 from ..datasets import OSCD
 from ..samplers.utils import _to_tuple
 from ..transforms import AugmentationSequential
 from ..transforms.transforms import _RandomNCrop
 from .geo import NonGeoDataModule
-from .utils import dataset_split
 
 MEAN = {
     "B01": 1583.0741,

--- a/torchgeo/datamodules/oscd.py
+++ b/torchgeo/datamodules/oscd.py
@@ -99,8 +99,9 @@ class OSCDDataModule(NonGeoDataModule):
         """
         if stage in ["fit", "validate"]:
             self.dataset = OSCD(split="train", **self.kwargs)
+            generator = torch.Generator().manual_seed(0)
             self.train_dataset, self.val_dataset = random_split(
-                self.dataset, val_pct=self.val_split_pct
+                self.dataset, [1 - self.val_split_pct, self.val_split_pct], generator
             )
         if stage in ["test"]:
             self.test_dataset = OSCD(split="test", **self.kwargs)

--- a/torchgeo/datamodules/oscd.py
+++ b/torchgeo/datamodules/oscd.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import kornia.augmentation as K
 import torch
-from torch.utils.data import dataset_split
+from torch.utils.data import random_split
 
 from ..datasets import OSCD
 from ..samplers.utils import _to_tuple
@@ -99,7 +99,7 @@ class OSCDDataModule(NonGeoDataModule):
         """
         if stage in ["fit", "validate"]:
             self.dataset = OSCD(split="train", **self.kwargs)
-            self.train_dataset, self.val_dataset = dataset_split(
+            self.train_dataset, self.val_dataset = random_split(
                 self.dataset, val_pct=self.val_split_pct
             )
         if stage in ["test"]:

--- a/torchgeo/datamodules/potsdam.py
+++ b/torchgeo/datamodules/potsdam.py
@@ -6,13 +6,13 @@
 from typing import Any
 
 import kornia.augmentation as K
+from torch.utils.data import dataset_split
 
 from ..datasets import Potsdam2D
 from ..samplers.utils import _to_tuple
 from ..transforms import AugmentationSequential
 from ..transforms.transforms import _RandomNCrop
 from .geo import NonGeoDataModule
-from .utils import dataset_split
 
 
 class Potsdam2DDataModule(NonGeoDataModule):

--- a/torchgeo/datamodules/potsdam.py
+++ b/torchgeo/datamodules/potsdam.py
@@ -6,7 +6,7 @@
 from typing import Any
 
 import kornia.augmentation as K
-from torch.utils.data import dataset_split
+from torch.utils.data import random_split
 
 from ..datasets import Potsdam2D
 from ..samplers.utils import _to_tuple
@@ -61,7 +61,7 @@ class Potsdam2DDataModule(NonGeoDataModule):
         """
         if stage in ["fit", "validate"]:
             self.dataset = Potsdam2D(split="train", **self.kwargs)
-            self.train_dataset, self.val_dataset = dataset_split(
+            self.train_dataset, self.val_dataset = random_split(
                 self.dataset, self.val_split_pct
             )
         if stage in ["test"]:

--- a/torchgeo/datamodules/potsdam.py
+++ b/torchgeo/datamodules/potsdam.py
@@ -6,6 +6,7 @@
 from typing import Any
 
 import kornia.augmentation as K
+import torch
 from torch.utils.data import random_split
 
 from ..datasets import Potsdam2D
@@ -61,8 +62,9 @@ class Potsdam2DDataModule(NonGeoDataModule):
         """
         if stage in ["fit", "validate"]:
             self.dataset = Potsdam2D(split="train", **self.kwargs)
+            generator = torch.Generator().manual_seed(0)
             self.train_dataset, self.val_dataset = random_split(
-                self.dataset, self.val_split_pct
+                self.dataset, [1 - self.val_split_pct, self.val_split_pct], generator
             )
         if stage in ["test"]:
             self.test_dataset = Potsdam2D(split="test", **self.kwargs)

--- a/torchgeo/datamodules/skippd.py
+++ b/torchgeo/datamodules/skippd.py
@@ -5,6 +5,7 @@
 
 from typing import Any
 
+import torch
 from torch.utils.data import random_split
 
 from ..datasets import SKIPPD
@@ -48,8 +49,9 @@ class SKIPPDDataModule(NonGeoDataModule):
         """
         if stage in ["fit", "validate"]:
             self.dataset = SKIPPD(split="trainval", **self.kwargs)
+            generator = torch.Generator().manual_seed(0)
             self.train_dataset, self.val_dataset = random_split(
-                self.dataset, val_pct=self.val_split_pct
+                self.dataset, [1 - self.val_split_pct, self.val_split_pct], generator
             )
         if stage in ["test"]:
             self.test_dataset = SKIPPD(split="test", **self.kwargs)

--- a/torchgeo/datamodules/skippd.py
+++ b/torchgeo/datamodules/skippd.py
@@ -5,9 +5,10 @@
 
 from typing import Any
 
+from torch.utils.data import dataset_split
+
 from ..datasets import SKIPPD
 from .geo import NonGeoDataModule
-from .utils import dataset_split
 
 
 class SKIPPDDataModule(NonGeoDataModule):

--- a/torchgeo/datamodules/skippd.py
+++ b/torchgeo/datamodules/skippd.py
@@ -5,7 +5,7 @@
 
 from typing import Any
 
-from torch.utils.data import dataset_split
+from torch.utils.data import random_split
 
 from ..datasets import SKIPPD
 from .geo import NonGeoDataModule
@@ -48,7 +48,7 @@ class SKIPPDDataModule(NonGeoDataModule):
         """
         if stage in ["fit", "validate"]:
             self.dataset = SKIPPD(split="trainval", **self.kwargs)
-            self.train_dataset, self.val_dataset = dataset_split(
+            self.train_dataset, self.val_dataset = random_split(
                 self.dataset, val_pct=self.val_split_pct
             )
         if stage in ["test"]:

--- a/torchgeo/datamodules/spacenet.py
+++ b/torchgeo/datamodules/spacenet.py
@@ -7,11 +7,11 @@ from typing import Any
 
 import kornia.augmentation as K
 from torch import Tensor
+from torch.utils.data import dataset_split
 
 from ..datasets import SpaceNet1
 from ..transforms import AugmentationSequential
 from .geo import NonGeoDataModule
-from .utils import dataset_split
 
 
 class SpaceNet1DataModule(NonGeoDataModule):

--- a/torchgeo/datamodules/spacenet.py
+++ b/torchgeo/datamodules/spacenet.py
@@ -6,6 +6,7 @@
 from typing import Any
 
 import kornia.augmentation as K
+import torch
 from torch import Tensor
 from torch.utils.data import random_split
 
@@ -68,8 +69,15 @@ class SpaceNet1DataModule(NonGeoDataModule):
             stage: Either 'fit', 'validate', 'test', or 'predict'.
         """
         self.dataset = SpaceNet1(**self.kwargs)
+        generator = torch.Generator().manual_seed(0)
         self.train_dataset, self.val_dataset, self.test_dataset = random_split(
-            self.dataset, self.val_split_pct, self.test_split_pct
+            self.dataset,
+            [
+                1 - self.val_split_pct - self.test_split_pct,
+                self.val_split_pct,
+                self.test_split_pct,
+            ],
+            generator,
         )
 
     def on_after_batch_transfer(

--- a/torchgeo/datamodules/spacenet.py
+++ b/torchgeo/datamodules/spacenet.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import kornia.augmentation as K
 from torch import Tensor
-from torch.utils.data import dataset_split
+from torch.utils.data import random_split
 
 from ..datasets import SpaceNet1
 from ..transforms import AugmentationSequential
@@ -68,7 +68,7 @@ class SpaceNet1DataModule(NonGeoDataModule):
             stage: Either 'fit', 'validate', 'test', or 'predict'.
         """
         self.dataset = SpaceNet1(**self.kwargs)
-        self.train_dataset, self.val_dataset, self.test_dataset = dataset_split(
+        self.train_dataset, self.val_dataset, self.test_dataset = random_split(
             self.dataset, self.val_split_pct, self.test_split_pct
         )
 

--- a/torchgeo/datamodules/utils.py
+++ b/torchgeo/datamodules/utils.py
@@ -10,11 +10,8 @@ from typing import Any
 import numpy as np
 import torch
 from einops import rearrange
-from torch import Generator, Tensor
+from torch import Tensor
 from torch.nn import Module
-from torch.utils.data import Subset, TensorDataset, random_split
-
-from ..datasets import NonGeoDataset
 
 
 # Based on lightning_lite.utilities.exceptions
@@ -100,44 +97,6 @@ def collate_fn_detection(batch: list[dict[str, Tensor]]) -> dict[str, Any]:
     if "masks" in batch[0]:
         output["masks"] = [sample["masks"] for sample in batch]
     return output
-
-
-def dataset_split(
-    dataset: TensorDataset | NonGeoDataset,
-    val_pct: float,
-    test_pct: float | None = None,
-) -> list[Subset[Any]]:
-    """Split a torch Dataset into train/val/test sets.
-
-    If ``test_pct`` is not set then only train and validation splits are returned.
-
-    .. deprecated:: 0.4
-       Use :func:`torch.utils.data.random_split` instead, ``random_split``
-       now supports percentages as of PyTorch 1.13.
-
-    Args:
-        dataset: dataset to be split into train/val or train/val/test subsets
-        val_pct: percentage of samples to be in validation set
-        test_pct: (Optional) percentage of samples to be in test set
-
-    Returns:
-        a list of the subset datasets. Either [train, val] or [train, val, test]
-    """
-    if test_pct is None:
-        val_length = round(len(dataset) * val_pct)
-        train_length = len(dataset) - val_length
-        return random_split(
-            dataset, [train_length, val_length], generator=Generator().manual_seed(0)
-        )
-    else:
-        val_length = round(len(dataset) * val_pct)
-        test_length = round(len(dataset) * test_pct)
-        train_length = len(dataset) - (val_length + test_length)
-        return random_split(
-            dataset,
-            [train_length, val_length, test_length],
-            generator=Generator().manual_seed(0),
-        )
 
 
 def group_shuffle_split(

--- a/torchgeo/datamodules/vaihingen.py
+++ b/torchgeo/datamodules/vaihingen.py
@@ -6,13 +6,13 @@
 from typing import Any
 
 import kornia.augmentation as K
+from torch.utils.data import dataset_split
 
 from ..datasets import Vaihingen2D
 from ..samplers.utils import _to_tuple
 from ..transforms import AugmentationSequential
 from ..transforms.transforms import _RandomNCrop
 from .geo import NonGeoDataModule
-from .utils import dataset_split
 
 
 class Vaihingen2DDataModule(NonGeoDataModule):

--- a/torchgeo/datamodules/vaihingen.py
+++ b/torchgeo/datamodules/vaihingen.py
@@ -6,6 +6,7 @@
 from typing import Any
 
 import kornia.augmentation as K
+import torch
 from torch.utils.data import random_split
 
 from ..datasets import Vaihingen2D
@@ -61,8 +62,9 @@ class Vaihingen2DDataModule(NonGeoDataModule):
         """
         if stage in ["fit", "validate"]:
             self.dataset = Vaihingen2D(split="train", **self.kwargs)
+            generator = torch.Generator().manual_seed(0)
             self.train_dataset, self.val_dataset = random_split(
-                self.dataset, self.val_split_pct
+                self.dataset, [1 - self.val_split_pct, self.val_split_pct], generator
             )
         if stage in ["test"]:
             self.test_dataset = Vaihingen2D(split="test", **self.kwargs)

--- a/torchgeo/datamodules/vaihingen.py
+++ b/torchgeo/datamodules/vaihingen.py
@@ -6,7 +6,7 @@
 from typing import Any
 
 import kornia.augmentation as K
-from torch.utils.data import dataset_split
+from torch.utils.data import random_split
 
 from ..datasets import Vaihingen2D
 from ..samplers.utils import _to_tuple
@@ -61,7 +61,7 @@ class Vaihingen2DDataModule(NonGeoDataModule):
         """
         if stage in ["fit", "validate"]:
             self.dataset = Vaihingen2D(split="train", **self.kwargs)
-            self.train_dataset, self.val_dataset = dataset_split(
+            self.train_dataset, self.val_dataset = random_split(
                 self.dataset, self.val_split_pct
             )
         if stage in ["test"]:

--- a/torchgeo/datamodules/vhr10.py
+++ b/torchgeo/datamodules/vhr10.py
@@ -12,8 +12,8 @@ from torch.utils.data import random_split
 from ..datasets import VHR10
 from ..samplers.utils import _to_tuple
 from ..transforms import AugmentationSequential
-from ..transforms.utils import AugPipe, collate_fn_detection
 from .geo import NonGeoDataModule
+from .utils import AugPipe, collate_fn_detection
 
 
 class VHR10DataModule(NonGeoDataModule):

--- a/torchgeo/datamodules/vhr10.py
+++ b/torchgeo/datamodules/vhr10.py
@@ -7,11 +7,12 @@ from typing import Any
 
 import kornia.augmentation as K
 import torch
-from torch.utils.data import AugPipe, collate_fn_detection, random_split
+from torch.utils.data import random_split
 
 from ..datasets import VHR10
 from ..samplers.utils import _to_tuple
 from ..transforms import AugmentationSequential
+from ..transforms.utils import AugPipe, collate_fn_detection
 from .geo import NonGeoDataModule
 
 
@@ -78,6 +79,13 @@ class VHR10DataModule(NonGeoDataModule):
             stage: Either 'fit', 'validate', 'test', or 'predict'.
         """
         self.dataset = VHR10(**self.kwargs)
+        generator = torch.Generator().manual_seed(0)
         self.train_dataset, self.val_dataset, self.test_dataset = random_split(
-            self.dataset, self.val_split_pct, self.test_split_pct
+            self.dataset,
+            [
+                1 - self.val_split_pct - self.test_split_pct,
+                self.val_split_pct,
+                self.test_split_pct,
+            ],
+            generator,
         )

--- a/torchgeo/datamodules/vhr10.py
+++ b/torchgeo/datamodules/vhr10.py
@@ -7,12 +7,12 @@ from typing import Any
 
 import kornia.augmentation as K
 import torch
+from torch.utils.data import AugPipe, collate_fn_detection, dataset_split
 
 from ..datasets import VHR10
 from ..samplers.utils import _to_tuple
 from ..transforms import AugmentationSequential
 from .geo import NonGeoDataModule
-from .utils import AugPipe, collate_fn_detection, dataset_split
 
 
 class VHR10DataModule(NonGeoDataModule):

--- a/torchgeo/datamodules/vhr10.py
+++ b/torchgeo/datamodules/vhr10.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import kornia.augmentation as K
 import torch
-from torch.utils.data import AugPipe, collate_fn_detection, dataset_split
+from torch.utils.data import AugPipe, collate_fn_detection, random_split
 
 from ..datasets import VHR10
 from ..samplers.utils import _to_tuple
@@ -78,6 +78,6 @@ class VHR10DataModule(NonGeoDataModule):
             stage: Either 'fit', 'validate', 'test', or 'predict'.
         """
         self.dataset = VHR10(**self.kwargs)
-        self.train_dataset, self.val_dataset, self.test_dataset = dataset_split(
+        self.train_dataset, self.val_dataset, self.test_dataset = random_split(
             self.dataset, self.val_split_pct, self.test_split_pct
         )

--- a/torchgeo/datamodules/xview.py
+++ b/torchgeo/datamodules/xview.py
@@ -5,9 +5,10 @@
 
 from typing import Any
 
+from torch.utils.data import dataset_split
+
 from ..datasets import XView2
 from .geo import NonGeoDataModule
-from .utils import dataset_split
 
 
 class XView2DataModule(NonGeoDataModule):

--- a/torchgeo/datamodules/xview.py
+++ b/torchgeo/datamodules/xview.py
@@ -5,6 +5,7 @@
 
 from typing import Any
 
+import torch
 from torch.utils.data import random_split
 
 from ..datasets import XView2
@@ -47,8 +48,9 @@ class XView2DataModule(NonGeoDataModule):
         """
         if stage in ["fit", "validate"]:
             self.dataset = XView2(split="train", **self.kwargs)
+            generator = torch.Generator().manual_seed(0)
             self.train_dataset, self.val_dataset = random_split(
-                self.dataset, val_pct=self.val_split_pct
+                self.dataset, [1 - self.val_split_pct, self.val_split_pct], generator
             )
         if stage in ["test"]:
             self.test_dataset = XView2(split="test", **self.kwargs)

--- a/torchgeo/datamodules/xview.py
+++ b/torchgeo/datamodules/xview.py
@@ -5,7 +5,7 @@
 
 from typing import Any
 
-from torch.utils.data import dataset_split
+from torch.utils.data import random_split
 
 from ..datasets import XView2
 from .geo import NonGeoDataModule
@@ -47,7 +47,7 @@ class XView2DataModule(NonGeoDataModule):
         """
         if stage in ["fit", "validate"]:
             self.dataset = XView2(split="train", **self.kwargs)
-            self.train_dataset, self.val_dataset = dataset_split(
+            self.train_dataset, self.val_dataset = random_split(
                 self.dataset, val_pct=self.val_split_pct
             )
         if stage in ["test"]:


### PR DESCRIPTION
This function was added as a wrapper around `torch.utils.data.random_split` with support for percentages. However, this feature was added upstream, and the minimum supported version of PyTorch now supports it. This wrapper can now be removed.

There are no backwards incompatible changes since this function was never documented.