### PR TITLE
Trainers should ignore the ignore parameter

### DIFF
--- a/torchgeo/trainers/base.py
+++ b/torchgeo/trainers/base.py
@@ -35,6 +35,12 @@ class BaseTask(LightningModule, ABC):
             ignore: Arguments to skip when saving hyperparameters.
         """
         super().__init__()
+        if ignore is None:
+            ignore = ['ignore']
+        elif isinstance(ignore, str):
+            ignore = [ignore, 'ignore']
+        else:
+            ignore = [*list(ignore), 'ignore']
         self.save_hyperparameters(ignore=ignore)
         self.configure_models()
         self.configure_losses()


### PR DESCRIPTION
If I create a new class that extends `SemanticSegmentationTask`:

```
class CustomSemanticSegmentationTask(SemanticSegmentationTask):

    # any keywords we add here between *args and **kwargs will be found in self.hparams
    def __init__(self, *args, tmax=50, eta_min=1e-6, **kwargs) -> None:
        super().__init__(*args, **kwargs)  # pass args and kwargs to the parent class
```

Everything works great when I first instantiate the class
```
task = CustomSemanticSegmentationTask(model="unet", tmax=100, ...)
```

However, when I go to load a checkpoint from file:
```
task = CustomSemanticSegmentationTask.load_from_checkpoint("lightning_logs/version_3/checkpoints/epoch=0-step=117.ckpt")
```

I get an error:
```
TypeError: SemanticSegmentationTask.__init__() got an unexpected keyword argument 'ignore'
```

This happens because there is an `ignore` parameter stored in task.hparams, because `SemanticSegmentationTask` passes it to `BaseTask`, -- https://github.com/microsoft/torchgeo/blob/main/torchgeo/trainers/segmentation.py#L98.

I can add `del kwargs["ignore"]` before `super()....` in the constructor of `CustomSemanticSegmentationTask` but this feels like a bad hack, so I just make `BaseTask` ignore `ignore` as a hyperparameter.


