### PR TITLE
Datasets: test length

### DIFF
--- a/tests/datasets/test_agb_live_woody_density.py
+++ b/tests/datasets/test_agb_live_woody_density.py
@@ -53,6 +53,9 @@ class TestAbovegroundLiveWoodyBiomassDensity:
         assert isinstance(x['crs'], CRS)
         assert isinstance(x['mask'], torch.Tensor)
 
+    def test_len(self, dataset: AbovegroundLiveWoodyBiomassDensity) -> None:
+        assert len(dataset) == 1
+
     def test_no_dataset(self, tmp_path: Path) -> None:
         with pytest.raises(DatasetNotFoundError, match='Dataset not found'):
             AbovegroundLiveWoodyBiomassDensity(str(tmp_path))

--- a/tests/datasets/test_astergdem.py
+++ b/tests/datasets/test_astergdem.py
@@ -41,6 +41,9 @@ class TestAsterGDEM:
         assert isinstance(x['crs'], CRS)
         assert isinstance(x['mask'], torch.Tensor)
 
+    def test_len(self, dataset: AsterGDEM) -> None:
+        assert len(dataset) == 2
+
     def test_and(self, dataset: AsterGDEM) -> None:
         ds = dataset & dataset
         assert isinstance(ds, IntersectionDataset)

--- a/tests/datasets/test_cbf.py
+++ b/tests/datasets/test_cbf.py
@@ -53,6 +53,9 @@ class TestCanadianBuildingFootprints:
         assert isinstance(x['crs'], CRS)
         assert isinstance(x['mask'], torch.Tensor)
 
+    def test_len(self, dataset: CanadianBuildingFootprints) -> None:
+        assert len(dataset) == 1
+
     def test_and(self, dataset: CanadianBuildingFootprints) -> None:
         ds = dataset & dataset
         assert isinstance(ds, IntersectionDataset)

--- a/tests/datasets/test_cdl.py
+++ b/tests/datasets/test_cdl.py
@@ -57,6 +57,9 @@ class TestCDL:
         assert isinstance(x['crs'], CRS)
         assert isinstance(x['mask'], torch.Tensor)
 
+    def test_len(self, dataset: CDL) -> None:
+        assert len(dataset) == 2
+
     def test_classes(self) -> None:
         root = os.path.join('tests', 'data', 'cdl')
         classes = list(CDL.cmap.keys())[:5]

--- a/tests/datasets/test_chesapeake.py
+++ b/tests/datasets/test_chesapeake.py
@@ -51,6 +51,9 @@ class TestChesapeake13:
         assert isinstance(x['crs'], CRS)
         assert isinstance(x['mask'], torch.Tensor)
 
+    def test_len(self, dataset: Chesapeake13) -> None:
+        assert len(dataset) == 1
+
     def test_and(self, dataset: Chesapeake13) -> None:
         ds = dataset & dataset
         assert isinstance(ds, IntersectionDataset)
@@ -161,6 +164,9 @@ class TestChesapeakeCVPR:
         assert isinstance(x, dict)
         assert isinstance(x['crs'], CRS)
         assert isinstance(x['mask'], torch.Tensor)
+
+    def test_len(self, dataset: ChesapeakeCVPR) -> None:
+        assert len(dataset) == 1
 
     def test_and(self, dataset: ChesapeakeCVPR) -> None:
         ds = dataset & dataset

--- a/tests/datasets/test_cloud_cover.py
+++ b/tests/datasets/test_cloud_cover.py
@@ -74,13 +74,13 @@ class TestCloudCoverDetection:
                 bands=invalid_bands,
             )
 
-    def test_get_item(self, dataset: CloudCoverDetection) -> None:
+    def test_getitem(self, dataset: CloudCoverDetection) -> None:
         x = dataset[0]
         assert isinstance(x, dict)
         assert isinstance(x['image'], torch.Tensor)
         assert isinstance(x['mask'], torch.Tensor)
 
-    def test_add(self, dataset: CloudCoverDetection) -> None:
+    def test_len(self, dataset: CloudCoverDetection) -> None:
         assert len(dataset) == 1
 
     def test_already_downloaded(self, dataset: CloudCoverDetection) -> None:

--- a/tests/datasets/test_cms_mangrove_canopy.py
+++ b/tests/datasets/test_cms_mangrove_canopy.py
@@ -49,6 +49,9 @@ class TestCMSGlobalMangroveCanopy:
         assert isinstance(x['crs'], CRS)
         assert isinstance(x['mask'], torch.Tensor)
 
