### PR TITLE
RasterDataset SITS support

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,6 +30,7 @@ torchgeo
 
    tutorials/getting_started
    tutorials/custom_raster_dataset
+   tutorials/sits_dataset
    tutorials/transforms
    tutorials/indices
    tutorials/trainers

--- a/tests/conf/landcoverai100.yaml
+++ b/tests/conf/landcoverai100.yaml
@@ -1,9 +1,9 @@
 model:
   class_path: SemanticSegmentationTask
   init_args:
-    loss: "ce"
-    model: "unet"
-    backbone: "resnet18"
+    loss: 'ce'
+    model: 'unet'
+    backbone: 'resnet18'
     in_channels: 3
     num_classes: 5
     num_filters: 1
@@ -13,4 +13,4 @@ data:
   init_args:
     batch_size: 1
   dict_kwargs:
-    root: "tests/data/landcoverai"
+    root: 'tests/data/landcoverai'

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -97,6 +97,9 @@ class GeoDataset(Dataset[dict[str, Any]], abc.ABC):
     #: a different file format than what it was originally downloaded as.
     filename_glob = '*'
 
+    # Whether to return the dataset as a Timeseries, this will add another dimension to the dataset
+    return_as_ts = False
+
     # NOTE: according to the Python docs:
     #
     # * https://docs.python.org/3/library/exceptions.html#NotImplementedError
@@ -982,6 +985,7 @@ class IntersectionDataset(GeoDataset):
             if not isinstance(ds, GeoDataset):
                 raise ValueError('IntersectionDataset only supports GeoDatasets')
 
+        self.return_as_ts = dataset1.return_as_ts or dataset2.return_as_ts
         self.crs = dataset1.crs
         self.res = dataset1.res
 
@@ -1142,6 +1146,7 @@ class UnionDataset(GeoDataset):
             if not isinstance(ds, GeoDataset):
                 raise ValueError('UnionDataset only supports GeoDatasets')
 
+        self.return_as_ts = dataset1.return_as_ts and dataset2.return_as_ts
         self.crs = dataset1.crs
         self.res = dataset1.res
 

--- a/torchgeo/samplers/single.py
+++ b/torchgeo/samplers/single.py
@@ -140,20 +140,21 @@ class RandomGeoSampler(GeoSampler):
             # Choose a random tile, weighted by area
             idx = torch.multinomial(self.areas, 1)
             hit = self.hits[idx]
-            bounds = BoundingBox(*hit.bounds)
 
-            # Choose a random index within that tile
-            bounding_box = get_random_bounding_box(bounds, self.size, self.res)
-
+            bounds = hit.bounds
             if self.dataset.return_as_ts:
                 mint = self.dataset.bounds.mint
                 maxt = self.dataset.bounds.maxt
             else:
                 mint = bounds.mint
                 maxt = bounds.maxt
+            bounds[-2] = mint
+            bounds[-1] = maxt
 
-            bounding_box.mint = mint
-            bounding_box.maxt = maxt
+            bounds = BoundingBox(*bounds)
+
+            # Choose a random index within that tile
+            bounding_box = get_random_bounding_box(bounds, self.size, self.res)
 
             yield bounding_box
 
@@ -325,8 +326,8 @@ class PreChippedGeoSampler(GeoSampler):
                 mint = bounding_box.mint
                 maxt = bounding_box.maxt
 
-            bounding_box.mint = mint
-            bounding_box.maxt = maxt
+            bounding_box[-2] = mint
+            bounding_box[-1] = maxt
             yield BoundingBox(*bounding_box)
 
     def __len__(self) -> int:

--- a/torchgeo/samplers/single.py
+++ b/torchgeo/samplers/single.py
@@ -145,11 +145,8 @@ class RandomGeoSampler(GeoSampler):
             if self.dataset.return_as_ts:
                 mint = self.dataset.bounds.mint
                 maxt = self.dataset.bounds.maxt
-            else:
-                mint = bounds.mint
-                maxt = bounds.maxt
-            bounds[-2] = mint
-            bounds[-1] = maxt
+                bounds[-2] = mint
+                bounds[-1] = maxt
 
             bounds = BoundingBox(*bounds)
 

--- a/torchgeo/samplers/single.py
+++ b/torchgeo/samplers/single.py
@@ -143,8 +143,8 @@ class RandomGeoSampler(GeoSampler):
 
             bounds = hit.bounds
             if self.dataset.return_as_ts:
-                mint = self.dataset.bounds.mint
-                maxt = self.dataset.bounds.maxt
+                mint = self.index.bounds.mint
+                maxt = self.index.bounds.maxt
                 bounds[-2] = mint
                 bounds[-1] = maxt
 
@@ -242,8 +242,8 @@ class GridGeoSampler(GeoSampler):
             rows, cols = tile_to_chips(bounds, self.size, self.stride)
 
             if self.dataset.return_as_ts:
-                mint = self.dataset.bounds.mint
-                maxt = self.dataset.bounds.maxt
+                mint = self.index.bounds.mint
+                maxt = self.index.bounds.maxt
             else:
                 mint = bounds.mint
                 maxt = bounds.maxt
@@ -317,8 +317,8 @@ class PreChippedGeoSampler(GeoSampler):
             bounding_box = self.hits[idx].bounds
 
             if self.dataset.return_as_ts:
-                mint = self.dataset.bounds.mint
-                maxt = self.dataset.bounds.maxt
+                mint = self.index.bounds.mint
+                maxt = self.index.bounds.maxt
             else:
                 mint = bounding_box.mint
                 maxt = bounding_box.maxt


### PR DESCRIPTION
First steps towards Satellite Imagery TimeSeries support within TorchGeo (following #640). Right now I have started with the RasterDataset, but I think my methods can be applied to other GeoDatasets too. I have created a sits_dataset notebook, so feel free to run and play with an example that I prepared.

**Notes**:
- This approach expects the `filename_glob` to be generic enough to pick up on all bands when dealing with `separate_files=True`, so that all files end up in the index. This would lead to the same sampler issues from #2222. If we agree with the general setup of this PR, I will create a separate PR for those sampler fixes. (I have this internally) 
- Currently whenever `return_as_ts=False` shape [c,h,w] is returned, and when `return_as_ts=True` shape [t,c,h,w] is returned. I personally would prefer to move to the [t,c,h,w] standard, and setting `t=1` for non-ts data.
- Next to the SITS, the `__get_item__` also returns the individual dates as an array, so that any model needing the individual dates for the sample can use it.
- Currently, samplers will take the `mint` and `maxt` from the sampler index for timeseries, so that the temporal aspect of the ROI could also limit the temporal aspect. By smartly combining multiple roi's we could then make timeseries for every combination of dates I think.
- `IntersectionDataset` and `UnionDataset` take the `return_as_ts` property based on their input datasets properties.

I have currently not created any unit tests, will do so once we agree on the best structure.