### PR TITLE
GlobBiomass: several bug fixes

### DIFF
--- a/tests/datasets/test_globbiomass.py
+++ b/tests/datasets/test_globbiomass.py
@@ -47,6 +47,9 @@ class TestGlobBiomass:
         assert isinstance(x['crs'], CRS)
         assert isinstance(x['mask'], torch.Tensor)
 
+    def test_len(self, dataset: GlobBiomass) -> None:
+        assert len(dataset) == 1
+
     def test_already_extracted(self, dataset: GlobBiomass) -> None:
         GlobBiomass(dataset.paths)
 

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -345,6 +345,12 @@ class RasterDataset(GeoDataset):
     #: ``start`` and ``stop`` groups.
     date_format = '%Y%m%d'
 
+    #: Minimum timestamp if not in filename
+    mint: float = 0
+
+    #: Maximum timestmap if not in filename
+    maxt: float = sys.maxsize
+
     #: True if the dataset only contains model inputs (such as images). False if the
     #: dataset only contains ground truth model outputs (such as segmentation masks).
     #:
@@ -462,8 +468,8 @@ class RasterDataset(GeoDataset):
                     # Skip files that rasterio is unable to read
                     continue
                 else:
-                    mint: float = 0
-                    maxt: float = sys.maxsize
+                    mint = self.mint
+                    maxt = self.maxt
                     if 'date' in match.groupdict():
                         date = match.group('date')
                         mint, maxt = disambiguate_timestamp(date, self.date_format)

--- a/torchgeo/datasets/globbiomass.py
+++ b/torchgeo/datasets/globbiomass.py
@@ -39,7 +39,7 @@ class GlobBiomass(RasterDataset):
     Dataset features:
 
     * Global estimates of AGB and GSV at ~100 m per pixel resolution
-      (45,000 x 45,0000 px)
+      (45,000 x 45,000 px)
     * Per-pixel uncertainty expressed as standard error
 
     Dataset format:


### PR DESCRIPTION
This PR fixes the following bugs:

- [x] GlobBiomass data is from 2010, although it isn't in the filename
- [x] Mask is for pixelwise regression, use float32, not long
- [x] Length of dataset was doubled due to unspecific filename_glob

I also improved the documentation to include definitions and units of AGB and GSV.

I didn't do these in this PR, but some suggestions for future contributions to this dataset:

- [ ] Add download support, URLs are public
- [ ] Add support for file extensions other than `.tif`
- [ ] Split estimation mask and uncertainty mask into two different dict keys (backwards incompatible)
- [ ] Treat measurements like bands and allow return both
- [ ] Treat measurements AND errors like bands and allow return both
- [ ] Add data module, our first real pixelwise regression dataset