### PR TITLE
Add Consistent `bands` Metadata to Vision Transformer and ResNet Weights

### DIFF
--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -20,42 +20,100 @@ from .swin import (
 
 # Landsat TM-toa 7 channels
 bands_7_channels_tm_toa = [
-    'B1', 'B2', 'B3', 'B4', 'B5', 'B6', 'B7'
+    'B1',
+    'B2',
+    'B3',
+    'B4',
+    'B5',
+    'B6',
+    'B7',
 ]  # https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LT05_C02_T1_TOA
 
 # Landsat ETM-toa 9 channels
 bands_9_channels_etm_toa = [
-    'B1', 'B2', 'B3', 'B4', 'B5', 'B6_VCID_1', 'B6_VCID_2', 'B7', 'B8'
+    'B1',
+    'B2',
+    'B3',
+    'B4',
+    'B5',
+    'B6_VCID_1',
+    'B6_VCID_2',
+    'B7',
+    'B8',
 ]  # https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LE07_C02_T1_TOA
 
 # Landsat ETM-sr 6 channels
 bands_6_channels_etm_sr = [
-    'SR_B1', 'SR_B2', 'SR_B3', 'SR_B4', 'SR_B5', 'SR_B7'
+    'SR_B1',
+    'SR_B2',
+    'SR_B3',
+    'SR_B4',
+    'SR_B5',
+    'SR_B7',
 ]  # https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LE07_C02_T1_L2
 
 # Landsat OLI_TIRS-toa 11 channels
 bands_11_channels_oli_tirs = [
-    'B1', 'B2', 'B3', 'B4', 'B5', 'B6', 'B7', 'B8', 'B9', 'B10', 'B11'
+    'B1',
+    'B2',
+    'B3',
+    'B4',
+    'B5',
+    'B6',
+    'B7',
+    'B8',
+    'B9',
+    'B10',
+    'B11',
 ]  # https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LC08_C02_T1_TOA
 
 # Landsat OLI-sr 7 channels
 bands_7_channels_oli_sr = [
-    'SR_B1', 'SR_B2', 'SR_B3', 'SR_B4', 'SR_B5', 'SR_B6', 'SR_B7'
+    'SR_B1',
+    'SR_B2',
+    'SR_B3',
+    'SR_B4',
+    'SR_B5',
+    'SR_B6',
+    'SR_B7',
 ]  # https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LC08_C02_T1_L2
 
 # All Sentinel-2 bands (13 channels)
 bands_13_channels_sentinel2 = [
-    'B1', 'B2', 'B3', 'B4', 'B5', 'B6', 'B7', 'B8', 'B8a', 'B9', 'B10', 'B11', 'B12'
+    'B1',
+    'B2',
+    'B3',
+    'B4',
+    'B5',
+    'B6',
+    'B7',
+    'B8',
+    'B8a',
+    'B9',
+    'B10',
+    'B11',
+    'B12',
 ]
 
 # RGB Sentinel-2 bands (3 channels)
-bands_3_channels_rgb = ['B2', 'B3', 'B4']
+bands_3_channels_rgb = [
+    'B2',
+    'B3',
+    'B4',
+]
 
 # RGB bands for fMoW dataset (3 channels)
-bands_3_channels_rgb_fmow = ['B2', 'B3', 'B4']
+bands_3_channels_rgb_fmow = [
+    'B2',
+    'B3',
+    'B4',
+]
 
 # Sentinel-1 bands (2 channels: VH and VV)
-bands_2_channels_sentinel1 = ['VH', 'VV']
+bands_2_channels_sentinel1 = [
+    'VH',
+    'VV',
+]
 
 # https://github.com/zhu-xlab/DeCUR/blob/f190e9a3895ef645c005c8c2fce287ffa5a937e3/src/transfer_classification_BE/linear_BE_resnet.py#L286
 # Normalization by channel-wise band statistics

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -13,11 +13,42 @@ from torchvision.models._api import Weights, WeightsEnum
 
 from .swin import (
     _satlas_bands,
-    _satlas_landsat_bands,
     _satlas_sentinel2_bands,
     _satlas_sentinel2_transforms,
     _satlas_transforms,
 )
+# Landsat TM-toa 7 channels
+_bands_7_channels_tm_toa = ('B1', 'B2', 'B3', 'B4', 'B5', 'B6', 'B7')
+#https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LT05_C02_T1_TOA
+
+#Landsat ETM-toa 9 channels
+bands_9_channels_etm_toa = ['B1', 'B2', 'B3', 'B4', 'B5', 'B6_VCID_1', 'B6_VCID_2', 'B7', 'B8']
+#https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LE07_C02_T1_TOA
+
+#Landsat ETM-sr 6 channels
+bands_6_channels_etm_sr = ['SR_B1', 'SR_B2', 'SR_B3', 'SR_B4', 'SR_B5', 'SR_B7']
+#https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LE07_C02_T1_L2
+
+#Landsat OLI_TIRS-toa 11 channels
+bands_11_channels_oli_tirs = ['B1', 'B2', 'B3', 'B4', 'B5', 'B6', 'B7', 'B8', 'B9', 'B10', 'B11']
+#https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LC08_C02_T1_TOA
+
+#Landsat OLI-sr 7 channels
+bands_7_channels_oli_sr = ['SR_B1', 'SR_B2', 'SR_B3', 'SR_B4', 'SR_B5', 'SR_B6', 'SR_B7']
+#https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LC08_C02_T1_L2
+
+# All Sentinel-2 bands (13 channels)
+bands_13_channels_sentinel2 = ['B1', 'B2', 'B3', 'B4', 'B5', 'B6', 'B7', 'B8', 'B8a', 'B9', 'B10', 'B11', 'B12']
+
+# RGB Sentinel-2 bands (3 channels)
+bands_3_channels_rgb = ['B2', 'B3', 'B4']
+
+# RGB bands for fMoW dataset (3 channels)
+bands_3_channels_rgb_fmow = ['B2', 'B3', 'B4']
+
+# Sentinel-1 bands (2 channels: VH and VV)
+bands_2_channels_sentinel1 = ['VH', 'VV']
+
 
 # https://github.com/zhu-xlab/DeCUR/blob/f190e9a3895ef645c005c8c2fce287ffa5a937e3/src/transfer_classification_BE/linear_BE_resnet.py#L286
 # Normalization by channel-wise band statistics
@@ -139,7 +170,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
-            'bands': _satlas_landsat_bands,
+            'bands': _bands_7_channels_tm_toa,
         },
     )
 
@@ -153,7 +184,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': _satlas_landsat_bands,
+            'bands': _bands_7_channels_tm_toa,
         },
     )
 
@@ -167,7 +198,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
-            'bands': _satlas_landsat_bands,
+            'bands': bands_9_channels_etm_toa,
         },
     )
 
@@ -181,7 +212,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': _satlas_landsat_bands,
+            'bands': bands_9_channels_etm_toa,
         },
     )
 
@@ -195,7 +226,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
-            'bands': _satlas_landsat_bands,
+            'bands': bands_6_channels_etm_sr,
         },
     )
 
@@ -209,7 +240,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': _satlas_landsat_bands,
+            'bands': bands_6_channels_etm_sr,
         },
     )
 
@@ -223,7 +254,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
-            'bands': _satlas_landsat_bands,
+            'bands': bands_11_channels_oli_tirs,
         },
     )
 
@@ -237,7 +268,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': _satlas_landsat_bands,
+            'bands': bands_11_channels_oli_tirs,
         },
     )
 
@@ -251,7 +282,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
-            'bands': _satlas_landsat_bands,
+            'bands': bands_7_channels_oli_sr,
         },
     )
 
@@ -265,7 +296,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': _satlas_landsat_bands,
+            'bands': bands_7_channels_oli_sr,
         },
     )
 
@@ -279,7 +310,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2211.07044',
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'moco',
-            'bands': _satlas_sentinel2_bands,
+            'bands': bands_13_channels_sentinel2,
         },
     )
 
@@ -293,7 +324,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2211.07044',
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'moco',
-            'bands': _satlas_bands,
+            'bands': bands_3_channels_rgb,
         },
     )
 
@@ -307,7 +338,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2103.16607',
             'repo': 'https://github.com/ServiceNow/seasonal-contrast',
             'ssl_method': 'seco',
-            'bands': _satlas_bands,
+            'bands': bands_3_channels_rgb,
         },
     )
 
@@ -331,7 +362,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2011.09980',
             'repo': 'https://github.com/sustainlab-group/geography-aware-ssl',
             'ssl_method': 'gassl',
-            'bands': ('R', 'G', 'B'),
+            'bands': bands_3_channels_rgb_fmow,
         },
     )
 
@@ -345,7 +376,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
-            'bands': _satlas_landsat_bands,
+            'bands': _bands_7_channels_tm_toa,
         },
     )
 
@@ -359,7 +390,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': _satlas_landsat_bands,
+            'bands': _bands_7_channels_tm_toa,
         },
     )
 
