### PR TITLE
pre-commit: newer skimage is required

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
           - pillow>=10.3.0
           - pytest>=6.1.2
           - pyvista>=0.34.2
-          - scikit-image>=0.18.0
+          - scikit-image>=0.22.0
           - torch>=2.2
           - torchmetrics>=0.10
         exclude: (build|data|dist|logo|logs|output)/


### PR DESCRIPTION
Otherwise it complains about an unused type ignore since https://github.com/microsoft/torchgeo/pull/1617