### PR TITLE
Tutorials: add Open in Studio badge

### DIFF
--- a/docs/_static/badge-height.css
+++ b/docs/_static/badge-height.css
@@ -1,0 +1,5 @@
+/* https://github.com/pytorch/pytorch_sphinx_theme/issues/140 */
+.tutorial-badge {
+  height: 50px !important;
+  width: auto !important;
+}

--- a/docs/_static/button-width.css
+++ b/docs/_static/button-width.css
@@ -1,4 +1,4 @@
-.colabbadge {
+.badge {
   height: 50px !important;
   width: auto !important;
 }

--- a/docs/_static/button-width.css
+++ b/docs/_static/button-width.css
@@ -1,4 +1,0 @@
-.colabbadge {
-  height: 50px !important;
-  width: auto !important;
-}

--- a/docs/_static/button-width.css
+++ b/docs/_static/button-width.css
@@ -1,4 +1,4 @@
-.badge {
+.colabbadge {
   height: 50px !important;
   width: auto !important;
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -131,19 +131,32 @@ nbsphinx_execute = 'never'
 # TODO: width option of image directive is broken, see:
 # https://github.com/pytorch/pytorch_sphinx_theme/issues/140
 nbsphinx_prolog = """
-{% set host = "https://colab.research.google.com" %}
-{% set repo = "microsoft/torchgeo" %}
-{% set urlpath = "docs/" ~ env.docname ~ ".ipynb" %}
 {% if "dev" in env.config.release %}
     {% set branch = "main" %}
 {% else %}
     {% set branch = "releases/v" ~ env.config.version %}
 {% endif %}
 
-.. image:: {{ host }}/assets/colab-badge.svg
-   :class: colabbadge
+{% set host = "https://colab.research.google.com" %}
+{% set badge = host ~ "/assets/colab-badge.svg" %}
+{% set repo = "microsoft/torchgeo" %}
+{% set path = "docs/" ~ env.docname ~ ".ipynb" %}
+
+.. image:: {{ badge }}
+   :class: badge
    :alt: Open in Colab
-   :target: {{ host }}/github/{{ repo }}/blob/{{ branch }}/{{ urlpath }}
+   :target: {{ host }}/github/{{ repo }}/blob/{{ branch }}/{{ path }}
+
+{% set host = "https://lightning.ai/new" %}
+{% set badge = "https://pl-bolts-doc-images.s3.us-east-2.amazonaws.com" %}
+{% set badge = badge ~ "/app-2/studio-badge.svg" %}
+{% set repo_url = "https://github.com/" ~ repo ~ "/blob/" ~ branch ~ "/" ~ path %}
+{% set repo_url = repo_url | replace(":", "%3A") | replace("/", "%2F") %}
+
+.. image:: {{ badge }}
+   :class: badge
+   :alt: Open in Studio
+   :target: {{ host }}?repo_url={{ repo_url }}
 """
 
 # Disables requirejs in nbsphinx to enable compatibility with the pytorch_sphinx_theme

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -146,6 +146,17 @@ nbsphinx_prolog = """
    :class: colabbadge
    :alt: Open in Colab
    :target: {{ host }}/github/{{ repo }}/blob/{{ branch }}/{{ path }}
+
+{% set host = "https://lightning.ai/new" %}
+{% set badge = "https://pl-bolts-doc-images.s3.us-east-2.amazonaws.com" %}
+{% set badge = badge ~ "/app-2/studio-badge.svg" %}
+{% set repo_url = "https://github.com/" ~ repo ~ "/blob/" ~ branch ~ "/" ~ path %}
+{% set repo_url = repo_url | replace(":", "%3A") | replace("/", "%2F") %}
+
+.. image:: {{ badge }}
+   :class: colabbadge
+   :alt: Open in Studio
+   :target: {{ host }}?repo_url={{ repo_url }}
 """
 
 # Disables requirejs in nbsphinx to enable compatibility with the pytorch_sphinx_theme

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -143,7 +143,6 @@ nbsphinx_prolog = """
 {% set path = "docs/" ~ env.docname ~ ".ipynb" %}
 
 .. image:: {{ badge }}
-   :class: colabbadge
    :alt: Open in Colab
    :target: {{ host }}/github/{{ repo }}/blob/{{ branch }}/{{ path }}
 
@@ -154,7 +153,6 @@ nbsphinx_prolog = """
 {% set repo_url = repo_url | replace(":", "%3A") | replace("/", "%2F") %}
 
 .. image:: {{ badge }}
-   :class: colabbadge
    :alt: Open in Studio
    :target: {{ host }}?repo_url={{ repo_url }}
 """

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -93,7 +93,7 @@ html_theme_options = {
 html_favicon = os.path.join('..', 'logo', 'favicon.ico')
 
 html_static_path = ['_static']
-html_css_files = ['button-width.css', 'notebook-prompt.css', 'table-scroll.css']
+html_css_files = ['badge-height.css', 'notebook-prompt.css', 'table-scroll.css']
 
 # -- Extension configuration -------------------------------------------------
 
@@ -127,37 +127,8 @@ intersphinx_mapping = {
 
 # nbsphinx
 nbsphinx_execute = 'never'
-# TODO: branch/tag should change depending on which version of docs you look at
-# TODO: width option of image directive is broken, see:
-# https://github.com/pytorch/pytorch_sphinx_theme/issues/140
-nbsphinx_prolog = """
-{% if "dev" in env.config.release %}
-    {% set branch = "main" %}
-{% else %}
-    {% set branch = "releases/v" ~ env.config.version %}
-{% endif %}
-
-{% set host = "https://colab.research.google.com" %}
-{% set badge = host ~ "/assets/colab-badge.svg" %}
-{% set repo = "microsoft/torchgeo" %}
-{% set path = "docs/" ~ env.docname ~ ".ipynb" %}
-
-.. image:: {{ badge }}
-   :class: colabbadge
-   :alt: Open in Colab
-   :target: {{ host }}/github/{{ repo }}/blob/{{ branch }}/{{ path }}
-
-{% set host = "https://lightning.ai/new" %}
-{% set badge = "https://pl-bolts-doc-images.s3.us-east-2.amazonaws.com" %}
-{% set badge = badge ~ "/app-2/studio-badge.svg" %}
-{% set repo_url = "https://github.com/" ~ repo ~ "/blob/" ~ branch ~ "/" ~ path %}
-{% set repo_url = repo_url | replace(":", "%3A") | replace("/", "%2F") %}
-
-.. image:: {{ badge }}
-   :class: colabbadge
-   :alt: Open in Studio
-   :target: {{ host }}?repo_url={{ repo_url }}
-"""
+with open(os.path.join('tutorials', 'prolog.rst.jinja')) as f:
+    nbsphinx_prolog = f.read()
 
 # Disables requirejs in nbsphinx to enable compatibility with the pytorch_sphinx_theme
 # See more information here https://github.com/spatialaudio/nbsphinx/issues/599

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -146,17 +146,6 @@ nbsphinx_prolog = """
    :class: colabbadge
    :alt: Open in Colab
    :target: {{ host }}/github/{{ repo }}/blob/{{ branch }}/{{ path }}
-
-{% set host = "https://lightning.ai/new" %}
-{% set badge = "https://pl-bolts-doc-images.s3.us-east-2.amazonaws.com" %}
-{% set badge = badge ~ "/app-2/studio-badge.svg" %}
-{% set repo_url = "https://github.com/" ~ repo ~ "/blob/" ~ branch ~ "/" ~ path %}
-{% set repo_url = repo_url | replace(":", "%3A") | replace("/", "%2F") %}
-
-.. image:: {{ badge }}
-   :class: colabbadge
-   :alt: Open in Studio
-   :target: {{ host }}?repo_url={{ repo_url }}
 """
 
 # Disables requirejs in nbsphinx to enable compatibility with the pytorch_sphinx_theme

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -143,6 +143,7 @@ nbsphinx_prolog = """
 {% set path = "docs/" ~ env.docname ~ ".ipynb" %}
 
 .. image:: {{ badge }}
+   :class: colabbadge
    :alt: Open in Colab
    :target: {{ host }}/github/{{ repo }}/blob/{{ branch }}/{{ path }}
 
@@ -153,6 +154,7 @@ nbsphinx_prolog = """
 {% set repo_url = repo_url | replace(":", "%3A") | replace("/", "%2F") %}
 
 .. image:: {{ badge }}
+   :class: colabbadge
    :alt: Open in Studio
    :target: {{ host }}?repo_url={{ repo_url }}
 """

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -143,7 +143,7 @@ nbsphinx_prolog = """
 {% set path = "docs/" ~ env.docname ~ ".ipynb" %}
 
 .. image:: {{ badge }}
-   :class: badge
+   :class: colabbadge
    :alt: Open in Colab
    :target: {{ host }}/github/{{ repo }}/blob/{{ branch }}/{{ path }}
 
@@ -154,7 +154,7 @@ nbsphinx_prolog = """
 {% set repo_url = repo_url | replace(":", "%3A") | replace("/", "%2F") %}
 
 .. image:: {{ badge }}
-   :class: badge
+   :class: colabbadge
    :alt: Open in Studio
    :target: {{ host }}?repo_url={{ repo_url }}
 """

--- a/docs/tutorials/prolog.rst.jinja
+++ b/docs/tutorials/prolog.rst.jinja
@@ -1,0 +1,31 @@
+{# Macros #}
+{% macro image(badge, class, alt, target) %}
+.. image:: {{ badge }}
+   :class: {{ class }}
+   :alt: {{ alt }}
+   :target: {{ target }}
+{% endmacro %}
+
+{# Global variables #}
+{% if "dev" in env.config.release %}
+    {% set branch = "main" %}
+{% else %}
+    {% set branch = "releases/v" ~ env.config.version %}
+{% endif %}
+{% set class = "tutorial-badge" %}
+{% set path = "/microsoft/torchgeo/blob/" ~ branch ~ "/docs/" ~ env.docname ~ ".ipynb" %}
+
+{# Lightning Studio #}
+{% set badge = "https://pl-bolts-doc-images.s3.us-east-2.amazonaws.com/app-2/studio-badge.svg" %}
+{% set alt = "Open in Studio" %}
+{% set repo_url = "https://github.com" ~ path %}
+{% set target = "https://lightning.ai/new?repo_url=" ~ repo_url | urlencode %}
+
+{{ image(badge, class, alt, target) }}
+
+{# Google Colab #}
+{% set badge = "https://colab.research.google.com/assets/colab-badge.svg" %}
+{% set alt = "Open in Colab" %}
+{% set target = "https://colab.research.google.com/github" ~ path %}
+
+{{ image(badge, class, alt, target) }}


### PR DESCRIPTION
Adds a new button to our tutorials to open them in the new Lightning Studio platform.

Based on https://lightning.ai/badge.

Still need to test, but I think this code organization is more clear in my mind.