### PR TITLE
Move dataset errors to separate file

### DIFF
--- a/tests/datasets/test_errors.py
+++ b/tests/datasets/test_errors.py
@@ -1,0 +1,61 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from typing import Any
+
+import pytest
+from torch.utils.data import Dataset
+
+from torchgeo.datasets import DatasetNotFoundError, RGBBandsMissingError
+
+
+class TestDatasetNotFoundError:
+    def test_none(self) -> None:
+        ds: Dataset[Any] = Dataset()
+        match = 'Dataset not found.'
+        with pytest.raises(DatasetNotFoundError, match=match):
+            raise DatasetNotFoundError(ds)
+
+    def test_root(self) -> None:
+        ds: Dataset[Any] = Dataset()
+        ds.root = 'foo'  # type: ignore[attr-defined]
+        match = "Dataset not found in `root='foo'` and cannot be automatically "
+        match += 'downloaded, either specify a different `root` or manually '
+        match += 'download the dataset.'
+        with pytest.raises(DatasetNotFoundError, match=match):
+            raise DatasetNotFoundError(ds)
+
+    def test_paths(self) -> None:
+        ds: Dataset[Any] = Dataset()
+        ds.paths = 'foo'  # type: ignore[attr-defined]
+        match = "Dataset not found in `paths='foo'` and cannot be automatically "
+        match += 'downloaded, either specify a different `paths` or manually '
+        match += 'download the dataset.'
+        with pytest.raises(DatasetNotFoundError, match=match):
+            raise DatasetNotFoundError(ds)
+
+    def test_root_download(self) -> None:
+        ds: Dataset[Any] = Dataset()
+        ds.root = 'foo'  # type: ignore[attr-defined]
+        ds.download = False  # type: ignore[attr-defined]
+        match = "Dataset not found in `root='foo'` and `download=False`, either "
+        match += 'specify a different `root` or use `download=True` to automatically '
+        match += 'download the dataset.'
+        with pytest.raises(DatasetNotFoundError, match=match):
+            raise DatasetNotFoundError(ds)
+
+    def test_paths_download(self) -> None:
+        ds: Dataset[Any] = Dataset()
+        ds.paths = 'foo'  # type: ignore[attr-defined]
+        ds.download = False  # type: ignore[attr-defined]
+        match = "Dataset not found in `paths='foo'` and `download=False`, either "
+        match += 'specify a different `paths` or use `download=True` to automatically '
+        match += 'download the dataset.'
+        with pytest.raises(DatasetNotFoundError, match=match):
+            raise DatasetNotFoundError(ds)
+
+
+def test_rgb_bands_missing() -> None:
+    match = 'Dataset does not contain some of the RGB bands'
+    with pytest.raises(RGBBandsMissingError, match=match):
+        raise RGBBandsMissingError()

--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -18,12 +18,10 @@ import pytest
 import torch
 from pytest import MonkeyPatch
 from rasterio.crs import CRS
