### PR TITLE
Dependabot: only update npm lockfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,3 +33,4 @@ updates:
     directory: "/requirements"
     schedule:
       interval: "weekly"
+    versioning-strategy: "lockfile-only"

--- a/requirements/package.json
+++ b/requirements/package.json
@@ -2,6 +2,6 @@
   "name": "torchgeo",
   "private": "true",
   "dependencies": {
-    "prettier": ">=3.3.3"
+    "prettier": ">=3"
   }
 }


### PR DESCRIPTION
Previously, dependabot would update both `package.json` (equivalent of `pyproject.toml`) and `package-lock.json` (equivalent of `requirements/style.txt`). Now it will only update the latter.

@Domejko