@@ -373,7 +404,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
-            'bands': _satlas_landsat_bands,
+            'bands': bands_9_channels_etm_toa,
         },
     )
 
@@ -387,7 +418,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': _satlas_landsat_bands,
+            'bands': bands_9_channels_etm_toa,
         },
     )
 
@@ -401,7 +432,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
-            'bands': _satlas_landsat_bands,
+            'bands': bands_6_channels_etm_sr,
         },
     )
 
@@ -415,7 +446,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': _satlas_landsat_bands,
+            'bands': bands_6_channels_etm_sr,
         },
     )
 
@@ -429,7 +460,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
-            'bands': _satlas_landsat_bands,
+            'bands': bands_11_channels_oli_tirs,
         },
     )
 
@@ -443,7 +474,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': _satlas_landsat_bands,
+            'bands': bands_11_channels_oli_tirs,
         },
     )
 
@@ -457,7 +488,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
-            'bands': _satlas_landsat_bands,
+            'bands': bands_7_channels_oli_sr,
         },
     )
 
@@ -471,7 +502,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': _satlas_landsat_bands,
+            'bands': bands_7_channels_oli_sr,
         },
     )
 
@@ -485,7 +516,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2309.05300',
             'repo': 'https://github.com/zhu-xlab/DeCUR',
             'ssl_method': 'decur',
-            'bands': ('VH', 'VV'),
+            'bands': bands_2_channels_sentinel1,
         },
     )
 
@@ -499,7 +530,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2211.07044',
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'moco',
-            'bands': ('VH', 'VV'),
+            'bands': bands_2_channels_sentinel1,
         },
     )
 
@@ -513,7 +544,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2309.05300',
             'repo': 'https://github.com/zhu-xlab/DeCUR',
             'ssl_method': 'decur',
-            'bands': _satlas_sentinel2_bands,
+            'bands': bands_13_channels_sentinel2,
         },
     )
 
@@ -527,7 +558,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2211.07044',
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'dino',
-            'bands': _satlas_sentinel2_bands,
+            'bands': bands_13_channels_sentinel2,
         },
     )
 
@@ -541,7 +572,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2211.07044',
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'moco',
-            'bands': _satlas_sentinel2_bands,
+            'bands': bands_13_channels_sentinel2,
         },
     )
 
@@ -581,7 +612,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2211.07044',
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'moco',
-            'bands': _satlas_bands,
+            'bands': bands_3_channels_rgb,
         },
     )
 
@@ -595,7 +626,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2103.16607',
             'repo': 'https://github.com/ServiceNow/seasonal-contrast',
             'ssl_method': 'seco',
-            'bands': _satlas_bands,
+            'bands': bands_3_channels_rgb,
         },
     )
 

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -102,7 +102,7 @@ bands_3_channels_rgb = ['B2', 'B3', 'B4']
 bands_3_channels_rgb_fmow = ['B2', 'B3', 'B4']
 
 # Sentinel-1 bands (2 channels: VH and VV)
-bands_2_channels_sentinel1 = ['VH','VV']
+bands_2_channels_sentinel1 = ['VH', 'VV']
 
 # https://github.com/zhu-xlab/DeCUR/blob/f190e9a3895ef645c005c8c2fce287ffa5a937e3/src/transfer_classification_BE/linear_BE_resnet.py#L286
 # Normalization by channel-wise band statistics

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -86,9 +86,6 @@ _sentinel2_rgb_bands = ['B4', 'B3', 'B2']
 # https://github.com/zhu-xlab/SSL4EO-S12/blob/main/src/download_data/convert_rgb.py
 _sentinel1_bands = ['VV', 'VH']
 
-# RGB bands for fMoW dataset (3 channels)
-_fmow_rgb_bands = ['B1', 'B2', 'B3']
-
 # https://github.com/zhu-xlab/DeCUR/blob/f190e9a3895ef645c005c8c2fce287ffa5a937e3/src/transfer_classification_BE/linear_BE_resnet.py#L286
 # Normalization by channel-wise band statistics
 _mean_s1 = torch.tensor([-12.59, -20.26])
@@ -401,7 +398,6 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2011.09980',
             'repo': 'https://github.com/sustainlab-group/geography-aware-ssl',
             'ssl_method': 'gassl',
-            'bands': _fmow_rgb_bands,
         },
     )
 

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -17,6 +17,7 @@ from .swin import (
     _satlas_sentinel2_transforms,
     _satlas_transforms,
 )
+
 # Landsat TM-toa 7 channels
 _bands_7_channels_tm_toa = ('B1', 'B2', 'B3', 'B4', 'B5', 'B6', 'B7')
 #https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LT05_C02_T1_TOA
@@ -48,7 +49,6 @@ bands_3_channels_rgb_fmow = ['B2', 'B3', 'B4']
 
 # Sentinel-1 bands (2 channels: VH and VV)
 bands_2_channels_sentinel1 = ['VH', 'VV']
-
 
 # https://github.com/zhu-xlab/DeCUR/blob/f190e9a3895ef645c005c8c2fce287ffa5a937e3/src/transfer_classification_BE/linear_BE_resnet.py#L286
 # Normalization by channel-wise band statistics

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -18,8 +18,9 @@ from .swin import (
     _satlas_transforms,
 )
 
-# Landsat TM-toa 7 channels
-bands_7_channels_tm_toa = [
+# Landsat TM-TOA 7 channels
+## https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LT05_C02_T1_TOA
+_landsat_tm_toa_bands = [
     'B1',
     'B2',
     'B3',
@@ -27,10 +28,11 @@ bands_7_channels_tm_toa = [
     'B5',
     'B6',
     'B7',
-]  # https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LT05_C02_T1_TOA
+]
 
-# Landsat ETM-toa 9 channels
-bands_9_channels_etm_toa = [
+# Landsat ETM-TOA 9 channels
+# https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LE07_C02_T1_TOA
+_landsat_etm_toa_bands = [
     'B1',
     'B2',
     'B3',
@@ -40,20 +42,22 @@ bands_9_channels_etm_toa = [
     'B6_VCID_2',
     'B7',
     'B8',
-]  # https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LE07_C02_T1_TOA
+]
 
-# Landsat ETM-sr 6 channels
-bands_6_channels_etm_sr = [
+# Landsat ETM-SR 6 channels
+# https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LE07_C02_T1_L2
+_landsat_etm_sr_bands = [
     'SR_B1',
     'SR_B2',
     'SR_B3',
     'SR_B4',
     'SR_B5',
     'SR_B7',
-]  # https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LE07_C02_T1_L2
+]
 
-# Landsat OLI_TIRS-toa 11 channels
-bands_11_channels_oli_tirs = [
+# Landsat OLI_TIRS-TOA 11 channels
+# https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LC08_C02_T1_TOA
+_landsat_oli_tirs_toa_bands = [
     'B1',
     'B2',
     'B3',
@@ -65,10 +69,11 @@ bands_11_channels_oli_tirs = [
     'B9',
     'B10',
     'B11',
-]  # https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LC08_C02_T1_TOA
+]
 
-# Landsat OLI-sr 7 channels
-bands_7_channels_oli_sr = [
+# Landsat OLI-SR 7 channels
+# https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LC08_C02_T1_L2
+_landsat_oli_sr_bands = [
     'SR_B1',
     'SR_B2',
     'SR_B3',
@@ -76,10 +81,10 @@ bands_7_channels_oli_sr = [
     'SR_B5',
     'SR_B6',
     'SR_B7',
-]  # https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LC08_C02_T1_L2
+]
 
 # All Sentinel-2 bands (13 channels)
-bands_13_channels_sentinel2 = [
+_sentinel2_all_bands = [
     'B1',
     'B2',
     'B3',
@@ -96,13 +101,13 @@ bands_13_channels_sentinel2 = [
 ]
 
 # RGB Sentinel-2 bands (3 channels)
-bands_3_channels_rgb = ['B2', 'B3', 'B4']
+_sentinel2_rgb_bands = ['B4', 'B3', 'B2']
 
 # RGB bands for fMoW dataset (3 channels)
-bands_3_channels_rgb_fmow = ['B2', 'B3', 'B4']
+_fmow_rgb_bands = ['B4', 'B3', 'B2']
 
 # Sentinel-1 bands (2 channels: VH and VV)
-bands_2_channels_sentinel1 = ['VH', 'VV']
+_sentinel1_bands = ['VH', 'VV']
 
 # https://github.com/zhu-xlab/DeCUR/blob/f190e9a3895ef645c005c8c2fce287ffa5a937e3/src/transfer_classification_BE/linear_BE_resnet.py#L286
 # Normalization by channel-wise band statistics
@@ -224,7 +229,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
-            'bands': bands_7_channels_tm_toa,
+            'bands': _landsat_tm_toa_bands,
         },
     )
 
@@ -238,7 +243,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': bands_7_channels_tm_toa,
+            'bands': _landsat_tm_toa_bands,
         },
     )
 
@@ -252,7 +257,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
-            'bands': bands_9_channels_etm_toa,
+            'bands': _landsat_etm_toa_bands,
         },
     )
 
