### PR TITLE
Datasets: add CLI support

### DIFF
--- a/tests/datasets/azcopy
+++ b/tests/datasets/azcopy
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+"""Basic mock-up of the azcopy CLI."""
+
+import argparse
+import shutil
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers()
+    sync = subparsers.add_parser("sync")
+    sync.add_argument("source")
+    sync.add_argument("destination")
+    args, _ = parser.parse_known_args()
+    shutil.copytree(args.source, args.destination, dirs_exist_ok=True)

--- a/tests/datasets/azcopy
+++ b/tests/datasets/azcopy
@@ -8,12 +8,20 @@
 import argparse
 import shutil
 
-
-if __name__ == "__main__":
+if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers()
-    sync = subparsers.add_parser("sync")
-    sync.add_argument("source")
-    sync.add_argument("destination")
+    copy = subparsers.add_parser('copy')
+    copy.add_argument('source')
+    copy.add_argument('destination')
+    copy.add_argument('--recursive', default='false')
+    sync = subparsers.add_parser('sync')
+    sync.add_argument('source')
+    sync.add_argument('destination')
+    sync.add_argument('--recursive', default='true')
     args, _ = parser.parse_known_args()
-    shutil.copytree(args.source, args.destination, dirs_exist_ok=True)
+
+    if args.recursive == 'true':
+        shutil.copytree(args.source, args.destination, dirs_exist_ok=True)
+    else:
+        shutil.copy(args.source, args.destination)

--- a/tests/datasets/conftest.py
+++ b/tests/datasets/conftest.py
@@ -1,0 +1,16 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import os
+
+import pytest
+from pytest import MonkeyPatch
+
+from torchgeo.datasets.utils import Executable, which
+
+
+@pytest.fixture
+def azcopy(monkeypatch: MonkeyPatch) -> Executable:
+    path = os.path.dirname(os.path.realpath(__file__))
+    monkeypatch.setenv('PATH', path, prepend=os.pathsep)
+    return which('azcopy')

--- a/tests/datasets/test_errors.py
+++ b/tests/datasets/test_errors.py
@@ -59,9 +59,10 @@ class TestDatasetNotFoundError:
             raise DatasetNotFoundError(ds)
 
 
-def test_missing_dependency() -> None:
-    with pytest.raises(DependencyNotFoundError, match='pip install foo'):
-        raise DependencyNotFoundError('foo')
+def test_dependency_not_found() -> None:
+    msg = 'foo not installed'
+    with pytest.raises(DependencyNotFoundError, match=msg):
+        raise DependencyNotFoundError(msg)
 
 
 def test_rgb_bands_missing() -> None:

--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -21,6 +21,7 @@ from rasterio.crs import CRS
 import torchgeo.datasets.utils
 from torchgeo.datasets import BoundingBox, DependencyNotFoundError
 from torchgeo.datasets.utils import (
+    Executable,
     array_to_tensor,
     concat_samples,
     disambiguate_timestamp,
@@ -33,6 +34,7 @@ from torchgeo.datasets.utils import (
     percentile_normalization,
     stack_samples,
     unbind_samples,
+    which,
     working_dir,
 )
 
@@ -590,3 +592,14 @@ def test_lazy_import(name: str) -> None:
 def test_lazy_import_missing(name: str) -> None:
     with pytest.raises(DependencyNotFoundError, match='pip install foo-bar\n'):
         lazy_import(name)
+
+
+def test_azcopy(tmp_path: Path, azcopy: Executable) -> None:
+    source = os.path.join('tests', 'data', 'cyclone')
+    azcopy('sync', source, tmp_path, '--recursive=true')
+    assert os.path.exists(tmp_path / 'nasa_tropical_storm_competition_test_labels')
+
+
+def test_which() -> None:
+    with pytest.raises(DependencyNotFoundError, match='foo is not installed'):
+        which('foo')

--- a/torchgeo/datasets/errors.py
+++ b/torchgeo/datasets/errors.py
@@ -49,30 +49,11 @@ class DatasetNotFoundError(FileNotFoundError):
         super().__init__(msg)
 
 
-class DependencyNotFoundError(ModuleNotFoundError):
+class DependencyNotFoundError(Exception):
     """Raised when an optional dataset dependency is not installed.
 
     .. versionadded:: 0.6
     """
-
-    def __init__(self, name: str) -> None:
-        """Initialize a new DependencyNotFoundError instance.
-
-        Args:
-            name: Name of missing dependency.
-        """
-        msg = f"""\
-{name} is not installed and is required to use this dataset. Either run:
-
-$ pip install {name}
-
-to install just this dependency, or:
-
-$ pip install torchgeo[datasets]
-
-to install all optional dataset dependencies."""
-
-        super().__init__(msg)
 
 
 class RGBBandsMissingError(ValueError):

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -418,7 +418,7 @@ class Executable:
         """
         self.name = name
 
-    def __call__(self, *args: Any, **kwargs: Any) -> subprocess.CompletedProcess:
+    def __call__(self, *args: Any, **kwargs: Any) -> subprocess.CompletedProcess[bytes]:
         """Run the command.
 
         Args:

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -418,15 +418,18 @@ class Executable:
         """
         self.name = name
 
-    def __call__(self, *args: Any, **kwargs: Any) -> None:
+    def __call__(self, *args: Any, **kwargs: Any) -> subprocess.CompletedProcess:
         """Run the command.
 
         Args:
             args: Arguments to pass to the command.
             kwargs: Keyword arguments to pass to :func:`subprocess.run`.
+
+        Returns:
+            The completed process.
         """
         kwargs['check'] = True
-        subprocess.run((self.name,) + args, **kwargs)
+        return subprocess.run((self.name,) + args, **kwargs)
 
 
 def disambiguate_timestamp(date_str: str, format: str) -> tuple[float, float]:


### PR DESCRIPTION
Alternative to #2043 

#2043 is difficult to test because it requires `azcopy` to _not_ be installed, but it seems like it is installed on the GitHub Actions runners.

This PR goes in a different direction by adding a generic `which` function that returns an `Executable` for interacting with _any_ command-line program, not just `azcopy`. This is a watered-down version of the same idea used by [Spack](https://github.com/spack/spack/blob/develop/lib/spack/spack/util/executable.py), and can be used as follows:
```python
from torchgeo.datasets.utils import which

azcopy = which("azcopy")
azcopy("sync", "https://radiantearth.blob.core.windows.net/mlhub/nasa-tropical-storm-challenge", ".", "--recursive=true")
```

Prerequisite for #1830 and #2068
Closes #1887
Closes #1915
Closes #2043