### PR TITLE
Tutorials: remove button for Planetary Computer Hub

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -144,22 +144,6 @@ nbsphinx_prolog = """
    :class: colabbadge
    :alt: Open in Colab
    :target: {{ host }}/github/{{ repo }}/blob/{{ branch }}/{{ urlpath }}
-
-{% set host = "https://pccompute.westeurope.cloudapp.azure.com" %}
-{% set host = host ~ "/compute/hub/user-redirect/git-pull" %}
-{% set repo = "https%3A%2F%2Fgithub.com%2Fmicrosoft%2Ftorchgeo" %}
-{% set urlpath = "tree%2Ftorchgeo%2Fdocs%2F" %}
-{% set urlpath = urlpath ~ env.docname | replace("/", "%2F") ~ ".ipynb" %}
-{% if "dev" in env.config.release %}
-    {% set branch = "main" %}
-{% else %}
-    {% set branch = "releases%2Fv" ~ env.config.version %}
-{% endif %}
-
-.. image:: https://img.shields.io/badge/-Open%20on%20Planetary%20Computer-blue
-   :class: colabbadge
-   :alt: Open on Planetary Computer
-   :target: {{ host }}?repo={{ repo }}&urlpath={{ urlpath }}&branch={{ branch }}
 """
 
 # Disables requirejs in nbsphinx to enable compatibility with the pytorch_sphinx_theme


### PR DESCRIPTION
Microsoft's Planetary Computer Hub will be retired tomorrow: https://github.com/microsoft/PlanetaryComputer/discussions/347

Let's remove the button from our tutorials.

Maybe we can add a button for Lightning Studios in a separate PR?