### PR TITLE
Docs: installation-agnostic prettier usage

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -83,7 +83,7 @@ jobs:
       - name: List npm dependencies
         run: npm ls --all
       - name: Run prettier formatting
-        run: npx prettier . --check
+        run: npx prettier --check .
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.head.label || github.head_ref || github.ref }}
   cancel-in-progress: true

--- a/docs/user/contributing.rst
+++ b/docs/user/contributing.rst
@@ -111,21 +111,11 @@ Mypy won't fix your code for you, but will warn you about potential issues with 
 
 If you've never used mypy before or aren't familiar with `Python type hints <https://docs.python.org/3/library/typing.html>`_, this check can be particularly daunting. Don't hesitate to ask for help with resolving any of these warnings on your pull request.
 
-Prettier is a code formatter that helps to ensure consistent code style across a project. It supports various languages. Follow these steps to install Prettier:
-
-1. Install Node.js: Prettier is a Node.js module, so you need to have Node.js installed on your system. You can download and install Node.js from the `Node.js official website <https://nodejs.org/en>`_.
-2. Install Prettier: Use the following command to install the Prettier module in your project:
+Prettier is a code formatter that helps to ensure consistent code style across a project. It supports various languages.
 
 .. code-block:: console
 
-   $ npm install prettier --no-save
-
-
-3. Run Prettier: Use the following command to run Prettier formating:
-
-.. code-block:: console
-
-   $ npx prettier . --write
+   $ prettier --write .
 
 
 You can also use `git pre-commit hooks <https://pre-commit.com/>`_ to automatically run these checks before each commit. pre-commit is a tool that automatically runs linters locally, so that you don't have to remember to run them manually and then have your code flagged by CI. You can set up pre-commit with:


### PR DESCRIPTION
We shouldn't specify how users should install prettier, they can use any node package manager they want. We already have a link to the prettier docs, which explain the many different ways to install prettier.

I also prefer to specify flags (`--write`) before directories (`.`).

@Domejko