### PR TITLE
EuroSAT: fix class name

### DIFF
--- a/torchgeo/datasets/eurosat.py
+++ b/torchgeo/datasets/eurosat.py
@@ -41,7 +41,7 @@ class EuroSAT(NonGeoClassificationDataset):
     * Permanent Crop
     * Residential Buildings
     * River
-    * SeaLake
+    * Sea & Lake
 
     This dataset uses the train/val/test splits defined in the "In-domain representation
     learning for remote sensing" paper:


### PR DESCRIPTION
According to figure 2 from https://doi.org/10.1109/JSTARS.2019.2918242, the class is called "Sea & Lake"