+    def test_len(self, dataset: CMSGlobalMangroveCanopy) -> None:
+        assert len(dataset) == 1
+
     def test_no_dataset(self, tmp_path: Path) -> None:
         with pytest.raises(DatasetNotFoundError, match='Dataset not found'):
             CMSGlobalMangroveCanopy(str(tmp_path))

--- a/tests/datasets/test_enviroatlas.py
+++ b/tests/datasets/test_enviroatlas.py
@@ -70,6 +70,9 @@ class TestEnviroAtlas:
         assert isinstance(x['crs'], CRS)
         assert isinstance(x['mask'], torch.Tensor)
 
+    def test_len(self, dataset: EnviroAtlas) -> None:
+        assert len(dataset) == 1
+
     def test_and(self, dataset: EnviroAtlas) -> None:
         ds = dataset & dataset
         assert isinstance(ds, IntersectionDataset)

--- a/tests/datasets/test_esri2020.py
+++ b/tests/datasets/test_esri2020.py
@@ -52,6 +52,9 @@ class TestEsri2020:
         assert isinstance(x['crs'], CRS)
         assert isinstance(x['mask'], torch.Tensor)
 
+    def test_len(self, dataset: Esri2020) -> None:
+        assert len(dataset) == 1
+
     def test_already_extracted(self, dataset: Esri2020) -> None:
         Esri2020(dataset.paths, download=True)
 

--- a/tests/datasets/test_eudem.py
+++ b/tests/datasets/test_eudem.py
@@ -38,6 +38,9 @@ class TestEUDEM:
         assert isinstance(x['crs'], CRS)
         assert isinstance(x['mask'], torch.Tensor)
 
+    def test_len(self, dataset: EUDEM) -> None:
+        assert len(dataset) == 1
+
     def test_extracted_already(self, dataset: EUDEM) -> None:
         assert isinstance(dataset.paths, str)
         zipfile = os.path.join(dataset.paths, 'eu_dem_v11_E30N10.zip')

--- a/tests/datasets/test_eurocrops.py
+++ b/tests/datasets/test_eurocrops.py
@@ -54,6 +54,9 @@ class TestEuroCrops:
         assert isinstance(x['crs'], CRS)
         assert isinstance(x['mask'], torch.Tensor)
 
+    def test_len(self, dataset: EuroCrops) -> None:
+        assert len(dataset) == 1
+
     def test_and(self, dataset: EuroCrops) -> None:
         ds = dataset & dataset
         assert isinstance(ds, IntersectionDataset)

--- a/tests/datasets/test_iobench.py
+++ b/tests/datasets/test_iobench.py
@@ -47,6 +47,9 @@ class TestIOBench:
         assert isinstance(x['image'], torch.Tensor)
         assert isinstance(x['mask'], torch.Tensor)
 
+    def test_len(self, dataset: IOBench) -> None:
+        assert len(dataset) == 1
+
     def test_and(self, dataset: IOBench) -> None:
         ds = dataset & dataset
         assert isinstance(ds, IntersectionDataset)

--- a/tests/datasets/test_l7irish.py
+++ b/tests/datasets/test_l7irish.py
@@ -52,6 +52,9 @@ class TestL7Irish:
         assert isinstance(x['image'], torch.Tensor)
         assert isinstance(x['mask'], torch.Tensor)
 
+    def test_len(self, dataset: L7Irish) -> None:
+        assert len(dataset) == 5
+
     def test_and(self, dataset: L7Irish) -> None:
         ds = dataset & dataset
         assert isinstance(ds, IntersectionDataset)

--- a/tests/datasets/test_l8biome.py
+++ b/tests/datasets/test_l8biome.py
@@ -52,6 +52,9 @@ class TestL8Biome:
         assert isinstance(x['image'], torch.Tensor)
         assert isinstance(x['mask'], torch.Tensor)
 
+    def test_len(self, dataset: L8Biome) -> None:
+        assert len(dataset) == 5
+
     def test_and(self, dataset: L8Biome) -> None:
         ds = dataset & dataset
         assert isinstance(ds, IntersectionDataset)

--- a/tests/datasets/test_landsat.py
+++ b/tests/datasets/test_landsat.py
@@ -44,6 +44,9 @@ class TestLandsat8:
         assert isinstance(x['crs'], CRS)
         assert isinstance(x['image'], torch.Tensor)
 