@@ -266,7 +271,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': bands_9_channels_etm_toa,
+            'bands': _landsat_etm_toa_bands,
         },
     )
 
@@ -280,7 +285,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
-            'bands': bands_6_channels_etm_sr,
+            'bands': _landsat_etm_sr_bands,
         },
     )
 
@@ -294,7 +299,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': bands_6_channels_etm_sr,
+            'bands': _landsat_etm_sr_bands,
         },
     )
 
@@ -308,7 +313,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
-            'bands': bands_11_channels_oli_tirs,
+            'bands': _landsat_oli_tirs_toa_bands,
         },
     )
 
@@ -322,7 +327,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': bands_11_channels_oli_tirs,
+            'bands': _landsat_oli_tirs_toa_bands,
         },
     )
 
@@ -336,7 +341,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
-            'bands': bands_7_channels_oli_sr,
+            'bands': _landsat_oli_sr_bands,
         },
     )
 
@@ -350,7 +355,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': bands_7_channels_oli_sr,
+            'bands': _landsat_oli_sr_bands,
         },
     )
 
@@ -364,7 +369,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2211.07044',
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'moco',
-            'bands': bands_13_channels_sentinel2,
+            'bands': _sentinel2_all_bands,
         },
     )
 
@@ -378,7 +383,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2211.07044',
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'moco',
-            'bands': bands_3_channels_rgb,
+            'bands': _sentinel2_rgb_bands,
         },
     )
 
@@ -392,7 +397,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2103.16607',
             'repo': 'https://github.com/ServiceNow/seasonal-contrast',
             'ssl_method': 'seco',
-            'bands': bands_3_channels_rgb,
+            'bands': _sentinel2_rgb_bands,
         },
     )
 
@@ -416,7 +421,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2011.09980',
             'repo': 'https://github.com/sustainlab-group/geography-aware-ssl',
             'ssl_method': 'gassl',
-            'bands': bands_3_channels_rgb_fmow,
+            'bands': _fmow_rgb_bands,
         },
     )
 
@@ -430,7 +435,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
-            'bands': bands_7_channels_tm_toa,
+            'bands': _landsat_tm_toa_bands,
         },
     )
 
@@ -444,7 +449,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': bands_7_channels_tm_toa,
+            'bands': _landsat_tm_toa_bands,
         },
     )
 
@@ -458,7 +463,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
-            'bands': bands_9_channels_etm_toa,
+            'bands': _landsat_etm_toa_bands,
         },
     )
 
@@ -472,7 +477,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': bands_9_channels_etm_toa,
+            'bands': _landsat_etm_toa_bands,
         },
     )
 
@@ -486,7 +491,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
-            'bands': bands_6_channels_etm_sr,
+            'bands': _landsat_etm_sr_bands,
         },
     )
 
@@ -500,7 +505,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': bands_6_channels_etm_sr,
+            'bands': _landsat_etm_sr_bands,
         },
     )
 
@@ -514,7 +519,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
-            'bands': bands_11_channels_oli_tirs,
+            'bands': _landsat_oli_tirs_toa_bands,
         },
     )
 
@@ -528,7 +533,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': bands_11_channels_oli_tirs,
+            'bands': _landsat_oli_tirs_toa_bands,
         },
     )
 
@@ -542,7 +547,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
-            'bands': bands_7_channels_oli_sr,
+            'bands': _landsat_oli_sr_bands,
         },
     )
 
@@ -556,7 +561,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': bands_7_channels_oli_sr,
+            'bands': _landsat_oli_sr_bands,
         },
     )
 
@@ -570,7 +575,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2309.05300',
             'repo': 'https://github.com/zhu-xlab/DeCUR',
             'ssl_method': 'decur',
-            'bands': bands_2_channels_sentinel1,
+            'bands': _sentinel1_bands,
         },
     )
 
@@ -584,7 +589,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2211.07044',
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'moco',
-            'bands': bands_2_channels_sentinel1,
+            'bands': _sentinel1_bands,
         },
     )
 
@@ -598,7 +603,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2309.05300',
             'repo': 'https://github.com/zhu-xlab/DeCUR',
             'ssl_method': 'decur',
-            'bands': bands_13_channels_sentinel2,
+            'bands': _sentinel2_all_bands,
         },
     )
 
@@ -612,7 +617,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2211.07044',
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'dino',
-            'bands': bands_13_channels_sentinel2,
+            'bands': _sentinel2_all_bands,
         },
     )
 
@@ -626,7 +631,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2211.07044',
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'moco',
-            'bands': bands_13_channels_sentinel2,
+            'bands': _sentinel2_all_bands,
         },
     )
 
@@ -666,7 +671,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2211.07044',
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'moco',
-            'bands': bands_3_channels_rgb,
+            'bands': _sentinel2_rgb_bands,
         },
     )
 
@@ -680,7 +685,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2103.16607',
             'repo': 'https://github.com/ServiceNow/seasonal-contrast',
             'ssl_method': 'seco',
-            'bands': bands_3_channels_rgb,
+            'bands': _sentinel2_rgb_bands,
         },
     )
 

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -61,7 +61,8 @@ _landsat_oli_tirs_toa_bands = [
 _landsat_oli_sr_bands = ['SR_B1', 'SR_B2', 'SR_B3', 'SR_B4', 'SR_B5', 'SR_B6', 'SR_B7']
 
 # All Sentinel-2 bands (13 channels)
-_sentinel2_all_bands = [
+# https://github.com/zhu-xlab/SSL4EO-S12/blob/main/src/download_data/convert_rgb.py
+_sentinel2_toa_all_bands = [
     'B1',
     'B2',
     'B3',
@@ -78,13 +79,15 @@ _sentinel2_all_bands = [
 ]
 
 # RGB Sentinel-2 bands (3 channels)
+# https://github.com/zhu-xlab/SSL4EO-S12/blob/main/src/download_data/convert_rgb.py
 _sentinel2_rgb_bands = ['B4', 'B3', 'B2']
 
-# RGB bands for fMoW dataset (3 channels)
-_fmow_rgb_bands = ['B4', 'B3', 'B2']
-
 # Sentinel-1 bands (2 channels: VH and VV)
-_sentinel1_bands = ['VH', 'VV']
+# https://github.com/zhu-xlab/SSL4EO-S12/blob/main/src/download_data/convert_rgb.py
+_sentinel1_bands = ['VV', 'VH']
+
+# RGB bands for fMoW dataset (3 channels)
+_fmow_rgb_bands = ['B1', 'B2', 'B3']
 
 # https://github.com/zhu-xlab/DeCUR/blob/f190e9a3895ef645c005c8c2fce287ffa5a937e3/src/transfer_classification_BE/linear_BE_resnet.py#L286
 # Normalization by channel-wise band statistics
@@ -346,7 +349,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2211.07044',
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'moco',
-            'bands': _sentinel2_all_bands,
+            'bands': _sentinel2_toa_all_bands,
         },
     )
 
@@ -580,7 +583,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2309.05300',
             'repo': 'https://github.com/zhu-xlab/DeCUR',
             'ssl_method': 'decur',
-            'bands': _sentinel2_all_bands,
+            'bands': _sentinel2_toa_all_bands,
         },
     )
 
@@ -594,7 +597,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2211.07044',
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'dino',
-            'bands': _sentinel2_all_bands,
+            'bands': _sentinel2_toa_all_bands,
         },
     )
 
@@ -608,7 +611,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2211.07044',
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'moco',
-            'bands': _sentinel2_all_bands,
+            'bands': _sentinel2_toa_all_bands,
         },
     )
 

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -18,11 +18,9 @@ from .swin import (
     _satlas_transforms,
 )
 
-# Landsat TM-TOA 7 channels
 # https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LT05_C02_T1_TOA
 _landsat_tm_toa_bands = ['B1', 'B2', 'B3', 'B4', 'B5', 'B6', 'B7']
 
