### PR TITLE
git blame: ignore revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,6 @@
+# Double quote -> single quote
+b09122f3e4a9cb422f6747bf33eca02993f67549
+# Prettier
+bd9c75798eede1a4b7d7ecd6203179d3cb5e54dd
+# Ruff
+d9991ed154dc81da4f1c76be777accad2d689b93


### PR DESCRIPTION
This PR adds a `.git-blame-ignore-revs` file. What does this magical file do? It ignores certain commits (revisions) when viewing file in `git blame` and the GitHub blame view: 

* https://github.blog/changelog/2022-03-24-ignore-commits-in-the-blame-view-beta/
* https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view
* https://git-scm.com/docs/git-blame/en

All of these commits change a large number of files, but only involve cosmetic changes, and should be ignored when looking for the origin of each line.