### PR TITLE
mypy: even more strict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,27 +141,42 @@ exclude_lines = [
     "@overload",
 ]
 
+# https://mypy.readthedocs.io/en/stable/config_file.html
 [tool.mypy]
-python_version = "3.10"
+# Import discovery
 ignore_missing_imports = true
-show_error_codes = true
-exclude = "(build|data|dist|docs/src|images|logo|logs|output)/"
+exclude = "(build|data|dist|docs/.*|images|logo|.*logs|output|requirements)/"
 
-# Strict
-warn_unused_configs = true
+# Disallow dynamic typing (TODO: work in progress)
+disallow_any_unimported = false
+disallow_any_expr = false
+disallow_any_decorated = false
+disallow_any_explicit = false
 disallow_any_generics = true
 disallow_subclassing_any = true
+
+# Untyped definitions and calls
 disallow_untyped_calls = true
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
-check_untyped_defs = true
 disallow_untyped_decorators = true
-no_implicit_optional = true
+
+# Configuring warnings
 warn_redundant_casts = true
 warn_unused_ignores = true
+warn_no_return = true
 warn_return_any = true
-no_implicit_reexport = true
+warn_unreachable = true
+
+# Miscellaneous strictness flags
 strict_equality = true
+strict = true
+
+# Configuring error messages
+pretty = true
+
+# Miscellaneous
+warn_unused_configs = true
 
 [tool.pytest.ini_options]
 # Skip slow tests by default

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -14,7 +14,7 @@ import pathlib
 import shutil
 import subprocess
 import sys
-from collections.abc import Iterable, Iterator, Sequence
+from collections.abc import Iterable, Iterator, Sequence, Mapping
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any, TypeAlias, cast, overload
@@ -367,7 +367,7 @@ def working_dir(dirname: Path, create: bool = False) -> Iterator[None]:
         os.chdir(cwd)
 
 
-def _list_dict_to_dict_list(samples: Iterable[dict[Any, Any]]) -> dict[Any, list[Any]]:
+def _list_dict_to_dict_list(samples: Iterable[Mapping[Any, Any]]) -> dict[Any, list[Any]]:
     """Convert a list of dictionaries to a dictionary of lists.
 
     Args:
@@ -385,7 +385,7 @@ def _list_dict_to_dict_list(samples: Iterable[dict[Any, Any]]) -> dict[Any, list
     return collated
 
 
-def _dict_list_to_list_dict(sample: dict[Any, Sequence[Any]]) -> list[dict[Any, Any]]:
+def _dict_list_to_list_dict(sample: Mapping[Any, Sequence[Any]]) -> list[dict[Any, Any]]:
     """Convert a dictionary of lists to a list of dictionaries.
 
     Args:
