### PR TITLE
TorchGeo is not yet compatible with rasterio 1.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,8 @@ dependencies = [
     # pyproj 3.3+ required for Python 3.10 wheels
     "pyproj>=3.3",
     # rasterio 1.3+ required for Python 3.10 wheels
+    # rasterio 1.4+ no longer supports merging WarpedVRT objects
+    # https://github.com/rasterio/rasterio/issues/3196
     "rasterio>=1.3,<1.4",
     # rtree 1+ required for Python 3.10 wheels
     "rtree>=1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ dependencies = [
     # pyproj 3.3+ required for Python 3.10 wheels
     "pyproj>=3.3",
     # rasterio 1.3+ required for Python 3.10 wheels
-    "rasterio>=1.3",
+    "rasterio>=1.3,<1.4",
     # rtree 1+ required for Python 3.10 wheels
     "rtree>=1",
     # segmentation-models-pytorch 0.2+ required for smp.losses module


### PR DESCRIPTION
Rasterio 1.4 no longer supports merging WarpedVRT objects. Based on https://github.com/rasterio/rasterio/issues/3196, it sounds like this wasn't directly intentional, but also like this also isn't exactly recommended. This may be changed in a future version of rasterio, but it won't be in 1.4.1. Let's pin rasterio for now and brainstorm ways of supporting rasterio 1.4 when we have more time.

Closes #2321