### PR TITLE
Datasets: add azcopy download support

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,14 +36,13 @@ jobs:
         uses: pyvista/setup-headless-display-action@v2
       - name: Install apt dependencies (Linux)
         run: |
-          sudo apt-get update
-          sudo apt-get install unrar
+          sudo apt-get install azcopy unrar
         if: ${{ runner.os == 'Linux' }}
       - name: Install brew dependencies (macOS)
-        run: brew install rar
+        run: brew install azcopy rar
         if: ${{ runner.os == 'macOS' }}
       - name: Install choco dependencies (Windows)
-        run: choco install 7zip
+        run: choco install azcopy 7zip
         if: ${{ runner.os == 'Windows' }}
       - name: Install pip dependencies
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,7 +36,10 @@ jobs:
         uses: pyvista/setup-headless-display-action@v2
       - name: Install apt dependencies (Linux)
         run: |
-          sudo apt-get install azcopy unrar
+          sudo apt-get install unrar
+          wget https://aka.ms/downloadazcopy-v10-linux
+          tar xvzf downloadazcopy-v10-linux
+          cp azcopy_linux_amd64_*/azcopy /usr/local/bin
         if: ${{ runner.os == 'Linux' }}
       - name: Install brew dependencies (macOS)
         run: brew install azcopy rar

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -38,8 +38,8 @@ jobs:
         run: |
           sudo apt-get install unrar
           wget https://aka.ms/downloadazcopy-v10-linux
-          tar xvzf downloadazcopy-v10-linux
-          cp azcopy_linux_amd64_*/azcopy /usr/local/bin
+          tar xzf downloadazcopy-v10-linux
+          cp azcopy_linux_amd64_*/azcopy /usr/local/bin/
         if: ${{ runner.os == 'Linux' }}
       - name: Install brew dependencies (macOS)
         run: brew install azcopy rar
@@ -84,8 +84,10 @@ jobs:
         uses: pyvista/setup-headless-display-action@v2
       - name: Install apt dependencies (Linux)
         run: |
-          sudo apt-get update
           sudo apt-get install unrar
+          wget https://aka.ms/downloadazcopy-v10-linux
+          tar xzf downloadazcopy-v10-linux
+          cp azcopy_linux_amd64_*/azcopy /usr/local/bin/
       - name: Install pip dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: |

--- a/tests/datasets/azcopy
+++ b/tests/datasets/azcopy
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+"""Basic mock-up of the azcopy CLI.
+
+Only needed until azcopy supports local <-> local transfers
+
+* https://github.com/Azure/azure-storage-azcopy/issues/2669
+"""
+
+import argparse
+import shutil
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers()
+    sync = subparsers.add_parser("sync")
+    sync.add_argument("source")
+    sync.add_argument("destination")
+    args, _ = parser.parse_known_args()
+    shutil.copytree(args.source, args.destination, dirs_exist_ok=True)