@@ -405,7 +405,7 @@ def _dict_list_to_list_dict(sample: dict[Any, Sequence[Any]]) -> list[dict[Any, 
     return uncollated
 
 
-def stack_samples(samples: Iterable[dict[Any, Any]]) -> dict[Any, Any]:
+def stack_samples(samples: Iterable[Mapping[Any, Any]]) -> dict[Any, Any]:
     """Stack a list of samples along a new axis.
 
     Useful for forming a mini-batch of samples to pass to
@@ -426,7 +426,7 @@ def stack_samples(samples: Iterable[dict[Any, Any]]) -> dict[Any, Any]:
     return collated
 
 
-def concat_samples(samples: Iterable[dict[Any, Any]]) -> dict[Any, Any]:
+def concat_samples(samples: Iterable[Mapping[Any, Any]]) -> dict[Any, Any]:
     """Concatenate a list of samples along an existing axis.
 
     Useful for joining samples in a :class:`torchgeo.datasets.IntersectionDataset`.
@@ -448,7 +448,7 @@ def concat_samples(samples: Iterable[dict[Any, Any]]) -> dict[Any, Any]:
     return collated
 
 
-def merge_samples(samples: Iterable[dict[Any, Any]]) -> dict[Any, Any]:
+def merge_samples(samples: Iterable[Mapping[Any, Any]]) -> dict[Any, Any]:
     """Merge a list of samples.
 
     Useful for joining samples in a :class:`torchgeo.datasets.UnionDataset`.
@@ -473,7 +473,7 @@ def merge_samples(samples: Iterable[dict[Any, Any]]) -> dict[Any, Any]:
     return collated
 
 
-def unbind_samples(sample: dict[Any, Sequence[Any]]) -> list[dict[Any, Any]]:
+def unbind_samples(sample: Mapping[Any, Sequence[Any]]) -> list[dict[Any, Any]]:
     """Reverse of :func:`stack_samples`.
 
     Useful for turning a mini-batch of samples into a list of samples. These individual

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -14,7 +14,7 @@ import pathlib
 import shutil
 import subprocess
 import sys
-from collections.abc import Iterable, Iterator, Sequence, Mapping
+from collections.abc import Iterable, Iterator, Mapping, MutableMapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any, TypeAlias, cast, overload
@@ -367,7 +367,9 @@ def working_dir(dirname: Path, create: bool = False) -> Iterator[None]:
         os.chdir(cwd)
 
 
-def _list_dict_to_dict_list(samples: Iterable[Mapping[Any, Any]]) -> dict[Any, list[Any]]:
+def _list_dict_to_dict_list(
+    samples: Iterable[Mapping[Any, Any]],
+) -> dict[Any, list[Any]]:
     """Convert a list of dictionaries to a dictionary of lists.
 
     Args:
@@ -385,7 +387,9 @@ def _list_dict_to_dict_list(samples: Iterable[Mapping[Any, Any]]) -> dict[Any, l
     return collated
 
 
-def _dict_list_to_list_dict(sample: Mapping[Any, Sequence[Any]]) -> list[dict[Any, Any]]:
+def _dict_list_to_list_dict(
+    sample: Mapping[Any, Sequence[Any]],
+) -> list[dict[Any, Any]]:
     """Convert a dictionary of lists to a list of dictionaries.
 
     Args:
@@ -473,7 +477,7 @@ def merge_samples(samples: Iterable[Mapping[Any, Any]]) -> dict[Any, Any]:
     return collated
 
 
-def unbind_samples(sample: Mapping[Any, Sequence[Any]]) -> list[dict[Any, Any]]:
+def unbind_samples(sample: MutableMapping[Any, Any]) -> list[dict[Any, Any]]:
     """Reverse of :func:`stack_samples`.
 
     Useful for turning a mini-batch of samples into a list of samples. These individual

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -14,10 +14,10 @@ import pathlib
 import shutil
 import subprocess
 import sys
-from collections.abc import Iterable, Iterator, Mapping, Sequence
+from collections.abc import Iterable, Iterator, Sequence, Mapping
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Any, TypeAlias, TypeVar, cast, overload
+from typing import Any, TypeAlias, cast, overload
 
 import numpy as np
 import rasterio
@@ -43,8 +43,6 @@ __all__ = (
 
 
 Path: TypeAlias = str | pathlib.Path
-K = TypeVar('K')
-V = TypeVar('V')
 
 
 @dataclass(frozen=True)
@@ -369,7 +367,7 @@ def working_dir(dirname: Path, create: bool = False) -> Iterator[None]:
         os.chdir(cwd)
 
 
-def _list_dict_to_dict_list(samples: Iterable[Mapping[K, V]]) -> dict[K, list[V]]:
+def _list_dict_to_dict_list(samples: Iterable[Mapping[Any, Any]]) -> dict[Any, list[Any]]:
     """Convert a list of dictionaries to a dictionary of lists.
 
     Args:
@@ -387,7 +385,7 @@ def _list_dict_to_dict_list(samples: Iterable[Mapping[K, V]]) -> dict[K, list[V]
     return collated
 
 
-def _dict_list_to_list_dict(sample: Mapping[K, Sequence[V]]) -> list[dict[K, V]]:
+def _dict_list_to_list_dict(sample: Mapping[Any, Sequence[Any]]) -> list[dict[Any, Any]]:
     """Convert a dictionary of lists to a list of dictionaries.
 
     Args:
@@ -398,14 +396,16 @@ def _dict_list_to_list_dict(sample: Mapping[K, Sequence[V]]) -> list[dict[K, V]]
 
     .. versionadded:: 0.2
     """
-    uncollated: list[dict[K, V]] = [{} for _ in range(max(map(len, sample.values())))]
+    uncollated: list[dict[Any, Any]] = [
+        {} for _ in range(max(map(len, sample.values())))
+    ]
     for key, values in sample.items():
         for i, value in enumerate(values):
             uncollated[i][key] = value
     return uncollated
 
 
-def stack_samples(samples: Iterable[Mapping[K, V]]) -> dict[K, V]:
+def stack_samples(samples: Iterable[Mapping[Any, Any]]) -> dict[Any, Any]:
     """Stack a list of samples along a new axis.
 
     Useful for forming a mini-batch of samples to pass to
@@ -419,14 +419,14 @@ def stack_samples(samples: Iterable[Mapping[K, V]]) -> dict[K, V]:
 
     .. versionadded:: 0.2
     """
-    collated: dict[K, V] = _list_dict_to_dict_list(samples)
+    collated: dict[Any, Any] = _list_dict_to_dict_list(samples)
     for key, value in collated.items():
         if isinstance(value[0], Tensor):
             collated[key] = torch.stack(value)
     return collated
 
 
-def concat_samples(samples: Iterable[Mapping[K, V]]) -> dict[K, V]:
+def concat_samples(samples: Iterable[Mapping[Any, Any]]) -> dict[Any, Any]:
     """Concatenate a list of samples along an existing axis.
 
     Useful for joining samples in a :class:`torchgeo.datasets.IntersectionDataset`.
@@ -439,7 +439,7 @@ def concat_samples(samples: Iterable[Mapping[K, V]]) -> dict[K, V]:
 
     .. versionadded:: 0.2
     """
-    collated: dict[K, V] = _list_dict_to_dict_list(samples)
+    collated: dict[Any, Any] = _list_dict_to_dict_list(samples)
     for key, value in collated.items():
         if isinstance(value[0], Tensor):
             collated[key] = torch.cat(value)
@@ -448,7 +448,7 @@ def concat_samples(samples: Iterable[Mapping[K, V]]) -> dict[K, V]:
     return collated
 
 
-def merge_samples(samples: Iterable[Mapping[K, V]]) -> dict[K, V]:
+def merge_samples(samples: Iterable[Mapping[Any, Any]]) -> dict[Any, Any]:
     """Merge a list of samples.
 
     Useful for joining samples in a :class:`torchgeo.datasets.UnionDataset`.
@@ -461,7 +461,7 @@ def merge_samples(samples: Iterable[Mapping[K, V]]) -> dict[K, V]:
 
     .. versionadded:: 0.2
     """
-    collated: dict[K, V] = {}
+    collated: dict[Any, Any] = {}
     for sample in samples:
         for key, value in sample.items():
             if key in collated and isinstance(value, Tensor):
@@ -473,7 +473,7 @@ def merge_samples(samples: Iterable[Mapping[K, V]]) -> dict[K, V]:
     return collated
 
 
-def unbind_samples(sample: Mapping[K, Sequence[V] | Tensor]) -> list[dict[K, V]]:
+def unbind_samples(sample: Mapping[Any, Sequence[Any]]) -> list[dict[Any, Any]]:
     """Reverse of :func:`stack_samples`.
 
     Useful for turning a mini-batch of samples into a list of samples. These individual

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -14,10 +14,10 @@ import pathlib
 import shutil
 import subprocess
 import sys
-from collections.abc import Iterable, Iterator, Sequence, Mapping
+from collections.abc import Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Any, TypeAlias, cast, overload
+from typing import Any, TypeAlias, TypeVar, cast, overload
 
 import numpy as np
 import rasterio
@@ -43,6 +43,8 @@ __all__ = (
 
 
 Path: TypeAlias = str | pathlib.Path
+K = TypeVar('K')
+V = TypeVar('V')
 
 
 @dataclass(frozen=True)
@@ -367,7 +369,7 @@ def working_dir(dirname: Path, create: bool = False) -> Iterator[None]:
         os.chdir(cwd)
 
 
-def _list_dict_to_dict_list(samples: Iterable[Mapping[Any, Any]]) -> dict[Any, list[Any]]:
+def _list_dict_to_dict_list(samples: Iterable[Mapping[K, V]]) -> dict[K, list[V]]:
     """Convert a list of dictionaries to a dictionary of lists.
 
     Args:
@@ -385,7 +387,7 @@ def _list_dict_to_dict_list(samples: Iterable[Mapping[Any, Any]]) -> dict[Any, l
     return collated
 
 
-def _dict_list_to_list_dict(sample: Mapping[Any, Sequence[Any]]) -> list[dict[Any, Any]]:
+def _dict_list_to_list_dict(sample: Mapping[K, Sequence[V]]) -> list[dict[K, V]]:
     """Convert a dictionary of lists to a list of dictionaries.
 
     Args:
@@ -396,16 +398,14 @@ def _dict_list_to_list_dict(sample: Mapping[Any, Sequence[Any]]) -> list[dict[An
 
     .. versionadded:: 0.2
     """
-    uncollated: list[dict[Any, Any]] = [
-        {} for _ in range(max(map(len, sample.values())))
-    ]
+    uncollated: list[dict[K, V]] = [{} for _ in range(max(map(len, sample.values())))]
     for key, values in sample.items():
         for i, value in enumerate(values):
             uncollated[i][key] = value
     return uncollated
 
 
-def stack_samples(samples: Iterable[Mapping[Any, Any]]) -> dict[Any, Any]:
+def stack_samples(samples: Iterable[Mapping[K, V]]) -> dict[K, V]:
     """Stack a list of samples along a new axis.
 
     Useful for forming a mini-batch of samples to pass to
@@ -419,14 +419,14 @@ def stack_samples(samples: Iterable[Mapping[Any, Any]]) -> dict[Any, Any]:
 
     .. versionadded:: 0.2
     """
-    collated: dict[Any, Any] = _list_dict_to_dict_list(samples)
+    collated: dict[K, V] = _list_dict_to_dict_list(samples)
     for key, value in collated.items():
         if isinstance(value[0], Tensor):
             collated[key] = torch.stack(value)
     return collated
 
 
-def concat_samples(samples: Iterable[Mapping[Any, Any]]) -> dict[Any, Any]:
+def concat_samples(samples: Iterable[Mapping[K, V]]) -> dict[K, V]:
     """Concatenate a list of samples along an existing axis.
 
     Useful for joining samples in a :class:`torchgeo.datasets.IntersectionDataset`.
@@ -439,7 +439,7 @@ def concat_samples(samples: Iterable[Mapping[Any, Any]]) -> dict[Any, Any]:
 
     .. versionadded:: 0.2
     """
-    collated: dict[Any, Any] = _list_dict_to_dict_list(samples)
+    collated: dict[K, V] = _list_dict_to_dict_list(samples)
     for key, value in collated.items():
         if isinstance(value[0], Tensor):
             collated[key] = torch.cat(value)
@@ -448,7 +448,7 @@ def concat_samples(samples: Iterable[Mapping[Any, Any]]) -> dict[Any, Any]:
     return collated
 
 
-def merge_samples(samples: Iterable[Mapping[Any, Any]]) -> dict[Any, Any]:
+def merge_samples(samples: Iterable[Mapping[K, V]]) -> dict[K, V]:
     """Merge a list of samples.
 
     Useful for joining samples in a :class:`torchgeo.datasets.UnionDataset`.
@@ -461,7 +461,7 @@ def merge_samples(samples: Iterable[Mapping[Any, Any]]) -> dict[Any, Any]:
 
     .. versionadded:: 0.2
     """
-    collated: dict[Any, Any] = {}
+    collated: dict[K, V] = {}
     for sample in samples:
         for key, value in sample.items():
             if key in collated and isinstance(value, Tensor):
@@ -473,7 +473,7 @@ def merge_samples(samples: Iterable[Mapping[Any, Any]]) -> dict[Any, Any]:
     return collated
 
 
-def unbind_samples(sample: Mapping[Any, Sequence[Any]]) -> list[dict[Any, Any]]:
+def unbind_samples(sample: Mapping[K, Sequence[V] | Tensor]) -> list[dict[K, V]]:
     """Reverse of :func:`stack_samples`.
 
     Useful for turning a mini-batch of samples into a list of samples. These individual

--- a/torchgeo/transforms/transforms.py
+++ b/torchgeo/transforms/transforms.py
@@ -99,7 +99,7 @@ class AugmentationSequential(Module):
 
         # Convert boxes to default [N, 4]
         if 'boxes' in batch:
-            batch['boxes'] = Boxes(batch['boxes']).to_tensor(mode='xyxy')  # type:ignore[assignment]
+            batch['boxes'] = Boxes(batch['boxes']).to_tensor(mode='xyxy')
 
         # Torchmetrics does not support masks with a channel dimension
         if 'mask' in batch and batch['mask'].shape[1] == 1:

--- a/torchgeo/transforms/transforms.py
+++ b/torchgeo/transforms/transforms.py
@@ -55,7 +55,7 @@ class AugmentationSequential(Module):
 
         self.augs = K.AugmentationSequential(*args, data_keys=keys, **kwargs)  # type: ignore[arg-type]
 
-    def forward(self, batch: dict[str, Tensor]) -> dict[str, Tensor]:
+    def forward(self, batch: dict[str, Any]) -> dict[str, Any]:
         """Perform augmentations and update data dict.
 
         Args:


### PR DESCRIPTION
Adds additional checks like `warn_unreachable` that revealed new bugs. And fixes those bugs!

I also played around with generics like:
```python
from typing import TypeVar

K = TypeVar('K')
V = TypeVar('V')

# replace all dict[Any, Any] with dict[K, V]
```
but ran into too many issues and gave up. Maybe another day.