### PR TITLE
pytest: measure branch coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,9 @@ exclude_also = [
     "@overload",
 ]
 
+[tool.coverage.run]
+branch = true
+
 # https://mypy.readthedocs.io/en/stable/config_file.html
 [tool.mypy]
 # Import discovery


### PR DESCRIPTION
By default, `coverage` only reports which lines were executed during unit testing. By enabling branch coverage, we can also see whether if-statements are tested for both True and False conditions.

Reference: https://coverage.readthedocs.io/en/latest/branch.html

This is a WIP until we get 100% coverage. If anyone would be interested in contributing to this, it would be a great first issue.