### PR TITLE
Update to readMe of generating testdata

### DIFF
--- a/tests/data/README.md
+++ b/tests/data/README.md
@@ -20,7 +20,7 @@ with rio.open(os.path.join(ROOT, FILENAME), "r") as src:
     dtype = src.profile["dtype"]
     Z = np.random.randint(np.iinfo(dtype).max, size=(SIZE, SIZE), dtype=dtype)
     with rio.open(FILENAME, "w", **src.profile) as dst:
-        for i in dst.profile.indexes:
+        for i in dst.indexes:
             dst.write(Z, i)
 ```
 


### PR DESCRIPTION
While generating fake rasterdata I noticed a small error in the readme that gave me an `AttributeError: 'Profile' object has no attribute 'indexes'`.