### PR TITLE
Rename bbox -> bounds

### DIFF
--- a/tests/data/western_usa_live_fuel_moisture/data.py
+++ b/tests/data/western_usa_live_fuel_moisture/data.py
@@ -172,7 +172,7 @@ STAC = {
             'type': 'text/csv',
         },
     },
-    'bbox': [-115.8855556, 42.44111111, -115.8855556, 42.44111111],
+    'geo_bbox': [-115.8855556, 42.44111111, -115.8855556, 42.44111111],
     'collection': 'su_sar_moisture_content',
     'geometry': {'coordinates': [-115.8855556, 42.44111111], 'type': 'Point'},
     'id': 'su_sar_moisture_content_0001',

--- a/tests/data/western_usa_live_fuel_moisture/data.py
+++ b/tests/data/western_usa_live_fuel_moisture/data.py
@@ -172,7 +172,7 @@ STAC = {
             'type': 'text/csv',
         },
     },
-    'bounds': [-115.8855556, 42.44111111, -115.8855556, 42.44111111],
+    'bbox': [-115.8855556, 42.44111111, -115.8855556, 42.44111111],
     'collection': 'su_sar_moisture_content',
     'geometry': {'coordinates': [-115.8855556, 42.44111111], 'type': 'Point'},
     'id': 'su_sar_moisture_content_0001',

--- a/tests/data/western_usa_live_fuel_moisture/data.py
+++ b/tests/data/western_usa_live_fuel_moisture/data.py
@@ -172,7 +172,7 @@ STAC = {
             'type': 'text/csv',
         },
     },
-    'geo_bbox': [-115.8855556, 42.44111111, -115.8855556, 42.44111111],
+    'bounds': [-115.8855556, 42.44111111, -115.8855556, 42.44111111],
     'collection': 'su_sar_moisture_content',
     'geometry': {'coordinates': [-115.8855556, 42.44111111], 'type': 'Point'},
     'id': 'su_sar_moisture_content_0001',

--- a/tests/datamodules/test_geo.py
+++ b/tests/datamodules/test_geo.py
@@ -32,7 +32,7 @@ class CustomGeoDataset(GeoDataset):
 
     def __getitem__(self, query: BoundingBox) -> dict[str, Any]:
         image = torch.arange(3 * 2 * 2).view(3, 2, 2)
-        return {'image': image, 'crs': CRS.from_epsg(4326), 'bbox': query}
+        return {'image': image, 'crs': CRS.from_epsg(4326), 'geo_bbox': query}
 
     def plot(self, *args: Any, **kwargs: Any) -> Figure:
         return plt.figure()

--- a/tests/datamodules/test_geo.py
+++ b/tests/datamodules/test_geo.py
@@ -32,7 +32,7 @@ class CustomGeoDataset(GeoDataset):
 
     def __getitem__(self, query: BoundingBox) -> dict[str, Any]:
         image = torch.arange(3 * 2 * 2).view(3, 2, 2)
-        return {'image': image, 'crs': CRS.from_epsg(4326), 'geo_bbox': query}
+        return {'image': image, 'crs': CRS.from_epsg(4326), 'bounds': query}
 
     def plot(self, *args: Any, **kwargs: Any) -> Figure:
         return plt.figure()

--- a/torchgeo/datamodules/geo.py
+++ b/torchgeo/datamodules/geo.py
@@ -353,7 +353,7 @@ class GeoDataModule(BaseDataModule):
         """
         # Non-Tensor values cannot be moved to a device
         del batch['crs']
-        del batch['geo_bbox']
+        del batch['bounds']
 
         batch = super().transfer_batch_to_device(batch, device, dataloader_idx)
         return batch

--- a/torchgeo/datamodules/geo.py
+++ b/torchgeo/datamodules/geo.py
@@ -353,7 +353,7 @@ class GeoDataModule(BaseDataModule):
         """
         # Non-Tensor values cannot be moved to a device
         del batch['crs']
-        del batch['bbox']
+        del batch['geo_bbox']
 
         batch = super().transfer_batch_to_device(batch, device, dataloader_idx)
         return batch

--- a/torchgeo/datasets/agrifieldnet.py
+++ b/torchgeo/datasets/agrifieldnet.py
@@ -221,7 +221,7 @@ class AgriFieldNet(RasterDataset):
 
         sample = {
             'crs': self.crs,
-            'bbox': query,
+            'geo_bbox': query,
             'image': image.float(),
             'mask': mask.long(),
         }

--- a/torchgeo/datasets/agrifieldnet.py
+++ b/torchgeo/datasets/agrifieldnet.py
@@ -221,7 +221,7 @@ class AgriFieldNet(RasterDataset):
 
         sample = {
             'crs': self.crs,
-            'geo_bbox': query,
+            'bounds': query,
             'image': image.float(),
             'mask': mask.long(),
         }

--- a/torchgeo/datasets/chesapeake.py
+++ b/torchgeo/datasets/chesapeake.py
@@ -607,7 +607,7 @@ class ChesapeakeCVPR(GeoDataset):
         hits = self.index.intersection(tuple(query), objects=True)
         filepaths = cast(list[dict[str, str]], [hit.object for hit in hits])
 
