### PR TITLE
pre-commit: avoid buggy matplotlib type hints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
           - einops>=0.6.0
           - kornia>=0.6.9
           - lightning>=2.0.9
-          - matplotlib>=3.8.1,!=3.9.0,!=3.9.1
+          - matplotlib>=3.8.1,!=3.9.1.*
           - numpy>=1.22
           - pillow>=10.4.0
           - pytest>=6.1.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
           - einops>=0.6.0
           - kornia>=0.6.9
           - lightning>=2.0.9
-          - matplotlib>=3.8.1
+          - matplotlib>=3.8.1,!=3.9.0,!=3.9.1
           - numpy>=1.22
           - pillow>=10.4.0
           - pytest>=6.1.2


### PR DESCRIPTION
The `pyplot.subplots` type hints were broken in https://github.com/matplotlib/matplotlib/pull/27001 (3.9.1) and fixed in https://github.com/matplotlib/matplotlib/pull/28518 (3.9.2, not yet released). This PR prevents pre-commit from using this bad version.