### PR TITLE
RasterDataset: support date_str containing % character

### DIFF
--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -369,6 +369,18 @@ class TestBoundingBox:
             datetime(2021, 9, 13, 17, 21, 53, 123).timestamp(),
             datetime(2021, 9, 13, 17, 21, 53, 123).timestamp(),
         ),
+        (
+            '2021-09-13%2017:21:53',
+            '%Y-%m-%d%%20%H:%M:%S',
+            datetime(2021, 9, 13, 17, 21, 53, 0).timestamp(),
+            datetime(2021, 9, 13, 17, 21, 53, 999999).timestamp(),
+        ),
+        (
+            '2021%m',
+            '%Y%%m',
+            datetime(2021, 1, 1, 0, 0, 0, 0).timestamp(),
+            datetime(2021, 12, 31, 23, 59, 59, 999999).timestamp(),
+        ),
     ],
 )
 def test_disambiguate_timestamp(

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -308,9 +308,13 @@ def disambiguate_timestamp(date_str: str, format: str) -> tuple[float, float]:
     Returns:
         (mint, maxt) tuple for indexing
     """
+    
+    format = format.replace('%%', 'TEMP_PERCENT_PLACEHOLDER')
+
     mint = datetime.strptime(date_str, format)
 
-    # TODO: This doesn't correctly handle literal `%%` characters in format
+    format = format.replace('TEMP_PERCENT_PLACEHOLDER', '%%')
+
     # TODO: May have issues with time zones, UTC vs. local time, and DST
     # TODO: This is really tedious, is there a better way to do this?
 

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -308,7 +308,6 @@ def disambiguate_timestamp(date_str: str, format: str) -> tuple[float, float]:
     Returns:
         (mint, maxt) tuple for indexing
     """
-    
     format = format.replace('%%', 'TEMP_PERCENT_PLACEHOLDER')
 
     mint = datetime.strptime(date_str, format)

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -308,11 +308,8 @@ def disambiguate_timestamp(date_str: str, format: str) -> tuple[float, float]:
     Returns:
         (mint, maxt) tuple for indexing
     """
-    format = format.replace('%%', 'TEMP_PERCENT_PLACEHOLDER')
-
     mint = datetime.strptime(date_str, format)
-
-    format = format.replace('TEMP_PERCENT_PLACEHOLDER', '%%')
+    format = format.replace('%%', '')
 
     # TODO: May have issues with time zones, UTC vs. local time, and DST
     # TODO: This is really tedious, is there a better way to do this?


### PR DESCRIPTION
A simple logic to replace %% with a placeholder string in _disambiguate_timestamp_ before parsing the date string and reverting it back afterward