### PR TITLE
Tests: set matplotlib backend locally too

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,8 +15,6 @@ jobs:
   latest:
     name: latest
     runs-on: ${{ matrix.os }}
-    env:
-      MPLBACKEND: Agg
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -55,8 +53,6 @@ jobs:
   minimum:
     name: minimum
     runs-on: ubuntu-latest
-    env:
-      MPLBACKEND: Agg
     steps:
       - name: Clone repo
         uses: actions/checkout@v4.1.7
@@ -90,8 +86,6 @@ jobs:
   datasets:
     name: datasets
     runs-on: ubuntu-latest
-    env:
-      MPLBACKEND: Agg
     steps:
       - name: Clone repo
         uses: actions/checkout@v4.1.7

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@
 from pathlib import Path
 from typing import Any
 
+import matplotlib
 import pytest
 import torch
 import torchvision
@@ -17,6 +18,11 @@ def load(*args: Any, progress: bool = False, **kwargs: Any) -> Any:
 @pytest.fixture
 def load_state_dict_from_url(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setattr(torchvision.models._api, 'load_state_dict_from_url', load)
+
+
+@pytest.fixture(autouse=True, scope='session')
+def matplotlib_backend() -> None:
+    matplotlib.use('agg')
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
The default matplotlib backend is interactive. In CI, this results in the tests hanging. Locally, this can result in the terminal losing focus. In CI, we worked around this by setting the `MPLBACKEND` environment variable. However, this doesn't solve the problem locally. This PR uses `matplotlib.use` instead, and works both locally and in CI.

Reference: https://matplotlib.org/stable/users/explain/figure/backends.html