-        sample = {'image': [], 'mask': [], 'crs': self.crs, 'geo_bbox': query}
+        sample = {'image': [], 'mask': [], 'crs': self.crs, 'bounds': query}
 
         if len(filepaths) == 0:
             raise IndexError(

--- a/torchgeo/datasets/chesapeake.py
+++ b/torchgeo/datasets/chesapeake.py
@@ -607,7 +607,7 @@ class ChesapeakeCVPR(GeoDataset):
         hits = self.index.intersection(tuple(query), objects=True)
         filepaths = cast(list[dict[str, str]], [hit.object for hit in hits])
 
-        sample = {'image': [], 'mask': [], 'crs': self.crs, 'bbox': query}
+        sample = {'image': [], 'mask': [], 'crs': self.crs, 'geo_bbox': query}
 
         if len(filepaths) == 0:
             raise IndexError(

--- a/torchgeo/datasets/eddmaps.py
+++ b/torchgeo/datasets/eddmaps.py
@@ -100,6 +100,6 @@ class EDDMapS(GeoDataset):
                 f'query: {query} not found in index with bounds: {self.bounds}'
             )
 
-        sample = {'crs': self.crs, 'geo_bbox': bboxes}
+        sample = {'crs': self.crs, 'bounds': bboxes}
 
         return sample

--- a/torchgeo/datasets/eddmaps.py
+++ b/torchgeo/datasets/eddmaps.py
@@ -100,6 +100,6 @@ class EDDMapS(GeoDataset):
                 f'query: {query} not found in index with bounds: {self.bounds}'
             )
 
-        sample = {'crs': self.crs, 'bbox': bboxes}
+        sample = {'crs': self.crs, 'geo_bbox': bboxes}
 
         return sample

--- a/torchgeo/datasets/enviroatlas.py
+++ b/torchgeo/datasets/enviroatlas.py
@@ -347,7 +347,7 @@ class EnviroAtlas(GeoDataset):
         hits = self.index.intersection(tuple(query), objects=True)
         filepaths = cast(list[dict[str, str]], [hit.object for hit in hits])
 
-        sample = {'image': [], 'mask': [], 'crs': self.crs, 'geo_bbox': query}
+        sample = {'image': [], 'mask': [], 'crs': self.crs, 'bounds': query}
 
         if len(filepaths) == 0:
             raise IndexError(

--- a/torchgeo/datasets/enviroatlas.py
+++ b/torchgeo/datasets/enviroatlas.py
@@ -347,7 +347,7 @@ class EnviroAtlas(GeoDataset):
         hits = self.index.intersection(tuple(query), objects=True)
         filepaths = cast(list[dict[str, str]], [hit.object for hit in hits])
 
-        sample = {'image': [], 'mask': [], 'crs': self.crs, 'bbox': query}
+        sample = {'image': [], 'mask': [], 'crs': self.crs, 'geo_bbox': query}
 
         if len(filepaths) == 0:
             raise IndexError(

--- a/torchgeo/datasets/gbif.py
+++ b/torchgeo/datasets/gbif.py
@@ -137,6 +137,6 @@ class GBIF(GeoDataset):
                 f'query: {query} not found in index with bounds: {self.bounds}'
             )
 
-        sample = {'crs': self.crs, 'geo_bbox': bboxes}
+        sample = {'crs': self.crs, 'bounds': bboxes}
 
         return sample

--- a/torchgeo/datasets/gbif.py
+++ b/torchgeo/datasets/gbif.py
@@ -137,6 +137,6 @@ class GBIF(GeoDataset):
                 f'query: {query} not found in index with bounds: {self.bounds}'
             )
 
-        sample = {'crs': self.crs, 'bbox': bboxes}
+        sample = {'crs': self.crs, 'geo_bbox': bboxes}
 
         return sample

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -546,7 +546,7 @@ class RasterDataset(GeoDataset):
         else:
             data = self._merge_files(filepaths, query, self.band_indexes)
 
-        sample = {'crs': self.crs, 'bbox': query}
+        sample = {'crs': self.crs, 'geo_bbox': query}
 
         data = data.to(self.dtype)
         if self.is_image:
@@ -776,7 +776,7 @@ class VectorDataset(GeoDataset):
         masks = array_to_tensor(masks)
 
         masks = masks.to(self.dtype)
-        sample = {'mask': masks, 'crs': self.crs, 'bbox': query}
+        sample = {'mask': masks, 'crs': self.crs, 'geo_bbox': query}
 
         if self.transforms is not None:
             sample = self.transforms(sample)

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -546,7 +546,7 @@ class RasterDataset(GeoDataset):
         else:
             data = self._merge_files(filepaths, query, self.band_indexes)
 
-        sample = {'crs': self.crs, 'geo_bbox': query}
+        sample = {'crs': self.crs, 'bounds': query}
 
         data = data.to(self.dtype)
         if self.is_image:
@@ -776,7 +776,7 @@ class VectorDataset(GeoDataset):
         masks = array_to_tensor(masks)
 
         masks = masks.to(self.dtype)
