### PR TITLE
Adding tensorboard to CI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Install pip dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          pip install .[docs,tests] planetary_computer pystac
+          pip install .[docs,tests] planetary_computer pystac tensorboard
           pip cache purge
       - name: List pip dependencies
         run: pip list

--- a/.github/workflows/tutorials.yaml
+++ b/.github/workflows/tutorials.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Install pip dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          pip install -r requirements/required.txt -r requirements/docs.txt -r requirements/tests.txt planetary_computer pystac .
+          pip install -r requirements/required.txt -r requirements/docs.txt -r requirements/tests.txt planetary_computer pystac tensorboard .
           pip cache purge
       - name: List pip dependencies
         run: pip list


### PR DESCRIPTION
In our tutorial notebooks we have an initial cell does a `%pip install torchgeo` along with any optional dependencies for that specific notebook (currently planetary-computer and pystac for downloading data). One notebook uses tensorboard so `pip install`s that as well. This PR adds tensorboard to the CI setup so we don't waste valuable time (time that we could spend running random data through random models to make sure dimensions align 😃) on downloading tensorboard at test time.