### PR TITLE
pytest: silence numpy 2 warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -247,6 +247,7 @@ filterwarnings = [
     "ignore:You are using `torch.load` with `weights_only=False`:FutureWarning",
     # https://github.com/pytorch/pytorch/issues/136264
     "ignore:__array__ implementation doesn't accept a copy keyword:DeprecationWarning",
+    "ignore:__array_wrap__ must accept context and return_scalar arguments:DeprecationWarning",
 
     # Expected warnings
     # Lightning warns us about using num_workers=0, but it's faster on macOS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -245,6 +245,8 @@ filterwarnings = [
     "ignore:torch.is_autocast_cpu_enabled\\(\\) is deprecated.:DeprecationWarning:kornia.utils.helpers",
     # https://github.com/pytorch/pytorch/pull/129239
     "ignore:You are using `torch.load` with `weights_only=False`:FutureWarning",
+    # https://github.com/pytorch/pytorch/issues/136264
+    "ignore:__array__ implementation doesn't accept a copy keyword:DeprecationWarning",
 
     # Expected warnings
     # Lightning warns us about using num_workers=0, but it's faster on macOS


### PR DESCRIPTION
PyTorch's `__array__` implementation is not fully compatible with NumPy 2's `__array__` implementation, leading to some warning messages. I reported this issue to PyTorch. Let's let them decide the right way to handle this.

* https://github.com/pytorch/pytorch/issues/136264