### PR TITLE
L7 Irish: convert to IntersectionDataset

### DIFF
--- a/tests/datasets/test_l7irish.py
+++ b/tests/datasets/test_l7irish.py
@@ -66,6 +66,7 @@ class TestL7Irish:
 
     def test_already_extracted(self, dataset: L7Irish) -> None:
         L7Irish(dataset.paths, download=True)
+        L7Irish([dataset.paths], download=True)
 
     def test_already_downloaded(self, tmp_path: Path) -> None:
         pathname = os.path.join('tests', 'data', 'l7irish', '*.tar.gz')

--- a/tests/datasets/test_l7irish.py
+++ b/tests/datasets/test_l7irish.py
@@ -5,6 +5,7 @@ import glob
 import os
 import shutil
 from pathlib import Path
+from typing import cast
 
 import matplotlib.pyplot as plt
 import pytest
@@ -65,8 +66,9 @@ class TestL7Irish:
         plt.close()
 
     def test_already_extracted(self, dataset: L7Irish) -> None:
-        L7Irish(dataset.paths, download=True)
-        L7Irish([dataset.paths], download=True)
+        paths = cast(str, dataset.paths)
+        L7Irish(paths, download=True)
+        L7Irish([paths], download=True)
 
     def test_already_downloaded(self, tmp_path: Path) -> None:
         pathname = os.path.join('tests', 'data', 'l7irish', '*.tar.gz')

--- a/torchgeo/datasets/l7irish.py
+++ b/torchgeo/datasets/l7irish.py
@@ -5,18 +5,20 @@
 
 import glob
 import os
+import re
 from collections.abc import Callable, Iterable, Sequence
-from typing import Any
+from typing import Any, cast
 
 import matplotlib.pyplot as plt
 import torch
 from matplotlib.figure import Figure
 from rasterio.crs import CRS
+from rtree.index import Index, Property
 from torch import Tensor
 
 from .errors import DatasetNotFoundError, RGBBandsMissingError
 from .geo import IntersectionDataset, RasterDataset
-from .utils import BoundingBox, download_url, extract_archive
+from .utils import BoundingBox, disambiguate_timestamp, download_url, extract_archive
 
 
 class L7IrishImage(RasterDataset):
@@ -56,6 +58,43 @@ class L7IrishMask(RasterDataset):
     ordinal_map[128] = 2
     ordinal_map[192] = 3
     ordinal_map[255] = 4
+
+    def __init__(
+        self,
+        paths: str | Iterable[str] = 'data',
+        crs: CRS | None = None,
+        res: float | None = None,
+        bands: Sequence[str] | None = None,
+        transforms: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        cache: bool = True,
+    ) -> None:
+        """Initialize a new L7IrishMask instance.
+
+        Args:
+            paths: one or more root directories to search or files to load
+            crs: :term:`coordinate reference system (CRS)` to warp to
+                (defaults to the CRS of the first file found)
+            res: resolution of the dataset in units of CRS
+                (defaults to the resolution of the first file found)
+            bands: bands to return (defaults to all bands)
+            transforms: a function/transform that takes an input sample
+                and returns a transformed version
+            cache: if True, cache file handle to speed up repeated sampling
+        """
+        super().__init__(paths, crs, res, bands, transforms, cache)
+
+        # Mask filename does not include the date, grab it from the image filename
+        filename_regex = re.compile(L7IrishImage.filename_regex, re.VERBOSE)
+        index = Index(interleaved=False, properties=Property(dimension=3))
+        for hit in self.index.intersection(self.index.bounds, objects=True):
+            dirname = os.path.dirname(cast(str, hit.object))
+            image = glob.glob(os.path.join(dirname, L7IrishImage.filename_glob))[0]
+            minx, maxx, miny, maxy, mint, maxt = hit.bounds
+            if match := re.match(filename_regex, os.path.basename(image)):
+                date = match.group('date')
+                mint, maxt = disambiguate_timestamp(date, L7IrishImage.date_format)
+            index.insert(hit.id, (minx, maxx, miny, maxy, mint, maxt), hit.object)
+        self.index = index
 
     def __getitem__(self, query: BoundingBox) -> dict[str, Any]:
         """Retrieve image/mask and metadata indexed by query.

--- a/torchgeo/datasets/l7irish.py
+++ b/torchgeo/datasets/l7irish.py
@@ -51,7 +51,7 @@ class L7IrishMask(RasterDataset):
     """
     is_image = False
     classes = ['Fill', 'Cloud Shadow', 'Clear', 'Thin Cloud', 'Cloud']
-    ordinal_map = torch.zeros(256, dtype=torch.uint8)
+    ordinal_map = torch.zeros(256, dtype=torch.long)
     ordinal_map[64] = 1
     ordinal_map[128] = 2
     ordinal_map[192] = 3

--- a/torchgeo/datasets/l7irish.py
+++ b/torchgeo/datasets/l7irish.py
@@ -207,6 +207,18 @@ class L7Irish(IntersectionDataset):
 
         super().__init__(self.image, self.mask)
 
+    def _merge_dataset_indices(self) -> None:
+        """Create a new R-tree out of the individual indices from two datasets."""
+        i = 0
+        ds1, ds2 = self.datasets
+        for hit1 in ds1.index.intersection(ds1.index.bounds, objects=True):
+            for hit2 in ds2.index.intersection(hit1.bounds, objects=True):
+                box1 = BoundingBox(*hit1.bounds)
+                box2 = BoundingBox(*hit2.bounds)
+                if box1 == box2:
+                    self.index.insert(i, tuple(box1 & box2))
+                    i += 1
+
     def _verify(self) -> None:
         """Verify the integrity of the dataset."""
         # Check if the extracted files already exist

--- a/torchgeo/datasets/l7irish.py
+++ b/torchgeo/datasets/l7irish.py
@@ -218,7 +218,7 @@ class L7Irish(IntersectionDataset):
         """Plot a sample from the dataset.
 
         Args:
-            sample: a sample returned by :meth:`__getitem__`
+            sample: a sample returned by :meth:`RasterDataset.__getitem__`
             show_titles: flag indicating whether to show titles above each panel
             suptitle: optional string to use as a suptitle
 


### PR DESCRIPTION
Converts L7 Irish to an IntersectionDataset following the design proposed in #1972.

This is needed for #2015 so that images and masks can independently control their resampling algorithm.

~Only remaining bug is that the length of the dataset jumped from 206 to 438, which implies that some images in the dataset overlap.~

Will do the same thing to L8 Biome after this is merged.

@yichiac