### PR TITLE
NumPy 2 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -266,7 +266,7 @@ quote-style = "single"
 skip-magic-trailing-comma = true
 
 [tool.ruff.lint]
-extend-select = ["D", "I", "UP"]
+extend-select = ["D", "I", "NPY201", "UP"]
 
 [tool.ruff.lint.per-file-ignores]
 "docs/**" = ["D"]

--- a/torchgeo/datasets/biomassters.py
+++ b/torchgeo/datasets/biomassters.py
@@ -196,7 +196,7 @@ class BioMassters(NonGeoDataset):
             target mask
         """
         with rasterio.open(os.path.join(self.root, 'train_agbm', filename), 'r') as src:
-            arr: np.typing.NDArray[np.float_] = src.read()
+            arr: np.typing.NDArray[np.float64] = src.read()
 
         target = torch.from_numpy(arr).float()
         return target

--- a/torchgeo/datasets/dfc2022.py
+++ b/torchgeo/datasets/dfc2022.py
@@ -235,7 +235,7 @@ class DFC2022(NonGeoDataset):
             the image
         """
         with rasterio.open(path) as f:
-            array: np.typing.NDArray[np.float_] = f.read(
+            array: np.typing.NDArray[np.float64] = f.read(
                 out_shape=shape, out_dtype='float32', resampling=Resampling.bilinear
             )
             tensor = torch.from_numpy(array)

--- a/torchgeo/datasets/eurocrops.py
+++ b/torchgeo/datasets/eurocrops.py
@@ -243,10 +243,12 @@ class EuroCrops(VectorDataset):
 
         fig, axs = plt.subplots(nrows=1, ncols=ncols, figsize=(4, 4))
 
-        def apply_cmap(arr: 'np.typing.NDArray[Any]') -> 'np.typing.NDArray[np.float_]':
+        def apply_cmap(
+            arr: 'np.typing.NDArray[Any]',
+        ) -> 'np.typing.NDArray[np.float64]':
             # Color 0 as black, while applying default color map for the class indices.
             cmap = plt.get_cmap('viridis')
-            im: np.typing.NDArray[np.float_] = cmap(arr / len(self.class_map))
+            im: np.typing.NDArray[np.float64] = cmap(arr / len(self.class_map))
             im[arr == 0] = 0
             return im
 


### PR DESCRIPTION
Uses ruff to upgrade TorchGeo to support NumPy 2.

We can't actually test NumPy 2 support because torchvision and lightly don't yet support NumPy 2. #2123 is stalled waiting for them to make new releases.