### PR TITLE
Prettier: ignore cache directories

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,7 @@
-# Ignore artifacts:
+# Ignore artifacts
 tests/data/*/**
+
+# Automatically igored by git, but not by prettier
+.mypy_cache
+.pytest_cache
+.ruff_cache


### PR DESCRIPTION
By default, prettier ignores everything in the root `.gitignore`. However, many of our tools create their own hidden directories with a `.gitignore` inside that prettier does not recognize. This PR adds those to the ignore, speeding up writing (`.ruff_cache` in particular was slowing things down).

@Domejko