### PR TITLE
Million-AID, ForestDamage: fix _verify docstring

### DIFF
--- a/torchgeo/datasets/forestdamage.py
+++ b/torchgeo/datasets/forestdamage.py
@@ -217,11 +217,7 @@ class ForestDamage(NonGeoDataset):
         return boxes, labels
 
     def _verify(self) -> None:
-        """Checks the integrity of the dataset structure.
-
-        Returns:
-            True if the dataset directories are found, else False
-        """
+        """Verify the integrity of the dataset."""
         filepath = os.path.join(self.root, self.data_dir)
         if os.path.isdir(filepath):
             return

--- a/torchgeo/datasets/millionaid.py
+++ b/torchgeo/datasets/millionaid.py
@@ -312,11 +312,7 @@ class MillionAID(NonGeoDataset):
             return tensor
 
     def _verify(self) -> None:
-        """Checks the integrity of the dataset structure.
-
-        Returns:
-            True if the dataset directories are found, else False
-        """
+        """Verify the integrity of the dataset."""
         filepath = os.path.join(self.root, self.split)
         if os.path.isdir(filepath):
             return


### PR DESCRIPTION
The dangers of copy-n-paste...

Neither of these methods return anything, but the docstring was copied from ADVANCE and no one noticed.