-# Landsat ETM-TOA 9 channels
 # https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LE07_C02_T1_TOA
 _landsat_etm_toa_bands = [
     'B1',
@@ -36,11 +34,9 @@ _landsat_etm_toa_bands = [
     'B8',
 ]
 
-# Landsat ETM-SR 6 channels
 # https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LE07_C02_T1_L2
 _landsat_etm_sr_bands = ['SR_B1', 'SR_B2', 'SR_B3', 'SR_B4', 'SR_B5', 'SR_B7']
 
-# Landsat OLI_TIRS-TOA 11 channels
 # https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LC08_C02_T1_TOA
 _landsat_oli_tirs_toa_bands = [
     'B1',
@@ -56,13 +52,11 @@ _landsat_oli_tirs_toa_bands = [
     'B11',
 ]
 
-# Landsat OLI-SR 7 channels
 # https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LC08_C02_T1_L2
 _landsat_oli_sr_bands = ['SR_B1', 'SR_B2', 'SR_B3', 'SR_B4', 'SR_B5', 'SR_B6', 'SR_B7']
 
-# All Sentinel-2 bands (13 channels)
 # https://github.com/zhu-xlab/SSL4EO-S12/blob/main/src/download_data/convert_rgb.py
-_sentinel2_toa_all_bands = [
+_sentinel2_toa_bands = [
     'B1',
     'B2',
     'B3',
@@ -78,11 +72,9 @@ _sentinel2_toa_all_bands = [
     'B12',
 ]
 
-# RGB Sentinel-2 bands (3 channels)
 # https://github.com/zhu-xlab/SSL4EO-S12/blob/main/src/download_data/convert_rgb.py
 _sentinel2_rgb_bands = ['B4', 'B3', 'B2']
 
-# Sentinel-1 bands (2 channels: VH and VV)
 # https://github.com/zhu-xlab/SSL4EO-S12/blob/main/src/download_data/convert_rgb.py
 _sentinel1_bands = ['VV', 'VH']
 
@@ -346,7 +338,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2211.07044',
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'moco',
-            'bands': _sentinel2_toa_all_bands,
+            'bands': _sentinel2_toa_bands,
         },
     )
 
@@ -579,7 +571,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2309.05300',
             'repo': 'https://github.com/zhu-xlab/DeCUR',
             'ssl_method': 'decur',
-            'bands': _sentinel2_toa_all_bands,
+            'bands': _sentinel2_toa_bands,
         },
     )
 
@@ -593,7 +585,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2211.07044',
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'dino',
-            'bands': _sentinel2_toa_all_bands,
+            'bands': _sentinel2_toa_bands,
         },
     )
 
@@ -607,7 +599,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2211.07044',
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'moco',
-            'bands': _sentinel2_toa_all_bands,
+            'bands': _sentinel2_toa_bands,
         },
     )
 

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -11,13 +11,9 @@ import torch
 from timm.models import ResNet
 from torchvision.models._api import Weights, WeightsEnum
 
-from .swin import (
-    _satlas_bands,
-    _satlas_sentinel2_bands,
-    _satlas_landsat_bands,
-    _satlas_sentinel2_transforms,
-    _satlas_transforms,
-)
+from .swin import (_satlas_bands, _satlas_landsat_bands,
+                   _satlas_sentinel2_bands, _satlas_sentinel2_transforms,
+                   _satlas_transforms)
 
 # https://github.com/zhu-xlab/DeCUR/blob/f190e9a3895ef645c005c8c2fce287ffa5a937e3/src/transfer_classification_BE/linear_BE_resnet.py#L286
 # Normalization by channel-wise band statistics
@@ -140,6 +136,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
             'bands': _satlas_landsat_bands,
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -153,6 +150,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
+            'bands': _satlas_landsat_bands,
             'bands': _satlas_landsat_bands,
         },
     )
@@ -168,6 +166,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
             'bands': _satlas_landsat_bands,
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -181,6 +180,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
+            'bands': _satlas_landsat_bands,
             'bands': _satlas_landsat_bands,
         },
     )
@@ -196,6 +196,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
             'bands': _satlas_landsat_bands,
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -209,6 +210,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
+            'bands': _satlas_landsat_bands,
             'bands': _satlas_landsat_bands,
         },
     )
@@ -224,6 +226,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
             'bands': _satlas_landsat_bands,
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -237,6 +240,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
+            'bands': _satlas_landsat_bands,
             'bands': _satlas_landsat_bands,
         },
     )
@@ -252,6 +256,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
             'bands': _satlas_landsat_bands,
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -265,6 +270,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
+            'bands': _satlas_landsat_bands,
             'bands': _satlas_landsat_bands,
         },
     )
@@ -280,6 +286,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'moco',
             'bands': _satlas_sentinel2_bands,
+            'bands': _satlas_sentinel2_bands,
         },
     )
 
@@ -294,6 +301,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'moco',
             'bands': _satlas_bands,
+            'bands': _satlas_bands,
         },
     )
 
@@ -307,6 +315,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2103.16607',
             'repo': 'https://github.com/ServiceNow/seasonal-contrast',
             'ssl_method': 'seco',
+            'bands': _satlas_bands,
             'bands': _satlas_bands,
         },
     )
@@ -332,6 +341,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/sustainlab-group/geography-aware-ssl',
             'ssl_method': 'gassl',
             'bands': ('R', 'G', 'B'),
+            'bands': ('R', 'G', 'B'),
         },
     )
 
@@ -345,6 +355,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
+            'bands': _satlas_landsat_bands,
             'bands': _satlas_landsat_bands,
         },
     )
@@ -360,6 +371,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
             'bands': _satlas_landsat_bands,
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -373,6 +385,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
+            'bands': _satlas_landsat_bands,
             'bands': _satlas_landsat_bands,
         },
     )
@@ -388,6 +401,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
             'bands': _satlas_landsat_bands,
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -401,6 +415,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
+            'bands': _satlas_landsat_bands,
             'bands': _satlas_landsat_bands,
         },
     )
@@ -416,6 +431,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
             'bands': _satlas_landsat_bands,
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -429,6 +445,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
+            'bands': _satlas_landsat_bands,
             'bands': _satlas_landsat_bands,
         },
     )
@@ -444,6 +461,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
             'bands': _satlas_landsat_bands,
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -457,6 +475,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
+            'bands': _satlas_landsat_bands,
             'bands': _satlas_landsat_bands,
         },
     )
@@ -472,6 +491,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
             'bands': _satlas_landsat_bands,
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -485,6 +505,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2309.05300',
             'repo': 'https://github.com/zhu-xlab/DeCUR',
             'ssl_method': 'decur',
+            'bands': ('VH', 'VV'),
             'bands': ('VH', 'VV'),
         },
     )
@@ -500,6 +521,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'moco',
             'bands': ('VH', 'VV'),
+            'bands': ('VH', 'VV'),
         },
     )
 
@@ -513,6 +535,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2309.05300',
             'repo': 'https://github.com/zhu-xlab/DeCUR',
             'ssl_method': 'decur',
+            'bands': _satlas_sentinel2_bands,
             'bands': _satlas_sentinel2_bands,
         },
     )
@@ -528,6 +551,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'dino',
             'bands': _satlas_sentinel2_bands,
+            'bands': _satlas_sentinel2_bands,
         },
     )
 
@@ -541,6 +565,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2211.07044',
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'moco',
+            'bands': _satlas_sentinel2_bands,
             'bands': _satlas_sentinel2_bands,
         },
     )
@@ -582,6 +607,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'moco',
             'bands': _satlas_bands,
+            'bands': _satlas_bands,
         },
     )
 
@@ -595,6 +621,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2103.16607',
             'repo': 'https://github.com/ServiceNow/seasonal-contrast',
             'ssl_method': 'seco',
+            'bands': _satlas_bands,
             'bands': _satlas_bands,
         },
     )

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -11,9 +11,8 @@ import torch
 from timm.models import ResNet
 from torchvision.models._api import Weights, WeightsEnum
 
-from .swin import (_satlas_bands, _satlas_landsat_bands,
-                   _satlas_sentinel2_bands, _satlas_sentinel2_transforms,
-                   _satlas_transforms)
+from .swin import (_satlas_bands, _satlas_landsat_bands, _satlas_sentinel2_bands, 
+                   _satlas_sentinel2_transforms, _satlas_transforms)
 
 # https://github.com/zhu-xlab/DeCUR/blob/f190e9a3895ef645c005c8c2fce287ffa5a937e3/src/transfer_classification_BE/linear_BE_resnet.py#L286
 # Normalization by channel-wise band statistics

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -19,7 +19,7 @@ from .swin import (
 )
 
 # Landsat TM-toa 7 channels
-_bands_7_channels_tm_toa = ('B1', 'B2', 'B3', 'B4', 'B5', 'B6', 'B7')
+bands_7_channels_tm_toa = ('B1', 'B2', 'B3', 'B4', 'B5', 'B6', 'B7')
 #https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LT05_C02_T1_TOA
 
 #Landsat ETM-toa 9 channels
@@ -170,7 +170,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
-            'bands': _bands_7_channels_tm_toa,
+            'bands': bands_7_channels_tm_toa,
         },
     )
 
@@ -184,7 +184,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': _bands_7_channels_tm_toa,
+            'bands': bands_7_channels_tm_toa,
         },
     )
 
@@ -376,7 +376,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
-            'bands': _bands_7_channels_tm_toa,
+            'bands': bands_7_channels_tm_toa,
         },
     )
 
