### PR TITLE
Custom raster datasets tutorial: download before super

### DIFF
--- a/docs/tutorials/custom_raster_dataset.ipynb
+++ b/docs/tutorials/custom_raster_dataset.ipynb
@@ -517,11 +517,11 @@
    "source": [
     "class Downloadable(RasterDataset):\n",
     "    def __init__(self, root, crs, res, transforms, cache, download=False):\n",
-    "        super().__init__(root, crs, res, transforms, cache)\n",
-    "\n",
     "        if download:\n",
     "            # download the dataset\n",
-    "            ..."
+    "            ...\n",
+    "\n",
+    "        super().__init__(root, crs, res, transforms, cache)"
    ]
   },
   {


### PR DESCRIPTION
The dataset has to be downloaded before you can call `super().__init__()`.