### PR TITLE
NAIP: update resolution

### DIFF
--- a/docs/api/datasets/geo_datasets.csv
+++ b/docs/api/datasets/geo_datasets.csv
@@ -20,7 +20,7 @@ Dataset,Type,Source,License,Size (px),Resolution (m)
 `L8 Biome`_,"Imagery, Masks",Landsat,"CC0-1.0","8,900x8,900","15, 30"
 `LandCover.ai Geo`_,"Imagery, Masks",Aerial,"CC-BY-NC-SA-4.0","4,200--9,500",0.25--0.5
 `Landsat`_,Imagery,Landsat,"public domain","8,900x8,900",30
-`NAIP`_,Imagery,Aerial,"public domain","6,100x7,600",0.6--1
+`NAIP`_,Imagery,Aerial,"public domain","6,100x7,600",0.3--2
 `NCCM`_,Masks,Sentinel-2,"CC-BY-4.0",-,10
 `NLCD`_,Masks,Landsat,"public domain",-,30
 `Open Buildings`_,Geometries,"Maxar, CNES/Airbus","CC-BY-4.0 OR ODbL-1.0",-,-

--- a/docs/api/datasets/geo_datasets.csv
+++ b/docs/api/datasets/geo_datasets.csv
@@ -20,7 +20,7 @@ Dataset,Type,Source,License,Size (px),Resolution (m)
 `L8 Biome`_,"Imagery, Masks",Landsat,"CC0-1.0","8,900x8,900","15, 30"
 `LandCover.ai Geo`_,"Imagery, Masks",Aerial,"CC-BY-NC-SA-4.0","4,200--9,500",0.25--0.5
 `Landsat`_,Imagery,Landsat,"public domain","8,900x8,900",30
-`NAIP`_,Imagery,Aerial,"public domain","6,100x7,600",1
+`NAIP`_,Imagery,Aerial,"public domain","6,100x7,600",0.6--1
 `NCCM`_,Masks,Sentinel-2,"CC-BY-4.0",-,10
 `NLCD`_,Masks,Landsat,"public domain",-,30
 `Open Buildings`_,Geometries,"Maxar, CNES/Airbus","CC-BY-4.0 OR ODbL-1.0",-,-


### PR DESCRIPTION
I'm seeing a lot of conflicting reports here:

* [USDA, 2013](https://www.fsa.usda.gov/Internet/FSA_File/naip_info_sheet_2013.pdf): "NAIP imagery has a 1-meter ground sample distance (GSD). Beginning with the 2011 NAIP season, ½-meter GSD imagery is an option... In earlier years of NAIP, some states were flown at a 2-meter GSD"
* [USGS, 2018](https://www.usgs.gov/centers/eros/science/usgs-eros-archive-aerial-photography-national-agriculture-imagery-program-naip): "a resolution of 1-meter ground sample distance (GSD) ... from 2003–2017... In 2018, the ground resolution standard changed to .6 meter with the option for .3 meter data was added for consideration..."
* [ESRI, 2020](https://www.esri.com/arcgis-blog/products/arcgis-living-atlas/imagery/fast-and-simple-naip-imagery/): "The spatial resolution of the imagery has historically ranged from 0.6 to 1.0 meters.  However, starting with 2018, ... NAIP imagery will be provided at 0.6-meters resolution."
* [EOS, 2023](https://eos.com/find-satellite/naip/): "1-meter ground sample resolution"
* [ArcGIS, 2024](https://storymaps.arcgis.com/stories/35c27c0e3f10406f91625c68e89cda0e): Year-by-year and state-by-state resolution maps, ranging from 0.3–2 m.

I'm trusting the newer and more detailed reports over the official reports from the people who produce it.