@@ -390,7 +390,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': _bands_7_channels_tm_toa,
+            'bands': bands_7_channels_tm_toa,
         },
     )
 

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -20,15 +20,7 @@ from .swin import (
 
 # Landsat TM-TOA 7 channels
 # https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LT05_C02_T1_TOA
-_landsat_tm_toa_bands = [
-    'B1',
-    'B2',
-    'B3',
-    'B4',
-    'B5',
-    'B6',
-    'B7',
-]
+_landsat_tm_toa_bands = ['B1', 'B2', 'B3', 'B4', 'B5', 'B6', 'B7']
 
 # Landsat ETM-TOA 9 channels
 # https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LE07_C02_T1_TOA
@@ -46,14 +38,7 @@ _landsat_etm_toa_bands = [
 
 # Landsat ETM-SR 6 channels
 # https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LE07_C02_T1_L2
-_landsat_etm_sr_bands = [
-    'SR_B1',
-    'SR_B2',
-    'SR_B3',
-    'SR_B4',
-    'SR_B5',
-    'SR_B7',
-]
+_landsat_etm_sr_bands = ['SR_B1', 'SR_B2', 'SR_B3', 'SR_B4', 'SR_B5', 'SR_B7']
 
 # Landsat OLI_TIRS-TOA 11 channels
 # https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LC08_C02_T1_TOA
@@ -73,15 +58,7 @@ _landsat_oli_tirs_toa_bands = [
 
 # Landsat OLI-SR 7 channels
 # https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LC08_C02_T1_L2
-_landsat_oli_sr_bands = [
-    'SR_B1',
-    'SR_B2',
-    'SR_B3',
-    'SR_B4',
-    'SR_B5',
-    'SR_B6',
-    'SR_B7',
-]
+_landsat_oli_sr_bands = ['SR_B1', 'SR_B2', 'SR_B3', 'SR_B4', 'SR_B5', 'SR_B6', 'SR_B7']
 
 # All Sentinel-2 bands (13 channels)
 _sentinel2_all_bands = [

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -136,7 +136,6 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
             'bands': _satlas_landsat_bands,
-            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -150,7 +149,6 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': _satlas_landsat_bands,
             'bands': _satlas_landsat_bands,
         },
     )
@@ -166,7 +164,6 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
             'bands': _satlas_landsat_bands,
-            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -180,7 +177,6 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': _satlas_landsat_bands,
             'bands': _satlas_landsat_bands,
         },
     )
@@ -196,7 +192,6 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
             'bands': _satlas_landsat_bands,
-            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -210,7 +205,6 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': _satlas_landsat_bands,
             'bands': _satlas_landsat_bands,
         },
     )
@@ -226,7 +220,6 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
             'bands': _satlas_landsat_bands,
-            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -240,7 +233,6 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': _satlas_landsat_bands,
             'bands': _satlas_landsat_bands,
         },
     )
@@ -256,7 +248,6 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
             'bands': _satlas_landsat_bands,
-            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -270,7 +261,6 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': _satlas_landsat_bands,
             'bands': _satlas_landsat_bands,
         },
     )
@@ -286,7 +276,6 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'moco',
             'bands': _satlas_sentinel2_bands,
-            'bands': _satlas_sentinel2_bands,
         },
     )
 
@@ -301,7 +290,6 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'moco',
             'bands': _satlas_bands,
-            'bands': _satlas_bands,
         },
     )
 
@@ -315,7 +303,6 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2103.16607',
             'repo': 'https://github.com/ServiceNow/seasonal-contrast',
             'ssl_method': 'seco',
-            'bands': _satlas_bands,
             'bands': _satlas_bands,
         },
     )
@@ -341,7 +328,6 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/sustainlab-group/geography-aware-ssl',
             'ssl_method': 'gassl',
             'bands': ('R', 'G', 'B'),
-            'bands': ('R', 'G', 'B'),
         },
     )
 
@@ -355,7 +341,6 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
-            'bands': _satlas_landsat_bands,
             'bands': _satlas_landsat_bands,
         },
     )
@@ -371,7 +356,6 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
             'bands': _satlas_landsat_bands,
-            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -385,7 +369,6 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
-            'bands': _satlas_landsat_bands,
             'bands': _satlas_landsat_bands,
         },
     )
@@ -401,7 +384,6 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
             'bands': _satlas_landsat_bands,
-            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -415,7 +397,6 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
-            'bands': _satlas_landsat_bands,
             'bands': _satlas_landsat_bands,
         },
     )
@@ -431,7 +412,6 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
             'bands': _satlas_landsat_bands,
-            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -445,7 +425,6 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
-            'bands': _satlas_landsat_bands,
             'bands': _satlas_landsat_bands,
         },
     )
@@ -461,7 +440,6 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
             'bands': _satlas_landsat_bands,
-            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -475,7 +453,6 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
-            'bands': _satlas_landsat_bands,
             'bands': _satlas_landsat_bands,
         },
     )
@@ -491,7 +468,6 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
             'bands': _satlas_landsat_bands,
-            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -505,7 +481,6 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2309.05300',
             'repo': 'https://github.com/zhu-xlab/DeCUR',
             'ssl_method': 'decur',
-            'bands': ('VH', 'VV'),
             'bands': ('VH', 'VV'),
         },
     )
@@ -521,7 +496,6 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'moco',
             'bands': ('VH', 'VV'),
-            'bands': ('VH', 'VV'),
         },
     )
 
@@ -535,7 +509,6 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2309.05300',
             'repo': 'https://github.com/zhu-xlab/DeCUR',
             'ssl_method': 'decur',
-            'bands': _satlas_sentinel2_bands,
             'bands': _satlas_sentinel2_bands,
         },
     )
@@ -551,7 +524,6 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'dino',
             'bands': _satlas_sentinel2_bands,
-            'bands': _satlas_sentinel2_bands,
         },
     )
 
@@ -565,7 +537,6 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2211.07044',
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'moco',
-            'bands': _satlas_sentinel2_bands,
             'bands': _satlas_sentinel2_bands,
         },
     )
@@ -607,7 +578,6 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'moco',
             'bands': _satlas_bands,
-            'bands': _satlas_bands,
         },
     )
 
@@ -621,7 +591,6 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2103.16607',
             'repo': 'https://github.com/ServiceNow/seasonal-contrast',
             'ssl_method': 'seco',
-            'bands': _satlas_bands,
             'bands': _satlas_bands,
         },
     )

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -96,24 +96,13 @@ bands_13_channels_sentinel2 = [
 ]
 
 # RGB Sentinel-2 bands (3 channels)
-bands_3_channels_rgb = [
-    'B2',
-    'B3',
-    'B4',
-]
+bands_3_channels_rgb = ['B2', 'B3', 'B4']
 
 # RGB bands for fMoW dataset (3 channels)
-bands_3_channels_rgb_fmow = [
-    'B2',
-    'B3',
-    'B4',
-]
+bands_3_channels_rgb_fmow = ['B2', 'B3', 'B4']
 
 # Sentinel-1 bands (2 channels: VH and VV)
-bands_2_channels_sentinel1 = [
-    'VH',
-    'VV',
-]
+bands_2_channels_sentinel1 = ['VH','VV']
 
 # https://github.com/zhu-xlab/DeCUR/blob/f190e9a3895ef645c005c8c2fce287ffa5a937e3/src/transfer_classification_BE/linear_BE_resnet.py#L286
 # Normalization by channel-wise band statistics

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -19,27 +19,34 @@ from .swin import (
 )
 
 # Landsat TM-toa 7 channels
-bands_7_channels_tm_toa = ('B1', 'B2', 'B3', 'B4', 'B5', 'B6', 'B7')
-#https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LT05_C02_T1_TOA
+bands_7_channels_tm_toa = [
+    'B1', 'B2', 'B3', 'B4', 'B5', 'B6', 'B7'
+]  # https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LT05_C02_T1_TOA
 
-#Landsat ETM-toa 9 channels
-bands_9_channels_etm_toa = ['B1', 'B2', 'B3', 'B4', 'B5', 'B6_VCID_1', 'B6_VCID_2', 'B7', 'B8']
-#https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LE07_C02_T1_TOA
+# Landsat ETM-toa 9 channels
+bands_9_channels_etm_toa = [
+    'B1', 'B2', 'B3', 'B4', 'B5', 'B6_VCID_1', 'B6_VCID_2', 'B7', 'B8'
+]  # https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LE07_C02_T1_TOA
 
-#Landsat ETM-sr 6 channels
-bands_6_channels_etm_sr = ['SR_B1', 'SR_B2', 'SR_B3', 'SR_B4', 'SR_B5', 'SR_B7']
-#https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LE07_C02_T1_L2
+# Landsat ETM-sr 6 channels
+bands_6_channels_etm_sr = [
+    'SR_B1', 'SR_B2', 'SR_B3', 'SR_B4', 'SR_B5', 'SR_B7'
+]  # https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LE07_C02_T1_L2
 
-#Landsat OLI_TIRS-toa 11 channels
-bands_11_channels_oli_tirs = ['B1', 'B2', 'B3', 'B4', 'B5', 'B6', 'B7', 'B8', 'B9', 'B10', 'B11']
-#https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LC08_C02_T1_TOA
+# Landsat OLI_TIRS-toa 11 channels
+bands_11_channels_oli_tirs = [
+    'B1', 'B2', 'B3', 'B4', 'B5', 'B6', 'B7', 'B8', 'B9', 'B10', 'B11'
+]  # https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LC08_C02_T1_TOA
 
