### PR TITLE
Set up continuous deployment for PyPI releases

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,45 @@
+name: deploy
+on:
+  release:
+    types:
+      - published
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v4.2.1
+      - name: Set up python
+        uses: actions/setup-python@v5.2.0
+        with:
+          python-version: '3.12'
+      - name: Install pip dependencies
+        run: pip install build
+      - name: List pip dependencies
+        run: pip list
+      - name: Build project
+        run: python3 -m build
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4.4.3
+        with:
+          name: pypi-dist
+          path: dist/
+  pypi:
+    name: pypi
+    needs:
+      - build
+    environment:
+      name: pypi
+      url: https://pypi.org/p/torchgeo
+    permissions:
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4.1.8
+        with:
+          name: pypi-dist
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.10.3


### PR DESCRIPTION
Closes #2269

We _could_ test this by enabling it on every push and releasing to testpypi instead of pypi, but I'm hoping it Just Works™.