### PR TITLE
pytest: set default --cov, --cov-report

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -46,7 +46,7 @@ jobs:
         run: pip list
       - name: Run pytest checks
         run: |
-          pytest --cov=torchgeo --cov-report=xml --durations=10
+          pytest --cov --cov-report=xml
           python3 -m torchgeo --help
       - name: Report coverage
         uses: codecov/codecov-action@v4.5.0
@@ -81,7 +81,7 @@ jobs:
         run: pip list
       - name: Run pytest checks
         run: |
-          pytest --cov=torchgeo --cov-report=xml --durations=10
+          pytest --cov --cov-report=xml
           python3 -m torchgeo --help
       - name: Report coverage
         uses: codecov/codecov-action@v4.5.0
@@ -114,7 +114,7 @@ jobs:
         run: pip list
       - name: Run pytest checks
         run: |
-          pytest --cov=torchgeo --cov-report=xml --durations=10
+          pytest --cov --cov-report=xml
           python3 -m torchgeo --help
       - name: Report coverage
         uses: codecov/codecov-action@v4.5.0

--- a/docs/user/contributing.rst
+++ b/docs/user/contributing.rst
@@ -56,7 +56,7 @@ For example, if you add a new dataset in ``torchgeo/datasets/foo.py``, you'll ne
 
 .. code-block:: console
 
-   $ pytest --cov=torchgeo/datasets --cov-report=term-missing tests/datasets/test_foo.py
+   $ pytest --cov=torchgeo.datasets.foo tests/datasets/test_foo.py
    ========================= test session starts =========================
    platform darwin -- Python 3.10.11, pytest-6.2.4, py-1.9.0, pluggy-0.13.0
    rootdir: ~/torchgeo, configfile: pyproject.toml
@@ -65,14 +65,12 @@ For example, if you add a new dataset in ``torchgeo/datasets/foo.py``, you'll ne
 
    tests/datasets/test_foo.py .......                              [100%]
 
-   ---------- coverage: platform darwin, python 3.10.11-final-0 -----------
+   --------- coverage: platform darwin, python 3.10.11-final-0 -----------
    Name                                      Stmts   Miss  Cover   Missing
    -----------------------------------------------------------------------
-   torchgeo/datasets/__init__.py                26      0   100%
    torchgeo/datasets/foo.py                    177     62    65%   376-403, 429-496, 504-509
-   ...
    -----------------------------------------------------------------------
-   TOTAL                                      1709    920    46%
+   TOTAL                                       177     62    65%
 
    ========================== 7 passed in 6.20s ==========================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,10 @@ Documentation = "https://torchgeo.readthedocs.io"
 exclude_also = [
     "@overload",
 ]
+show_missing = true
+
+[tool.coverage.run]
+source = ["torchgeo"]
 
 # https://mypy.readthedocs.io/en/stable/config_file.html
 [tool.mypy]


### PR DESCRIPTION
With this, you can now use `pytest --cov` and pytest will automatically know you want coverage specifically for `--cov=torchgeo` and `--cov-report=term-missing`. This can also easily be overridden on the command line:
```console
> pytest --cov=torchgeo.datasets.foo --cov-report=xml
```
I haven't yet found a way to enable coverage by default (without needing `--cov`) in a way that can also be overridden on the command line, but I'm pretty happy with this for now.

P.S. I also removed the 10 slowest tests reports, as we don't really pay any attention to these.