-#Landsat OLI-sr 7 channels
-bands_7_channels_oli_sr = ['SR_B1', 'SR_B2', 'SR_B3', 'SR_B4', 'SR_B5', 'SR_B6', 'SR_B7']
-#https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LC08_C02_T1_L2
+# Landsat OLI-sr 7 channels
+bands_7_channels_oli_sr = [
+    'SR_B1', 'SR_B2', 'SR_B3', 'SR_B4', 'SR_B5', 'SR_B6', 'SR_B7'
+]  # https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LC08_C02_T1_L2
 
 # All Sentinel-2 bands (13 channels)
-bands_13_channels_sentinel2 = ['B1', 'B2', 'B3', 'B4', 'B5', 'B6', 'B7', 'B8', 'B8a', 'B9', 'B10', 'B11', 'B12']
+bands_13_channels_sentinel2 = [
+    'B1', 'B2', 'B3', 'B4', 'B5', 'B6', 'B7', 'B8', 'B8a', 'B9', 'B10', 'B11', 'B12'
+]
 
 # RGB Sentinel-2 bands (3 channels)
 bands_3_channels_rgb = ['B2', 'B3', 'B4']

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -11,8 +11,13 @@ import torch
 from timm.models import ResNet
 from torchvision.models._api import Weights, WeightsEnum
 
-from .swin import (_satlas_bands, _satlas_landsat_bands, _satlas_sentinel2_bands, 
-                   _satlas_sentinel2_transforms, _satlas_transforms)
+from .swin import (
+    _satlas_bands,
+    _satlas_landsat_bands,
+    _satlas_sentinel2_bands,
+    _satlas_sentinel2_transforms,
+    _satlas_transforms,
+)
 
 # https://github.com/zhu-xlab/DeCUR/blob/f190e9a3895ef645c005c8c2fce287ffa5a937e3/src/transfer_classification_BE/linear_BE_resnet.py#L286
 # Normalization by channel-wise band statistics

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -19,7 +19,7 @@ from .swin import (
 )
 
 # Landsat TM-TOA 7 channels
-## https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LT05_C02_T1_TOA
+# https://developers.google.com/earth-engine/datasets/catalog/LANDSAT_LT05_C02_T1_TOA
 _landsat_tm_toa_bands = [
     'B1',
     'B2',

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -14,6 +14,7 @@ from torchvision.models._api import Weights, WeightsEnum
 from .swin import (
     _satlas_bands,
     _satlas_sentinel2_bands,
+    _satlas_landsat_bands,
     _satlas_sentinel2_transforms,
     _satlas_transforms,
 )
@@ -138,6 +139,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -151,6 +153,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -164,6 +167,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -177,6 +181,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -190,6 +195,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -203,6 +209,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -216,6 +223,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -229,6 +237,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -242,6 +251,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -255,6 +265,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -268,6 +279,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2211.07044',
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'moco',
+            'bands': _satlas_sentinel2_bands,
         },
     )
 
@@ -281,6 +293,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2211.07044',
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'moco',
+            'bands': _satlas_bands,
         },
     )
 
@@ -294,6 +307,7 @@ class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2103.16607',
             'repo': 'https://github.com/ServiceNow/seasonal-contrast',
             'ssl_method': 'seco',
+            'bands': _satlas_bands,
         },
     )
 
@@ -317,6 +331,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2011.09980',
             'repo': 'https://github.com/sustainlab-group/geography-aware-ssl',
             'ssl_method': 'gassl',
+            'bands': ('R', 'G', 'B'),
         },
     )
 
@@ -330,6 +345,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -343,6 +359,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -356,6 +373,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -369,6 +387,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -382,6 +401,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -395,6 +415,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -408,6 +429,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -421,6 +443,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -434,6 +457,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -447,6 +471,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -460,6 +485,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2309.05300',
             'repo': 'https://github.com/zhu-xlab/DeCUR',
             'ssl_method': 'decur',
+            'bands': ('VH', 'VV'),
         },
     )
 
@@ -473,6 +499,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2211.07044',
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'moco',
+            'bands': ('VH', 'VV'),
         },
     )
 
@@ -486,6 +513,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2309.05300',
             'repo': 'https://github.com/zhu-xlab/DeCUR',
             'ssl_method': 'decur',
+            'bands': _satlas_sentinel2_bands,
         },
     )
 
@@ -499,6 +527,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2211.07044',
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'dino',
+            'bands': _satlas_sentinel2_bands,
         },
     )
 
@@ -512,6 +541,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2211.07044',
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'moco',
+            'bands': _satlas_sentinel2_bands,
         },
     )
 
@@ -551,6 +581,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2211.07044',
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'moco',
+            'bands': _satlas_bands,
         },
     )
 
@@ -564,6 +595,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2103.16607',
             'repo': 'https://github.com/ServiceNow/seasonal-contrast',
             'ssl_method': 'seco',
+            'bands': _satlas_bands,
         },
     )
 

--- a/torchgeo/models/scale_mae.py
+++ b/torchgeo/models/scale_mae.py
@@ -14,6 +14,8 @@ from timm.models.vision_transformer import VisionTransformer
 from torch import Tensor
 from torchvision.models._api import Weights, WeightsEnum
 
+from .resnet import _fmow_rgb_bands
+
 _mean = torch.tensor([0.485, 0.456, 0.406])
 _std = torch.tensor([0.229, 0.224, 0.225])
 _scale_mae_transforms = K.AugmentationSequential(
@@ -204,6 +206,7 @@ class ScaleMAELarge16_Weights(WeightsEnum):  # type: ignore[misc]
             'model': 'vit_large_patch16',
             'publication': 'https://arxiv.org/abs/2212.14532',
             'repo': 'https://github.com/bair-climate-initiative/scale-mae',
+            'bands': _fmow_rgb_bands,
         },
     )
 

--- a/torchgeo/models/scale_mae.py
+++ b/torchgeo/models/scale_mae.py
@@ -14,8 +14,6 @@ from timm.models.vision_transformer import VisionTransformer
 from torch import Tensor
 from torchvision.models._api import Weights, WeightsEnum
 
-from .resnet import _fmow_rgb_bands
-
 _mean = torch.tensor([0.485, 0.456, 0.406])
 _std = torch.tensor([0.229, 0.224, 0.225])
 _scale_mae_transforms = K.AugmentationSequential(
@@ -206,7 +204,6 @@ class ScaleMAELarge16_Weights(WeightsEnum):  # type: ignore[misc]
             'model': 'vit_large_patch16',
             'publication': 'https://arxiv.org/abs/2212.14532',
             'repo': 'https://github.com/bair-climate-initiative/scale-mae',
-            'bands': _fmow_rgb_bands,
         },
     )
 

--- a/torchgeo/models/vit.py
+++ b/torchgeo/models/vit.py
@@ -11,14 +11,7 @@ import torch
 from timm.models.vision_transformer import VisionTransformer
 from torchvision.models._api import Weights, WeightsEnum
 
-from .resnet import (
-    _bands_7_channels_tm_toa, 
-    bands_9_channels_etm_toa, 
-    bands_6_channels_etm_sr, 
-    bands_11_channels_oli_tirs, 
-    bands_7_channels_oli_sr, 
-    bands_13_channels_sentinel2
-)
+from .resnet import bands_7_channels_tm_toa, bands_9_channels_etm_toa, bands_6_channels_etm_sr, bands_11_channels_oli_tirs, bands_7_channels_oli_sr, bands_13_channels_sentinel2
 
 # https://github.com/zhu-xlab/SSL4EO-S12/blob/d2868adfada65e40910bfcedfc49bc3b20df2248/src/benchmark/transfer_classification/linear_BE_moco.py#L167
 # https://github.com/zhu-xlab/SSL4EO-S12/blob/d2868adfada65e40910bfcedfc49bc3b20df2248/src/benchmark/transfer_classification/datasets/EuroSat/eurosat_dataset.py#L97
@@ -62,7 +55,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
-            'bands': _bands_7_channels_tm_toa,
+            'bands': bands_7_channels_tm_toa,
         },
     )
 
@@ -76,7 +69,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': _bands_7_channels_tm_toa,
+            'bands': bands_7_channels_tm_toa,
         },
     )
 

--- a/torchgeo/models/vit.py
+++ b/torchgeo/models/vit.py
@@ -10,7 +10,10 @@ import timm
 import torch
 from timm.models.vision_transformer import VisionTransformer
 from torchvision.models._api import Weights, WeightsEnum
-
+from .swin import (
+    _satlas_sentinel2_bands,
+    _satlas_landsat_bands,
+)
 # https://github.com/zhu-xlab/SSL4EO-S12/blob/d2868adfada65e40910bfcedfc49bc3b20df2248/src/benchmark/transfer_classification/linear_BE_moco.py#L167
 # https://github.com/zhu-xlab/SSL4EO-S12/blob/d2868adfada65e40910bfcedfc49bc3b20df2248/src/benchmark/transfer_classification/datasets/EuroSat/eurosat_dataset.py#L97
 # Normalization either by 10K or channel-wise with band statistics
