### PR TITLE
Removing eval in model weight API

### DIFF
--- a/tests/models/test_api.py
+++ b/tests/models/test_api.py
@@ -80,3 +80,8 @@ def test_get_weight(enum: WeightsEnum) -> None:
 def test_list_models() -> None:
     models = [builder.__name__ for builder in builders]
     assert set(models) == set(list_models())
+
+
+def test_invalid_model() -> None:
+    with pytest.raises(ValueError, match='bad_model is not a valid WeightsEnum'):
+        get_weight('bad_model')

--- a/torchgeo/models/api.py
+++ b/torchgeo/models/api.py
@@ -111,12 +111,11 @@ def get_weight(name: str) -> WeightsEnum:
         The requested weight enum.
 
     Raises:
-        ValueError: if `name` doesn't point to a valid WeightsEnum 
+        ValueError: if `name` doesn't point to a valid WeightsEnum
     """
     if name in _model_weights:
         return _model_weights[name]
     else:
-        sub_weights = {}
         for name, weight_enum in _model_weights.items():
             if isinstance(name, str):
                 for sub_weight_enum in weight_enum:

--- a/torchgeo/models/api.py
+++ b/torchgeo/models/api.py
@@ -67,6 +67,11 @@ _model_weights = {
     'vit_small_patch16_224': ViTSmall16_Weights,
 }
 
+for name, weight_enum in _model_weights.items():
+    if isinstance(name, str):
+        for sub_weight_enum in weight_enum:
+            _model_weights[str(sub_weight_enum)] = sub_weight_enum
+
 
 def get_model(name: str, *args: Any, **kwargs: Any) -> nn.Module:
     """Get an instantiated model from its name.

--- a/torchgeo/models/api.py
+++ b/torchgeo/models/api.py
@@ -46,7 +46,7 @@ _model = {
     'vit_small_patch16_224': vit_small_patch16_224,
 }
 
-_model_weights = {
+_model_weights: dict[str | Callable[..., nn.Module], WeightsEnum] = {
     dofa_base_patch16_224: DOFABase16_Weights,
     dofa_large_patch16_224: DOFALarge16_Weights,
     resnet18: ResNet18_Weights,
@@ -116,8 +116,8 @@ def get_weight(name: str) -> WeightsEnum:
     if name in _model_weights:
         return _model_weights[name]
     else:
-        for name, weight_enum in _model_weights.items():
-            if isinstance(name, str):
+        for weight_name, weight_enum in _model_weights.items():
+            if isinstance(weight_name, str):
                 for sub_weight_enum in weight_enum:
                     if name == str(sub_weight_enum):
                         return sub_weight_enum

--- a/torchgeo/models/api.py
+++ b/torchgeo/models/api.py
@@ -67,11 +67,6 @@ _model_weights = {
     'vit_small_patch16_224': ViTSmall16_Weights,
 }
 
-for name, weight_enum in _model_weights.items():
-    if isinstance(name, str):
-        for sub_weight_enum in weight_enum:
-            _model_weights[str(sub_weight_enum)] = sub_weight_enum
-
 
 def get_model(name: str, *args: Any, **kwargs: Any) -> nn.Module:
     """Get an instantiated model from its name.
@@ -114,8 +109,21 @@ def get_weight(name: str) -> WeightsEnum:
 
     Returns:
         The requested weight enum.
+
+    Raises:
+        ValueError: if `name` doesn't point to a valid WeightsEnum 
     """
-    return _model_weights[name]
+    if name in _model_weights:
+        return _model_weights[name]
+    else:
+        sub_weights = {}
+        for name, weight_enum in _model_weights.items():
+            if isinstance(name, str):
+                for sub_weight_enum in weight_enum:
+                    if name == str(sub_weight_enum):
+                        return sub_weight_enum
+
+        raise ValueError(f"{name} isn't a valid WeightsEnum")
 
 
 def list_models() -> list[str]:

--- a/torchgeo/models/api.py
+++ b/torchgeo/models/api.py
@@ -111,7 +111,7 @@ def get_weight(name: str) -> WeightsEnum:
         The requested weight enum.
 
     Raises:
-        ValueError: if `name` doesn't point to a valid WeightsEnum
+        ValueError: If *name* is not a valid WeightsEnum.
     """
     for weight_name, weight_enum in _model_weights.items():
         if isinstance(weight_name, str):

--- a/torchgeo/models/api.py
+++ b/torchgeo/models/api.py
@@ -110,7 +110,7 @@ def get_weight(name: str) -> WeightsEnum:
     Returns:
         The requested weight enum.
     """
-    return eval(name)
+    return _model_weights[name]
 
 
 def list_models() -> list[str]:

--- a/torchgeo/models/api.py
+++ b/torchgeo/models/api.py
@@ -113,16 +113,13 @@ def get_weight(name: str) -> WeightsEnum:
     Raises:
         ValueError: if `name` doesn't point to a valid WeightsEnum
     """
-    if name in _model_weights:
-        return _model_weights[name]
-    else:
-        for weight_name, weight_enum in _model_weights.items():
-            if isinstance(weight_name, str):
-                for sub_weight_enum in weight_enum:
-                    if name == str(sub_weight_enum):
-                        return sub_weight_enum
+    for weight_name, weight_enum in _model_weights.items():
+        if isinstance(weight_name, str):
+            for sub_weight_enum in weight_enum:
+                if name == str(sub_weight_enum):
+                    return sub_weight_enum
 
-        raise ValueError(f"{name} isn't a valid WeightsEnum")
+    raise ValueError(f'{name} is not a valid WeightsEnum')
 
 
 def list_models() -> list[str]:


### PR DESCRIPTION
Removing use of eval.

~@nilsleh -- do you remember what the use case for eval was? If not, I say we replace all instances of `get_weight` with `get_model_weights` and remove `get_weight`.~ Nevermind, I understand it now.

`get_weight(...)` allows a user to pass a string "ResNet18_Weights.LANDSAT_ETM_SR_MOCO" and get back the object `ResNet18_Weights.LANDSAT_ETM_SR_MOCO` WeightEnum. Previously we did this with `eval("ResNet18_Weights.LANDSAT_ETM_SR_MOCO")` which is _bad_. This proposed fix simply iterates through all available WeightEnums to look for matches and has the benefit of raising an error that makes sense if there is no match (vs. the `eval(...)` which would do whatever).