-from torch.utils.data import Dataset
 
 import torchgeo.datasets.utils
 from torchgeo.datasets.utils import (
     BoundingBox,
-    DatasetNotFoundError,
     array_to_tensor,
     concat_samples,
     disambiguate_timestamp,
@@ -37,52 +35,6 @@ from torchgeo.datasets.utils import (
     unbind_samples,
     working_dir,
 )
-
-
-class TestDatasetNotFoundError:
-    def test_none(self) -> None:
-        ds: Dataset[Any] = Dataset()
-        match = 'Dataset not found.'
-        with pytest.raises(DatasetNotFoundError, match=match):
-            raise DatasetNotFoundError(ds)
-
-    def test_root(self) -> None:
-        ds: Dataset[Any] = Dataset()
-        ds.root = 'foo'  # type: ignore[attr-defined]
-        match = "Dataset not found in `root='foo'` and cannot be automatically "
-        match += 'downloaded, either specify a different `root` or manually '
-        match += 'download the dataset.'
-        with pytest.raises(DatasetNotFoundError, match=match):
-            raise DatasetNotFoundError(ds)
-
-    def test_paths(self) -> None:
-        ds: Dataset[Any] = Dataset()
-        ds.paths = 'foo'  # type: ignore[attr-defined]
-        match = "Dataset not found in `paths='foo'` and cannot be automatically "
-        match += 'downloaded, either specify a different `paths` or manually '
-        match += 'download the dataset.'
-        with pytest.raises(DatasetNotFoundError, match=match):
-            raise DatasetNotFoundError(ds)
-
-    def test_root_download(self) -> None:
-        ds: Dataset[Any] = Dataset()
-        ds.root = 'foo'  # type: ignore[attr-defined]
-        ds.download = False  # type: ignore[attr-defined]
-        match = "Dataset not found in `root='foo'` and `download=False`, either "
-        match += 'specify a different `root` or use `download=True` to automatically '
-        match += 'download the dataset.'
-        with pytest.raises(DatasetNotFoundError, match=match):
-            raise DatasetNotFoundError(ds)
-
-    def test_paths_download(self) -> None:
-        ds: Dataset[Any] = Dataset()
-        ds.paths = 'foo'  # type: ignore[attr-defined]
-        ds.download = False  # type: ignore[attr-defined]
-        match = "Dataset not found in `paths='foo'` and `download=False`, either "
-        match += 'specify a different `paths` or use `download=True` to automatically '
-        match += 'download the dataset.'
-        with pytest.raises(DatasetNotFoundError, match=match):
-            raise DatasetNotFoundError(ds)
 
 
 @pytest.fixture

--- a/torchgeo/datamodules/levircd.py
+++ b/torchgeo/datamodules/levircd.py
@@ -9,9 +9,8 @@ import kornia.augmentation as K
 import torch
 from torch.utils.data import random_split
 
-from torchgeo.samplers.utils import _to_tuple
-
 from ..datasets import LEVIRCD, LEVIRCDPlus
+from ..samplers.utils import _to_tuple
 from ..transforms import AugmentationSequential
 from ..transforms.transforms import _RandomNCrop
 from .geo import NonGeoDataModule

--- a/torchgeo/datasets/__init__.py
+++ b/torchgeo/datasets/__init__.py
@@ -37,6 +37,7 @@ from .deepglobelandcover import DeepGlobeLandCover
 from .dfc2022 import DFC2022
 from .eddmaps import EDDMapS
 from .enviroatlas import EnviroAtlas
+from .errors import DatasetNotFoundError, RGBBandsMissingError
 from .esri2020 import Esri2020
 from .etci2021 import ETCI2021
 from .eudem import EUDEM
@@ -127,8 +128,6 @@ from .ucmerced import UCMerced
 from .usavars import USAVars
 from .utils import (
     BoundingBox,
-    DatasetNotFoundError,
-    RGBBandsMissingError,
     concat_samples,
     merge_samples,
     stack_samples,

--- a/torchgeo/datasets/advance.py
+++ b/torchgeo/datasets/advance.py
@@ -15,8 +15,9 @@ from matplotlib.figure import Figure
 from PIL import Image
 from torch import Tensor
 
+from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import DatasetNotFoundError, download_and_extract_archive
+from .utils import download_and_extract_archive
 
 
 class ADVANCE(NonGeoDataset):

--- a/torchgeo/datasets/agb_live_woody_density.py
+++ b/torchgeo/datasets/agb_live_woody_density.py
@@ -12,8 +12,9 @@ import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
 from rasterio.crs import CRS
 
+from .errors import DatasetNotFoundError
 from .geo import RasterDataset
-from .utils import DatasetNotFoundError, download_url
+from .utils import download_url
 
 
 class AbovegroundLiveWoodyBiomassDensity(RasterDataset):

--- a/torchgeo/datasets/agrifieldnet.py
+++ b/torchgeo/datasets/agrifieldnet.py
@@ -14,8 +14,9 @@ from matplotlib.figure import Figure
 from rasterio.crs import CRS
 from torch import Tensor
 
+from .errors import RGBBandsMissingError
 from .geo import RasterDataset
-from .utils import BoundingBox, RGBBandsMissingError
+from .utils import BoundingBox
 
 
 class AgriFieldNet(RasterDataset):

--- a/torchgeo/datasets/airphen.py
+++ b/torchgeo/datasets/airphen.py
@@ -8,8 +8,9 @@ from typing import Any
 import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
 
+from .errors import RGBBandsMissingError
 from .geo import RasterDataset
-from .utils import RGBBandsMissingError, percentile_normalization
+from .utils import percentile_normalization
 
 
 class Airphen(RasterDataset):

--- a/torchgeo/datasets/astergdem.py
+++ b/torchgeo/datasets/astergdem.py
@@ -10,8 +10,8 @@ import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
 from rasterio.crs import CRS
 
+from .errors import DatasetNotFoundError
 from .geo import RasterDataset
-from .utils import DatasetNotFoundError
 
 
 class AsterGDEM(RasterDataset):

--- a/torchgeo/datasets/benin_cashews.py
+++ b/torchgeo/datasets/benin_cashews.py
@@ -17,14 +17,9 @@ from matplotlib.figure import Figure
 from rasterio.crs import CRS
 from torch import Tensor
 
+from .errors import DatasetNotFoundError, RGBBandsMissingError
 from .geo import NonGeoDataset
-from .utils import (
-    DatasetNotFoundError,
-    RGBBandsMissingError,
-    check_integrity,
-    download_radiant_mlhub_collection,
-    extract_archive,
-)
+from .utils import check_integrity, download_radiant_mlhub_collection, extract_archive
 
 
 # TODO: read geospatial information from stac.json files

--- a/torchgeo/datasets/bigearthnet.py
+++ b/torchgeo/datasets/bigearthnet.py
@@ -16,13 +16,9 @@ from matplotlib.figure import Figure
 from rasterio.enums import Resampling
 from torch import Tensor
 
+from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import (
-    DatasetNotFoundError,
-    download_url,
-    extract_archive,
-    sort_sentinel2_bands,
-)
+from .utils import download_url, extract_archive, sort_sentinel2_bands
 
 
 class BigEarthNet(NonGeoDataset):

--- a/torchgeo/datasets/biomassters.py
+++ b/torchgeo/datasets/biomassters.py
@@ -14,8 +14,9 @@ import torch
 from matplotlib.figure import Figure
 from torch import Tensor
 
+from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import DatasetNotFoundError, percentile_normalization
+from .utils import percentile_normalization
 
 
 class BioMassters(NonGeoDataset):

--- a/torchgeo/datasets/cbf.py
+++ b/torchgeo/datasets/cbf.py
@@ -11,8 +11,9 @@ import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
 from rasterio.crs import CRS
 
+from .errors import DatasetNotFoundError
 from .geo import VectorDataset
-from .utils import DatasetNotFoundError, check_integrity, download_and_extract_archive
+from .utils import check_integrity, download_and_extract_archive
 
 
 class CanadianBuildingFootprints(VectorDataset):

--- a/torchgeo/datasets/cdl.py
+++ b/torchgeo/datasets/cdl.py
@@ -12,8 +12,9 @@ import torch
 from matplotlib.figure import Figure
 from rasterio.crs import CRS
 
+from .errors import DatasetNotFoundError
 from .geo import RasterDataset
-from .utils import BoundingBox, DatasetNotFoundError, download_url, extract_archive
+from .utils import BoundingBox, download_url, extract_archive
 
 
 class CDL(RasterDataset):

--- a/torchgeo/datasets/chabud.py
+++ b/torchgeo/datasets/chabud.py
@@ -12,8 +12,9 @@ import torch
 from matplotlib.figure import Figure
 from torch import Tensor
 
+from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import DatasetNotFoundError, download_url, percentile_normalization
+from .utils import download_url, percentile_normalization
 
 
 class ChaBuD(NonGeoDataset):

--- a/torchgeo/datasets/chesapeake.py
+++ b/torchgeo/datasets/chesapeake.py
@@ -23,9 +23,10 @@ from matplotlib.figure import Figure
 from rasterio.crs import CRS
 from torch import Tensor
 
+from .errors import DatasetNotFoundError
 from .geo import GeoDataset, RasterDataset
 from .nlcd import NLCD
-from .utils import BoundingBox, DatasetNotFoundError, download_url, extract_archive
+from .utils import BoundingBox, download_url, extract_archive
 
 
 class Chesapeake(RasterDataset, abc.ABC):

--- a/torchgeo/datasets/cloud_cover.py
+++ b/torchgeo/datasets/cloud_cover.py
@@ -15,14 +15,9 @@ import torch
 from matplotlib.figure import Figure
 from torch import Tensor
 
+from .errors import DatasetNotFoundError, RGBBandsMissingError
 from .geo import NonGeoDataset
-from .utils import (
-    DatasetNotFoundError,
-    RGBBandsMissingError,
-    check_integrity,
-    download_radiant_mlhub_collection,
-    extract_archive,
-)
+from .utils import check_integrity, download_radiant_mlhub_collection, extract_archive
 
 
 # TODO: read geospatial information from stac.json files

--- a/torchgeo/datasets/cms_mangrove_canopy.py
+++ b/torchgeo/datasets/cms_mangrove_canopy.py
@@ -11,8 +11,9 @@ import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
 from rasterio.crs import CRS
 
+from .errors import DatasetNotFoundError
 from .geo import RasterDataset
-from .utils import DatasetNotFoundError, check_integrity, extract_archive
+from .utils import check_integrity, extract_archive
 
 
 class CMSGlobalMangroveCanopy(RasterDataset):

--- a/torchgeo/datasets/cowc.py
+++ b/torchgeo/datasets/cowc.py
@@ -16,8 +16,9 @@ from matplotlib.figure import Figure
 from PIL import Image
 from torch import Tensor
 
+from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import DatasetNotFoundError, check_integrity, download_and_extract_archive
+from .utils import check_integrity, download_and_extract_archive
 
 
 class COWC(NonGeoDataset, abc.ABC):

--- a/torchgeo/datasets/cropharvest.py
+++ b/torchgeo/datasets/cropharvest.py
@@ -15,8 +15,9 @@ import torch
 from matplotlib.figure import Figure
 from torch import Tensor
 
+from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import DatasetNotFoundError, download_url, extract_archive
+from .utils import download_url, extract_archive
 
 
 class CropHarvest(NonGeoDataset):

--- a/torchgeo/datasets/cv4a_kenya_crop_type.py
+++ b/torchgeo/datasets/cv4a_kenya_crop_type.py
@@ -15,14 +15,9 @@ from matplotlib.figure import Figure
 from PIL import Image
 from torch import Tensor
 
+from .errors import DatasetNotFoundError, RGBBandsMissingError
 from .geo import NonGeoDataset
-from .utils import (
-    DatasetNotFoundError,
-    RGBBandsMissingError,
-    check_integrity,
-    download_radiant_mlhub_collection,
-    extract_archive,
-)
+from .utils import check_integrity, download_radiant_mlhub_collection, extract_archive
 
 
 # TODO: read geospatial information from stac.json files

--- a/torchgeo/datasets/cyclone.py
+++ b/torchgeo/datasets/cyclone.py
@@ -16,13 +16,9 @@ from matplotlib.figure import Figure
 from PIL import Image
 from torch import Tensor
 
+from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import (
-    DatasetNotFoundError,
-    check_integrity,
-    download_radiant_mlhub_collection,
-    extract_archive,
-)
+from .utils import check_integrity, download_radiant_mlhub_collection, extract_archive
 
 
 class TropicalCyclone(NonGeoDataset):

--- a/torchgeo/datasets/deepglobelandcover.py
+++ b/torchgeo/datasets/deepglobelandcover.py
@@ -13,9 +13,9 @@ from matplotlib.figure import Figure
 from PIL import Image
 from torch import Tensor
 
+from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
 from .utils import (
-    DatasetNotFoundError,
     check_integrity,
     draw_semantic_segmentation_masks,
     extract_archive,

--- a/torchgeo/datasets/dfc2022.py
+++ b/torchgeo/datasets/dfc2022.py
@@ -16,13 +16,9 @@ from matplotlib.figure import Figure
 from rasterio.enums import Resampling
 from torch import Tensor
 
+from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import (
-    DatasetNotFoundError,
-    check_integrity,
-    extract_archive,
-    percentile_normalization,
-)
+from .utils import check_integrity, extract_archive, percentile_normalization
 
 
 class DFC2022(NonGeoDataset):

--- a/torchgeo/datasets/eddmaps.py
+++ b/torchgeo/datasets/eddmaps.py
@@ -11,8 +11,9 @@ import numpy as np
 import pandas as pd
 from rasterio.crs import CRS
 
+from .errors import DatasetNotFoundError
 from .geo import GeoDataset
-from .utils import BoundingBox, DatasetNotFoundError, disambiguate_timestamp
+from .utils import BoundingBox, disambiguate_timestamp
 
 
 class EDDMapS(GeoDataset):

--- a/torchgeo/datasets/enviroatlas.py
+++ b/torchgeo/datasets/enviroatlas.py
@@ -21,8 +21,9 @@ from matplotlib.colors import ListedColormap
 from matplotlib.figure import Figure
 from rasterio.crs import CRS
 
+from .errors import DatasetNotFoundError
 from .geo import GeoDataset
-from .utils import BoundingBox, DatasetNotFoundError, download_url, extract_archive
+from .utils import BoundingBox, download_url, extract_archive
 
 
 class EnviroAtlas(GeoDataset):

--- a/torchgeo/datasets/errors.py
+++ b/torchgeo/datasets/errors.py
@@ -1,0 +1,61 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+"""Dataset-specific exceptions."""
+
+from torch.utils.data import Dataset
+
+
+class DatasetNotFoundError(FileNotFoundError):
+    """Raised when a dataset is requested but doesn't exist.
+
+    .. versionadded:: 0.6
+    """
+
+    def __init__(self, dataset: Dataset[object]) -> None:
+        """Initialize a new DatasetNotFoundError instance.
+
+        Args:
+            dataset: The dataset that was requested.
+        """
+        msg = 'Dataset not found'
+
+        if hasattr(dataset, 'root'):
+            var = 'root'
+            val = dataset.root
+        elif hasattr(dataset, 'paths'):
+            var = 'paths'
+            val = dataset.paths
+        else:
+            super().__init__(f'{msg}.')
+            return
+
+        msg += f' in `{var}={val!r}` and '
+
+        if hasattr(dataset, 'download') and not dataset.download:
+            msg += '`download=False`'
+        else:
+            msg += 'cannot be automatically downloaded'
+
+        msg += f', either specify a different `{var}` or '
+
+        if hasattr(dataset, 'download') and not dataset.download:
+            msg += 'use `download=True` to automatically'
+        else:
+            msg += 'manually'
+
+        msg += ' download the dataset.'
+
+        super().__init__(msg)
+
+
+class RGBBandsMissingError(ValueError):
+    """Raised when a dataset is missing RGB bands for plotting.
+
+    .. versionadded:: 0.6
+    """
+
+    def __init__(self) -> None:
+        """Initialize a new RGBBandsMissingError instance."""
+        msg = 'Dataset does not contain some of the RGB bands'
+        super().__init__(msg)

--- a/torchgeo/datasets/esri2020.py
+++ b/torchgeo/datasets/esri2020.py
@@ -12,8 +12,9 @@ import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
 from rasterio.crs import CRS
 
+from .errors import DatasetNotFoundError
 from .geo import RasterDataset
-from .utils import DatasetNotFoundError, download_url, extract_archive
+from .utils import download_url, extract_archive
 
 
 class Esri2020(RasterDataset):

--- a/torchgeo/datasets/etci2021.py
+++ b/torchgeo/datasets/etci2021.py
@@ -14,8 +14,9 @@ from matplotlib.figure import Figure
 from PIL import Image
 from torch import Tensor
 
+from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import DatasetNotFoundError, download_and_extract_archive
+from .utils import download_and_extract_archive
 
 
 class ETCI2021(NonGeoDataset):

--- a/torchgeo/datasets/eudem.py
+++ b/torchgeo/datasets/eudem.py
@@ -12,8 +12,9 @@ import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
 from rasterio.crs import CRS
 
+from .errors import DatasetNotFoundError
 from .geo import RasterDataset
-from .utils import DatasetNotFoundError, check_integrity, extract_archive
+from .utils import check_integrity, extract_archive
 
 
 class EUDEM(RasterDataset):

--- a/torchgeo/datasets/eurocrops.py
+++ b/torchgeo/datasets/eurocrops.py
@@ -14,13 +14,9 @@ import numpy as np
 from matplotlib.figure import Figure
 from rasterio.crs import CRS
 
+from .errors import DatasetNotFoundError
 from .geo import VectorDataset
-from .utils import (
-    DatasetNotFoundError,
-    check_integrity,
-    download_and_extract_archive,
-    download_url,
-)
+from .utils import check_integrity, download_and_extract_archive, download_url
 
 
 class EuroCrops(VectorDataset):

--- a/torchgeo/datasets/eurosat.py
+++ b/torchgeo/datasets/eurosat.py
@@ -13,15 +13,9 @@ import torch
 from matplotlib.figure import Figure
 from torch import Tensor
 
+from .errors import DatasetNotFoundError, RGBBandsMissingError
 from .geo import NonGeoClassificationDataset
-from .utils import (
-    DatasetNotFoundError,
-    RGBBandsMissingError,
-    check_integrity,
-    download_url,
-    extract_archive,
-    rasterio_loader,
-)
+from .utils import check_integrity, download_url, extract_archive, rasterio_loader
 
 
 class EuroSAT(NonGeoClassificationDataset):

--- a/torchgeo/datasets/fair1m.py
+++ b/torchgeo/datasets/fair1m.py
@@ -17,8 +17,9 @@ from matplotlib.figure import Figure
 from PIL import Image
 from torch import Tensor
 
+from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import DatasetNotFoundError, check_integrity, download_url, extract_archive
+from .utils import check_integrity, download_url, extract_archive
 
 
 def parse_pascal_voc(path: str) -> dict[str, Any]:

--- a/torchgeo/datasets/fire_risk.py
+++ b/torchgeo/datasets/fire_risk.py
@@ -11,8 +11,9 @@ import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
 from torch import Tensor
 
+from .errors import DatasetNotFoundError
 from .geo import NonGeoClassificationDataset
-from .utils import DatasetNotFoundError, download_url, extract_archive
+from .utils import download_url, extract_archive
 
 
 class FireRisk(NonGeoClassificationDataset):

--- a/torchgeo/datasets/forestdamage.py
+++ b/torchgeo/datasets/forestdamage.py
@@ -17,13 +17,9 @@ from matplotlib.figure import Figure
 from PIL import Image
 from torch import Tensor
 
+from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import (
-    DatasetNotFoundError,
-    check_integrity,
-    download_and_extract_archive,
-    extract_archive,
-)
+from .utils import check_integrity, download_and_extract_archive, extract_archive
 
 
 def parse_pascal_voc(path: str) -> dict[str, Any]:

--- a/torchgeo/datasets/gbif.py
+++ b/torchgeo/datasets/gbif.py
@@ -13,8 +13,9 @@ import numpy as np
 import pandas as pd
 from rasterio.crs import CRS
 
+from .errors import DatasetNotFoundError
 from .geo import GeoDataset
-from .utils import BoundingBox, DatasetNotFoundError
+from .utils import BoundingBox
 
 
 def _disambiguate_timestamps(

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -30,9 +30,9 @@ from torch.utils.data import Dataset
 from torchvision.datasets import ImageFolder
 from torchvision.datasets.folder import default_loader as pil_loader
 
+from .errors import DatasetNotFoundError
 from .utils import (
     BoundingBox,
-    DatasetNotFoundError,
     array_to_tensor,
     concat_samples,
     disambiguate_timestamp,

--- a/torchgeo/datasets/gid15.py
+++ b/torchgeo/datasets/gid15.py
@@ -14,8 +14,9 @@ from matplotlib.figure import Figure
 from PIL import Image
 from torch import Tensor
 
+from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import DatasetNotFoundError, download_and_extract_archive
+from .utils import download_and_extract_archive
 
 
 class GID15(NonGeoDataset):

--- a/torchgeo/datasets/globbiomass.py
+++ b/torchgeo/datasets/globbiomass.py
@@ -13,8 +13,9 @@ import torch
 from matplotlib.figure import Figure
 from rasterio.crs import CRS
 
+from .errors import DatasetNotFoundError
 from .geo import RasterDataset
-from .utils import BoundingBox, DatasetNotFoundError, check_integrity, extract_archive
+from .utils import BoundingBox, check_integrity, extract_archive
 
 
 class GlobBiomass(RasterDataset):

--- a/torchgeo/datasets/idtrees.py
+++ b/torchgeo/datasets/idtrees.py
@@ -20,8 +20,9 @@ from torch import Tensor
 from torchvision.ops import clip_boxes_to_image, remove_small_boxes
 from torchvision.utils import draw_bounding_boxes
 
+from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import DatasetNotFoundError, download_url, extract_archive
+from .utils import download_url, extract_archive
 
 
 class IDTReeS(NonGeoDataset):

--- a/torchgeo/datasets/inaturalist.py
+++ b/torchgeo/datasets/inaturalist.py
@@ -11,8 +11,9 @@ from typing import Any
 import pandas as pd
 from rasterio.crs import CRS
 
+from .errors import DatasetNotFoundError
 from .geo import GeoDataset
-from .utils import BoundingBox, DatasetNotFoundError, disambiguate_timestamp
+from .utils import BoundingBox, disambiguate_timestamp
 
 
 class INaturalist(GeoDataset):

--- a/torchgeo/datasets/inria.py
+++ b/torchgeo/datasets/inria.py
@@ -16,13 +16,9 @@ import torch
 from matplotlib.figure import Figure
 from torch import Tensor
 
+from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import (
-    DatasetNotFoundError,
-    check_integrity,
-    extract_archive,
-    percentile_normalization,
-)
+from .utils import check_integrity, extract_archive, percentile_normalization
 
 
 class InriaAerialImageLabeling(NonGeoDataset):

--- a/torchgeo/datasets/iobench.py
+++ b/torchgeo/datasets/iobench.py
@@ -13,14 +13,10 @@ from matplotlib.figure import Figure
 from rasterio.crs import CRS
 
 from .cdl import CDL
+from .errors import DatasetNotFoundError, RGBBandsMissingError
 from .geo import IntersectionDataset
 from .landsat import Landsat9
-from .utils import (
-    DatasetNotFoundError,
-    RGBBandsMissingError,
-    download_url,
-    extract_archive,
-)
+from .utils import download_url, extract_archive
 
 
 class IOBench(IntersectionDataset):

--- a/torchgeo/datasets/l7irish.py
+++ b/torchgeo/datasets/l7irish.py
@@ -13,14 +13,9 @@ from matplotlib.figure import Figure
 from rasterio.crs import CRS
 from torch import Tensor
 
+from .errors import DatasetNotFoundError, RGBBandsMissingError
 from .geo import RasterDataset
-from .utils import (
-    BoundingBox,
-    DatasetNotFoundError,
-    RGBBandsMissingError,
-    download_url,
-    extract_archive,
-)
+from .utils import BoundingBox, download_url, extract_archive
 
 
 class L7Irish(RasterDataset):

--- a/torchgeo/datasets/l8biome.py
+++ b/torchgeo/datasets/l8biome.py
@@ -13,14 +13,9 @@ from matplotlib.figure import Figure
 from rasterio.crs import CRS
 from torch import Tensor
 
+from .errors import DatasetNotFoundError, RGBBandsMissingError
 from .geo import RasterDataset
-from .utils import (
-    BoundingBox,
-    DatasetNotFoundError,
-    RGBBandsMissingError,
-    download_url,
-    extract_archive,
-)
+from .utils import BoundingBox, download_url, extract_archive
 
 
 class L8Biome(RasterDataset):

--- a/torchgeo/datasets/landcoverai.py
+++ b/torchgeo/datasets/landcoverai.py
@@ -21,14 +21,9 @@ from rasterio.crs import CRS
 from torch import Tensor
 from torch.utils.data import Dataset
 
+from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset, RasterDataset
-from .utils import (
-    BoundingBox,
-    DatasetNotFoundError,
-    download_url,
-    extract_archive,
-    working_dir,
-)
+from .utils import BoundingBox, download_url, extract_archive, working_dir
 
 
 class LandCoverAIBase(Dataset[dict[str, Any]], abc.ABC):

--- a/torchgeo/datasets/landsat.py
+++ b/torchgeo/datasets/landsat.py
@@ -11,8 +11,8 @@ import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
 from rasterio.crs import CRS
 
+from .errors import RGBBandsMissingError
 from .geo import RasterDataset
-from .utils import RGBBandsMissingError
 
 
 class Landsat(RasterDataset, abc.ABC):

--- a/torchgeo/datasets/levircd.py
+++ b/torchgeo/datasets/levircd.py
@@ -15,12 +15,9 @@ from matplotlib.figure import Figure
 from PIL import Image
 from torch import Tensor
 
+from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import (
-    DatasetNotFoundError,
-    download_and_extract_archive,
-    percentile_normalization,
-)
+from .utils import download_and_extract_archive, percentile_normalization
 
 
 class LEVIRCDBase(NonGeoDataset, abc.ABC):

--- a/torchgeo/datasets/loveda.py
+++ b/torchgeo/datasets/loveda.py
@@ -14,8 +14,9 @@ from matplotlib.figure import Figure
 from PIL import Image
 from torch import Tensor
 
+from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import DatasetNotFoundError, download_and_extract_archive
+from .utils import download_and_extract_archive
 
 
 class LoveDA(NonGeoDataset):

--- a/torchgeo/datasets/mapinwild.py
+++ b/torchgeo/datasets/mapinwild.py
@@ -16,9 +16,9 @@ import torch
 from matplotlib.figure import Figure
 from torch import Tensor
 
+from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
 from .utils import (
-    DatasetNotFoundError,
     check_integrity,
     download_url,
     extract_archive,

--- a/torchgeo/datasets/millionaid.py
+++ b/torchgeo/datasets/millionaid.py
@@ -15,9 +15,9 @@ from matplotlib.figure import Figure
 from PIL import Image
 from torch import Tensor
 
-from torchgeo.datasets import NonGeoDataset
-
-from .utils import DatasetNotFoundError, check_integrity, extract_archive
+from .errors import DatasetNotFoundError
+from .geo import NonGeoDataset
+from .utils import check_integrity, extract_archive
 
 
 class MillionAID(NonGeoDataset):

--- a/torchgeo/datasets/nasa_marine_debris.py
+++ b/torchgeo/datasets/nasa_marine_debris.py
@@ -14,13 +14,9 @@ from matplotlib.figure import Figure
 from torch import Tensor
 from torchvision.utils import draw_bounding_boxes
 
+from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import (
-    DatasetNotFoundError,
-    check_integrity,
-    download_radiant_mlhub_collection,
-    extract_archive,
-)
+from .utils import check_integrity, download_radiant_mlhub_collection, extract_archive
 
 
 class NASAMarineDebris(NonGeoDataset):

--- a/torchgeo/datasets/nccm.py
+++ b/torchgeo/datasets/nccm.py
@@ -11,8 +11,9 @@ import torch
 from matplotlib.figure import Figure
 from rasterio.crs import CRS
 
+from .errors import DatasetNotFoundError
 from .geo import RasterDataset
-from .utils import BoundingBox, DatasetNotFoundError, download_url
+from .utils import BoundingBox, download_url
 
 
 class NCCM(RasterDataset):

--- a/torchgeo/datasets/nlcd.py
+++ b/torchgeo/datasets/nlcd.py
@@ -13,8 +13,9 @@ import torch
 from matplotlib.figure import Figure
 from rasterio.crs import CRS
 
+from .errors import DatasetNotFoundError
 from .geo import RasterDataset
-from .utils import BoundingBox, DatasetNotFoundError, download_url, extract_archive
+from .utils import BoundingBox, download_url, extract_archive
 
 
 class NLCD(RasterDataset):

--- a/torchgeo/datasets/openbuildings.py
+++ b/torchgeo/datasets/openbuildings.py
@@ -22,8 +22,9 @@ from matplotlib.figure import Figure
 from rasterio.crs import CRS
 from rtree.index import Index, Property
 
+from .errors import DatasetNotFoundError
 from .geo import VectorDataset
-from .utils import BoundingBox, DatasetNotFoundError, check_integrity
+from .utils import BoundingBox, check_integrity
 
 
 class OpenBuildings(VectorDataset):

--- a/torchgeo/datasets/oscd.py
+++ b/torchgeo/datasets/oscd.py
@@ -14,10 +14,9 @@ from matplotlib.figure import Figure
 from PIL import Image
 from torch import Tensor
 
+from .errors import DatasetNotFoundError, RGBBandsMissingError
 from .geo import NonGeoDataset
 from .utils import (
-    DatasetNotFoundError,
-    RGBBandsMissingError,
     download_url,
     draw_semantic_segmentation_masks,
     extract_archive,

--- a/torchgeo/datasets/pastis.py
+++ b/torchgeo/datasets/pastis.py
@@ -14,8 +14,9 @@ from matplotlib.colors import ListedColormap
 from matplotlib.figure import Figure
 from torch import Tensor
 
+from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import DatasetNotFoundError, check_integrity, download_url, extract_archive
+from .utils import check_integrity, download_url, extract_archive
 
 
 class PASTIS(NonGeoDataset):

--- a/torchgeo/datasets/patternnet.py
+++ b/torchgeo/datasets/patternnet.py
@@ -11,8 +11,9 @@ import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
 from torch import Tensor
 
+from .errors import DatasetNotFoundError
 from .geo import NonGeoClassificationDataset
-from .utils import DatasetNotFoundError, download_url, extract_archive
+from .utils import download_url, extract_archive
 
 
 class PatternNet(NonGeoClassificationDataset):

--- a/torchgeo/datasets/potsdam.py
+++ b/torchgeo/datasets/potsdam.py
@@ -14,9 +14,9 @@ from matplotlib.figure import Figure
 from PIL import Image
 from torch import Tensor
 
+from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
 from .utils import (
-    DatasetNotFoundError,
     check_integrity,
     draw_semantic_segmentation_masks,
     extract_archive,

--- a/torchgeo/datasets/quakeset.py
+++ b/torchgeo/datasets/quakeset.py
@@ -13,8 +13,9 @@ import torch
 from matplotlib.figure import Figure
 from torch import Tensor
 
+from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import DatasetNotFoundError, download_url, percentile_normalization
+from .utils import download_url, percentile_normalization
 
 
 class QuakeSet(NonGeoDataset):

--- a/torchgeo/datasets/reforestree.py
+++ b/torchgeo/datasets/reforestree.py
@@ -16,13 +16,9 @@ from matplotlib.figure import Figure
 from PIL import Image
 from torch import Tensor
 
+from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import (
-    DatasetNotFoundError,
-    check_integrity,
-    download_and_extract_archive,
-    extract_archive,
-)
+from .utils import check_integrity, download_and_extract_archive, extract_archive
 
 
 class ReforesTree(NonGeoDataset):

--- a/torchgeo/datasets/resisc45.py
+++ b/torchgeo/datasets/resisc45.py
@@ -12,8 +12,9 @@ import numpy as np
 from matplotlib.figure import Figure
 from torch import Tensor
 
+from .errors import DatasetNotFoundError
 from .geo import NonGeoClassificationDataset
-from .utils import DatasetNotFoundError, download_url, extract_archive
+from .utils import download_url, extract_archive
 
 
 class RESISC45(NonGeoClassificationDataset):

--- a/torchgeo/datasets/rwanda_field_boundary.py
+++ b/torchgeo/datasets/rwanda_field_boundary.py
@@ -14,14 +14,9 @@ import torch
 from matplotlib.figure import Figure
 from torch import Tensor
 
+from .errors import DatasetNotFoundError, RGBBandsMissingError
 from .geo import NonGeoDataset
-from .utils import (
-    DatasetNotFoundError,
-    RGBBandsMissingError,
-    check_integrity,
-    download_radiant_mlhub_collection,
-    extract_archive,
-)
+from .utils import check_integrity, download_radiant_mlhub_collection, extract_archive
 
 
 class RwandaFieldBoundary(NonGeoDataset):

--- a/torchgeo/datasets/seasonet.py
+++ b/torchgeo/datasets/seasonet.py
@@ -18,14 +18,9 @@ from matplotlib.figure import Figure
 from rasterio.enums import Resampling
 from torch import Tensor
 
+from .errors import DatasetNotFoundError, RGBBandsMissingError
 from .geo import NonGeoDataset
-from .utils import (
-    DatasetNotFoundError,
-    RGBBandsMissingError,
-    download_url,
-    extract_archive,
-    percentile_normalization,
-)
+from .utils import download_url, extract_archive, percentile_normalization
 
 
 class SeasoNet(NonGeoDataset):

--- a/torchgeo/datasets/seco.py
+++ b/torchgeo/datasets/seco.py
@@ -15,14 +15,9 @@ from matplotlib.figure import Figure
 from PIL import Image
 from torch import Tensor
 
+from .errors import DatasetNotFoundError, RGBBandsMissingError
 from .geo import NonGeoDataset
-from .utils import (
-    DatasetNotFoundError,
-    RGBBandsMissingError,
-    download_url,
-    extract_archive,
-    percentile_normalization,
-)
+from .utils import download_url, extract_archive, percentile_normalization
 
 
 class SeasonalContrastS2(NonGeoDataset):

--- a/torchgeo/datasets/sen12ms.py
+++ b/torchgeo/datasets/sen12ms.py
@@ -13,13 +13,9 @@ import torch
 from matplotlib.figure import Figure
 from torch import Tensor
 
+from .errors import DatasetNotFoundError, RGBBandsMissingError
 from .geo import NonGeoDataset
-from .utils import (
-    DatasetNotFoundError,
-    RGBBandsMissingError,
-    check_integrity,
-    percentile_normalization,
-)
+from .utils import check_integrity, percentile_normalization
 
 
 class SEN12MS(NonGeoDataset):

--- a/torchgeo/datasets/sentinel.py
+++ b/torchgeo/datasets/sentinel.py
@@ -11,8 +11,8 @@ import torch
 from matplotlib.figure import Figure
 from rasterio.crs import CRS
 
+from .errors import RGBBandsMissingError
 from .geo import RasterDataset
-from .utils import RGBBandsMissingError
 
 
 class Sentinel(RasterDataset):

--- a/torchgeo/datasets/skippd.py
+++ b/torchgeo/datasets/skippd.py
@@ -14,8 +14,9 @@ from einops import rearrange
 from matplotlib.figure import Figure
 from torch import Tensor
 
+from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import DatasetNotFoundError, download_url, extract_archive
+from .utils import download_url, extract_archive
 
 
 class SKIPPD(NonGeoDataset):

--- a/torchgeo/datasets/so2sat.py
+++ b/torchgeo/datasets/so2sat.py
@@ -13,13 +13,9 @@ import torch
 from matplotlib.figure import Figure
 from torch import Tensor
 
+from .errors import DatasetNotFoundError, RGBBandsMissingError
 from .geo import NonGeoDataset
-from .utils import (
-    DatasetNotFoundError,
-    RGBBandsMissingError,
-    check_integrity,
-    percentile_normalization,
-)
+from .utils import check_integrity, percentile_normalization
 
 
 class So2Sat(NonGeoDataset):

--- a/torchgeo/datasets/south_africa_crop_type.py
+++ b/torchgeo/datasets/south_africa_crop_type.py
@@ -14,8 +14,9 @@ from matplotlib.figure import Figure
 from rasterio.crs import CRS
 from torch import Tensor
 
+from .errors import RGBBandsMissingError
 from .geo import RasterDataset
-from .utils import BoundingBox, RGBBandsMissingError
+from .utils import BoundingBox
 
 
 class SouthAfricaCropType(RasterDataset):

--- a/torchgeo/datasets/south_america_soybean.py
+++ b/torchgeo/datasets/south_america_soybean.py
@@ -10,8 +10,9 @@ import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
 from rasterio.crs import CRS
 
+from .errors import DatasetNotFoundError
 from .geo import RasterDataset
-from .utils import DatasetNotFoundError, download_url
+from .utils import download_url
 
 
 class SouthAmericaSoybean(RasterDataset):

--- a/torchgeo/datasets/spacenet.py
+++ b/torchgeo/datasets/spacenet.py
@@ -25,9 +25,9 @@ from rasterio.features import rasterize
 from rasterio.transform import Affine
 from torch import Tensor
 
+from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
 from .utils import (
-    DatasetNotFoundError,
     check_integrity,
     download_radiant_mlhub_collection,
     download_radiant_mlhub_dataset,

--- a/torchgeo/datasets/ssl4eo.py
+++ b/torchgeo/datasets/ssl4eo.py
@@ -16,8 +16,9 @@ import torch
 from matplotlib.figure import Figure
 from torch import Tensor
 
+from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import DatasetNotFoundError, check_integrity, download_url, extract_archive
+from .utils import check_integrity, download_url, extract_archive
 
 
 class SSL4EO(NonGeoDataset):

--- a/torchgeo/datasets/ssl4eo_benchmark.py
+++ b/torchgeo/datasets/ssl4eo_benchmark.py
@@ -15,9 +15,10 @@ from matplotlib.figure import Figure
 from torch import Tensor
 
 from .cdl import CDL
+from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
 from .nlcd import NLCD
-from .utils import DatasetNotFoundError, download_url, extract_archive
+from .utils import download_url, extract_archive
 
 
 class SSL4EOLBenchmark(NonGeoDataset):

--- a/torchgeo/datasets/sustainbench_crop_yield.py
+++ b/torchgeo/datasets/sustainbench_crop_yield.py
@@ -13,8 +13,9 @@ import torch
 from matplotlib.figure import Figure
 from torch import Tensor
 
+from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import DatasetNotFoundError, download_url, extract_archive
+from .utils import download_url, extract_archive
 
 
 class SustainBenchCropYield(NonGeoDataset):

--- a/torchgeo/datasets/ucmerced.py
+++ b/torchgeo/datasets/ucmerced.py
@@ -13,8 +13,9 @@ import torchvision.transforms.functional as F
 from matplotlib.figure import Figure
 from torch import Tensor
 
+from .errors import DatasetNotFoundError
 from .geo import NonGeoClassificationDataset
-from .utils import DatasetNotFoundError, check_integrity, download_url, extract_archive
+from .utils import check_integrity, download_url, extract_archive
 
 
 class UCMerced(NonGeoClassificationDataset):

--- a/torchgeo/datasets/usavars.py
+++ b/torchgeo/datasets/usavars.py
@@ -15,8 +15,9 @@ import torch
 from matplotlib.figure import Figure
 from torch import Tensor
 
+from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import DatasetNotFoundError, download_url, extract_archive
+from .utils import download_url, extract_archive
 
 
 class USAVars(NonGeoDataset):

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -23,67 +23,11 @@ import numpy as np
 import rasterio
 import torch
 from torch import Tensor
-from torch.utils.data import Dataset
 from torchvision.datasets.utils import check_integrity, download_url
 from torchvision.utils import draw_segmentation_masks
 
 # Only include import redirects
 __all__ = ('check_integrity', 'download_url')
-
-
-class DatasetNotFoundError(FileNotFoundError):
-    """Raised when a dataset is requested but doesn't exist.
-
-    .. versionadded:: 0.6
-    """
-
-    def __init__(self, dataset: Dataset[object]) -> None:
-        """Intstantiate a new DatasetNotFoundError instance.
-
-        Args:
-            dataset: The dataset that was requested.
-        """
-        msg = 'Dataset not found'
-
-        if hasattr(dataset, 'root'):
-            var = 'root'
-            val = dataset.root
-        elif hasattr(dataset, 'paths'):
-            var = 'paths'
-            val = dataset.paths
-        else:
-            super().__init__(f'{msg}.')
-            return
-
-        msg += f' in `{var}={val!r}` and '
-
-        if hasattr(dataset, 'download') and not dataset.download:
-            msg += '`download=False`'
-        else:
-            msg += 'cannot be automatically downloaded'
-
-        msg += f', either specify a different `{var}` or '
-
-        if hasattr(dataset, 'download') and not dataset.download:
-            msg += 'use `download=True` to automatically'
-        else:
-            msg += 'manually'
-
-        msg += ' download the dataset.'
-
-        super().__init__(msg)
-
-
-class RGBBandsMissingError(ValueError):
-    """Raised when a dataset is missing RGB bands for plotting.
-
-    .. versionadded:: 0.6
-    """
-
-    def __init__(self) -> None:
-        """Instantiate a new RGBBandsMissingError instance."""
-        msg = 'Dataset does not contain some of the RGB bands'
-        super().__init__(msg)
 
 
 class _rarfile:

--- a/torchgeo/datasets/vaihingen.py
+++ b/torchgeo/datasets/vaihingen.py
@@ -13,9 +13,9 @@ from matplotlib.figure import Figure
 from PIL import Image
 from torch import Tensor
 
+from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
 from .utils import (
-    DatasetNotFoundError,
     check_integrity,
     draw_semantic_segmentation_masks,
     extract_archive,

--- a/torchgeo/datasets/vhr10.py
+++ b/torchgeo/datasets/vhr10.py
@@ -15,13 +15,9 @@ from matplotlib.figure import Figure
 from PIL import Image
 from torch import Tensor
 
+from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import (
-    DatasetNotFoundError,
-    check_integrity,
-    download_and_extract_archive,
-    download_url,
-)
+from .utils import check_integrity, download_and_extract_archive, download_url
 
 
 def convert_coco_poly_to_mask(

--- a/torchgeo/datasets/western_usa_live_fuel_moisture.py
+++ b/torchgeo/datasets/western_usa_live_fuel_moisture.py
@@ -13,12 +13,9 @@ import pandas as pd
 import torch
 from torch import Tensor
 
+from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import (
-    DatasetNotFoundError,
-    download_radiant_mlhub_collection,
-    extract_archive,
-)
+from .utils import download_radiant_mlhub_collection, extract_archive
 
 
 class WesternUSALiveFuelMoisture(NonGeoDataset):

--- a/torchgeo/datasets/xview.py
+++ b/torchgeo/datasets/xview.py
@@ -14,13 +14,9 @@ from matplotlib.figure import Figure
 from PIL import Image
 from torch import Tensor
 
+from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import (
-    DatasetNotFoundError,
-    check_integrity,
-    draw_semantic_segmentation_masks,
-    extract_archive,
-)
+from .utils import check_integrity, draw_semantic_segmentation_masks, extract_archive
 
 
 class XView2(NonGeoDataset):

--- a/torchgeo/datasets/zuericrop.py
+++ b/torchgeo/datasets/zuericrop.py
@@ -11,13 +11,9 @@ import torch
 from matplotlib.figure import Figure
 from torch import Tensor
 
+from .errors import DatasetNotFoundError, RGBBandsMissingError
 from .geo import NonGeoDataset
-from .utils import (
-    DatasetNotFoundError,
-    RGBBandsMissingError,
-    download_url,
-    percentile_normalization,
-)
+from .utils import download_url, percentile_normalization
 
 
 class ZueriCrop(NonGeoDataset):

--- a/torchgeo/trainers/detection.py
+++ b/torchgeo/trainers/detection.py
@@ -19,7 +19,7 @@ from torchvision.models.detection.retinanet import RetinaNetHead
 from torchvision.models.detection.rpn import AnchorGenerator
 from torchvision.ops import MultiScaleRoIAlign, feature_pyramid_network, misc
 
-from ..datasets.utils import RGBBandsMissingError, unbind_samples
+from ..datasets import RGBBandsMissingError, unbind_samples
 from .base import BaseTask
 
 BACKBONE_LAT_DIM_MAP = {


### PR DESCRIPTION
I'm planning on adding new dataset-specific errors and this file was starting to get too big. Let's keep `utils.py` for utility functions and `errors.py` for error classes.