### PR TITLE
Remove Chesapeake7 and Chesapeake13

### DIFF
--- a/torchgeo/datasets/__init__.py
+++ b/torchgeo/datasets/__init__.py
@@ -155,8 +155,6 @@ __all__ = (
     'CanadianBuildingFootprints',
     'CDL',
     'Chesapeake',
-    'Chesapeake7',
-    'Chesapeake13',
     'ChesapeakeDC',
     'ChesapeakeDE',
     'ChesapeakeMD',


### PR DESCRIPTION
`Chesapeake7` and `Chesapeake13` are not found in the datasets. They should be removed. 