### PR TITLE
Update utils.py

### DIFF
--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -173,8 +173,8 @@ class BoundingBox:
                 min(self.maxx, other.maxx),
                 max(self.miny, other.miny),
                 min(self.maxy, other.maxy),
-                max(self.mint, other.mint),
-                min(self.maxt, other.maxt),
+                min(self.mint, other.mint),
+                max(self.maxt, other.maxt),
             )
         except ValueError:
             raise ValueError(f'Bounding boxes {self} and {other} do not overlap')


### PR DESCRIPTION
fix the bug！
when running code:
dataset = naip & chesapeake  
from https://torchgeo.readthedocs.io/en/stable/tutorials/getting_started.html;  
it generates an err: 
ValueError: Bounding boxes BoundingBox(minx=440055.0, maxx=446085.0, miny=4295910.600000001, maxy=4303429.2, mint=1541260800.0, maxt=1541347199.999999) and BoundingBox(minx=402172.2959946942, maxx=532531.001762003, miny=4244077.01658443, maxy=4414067.523828775, mint=1356969600.0, maxt=1388505599.999999) do not overlap.

This new request  fix the err .