### PR TITLE
GeoDataset: don't warn about missing files for downloadable datasets

### DIFF
--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -309,7 +309,7 @@ class GeoDataset(Dataset[dict[str, Any]], abc.ABC):
                 files |= set(glob.iglob(pathname, recursive=True))
             elif os.path.isfile(path) or path_is_vsi(path):
                 files.add(path)
-            else:
+            elif not hasattr(self, "download"):
                 warnings.warn(
                     f"Could not find any relevant files for provided path '{path}'. "
                     f"Path was ignored.",


### PR DESCRIPTION
Many of our GeoDatasets use `self.files` to check if the dataset has already been downloaded. However, `self.files` warns if this is not the case. This results in situations like:
```pycon
>>> from torchgeo.datasets import L7Irish, L8Biome
>>> L7Irish('data/l7irish', download=True, checksum=True)
/Users/Adam/torchgeo/torchgeo/datasets/geo.py:313: UserWarning: Could not find any relevant files for provided path 'data/l7irish'. Path was ignored.
  warnings.warn(
Downloading https://cdn-lfs.huggingface.co/repos/0e/db/0edbfb877a18f0d038f1adf0a0a8f2cbc1cf4d3ac25ad56be221421cb1667b22/9b025debb20791cd3279cbc56f39dcd42fa7f20f172608a750e06b31c153457e?response-content-disposition=attachment%3B+filename*%3DUTF-8%27%27austral.tar.gz%3B+filename%3D%22austral.tar.gz%22%3B&response-content-type=application%2Fgzip&Expires=1714477090&Policy=eyJTdGF0ZW1lbnQiOlt7IkNvbmRpdGlvbiI6eyJEYXRlTGVzc1RoYW4iOnsiQVdTOkVwb2NoVGltZSI6MTcxNDQ3NzA5MH19LCJSZXNvdXJjZSI6Imh0dHBzOi8vY2RuLWxmcy5odWdnaW5nZmFjZS5jby9yZXBvcy8wZS9kYi8wZWRiZmI4NzdhMThmMGQwMzhmMWFkZjBhMGE4ZjJjYmMxY2Y0ZDNhYzI1YWQ1NmJlMjIxNDIxY2IxNjY3YjIyLzliMDI1ZGViYjIwNzkxY2QzMjc5Y2JjNTZmMzlkY2Q0MmZhN2YyMGYxNzI2MDhhNzUwZTA2YjMxYzE1MzQ1N2U%7EcmVzcG9uc2UtY29udGVudC1kaXNwb3NpdGlvbj0qJnJlc3BvbnNlLWNvbnRlbnQtdHlwZT0qIn1dfQ__&Signature=FHGdoR-EJpgzbzJ8IMhC7P3OtnBcT7ER2BGYjcbIs1fMQm57bFSVoDWj3jLc7driKDf%7EFC-UPMQJTlcGq7o26PO2OIN-lApDwc6RiZcvEAwhtVC1ngXRFKPGww%7Ec93G0FW-GhSRgsaW04nTY1ubZ%7E-dOU2WsUMiIPfETL7rCAG2x1YxwiQ5r0Yh5j-w-F-qgD0hwWvPQVFO9xUdp2zcevPg5fLR6t8%7ESZQSknq4lRbbhYBPUCC7t3ZR%7EbWmvMm4anEGYroevyE0%7EJdcSnGrAsHUQFpmi3IjXoIx9zdrwV7CHYuhAVqjm9TE8-%7EZbBNcM5XP29qtcHEp-NB%7EjfTl5rg__&Key-Pair-Id=KVTP0A1DKRTAX to data/l7irish/austral.tar.gz
```
This is misleading since the path isn't ignored, it's used to download. We have a few options:

1. Remove this warning entirely
2. Remove this warning for datasets with a download attribute
3. Remove this warning for datasets with a _download function
4. Warn that nothing is found, but don't mention that the path will be skipped
5. Warn that nothing is found, so we'll download it instead