+    def test_len(self, dataset: Landsat8) -> None:
+        assert len(dataset) == 1
+
     def test_and(self, dataset: Landsat8) -> None:
         ds = dataset & dataset
         assert isinstance(ds, IntersectionDataset)

--- a/tests/datasets/test_naip.py
+++ b/tests/datasets/test_naip.py
@@ -32,6 +32,9 @@ class TestNAIP:
         assert isinstance(x['crs'], CRS)
         assert isinstance(x['image'], torch.Tensor)
 
+    def test_len(self, dataset: NAIP) -> None:
+        assert len(dataset) == 2
+
     def test_and(self, dataset: NAIP) -> None:
         ds = dataset & dataset
         assert isinstance(ds, IntersectionDataset)

--- a/tests/datasets/test_nccm.py
+++ b/tests/datasets/test_nccm.py
@@ -52,6 +52,9 @@ class TestNCCM:
         assert isinstance(x['crs'], CRS)
         assert isinstance(x['mask'], torch.Tensor)
 
+    def test_len(self, dataset: NCCM) -> None:
+        assert len(dataset) == 1
+
     def test_and(self, dataset: NCCM) -> None:
         ds = dataset & dataset
         assert isinstance(ds, IntersectionDataset)

--- a/tests/datasets/test_nlcd.py
+++ b/tests/datasets/test_nlcd.py
@@ -58,6 +58,9 @@ class TestNLCD:
         assert isinstance(x['crs'], CRS)
         assert isinstance(x['mask'], torch.Tensor)
 
+    def test_len(self, dataset: NLCD) -> None:
+        assert len(dataset) == 2
+
     def test_classes(self) -> None:
         root = os.path.join('tests', 'data', 'nlcd')
         classes = list(NLCD.cmap.keys())[:5]

--- a/tests/datasets/test_openbuildings.py
+++ b/tests/datasets/test_openbuildings.py
@@ -81,6 +81,9 @@ class TestOpenBuildings:
         assert isinstance(x['crs'], CRS)
         assert isinstance(x['mask'], torch.Tensor)
 
+    def test_len(self, dataset: OpenBuildings) -> None:
+        assert len(dataset) == 1
+
     def test_and(self, dataset: OpenBuildings) -> None:
         ds = dataset & dataset
         assert isinstance(ds, IntersectionDataset)

--- a/tests/datasets/test_sentinel.py
+++ b/tests/datasets/test_sentinel.py
@@ -52,6 +52,9 @@ class TestSentinel1:
         assert isinstance(x['crs'], CRS)
         assert isinstance(x['image'], torch.Tensor)
 
+    def test_len(self, dataset: Sentinel1) -> None:
+        assert len(dataset) == 1
+
     def test_and(self, dataset: Sentinel1) -> None:
         ds = dataset & dataset
         assert isinstance(ds, IntersectionDataset)
@@ -115,6 +118,9 @@ class TestSentinel2:
         assert isinstance(x, dict)
         assert isinstance(x['crs'], CRS)
         assert isinstance(x['image'], torch.Tensor)
+
+    def test_len(self, dataset: Sentinel2) -> None:
+        assert len(dataset) == 2
 
     def test_and(self, dataset: Sentinel2) -> None:
         ds = dataset & dataset

--- a/tests/datasets/test_sentinel.py
+++ b/tests/datasets/test_sentinel.py
@@ -120,7 +120,7 @@ class TestSentinel2:
         assert isinstance(x['image'], torch.Tensor)
 
     def test_len(self, dataset: Sentinel2) -> None:
-        assert len(dataset) == 2
+        assert len(dataset) == 4
 
     def test_and(self, dataset: Sentinel2) -> None:
         ds = dataset & dataset

--- a/tests/datasets/test_south_america_soybean.py
+++ b/tests/datasets/test_south_america_soybean.py
@@ -52,6 +52,9 @@ class TestSouthAmericaSoybean:
         assert isinstance(x['crs'], CRS)
         assert isinstance(x['mask'], torch.Tensor)
 
+    def test_len(self, dataset: SouthAmericaSoybean) -> None:
+        assert len(dataset) == 2
+
     def test_and(self, dataset: SouthAmericaSoybean) -> None:
         ds = dataset & dataset
         assert isinstance(ds, IntersectionDataset)


### PR DESCRIPTION
Many of our datasets lacked any method to test the length of the dataset. Adding these tests uncovered several issues (#2086, #2087, #2089). This PR adds these tests to the remaining datasets that did not contain any bugs.