-        sample = {'mask': masks, 'crs': self.crs, 'geo_bbox': query}
+        sample = {'mask': masks, 'crs': self.crs, 'bounds': query}
 
         if self.transforms is not None:
             sample = self.transforms(sample)

--- a/torchgeo/datasets/globbiomass.py
+++ b/torchgeo/datasets/globbiomass.py
@@ -207,7 +207,7 @@ class GlobBiomass(RasterDataset):
 
         mask = torch.cat((mask, std_err_mask), dim=0)
 
-        sample = {'mask': mask, 'crs': self.crs, 'bbox': query}
+        sample = {'mask': mask, 'crs': self.crs, 'geo_bbox': query}
 
         if self.transforms is not None:
             sample = self.transforms(sample)

--- a/torchgeo/datasets/globbiomass.py
+++ b/torchgeo/datasets/globbiomass.py
@@ -207,7 +207,7 @@ class GlobBiomass(RasterDataset):
 
         mask = torch.cat((mask, std_err_mask), dim=0)
 
-        sample = {'mask': mask, 'crs': self.crs, 'geo_bbox': query}
+        sample = {'mask': mask, 'crs': self.crs, 'bounds': query}
 
         if self.transforms is not None:
             sample = self.transforms(sample)

--- a/torchgeo/datasets/inaturalist.py
+++ b/torchgeo/datasets/inaturalist.py
@@ -107,6 +107,6 @@ class INaturalist(GeoDataset):
                 f'query: {query} not found in index with bounds: {self.bounds}'
             )
 
-        sample = {'crs': self.crs, 'geo_bbox': bboxes}
+        sample = {'crs': self.crs, 'bounds': bboxes}
 
         return sample

--- a/torchgeo/datasets/inaturalist.py
+++ b/torchgeo/datasets/inaturalist.py
@@ -107,6 +107,6 @@ class INaturalist(GeoDataset):
                 f'query: {query} not found in index with bounds: {self.bounds}'
             )
 
-        sample = {'crs': self.crs, 'bbox': bboxes}
+        sample = {'crs': self.crs, 'geo_bbox': bboxes}
 
         return sample

--- a/torchgeo/datasets/landcoverai.py
+++ b/torchgeo/datasets/landcoverai.py
@@ -268,7 +268,7 @@ class LandCoverAIGeo(LandCoverAIBase, RasterDataset):
         mask = self._merge_files(mask_filepaths, query, self.band_indexes)
         sample = {
             'crs': self.crs,
-            'bbox': query,
+            'geo_bbox': query,
             'image': img.float(),
             'mask': mask.long(),
         }

--- a/torchgeo/datasets/landcoverai.py
+++ b/torchgeo/datasets/landcoverai.py
@@ -268,7 +268,7 @@ class LandCoverAIGeo(LandCoverAIBase, RasterDataset):
         mask = self._merge_files(mask_filepaths, query, self.band_indexes)
         sample = {
             'crs': self.crs,
-            'geo_bbox': query,
+            'bounds': query,
             'image': img.float(),
             'mask': mask.long(),
         }

--- a/torchgeo/datasets/openbuildings.py
+++ b/torchgeo/datasets/openbuildings.py
@@ -328,7 +328,7 @@ class OpenBuildings(VectorDataset):
         else:
             masks = torch.zeros(size=(1, round(height), round(width)))
 
-        sample = {'mask': masks, 'crs': self.crs, 'bbox': query}
+        sample = {'mask': masks, 'crs': self.crs, 'geo_bbox': query}
 
         if self.transforms is not None:
             sample = self.transforms(sample)

--- a/torchgeo/datasets/openbuildings.py
+++ b/torchgeo/datasets/openbuildings.py
@@ -328,7 +328,7 @@ class OpenBuildings(VectorDataset):
         else:
             masks = torch.zeros(size=(1, round(height), round(width)))
 
-        sample = {'mask': masks, 'crs': self.crs, 'geo_bbox': query}
+        sample = {'mask': masks, 'crs': self.crs, 'bounds': query}
 
         if self.transforms is not None:
             sample = self.transforms(sample)

--- a/torchgeo/datasets/south_africa_crop_type.py
+++ b/torchgeo/datasets/south_africa_crop_type.py
@@ -228,7 +228,7 @@ class SouthAfricaCropType(RasterDataset):
 
         sample = {
             'crs': self.crs,
-            'geo_bbox': query,
+            'bounds': query,
             'image': image.float(),
             'mask': mask.long(),
         }

--- a/torchgeo/datasets/south_africa_crop_type.py
+++ b/torchgeo/datasets/south_africa_crop_type.py
@@ -228,7 +228,7 @@ class SouthAfricaCropType(RasterDataset):
 
         sample = {
             'crs': self.crs,
-            'bbox': query,
+            'geo_bbox': query,
             'image': image.float(),
             'mask': mask.long(),
         }


### PR DESCRIPTION
'bbox' in kornia augmentations is used to identify bounding boxes of instances in an image. However, in GeoDatasets, bbox refers to the geographic bounds of the data. This PR aims to make these distinct by renaming 'bbox' in GeoDatasets to 'geo_bbox'

`bounds` could also be another option.