### PR TITLE
Avoid use of __all__

### DIFF
--- a/torchgeo/datasets/splits.py
+++ b/torchgeo/datasets/splits.py
@@ -15,14 +15,6 @@ from torch import Generator, default_generator, randint, randperm
 from ..datasets import GeoDataset
 from .utils import BoundingBox
 
-__all__ = (
-    'random_bbox_assignment',
-    'random_bbox_splitting',
-    'random_grid_cell_assignment',
-    'roi_split',
-    'time_series_split',
-)
-
 
 def _fractions_to_lengths(fractions: Sequence[float], total: int) -> Sequence[int]:
     """Utility to divide a number into a list of integers according to fractions.

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -27,26 +27,8 @@ from torch.utils.data import Dataset
 from torchvision.datasets.utils import check_integrity, download_url
 from torchvision.utils import draw_segmentation_masks
 
-__all__ = (
-    'check_integrity',
-    'DatasetNotFoundError',
-    'RGBBandsMissingError',
-    'download_url',
-    'download_and_extract_archive',
-    'extract_archive',
-    'BoundingBox',
-    'disambiguate_timestamp',
-    'working_dir',
-    'stack_samples',
-    'concat_samples',
-    'merge_samples',
-    'unbind_samples',
-    'rasterio_loader',
-    'sort_sentinel2_bands',
-    'draw_semantic_segmentation_masks',
-    'rgb_to_mask',
-    'percentile_normalization',
-)
+# Only include import redirects
+__all__ = ('check_integrity', 'download_url')
 
 
 class DatasetNotFoundError(FileNotFoundError):

--- a/torchgeo/models/dofa.py
+++ b/torchgeo/models/dofa.py
@@ -15,8 +15,6 @@ from timm.models.vision_transformer import Block
 from torch import Tensor
 from torchvision.models._api import Weights, WeightsEnum
 
-__all__ = ['DOFABase16_Weights', 'DOFALarge16_Weights']
-
 
 def position_embedding(embed_dim: int, pos: Tensor) -> Tensor:
     """Compute the 1D sine/cosine position embedding.

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -11,9 +11,6 @@ import torch
 from timm.models import ResNet
 from torchvision.models._api import Weights, WeightsEnum
 
-__all__ = ['ResNet50_Weights', 'ResNet18_Weights']
-
-
 # https://github.com/zhu-xlab/SSL4EO-S12/blob/d2868adfada65e40910bfcedfc49bc3b20df2248/src/benchmark/transfer_classification/linear_BE_moco.py#L167  # noqa: E501
 # https://github.com/zhu-xlab/SSL4EO-S12/blob/d2868adfada65e40910bfcedfc49bc3b20df2248/src/benchmark/transfer_classification/datasets/EuroSat/eurosat_dataset.py#L97  # noqa: E501
 # Normalization either by 10K or channel-wise with band statistics

--- a/torchgeo/models/swin.py
+++ b/torchgeo/models/swin.py
@@ -12,8 +12,6 @@ from kornia.contrib import Lambda
 from torchvision.models import SwinTransformer
 from torchvision.models._api import Weights, WeightsEnum
 
-__all__ = ['Swin_V2_B_Weights']
-
 # https://github.com/allenai/satlas/blob/bcaa968da5395f675d067613e02613a344e81415/satlas/cmd/model/train.py#L42 # noqa: E501
 # Satlas uses the TCI product for Sentinel-2 RGB, which is in the range (0, 255).
 # See details:  https://github.com/allenai/satlas/blob/main/Normalization.md#sentinel-2-images.  # noqa: E501

--- a/torchgeo/models/vit.py
+++ b/torchgeo/models/vit.py
@@ -11,8 +11,6 @@ import torch
 from timm.models.vision_transformer import VisionTransformer
 from torchvision.models._api import Weights, WeightsEnum
 
-__all__ = ['ViTSmall16_Weights']
-
 # https://github.com/zhu-xlab/SSL4EO-S12/blob/d2868adfada65e40910bfcedfc49bc3b20df2248/src/benchmark/transfer_classification/linear_BE_moco.py#L167 # noqa: E501
 # https://github.com/zhu-xlab/SSL4EO-S12/blob/d2868adfada65e40910bfcedfc49bc3b20df2248/src/benchmark/transfer_classification/datasets/EuroSat/eurosat_dataset.py#L97 # noqa: E501
 # Normalization either by 10K or channel-wise with band statistics


### PR DESCRIPTION
In TorchGeo, we use `__all__` to prevent "unused import" errors from ruff (formerly flake8). These are only needed in `__init__.py` files to support import aliasing. However, this has led to the proliferation of `__all__` in a few other places. This PR cleans those up.