### PR TITLE
Samplers: avoid computing intersection multiple times

### DIFF
--- a/torchgeo/samplers/batch.py
+++ b/torchgeo/samplers/batch.py
@@ -32,18 +32,9 @@ class BatchGeoSampler(Sampler[list[BoundingBox]], abc.ABC):
             roi: region of interest to sample from (minx, maxx, miny, maxy, mint, maxt)
                 (defaults to the bounds of ``dataset.index``)
         """
-        if roi is None:
-            self.index = dataset.index
-            roi = BoundingBox(*self.index.bounds)
-        else:
-            self.index = Index(interleaved=False, properties=Property(dimension=3))
-            hits = dataset.index.intersection(tuple(roi), objects=True)
-            for hit in hits:
-                bbox = BoundingBox(*hit.bounds) & roi
-                self.index.insert(hit.id, tuple(bbox), hit.object)
-
+        self.index = dataset.index
         self.res = dataset.res
-        self.roi = roi
+        self.roi = roi or BoundingBox(*self.index.bounds)
 
     @abc.abstractmethod
     def __iter__(self) -> Iterator[list[BoundingBox]]:

--- a/torchgeo/samplers/batch.py
+++ b/torchgeo/samplers/batch.py
@@ -99,18 +99,18 @@ class RandomBatchGeoSampler(BatchGeoSampler):
         self.hits = []
         areas = []
         for hit in self.index.intersection(tuple(self.roi), objects=True):
-            bounds = BoundingBox(*hit.bounds)
+            hit.bounds = BoundingBox(*hit.bounds) & self.roi
             if (
-                bounds.maxx - bounds.minx >= self.size[1]
-                and bounds.maxy - bounds.miny >= self.size[0]
+                hit.bounds.maxx - hit.bounds.minx >= self.size[1]
+                and hit.bounds.maxy - hit.bounds.miny >= self.size[0]
             ):
-                if bounds.area > 0:
-                    rows, cols = tile_to_chips(bounds, self.size)
+                if hit.bounds.area > 0:
+                    rows, cols = tile_to_chips(hit.bounds, self.size)
                     self.length += rows * cols
                 else:
                     self.length += 1
                 self.hits.append(hit)
-                areas.append(bounds.area)
+                areas.append(hit.bounds.area)
         if length is not None:
             self.length = length
 

--- a/torchgeo/samplers/batch.py
+++ b/torchgeo/samplers/batch.py
@@ -7,7 +7,6 @@ import abc
 from collections.abc import Iterator
 
 import torch
-from rtree.index import Index, Property
 from torch.utils.data import Sampler
 
 from ..datasets import BoundingBox, GeoDataset

--- a/torchgeo/samplers/single.py
+++ b/torchgeo/samplers/single.py
@@ -99,18 +99,18 @@ class RandomGeoSampler(GeoSampler):
         self.hits = []
         areas = []
         for hit in self.index.intersection(tuple(self.roi), objects=True):
-            bounds = BoundingBox(*hit.bounds)
+            hit.bounds = BoundingBox(*hit.bounds) & self.roi
             if (
-                bounds.maxx - bounds.minx >= self.size[1]
-                and bounds.maxy - bounds.miny >= self.size[0]
+                hit.bounds.maxx - hit.bounds.minx >= self.size[1]
+                and hit.bounds.maxy - hit.bounds.miny >= self.size[0]
             ):
-                if bounds.area > 0:
-                    rows, cols = tile_to_chips(bounds, self.size)
+                if hit.bounds.area > 0:
+                    rows, cols = tile_to_chips(hit.bounds, self.size)
                     self.length += rows * cols
                 else:
                     self.length += 1
                 self.hits.append(hit)
-                areas.append(bounds.area)
+                areas.append(hit.bounds.area)
         if length is not None:
             self.length = length
 
@@ -196,20 +196,17 @@ class GridGeoSampler(GeoSampler):
             self.size = (self.size[0] * self.res, self.size[1] * self.res)
             self.stride = (self.stride[0] * self.res, self.stride[1] * self.res)
 
+        self.length = 0
         self.hits = []
         for hit in self.index.intersection(tuple(self.roi), objects=True):
-            bounds = BoundingBox(*hit.bounds)
+            hit.bounds = BoundingBox(*hit.bounds) & self.roi
             if (
-                bounds.maxx - bounds.minx >= self.size[1]
-                and bounds.maxy - bounds.miny >= self.size[0]
+                hit.bounds.maxx - hit.bounds.minx >= self.size[1]
+                and hit.bounds.maxy - hit.bounds.miny >= self.size[0]
             ):
                 self.hits.append(hit)
-
-        self.length = 0
-        for hit in self.hits:
-            bounds = BoundingBox(*hit.bounds)
-            rows, cols = tile_to_chips(bounds, self.size, self.stride)
-            self.length += rows * cols
+                rows, cols = tile_to_chips(hit.bounds, self.size, self.stride)
+                self.length += rows * cols
 
     def __iter__(self) -> Iterator[BoundingBox]:
         """Return the index of a dataset.
@@ -277,6 +274,7 @@ class PreChippedGeoSampler(GeoSampler):
 
         self.hits = []
         for hit in self.index.intersection(tuple(self.roi), objects=True):
+            hit.bounds = BoundingBox(*hit.bounds) & self.roi
             self.hits.append(hit)
 
     def __iter__(self) -> Iterator[BoundingBox]:

--- a/torchgeo/samplers/single.py
+++ b/torchgeo/samplers/single.py
@@ -32,18 +32,9 @@ class GeoSampler(Sampler[BoundingBox], abc.ABC):
             roi: region of interest to sample from (minx, maxx, miny, maxy, mint, maxt)
                 (defaults to the bounds of ``dataset.index``)
         """
-        if roi is None:
-            self.index = dataset.index
-            roi = BoundingBox(*self.index.bounds)
-        else:
-            self.index = Index(interleaved=False, properties=Property(dimension=3))
-            hits = dataset.index.intersection(tuple(roi), objects=True)
-            for hit in hits:
-                bbox = BoundingBox(*hit.bounds) & roi
-                self.index.insert(hit.id, tuple(bbox), hit.object)
-
+        self.index = dataset.index
         self.res = dataset.res
-        self.roi = roi
+        self.roi = roi or BoundingBox(*self.index.bounds)
 
     @abc.abstractmethod
     def __iter__(self) -> Iterator[BoundingBox]:

--- a/torchgeo/samplers/single.py
+++ b/torchgeo/samplers/single.py
@@ -7,7 +7,6 @@ import abc
 from collections.abc import Callable, Iterable, Iterator
 
 import torch
-from rtree.index import Index, Property
 from torch.utils.data import Sampler
 
 from ..datasets import BoundingBox, GeoDataset


### PR DESCRIPTION
This should theoretically double the speed of sampler initialization when an `roi` is passed.

Closes #537 @Modexus, sorry I didn't get to this earlier.