--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -103,16 +103,16 @@ def test_download_and_extract_archive(tmp_path: Path, monkeypatch: MonkeyPatch) 
 
 
 def test_azcopy(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
-    source = os.path.join("tests", "data", "cyclone")
-    if shutil.which("azcopy"):
+    source = os.path.join('tests', 'data', 'cyclone')
+    if shutil.which('azcopy'):
         path = os.path.dirname(os.path.realpath(__file__))
-        monkeypatch.setenv("PATH", path, prepend=os.pathsep)
-        azcopy("sync", source, tmp_path, "--recursive=true")
-        assert os.path.exists(tmp_path / "nasa_tropical_storm_competition_test_labels")
+        monkeypatch.setenv('PATH', path, prepend=os.pathsep)
+        azcopy('sync', source, tmp_path, '--recursive=true')
+        assert os.path.exists(tmp_path / 'nasa_tropical_storm_competition_test_labels')
     else:
-        match = "azcopy is not installed and is required to download this dataset"
+        match = 'azcopy is not installed and is required to download this dataset'
         with pytest.raises(FileNotFoundError, match=match):
-            azcopy("sync", source, tmp_path, "--recursive=true")
+            azcopy('sync', source, tmp_path, '--recursive=true')
 
 
 def test_download_radiant_mlhub_dataset(

--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -22,6 +22,7 @@ import torchgeo.datasets.utils
 from torchgeo.datasets import BoundingBox, DependencyNotFoundError
 from torchgeo.datasets.utils import (
     array_to_tensor,
+    azcopy,
     concat_samples,
     disambiguate_timestamp,
     download_and_extract_archive,
@@ -99,6 +100,19 @@ def test_download_and_extract_archive(tmp_path: Path, monkeypatch: MonkeyPatch) 
         os.path.join('tests', 'data', 'landcoverai', 'landcover.ai.v1.zip'),
         str(tmp_path),
     )
+
+
+def test_azcopy(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    source = os.path.join("tests", "data", "cyclone")
+    if shutil.which("azcopy"):
+        path = os.path.dirname(os.path.realpath(__file__))
+        monkeypatch.setenv("PATH", path, prepend=os.pathsep)
+        azcopy("sync", source, tmp_path, "--recursive=true")
+        assert os.path.exists(tmp_path / "nasa_tropical_storm_competition_test_labels")
+    else:
+        match = "azcopy is not installed and is required to download this dataset"
+        with pytest.raises(FileNotFoundError, match=match):
+            azcopy("sync", source, tmp_path, "--recursive=true")
 
 
 def test_download_radiant_mlhub_dataset(

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -156,11 +156,11 @@ def azcopy(*args: Any, **kwargs: Any) -> None:
 
     .. versionadded:: 0.6
     """
-    kwargs["check"] = True
+    kwargs['check'] = True
     try:
-        subprocess.run(("azcopy",) + args, **kwargs)
+        subprocess.run(('azcopy',) + args, **kwargs)
     except FileNotFoundError:
-        msg = "azcopy is not installed and is required to download this dataset"
+        msg = 'azcopy is not installed and is required to download this dataset'
         raise FileNotFoundError(msg)
 
 

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -13,6 +13,7 @@ import gzip
 import importlib
 import lzma
 import os
+import subprocess
 import sys
 import tarfile
 from collections.abc import Iterable, Iterator, Sequence
@@ -141,6 +142,26 @@ def download_and_extract_archive(
     archive = os.path.join(download_root, filename)
     print(f'Extracting {archive} to {extract_root}')
     extract_archive(archive, extract_root)
+
+
+def azcopy(*args: Any, **kwargs: Any) -> None:
+    """Wrapper around ``azcopy`` command.
+
+    Args:
+        args: Arguments to pass to ``azcopy``.
+        kwargs: Keyword arguments to pass to ``subprocess.run``.
+
+    Raises:
+        FileNotFoundError: If ``azcopy`` is not installed.
+
+    .. versionadded:: 0.6
+    """
+    kwargs["check"] = True
+    try:
+        subprocess.run(("azcopy",) + args, **kwargs)
+    except FileNotFoundError:
+        msg = "azcopy is not installed and is required to download this dataset"
+        raise FileNotFoundError(msg)
 
 
 def download_radiant_mlhub_dataset(


### PR DESCRIPTION
This PR adds an `azcopy` function to `torchgeo.datasets.utils` that makes it easier to download datasets from Azure Blob Storage (such as Source Cooperative). It's basically just a wrapper around `subprocess.run`, but with a more useful error message if azcopy isn't installed. It can be used as follows:
```python
from torchgeo.datasets.utils import azcopy

azcopy("sync", "https://radiantearth.blob.core.windows.net/mlhub/nasa-tropical-storm-challenge", ".", "--recursive=true")
```
The hardest part was testing. We don't want our tests to require internet access or download massive datasets, so we need to use local fake data to test. But we also can't get full test coverage unless we actually attempt to "download" the data, and `azcopy` doesn't support local <-> local file transfers like rsync does. My solution was to create a fake `azcopy` command that can copy local files and inject this first in the `PATH`. I don't know of a reliable way to test when this command isn't available, so we may need to change CI a bit.

Prerequisite for #1830 
Closes #1887 
Closes #1915

@Haimantika @darkblue-b Once this is reviewed and merged, I could use your help in porting our existing datasets to use this (full list in #1830). Unfortunately, many of the datasets seemingly completely changed their file hierarchy, so some of them may require more than just a simple one-function update.