### PR TITLE
GeoDataset: allow a mix of str and pathlib paths

### DIFF
--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -205,6 +205,14 @@ class TestGeoDataset:
             CustomGeoDataset(paths=paths1).files == CustomGeoDataset(paths=paths2).files
         )
 
+    def test_files_property_mix_str_and_pathlib(self, tmp_path: Path) -> None:
+        foo = tmp_path / 'foo.txt'
+        bar = tmp_path / 'bar.txt'
+        foo.touch()
+        bar.touch()
+        ds = CustomGeoDataset(paths=[str(foo), bar])
+        assert ds.files == [str(bar), str(foo)]
+
 
 class TestRasterDataset:
     naip_dir = os.path.join('tests', 'data', 'naip')

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -306,7 +306,7 @@ class GeoDataset(Dataset[dict[str, Any]], abc.ABC):
             paths = self.paths
 
         # Using set to remove any duplicates if directories are overlapping
-        files: set[Path] = set()
+        files: set[str] = set()
         for path in paths:
             if os.path.isdir(path):
                 pathname = os.path.join(path, '**', self.filename_glob)
@@ -314,7 +314,7 @@ class GeoDataset(Dataset[dict[str, Any]], abc.ABC):
             elif (os.path.isfile(path) or path_is_vsi(path)) and fnmatch.fnmatch(
                 str(path), f'*{self.filename_glob}'
             ):
-                files.add(path)
+                files.add(str(path))
             elif not hasattr(self, 'download'):
                 warnings.warn(
                     f"Could not find any relevant files for provided path '{path}'. "
@@ -323,7 +323,7 @@ class GeoDataset(Dataset[dict[str, Any]], abc.ABC):
                 )
 
         # Sort the output to enforce deterministic behavior.
-        return sorted(map(str, files))
+        return sorted(files)
 
 
 class RasterDataset(GeoDataset):

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -323,7 +323,7 @@ class GeoDataset(Dataset[dict[str, Any]], abc.ABC):
                 )
 
         # Sort the output to enforce deterministic behavior.
-        return sorted(files)
+        return sorted(map(str, files))
 
 
 class RasterDataset(GeoDataset):

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -291,7 +291,7 @@ class GeoDataset(Dataset[dict[str, Any]], abc.ABC):
         self._res = new_res
 
     @property
-    def files(self) -> list[Path]:
+    def files(self) -> list[str]:
         """A list of all files in the dataset.
 
         Returns:


### PR DESCRIPTION
Currently, if a user passes in both str and pathlib.Path paths, GeoDataset crashes:
```
        # Sort the output to enforce deterministic behavior.
>       return sorted(files)
E       TypeError: '<' not supported between instances of 'PosixPath' and 'str'
```
The easiest solution is to convert all values to the same type for easy comparison. This also prevents duplicates, since:
```pycon
>>> import os
>>> import pathlib
>>> x = "foo/bar"
>>> y = pathlib.Path("foo/bar")
>>> x == y
False
```

FYI @pioneerHitesh @adriantre