@@ -53,6 +56,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -66,6 +70,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -79,6 +84,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -92,6 +98,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -105,6 +112,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -118,6 +126,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -131,6 +140,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -144,6 +154,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -157,6 +168,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -170,6 +182,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -183,6 +196,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2211.07044',
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'dino',
+            'bands': _satlas_sentinel2_bands,
         },
     )
 
@@ -196,6 +210,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2211.07044',
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'moco',
+            'bands': _satlas_sentinel2_bands,
         },
     )
 

--- a/torchgeo/models/vit.py
+++ b/torchgeo/models/vit.py
@@ -56,7 +56,6 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
             'bands': _satlas_landsat_bands,
-            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -70,7 +69,6 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': _satlas_landsat_bands,
             'bands': _satlas_landsat_bands,
         },
     )
@@ -86,7 +84,6 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
             'bands': _satlas_landsat_bands,
-            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -100,7 +97,6 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': _satlas_landsat_bands,
             'bands': _satlas_landsat_bands,
         },
     )
@@ -116,7 +112,6 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
             'bands': _satlas_landsat_bands,
-            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -130,7 +125,6 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': _satlas_landsat_bands,
             'bands': _satlas_landsat_bands,
         },
     )
@@ -146,7 +140,6 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
             'bands': _satlas_landsat_bands,
-            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -160,7 +153,6 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': _satlas_landsat_bands,
             'bands': _satlas_landsat_bands,
         },
     )
@@ -176,7 +168,6 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
             'bands': _satlas_landsat_bands,
-            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -190,7 +181,6 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': _satlas_landsat_bands,
             'bands': _satlas_landsat_bands,
         },
     )
@@ -206,7 +196,6 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'dino',
             'bands': _satlas_sentinel2_bands,
-            'bands': _satlas_sentinel2_bands,
         },
     )
 
@@ -220,7 +209,6 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2211.07044',
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'moco',
-            'bands': _satlas_sentinel2_bands,
             'bands': _satlas_sentinel2_bands,
         },
     )

--- a/torchgeo/models/vit.py
+++ b/torchgeo/models/vit.py
@@ -11,7 +11,14 @@ import torch
 from timm.models.vision_transformer import VisionTransformer
 from torchvision.models._api import Weights, WeightsEnum
 
-from .resnet import _bands_7_channels_tm_toa, bands_9_channels_etm_toa, bands_6_channels_etm_sr, bands_11_channels_oli_tirs, bands_7_channels_oli_sr, bands_13_channels_sentinel2
+from .resnet import (
+    _bands_7_channels_tm_toa, 
+    bands_9_channels_etm_toa, 
+    bands_6_channels_etm_sr, 
+    bands_11_channels_oli_tirs, 
+    bands_7_channels_oli_sr, 
+    bands_13_channels_sentinel2
+)
 
 # https://github.com/zhu-xlab/SSL4EO-S12/blob/d2868adfada65e40910bfcedfc49bc3b20df2248/src/benchmark/transfer_classification/linear_BE_moco.py#L167
 # https://github.com/zhu-xlab/SSL4EO-S12/blob/d2868adfada65e40910bfcedfc49bc3b20df2248/src/benchmark/transfer_classification/datasets/EuroSat/eurosat_dataset.py#L97

--- a/torchgeo/models/vit.py
+++ b/torchgeo/models/vit.py
@@ -10,10 +10,9 @@ import timm
 import torch
 from timm.models.vision_transformer import VisionTransformer
 from torchvision.models._api import Weights, WeightsEnum
-from .swin import (
-    _satlas_sentinel2_bands,
-    _satlas_landsat_bands,
-)
+
+from .swin import _satlas_landsat_bands, _satlas_sentinel2_bands
+
 # https://github.com/zhu-xlab/SSL4EO-S12/blob/d2868adfada65e40910bfcedfc49bc3b20df2248/src/benchmark/transfer_classification/linear_BE_moco.py#L167
 # https://github.com/zhu-xlab/SSL4EO-S12/blob/d2868adfada65e40910bfcedfc49bc3b20df2248/src/benchmark/transfer_classification/datasets/EuroSat/eurosat_dataset.py#L97
 # Normalization either by 10K or channel-wise with band statistics
@@ -57,6 +56,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
             'bands': _satlas_landsat_bands,
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -70,6 +70,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
+            'bands': _satlas_landsat_bands,
             'bands': _satlas_landsat_bands,
         },
     )
@@ -85,6 +86,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
             'bands': _satlas_landsat_bands,
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -98,6 +100,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
+            'bands': _satlas_landsat_bands,
             'bands': _satlas_landsat_bands,
         },
     )
@@ -113,6 +116,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
             'bands': _satlas_landsat_bands,
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -126,6 +130,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
+            'bands': _satlas_landsat_bands,
             'bands': _satlas_landsat_bands,
         },
     )
@@ -141,6 +146,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
             'bands': _satlas_landsat_bands,
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -154,6 +160,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
+            'bands': _satlas_landsat_bands,
             'bands': _satlas_landsat_bands,
         },
     )
@@ -169,6 +176,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
             'bands': _satlas_landsat_bands,
+            'bands': _satlas_landsat_bands,
         },
     )
 
@@ -182,6 +190,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
+            'bands': _satlas_landsat_bands,
             'bands': _satlas_landsat_bands,
         },
     )
@@ -197,6 +206,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'dino',
             'bands': _satlas_sentinel2_bands,
+            'bands': _satlas_sentinel2_bands,
         },
     )
 
@@ -210,6 +220,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2211.07044',
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'moco',
+            'bands': _satlas_sentinel2_bands,
             'bands': _satlas_sentinel2_bands,
         },
     )

--- a/torchgeo/models/vit.py
+++ b/torchgeo/models/vit.py
@@ -12,12 +12,12 @@ from timm.models.vision_transformer import VisionTransformer
 from torchvision.models._api import Weights, WeightsEnum
 
 from .resnet import (
-    bands_6_channels_etm_sr,
-    bands_7_channels_oli_sr,
-    bands_7_channels_tm_toa,
-    bands_9_channels_etm_toa,
-    bands_11_channels_oli_tirs,
-    bands_13_channels_sentinel2,
+    _landsat_etm_sr_bands,
+    _landsat_oli_sr_bands,
+    _landsat_tm_toa_bands,
+    _landsat_etm_toa_bands,
+    _landsat_oli_tirs_toa_bands,
+    _sentinel2_all_bands,
 )
 
 # https://github.com/zhu-xlab/SSL4EO-S12/blob/d2868adfada65e40910bfcedfc49bc3b20df2248/src/benchmark/transfer_classification/linear_BE_moco.py#L167
@@ -62,7 +62,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
-            'bands': bands_7_channels_tm_toa,
+            'bands': _landsat_tm_toa_bands,
         },
     )
 
@@ -76,7 +76,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': bands_7_channels_tm_toa,
+            'bands': _landsat_tm_toa_bands,
         },
     )
 
@@ -90,7 +90,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
-            'bands': bands_9_channels_etm_toa,
+            'bands': _landsat_etm_toa_bands,
         },
     )
 
@@ -104,7 +104,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': bands_9_channels_etm_toa,
+            'bands': _landsat_etm_toa_bands,
         },
     )
 
@@ -118,7 +118,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
-            'bands': bands_6_channels_etm_sr,
+            'bands': _landsat_etm_sr_bands,
         },
     )
 
@@ -132,7 +132,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': bands_6_channels_etm_sr,
+            'bands': _landsat_etm_sr_bands,
         },
     )
 
@@ -146,7 +146,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
-            'bands': bands_11_channels_oli_tirs,
+            'bands': _landsat_oli_tirs_toa_bands,
         },
     )
 
@@ -160,7 +160,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': bands_11_channels_oli_tirs,
+            'bands': _landsat_oli_tirs_toa_bands,
         },
     )
 
@@ -174,7 +174,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
-            'bands': bands_7_channels_oli_sr,
+            'bands': _landsat_oli_sr_bands,
         },
     )
 
@@ -188,7 +188,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': bands_7_channels_oli_sr,
+            'bands': _landsat_oli_sr_bands,
         },
     )
 
@@ -202,7 +202,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2211.07044',
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'dino',
-            'bands': bands_13_channels_sentinel2,
+            'bands': _sentinel2_all_bands,
         },
     )
 
@@ -216,7 +216,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2211.07044',
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'moco',
-            'bands': bands_13_channels_sentinel2,
+            'bands': _sentinel2_all_bands,
         },
     )
 

--- a/torchgeo/models/vit.py
+++ b/torchgeo/models/vit.py
@@ -11,7 +11,7 @@ import torch
 from timm.models.vision_transformer import VisionTransformer
 from torchvision.models._api import Weights, WeightsEnum
 
-from .swin import _satlas_landsat_bands, _satlas_sentinel2_bands
+from .resnet import _bands_7_channels_tm_toa, bands_9_channels_etm_toa, bands_6_channels_etm_sr, bands_11_channels_oli_tirs, bands_7_channels_oli_sr, bands_13_channels_sentinel2
 
 # https://github.com/zhu-xlab/SSL4EO-S12/blob/d2868adfada65e40910bfcedfc49bc3b20df2248/src/benchmark/transfer_classification/linear_BE_moco.py#L167
 # https://github.com/zhu-xlab/SSL4EO-S12/blob/d2868adfada65e40910bfcedfc49bc3b20df2248/src/benchmark/transfer_classification/datasets/EuroSat/eurosat_dataset.py#L97
@@ -55,7 +55,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
-            'bands': _satlas_landsat_bands,
+            'bands': _bands_7_channels_tm_toa,
         },
     )
 
@@ -69,7 +69,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': _satlas_landsat_bands,
+            'bands': _bands_7_channels_tm_toa,
         },
     )
 
@@ -83,7 +83,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
-            'bands': _satlas_landsat_bands,
+            'bands': bands_9_channels_etm_toa,
         },
     )
 
@@ -97,7 +97,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': _satlas_landsat_bands,
+            'bands': bands_9_channels_etm_toa,
         },
     )
 
@@ -111,7 +111,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
-            'bands': _satlas_landsat_bands,
+            'bands': bands_6_channels_etm_sr,
         },
     )
 
@@ -125,7 +125,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': _satlas_landsat_bands,
+            'bands': bands_6_channels_etm_sr,
         },
     )
 
@@ -139,7 +139,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
-            'bands': _satlas_landsat_bands,
+            'bands': bands_11_channels_oli_tirs,
         },
     )
 
@@ -153,7 +153,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': _satlas_landsat_bands,
+            'bands': bands_11_channels_oli_tirs,
         },
     )
 
@@ -167,7 +167,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'moco',
-            'bands': _satlas_landsat_bands,
+            'bands': bands_7_channels_oli_sr,
         },
     )
 
@@ -181,7 +181,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2306.09424',
             'repo': 'https://github.com/microsoft/torchgeo',
             'ssl_method': 'simclr',
-            'bands': _satlas_landsat_bands,
+            'bands': bands_7_channels_oli_sr,
         },
     )
 
@@ -195,7 +195,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2211.07044',
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'dino',
-            'bands': _satlas_sentinel2_bands,
+            'bands': bands_13_channels_sentinel2,
         },
     )
 
@@ -209,7 +209,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2211.07044',
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'moco',
-            'bands': _satlas_sentinel2_bands,
+            'bands': bands_13_channels_sentinel2,
         },
     )
 

--- a/torchgeo/models/vit.py
+++ b/torchgeo/models/vit.py
@@ -17,7 +17,7 @@ from .resnet import (
     _landsat_oli_sr_bands,
     _landsat_oli_tirs_toa_bands,
     _landsat_tm_toa_bands,
-    _sentinel2_all_bands,
+    _sentinel2_toa_all_bands,
 )
 
 # https://github.com/zhu-xlab/SSL4EO-S12/blob/d2868adfada65e40910bfcedfc49bc3b20df2248/src/benchmark/transfer_classification/linear_BE_moco.py#L167
@@ -202,7 +202,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2211.07044',
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'dino',
-            'bands': _sentinel2_all_bands,
+            'bands': _sentinel2_toa_all_bands,
         },
     )
 
@@ -216,7 +216,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2211.07044',
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'moco',
-            'bands': _sentinel2_all_bands,
+            'bands': _sentinel2_toa_all_bands,
         },
     )
 

--- a/torchgeo/models/vit.py
+++ b/torchgeo/models/vit.py
@@ -3,15 +3,22 @@
 
 """Pre-trained Vision Transformer models."""
 
-from typing import Any
+from typing import Any  # Standard library imports
 
-import kornia.augmentation as K
+import kornia.augmentation as K  # Third-party imports
 import timm
 import torch
 from timm.models.vision_transformer import VisionTransformer
 from torchvision.models._api import Weights, WeightsEnum
 
-from .resnet import bands_7_channels_tm_toa, bands_9_channels_etm_toa, bands_6_channels_etm_sr, bands_11_channels_oli_tirs, bands_7_channels_oli_sr, bands_13_channels_sentinel2
+from .resnet import (  # Local module imports
+    _bands_7_channels_tm_toa,
+    bands_9_channels_etm_toa,
+    bands_6_channels_etm_sr,
+    bands_11_channels_oli_tirs,
+    bands_7_channels_oli_sr,
+    bands_13_channels_sentinel2,
+)
 
 # https://github.com/zhu-xlab/SSL4EO-S12/blob/d2868adfada65e40910bfcedfc49bc3b20df2248/src/benchmark/transfer_classification/linear_BE_moco.py#L167
 # https://github.com/zhu-xlab/SSL4EO-S12/blob/d2868adfada65e40910bfcedfc49bc3b20df2248/src/benchmark/transfer_classification/datasets/EuroSat/eurosat_dataset.py#L97

--- a/torchgeo/models/vit.py
+++ b/torchgeo/models/vit.py
@@ -3,20 +3,20 @@
 
 """Pre-trained Vision Transformer models."""
 
-from typing import Any  # Standard library imports
+from typing import Any
 
-import kornia.augmentation as K  # Third-party imports
+import kornia.augmentation as K
 import timm
 import torch
 from timm.models.vision_transformer import VisionTransformer
 from torchvision.models._api import Weights, WeightsEnum
 
-from .resnet import (  # Local module imports
+from .resnet import (
+    bands_6_channels_etm_sr,
+    bands_7_channels_oli_sr,
     bands_7_channels_tm_toa,
     bands_9_channels_etm_toa,
-    bands_6_channels_etm_sr,
     bands_11_channels_oli_tirs,
-    bands_7_channels_oli_sr,
     bands_13_channels_sentinel2,
 )
 

--- a/torchgeo/models/vit.py
+++ b/torchgeo/models/vit.py
@@ -12,7 +12,7 @@ from timm.models.vision_transformer import VisionTransformer
 from torchvision.models._api import Weights, WeightsEnum
 
 from .resnet import (  # Local module imports
-    _bands_7_channels_tm_toa,
+    bands_7_channels_tm_toa,
     bands_9_channels_etm_toa,
     bands_6_channels_etm_sr,
     bands_11_channels_oli_tirs,

--- a/torchgeo/models/vit.py
+++ b/torchgeo/models/vit.py
@@ -13,10 +13,10 @@ from torchvision.models._api import Weights, WeightsEnum
 
 from .resnet import (
     _landsat_etm_sr_bands,
-    _landsat_oli_sr_bands,
-    _landsat_tm_toa_bands,
     _landsat_etm_toa_bands,
+    _landsat_oli_sr_bands,
     _landsat_oli_tirs_toa_bands,
+    _landsat_tm_toa_bands,
     _sentinel2_all_bands,
 )
 

--- a/torchgeo/models/vit.py
+++ b/torchgeo/models/vit.py
@@ -17,7 +17,7 @@ from .resnet import (
     _landsat_oli_sr_bands,
     _landsat_oli_tirs_toa_bands,
     _landsat_tm_toa_bands,
-    _sentinel2_toa_all_bands,
+    _sentinel2_toa_bands,
 )
 
 # https://github.com/zhu-xlab/SSL4EO-S12/blob/d2868adfada65e40910bfcedfc49bc3b20df2248/src/benchmark/transfer_classification/linear_BE_moco.py#L167
@@ -202,7 +202,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2211.07044',
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'dino',
-            'bands': _sentinel2_toa_all_bands,
+            'bands': _sentinel2_toa_bands,
         },
     )
 
@@ -216,7 +216,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2211.07044',
             'repo': 'https://github.com/zhu-xlab/SSL4EO-S12',
             'ssl_method': 'moco',
-            'bands': _sentinel2_toa_all_bands,
+            'bands': _sentinel2_toa_bands,
         },
     )
 


### PR DESCRIPTION
This PR introduces consistent `bands` metadata across `vit.py` and `resnet.py` weight classes to enhance usability and ensure alignment with existing metadata standards in the project.

#### Changes to `vit.py`
- Added `bands` metadata for Vision Transformer (ViT) weight classes.
- Updated `vit.py` to import `_satlas_bands`, `_satlas_sentinel2_bands`, and `_satlas_landsat_bands` from `swin.py` for consistent band definitions.
- Applied correct band metadata for each ViT weight class, supporting Landsat and Sentinel datasets, ensuring metadata aligns with project standards.

#### Changes to `resnet.py`
- Added `bands` metadata for ResNet weight classes, providing consistent metadata across ResNet weights.
- Updated `resnet.py` to import `_satlas_bands`, `_satlas_sentinel2_bands`, and `_satlas_landsat_bands` from `swin.py`.
- Updated metadata fields to align with the Sentinel and Landsat dataset specifications, improving compatibility and usability for model users.
Fixes #2364 
