### PR TITLE
Multi-bbox timeseries querying

### DIFF
--- a/test.ipynb
+++ b/test.ipynb
@@ -95,21 +95,1079 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import plotly.express as px\n",
+    "\n",
+    "def plot(\n",
+    "    sample: dict,\n",
+    "    indices_to_plot,\n",
+    "    show = False,\n",
+    "    **kwargs,\n",
+    "):\n",
+    "    \"\"\"Plots the image data from the given sample.\n",
+    "\n",
+    "    Args:\n",
+    "        sample (dict): A dictionary containing the image data returned by self.__get_item__. Should contain the key \"image\".\n",
+    "        indices_to_plot (list, optional): A list of indices to plot. If not provided, the method will use the RGB bands defined in `self.rgb_bands`.\n",
+    "        show (bool, optional): Whether to display the plot. Defaults to False.\n",
+    "        **kwargs (dict): Additional keyword arguments to be passed to `px.imshow`.\n",
+    "\n",
+    "    Returns:\n",
+    "        fig: The plotly figure object.\n",
+    "    \"\"\"\n",
+    "    image = sample[\"image\"]\n",
+    "\n",
+    "    # Reorder and rescale the image\n",
+    "    if (sample[\"image\"].ndim == 4) and (sample[\"image\"].shape[0] > 1):\n",
+    "        # Shape of image = [d, c, h, w]\n",
+    "        image = image[:, indices_to_plot, :, :].permute(0, 2, 3, 1)\n",
+    "        if image.shape[-1] == 1:\n",
+    "            image = image.squeeze(-1)\n",
+    "        image = torch.clamp(image / 10000, min=0, max=1).numpy()\n",
+    "\n",
+    "        fig = px.imshow(\n",
+    "            image, animation_frame=0, labels={\"animation_frame\": \"Date\"}, **kwargs\n",
+    "        )\n",
+    "        # Todo, currently taking the first date, need to handle multiple dates\n",
+    "        date_labels = [\n",
+    "            dates[0].strftime(\"%m/%d/%Y, %H:%M:%S\") for dates in sample[\"dates\"]\n",
+    "        ]\n",
+    "        for i, label in enumerate(date_labels):\n",
+    "            fig.layout.sliders[0].steps[i].label = label\n",
+    "\n",
+    "    else:\n",
+    "        image = image[indices_to_plot].permute(1, 2, 0)\n",
+    "        image = torch.clamp(image / 10000, min=0, max=1).numpy()\n",
+    "\n",
+    "        # Plot the image\n",
+    "        fig = px.imshow(image, **kwargs)\n",
+    "\n",
+    "    fig.update_xaxes(showticklabels=False).update_yaxes(showticklabels=False)\n",
+    "    if show:\n",
+    "        fig.show()\n",
+    "    return fig"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "None\n"
-     ]
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "hovertemplate": "x: %{x}<br>y: %{y}<extra></extra>",
+         "name": "0",
+         "source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAANCAIAAAD9iXMrAAAAfElEQVR4XpWRsQ0CMQxFP0hXs8wtwRD0twk912aJXE/NOqGF4lEQRbHPkeBV9rflb8uip5B5AXAjmcoB0A8cvTDg/75HpwaYbRsXL7Q73tLkRvQ037hpk6RV+vpmZxJQ9yuQoNgaVzjXML5j9sLgH0/pZNL7bl7/1rS08AMeovHfi9t0qgAAAABJRU5ErkJggg==",
+         "type": "image",
+         "xaxis": "x",
+         "yaxis": "y"
+        }
+       ],
+       "frames": [
+        {
+         "data": [
+          {
+           "name": "0",
+           "source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAANCAIAAAD9iXMrAAAAfElEQVR4XpWRsQ0CMQxFP0hXs8wtwRD0twk912aJXE/NOqGF4lEQRbHPkeBV9rflb8uip5B5AXAjmcoB0A8cvTDg/75HpwaYbRsXL7Q73tLkRvQ037hpk6RV+vpmZxJQ9yuQoNgaVzjXML5j9sLgH0/pZNL7bl7/1rS08AMeovHfi9t0qgAAAABJRU5ErkJggg==",
+           "type": "image"
+          }
+         ],
+         "layout": {
+          "margin": {
+           "t": 60
+          }
+         },
+         "name": "0"
+        },
+        {
+         "data": [
+          {
+           "name": "1",
+           "source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAANCAIAAAD9iXMrAAAAjUlEQVR4XnWQuxXDMAhFXzJLqtRawptoEw+QNku4zybyEm7T3BRGgHyU2wBPfARiQgXaKN014aldjywcUi+obLn+iucBn+QbPj3nTamnsbyY2QDeEVpHAW1x2Yi8zg3Im/0j7rK7d5zm5YIUd+lc7rsCbFQNf1vwBY2+4NhvBb4exREKSg0qxV/MNaHwA3n7fU3SxPVDAAAAAElFTkSuQmCC",
+           "type": "image"
+          }
+         ],
+         "layout": {
+          "margin": {
+           "t": 60
+          }
+         },
+         "name": "1"
+        }
+       ],
+       "layout": {
+        "margin": {
+         "t": 60
+        },
+        "sliders": [
+         {
+          "active": 0,
+          "currentvalue": {
+           "prefix": "Date="
+          },
+          "len": 0.9,
+          "pad": {
+           "b": 10,
+           "t": 60
+          },
+          "steps": [
+           {
+            "args": [
+             [
+              "0"
+             ],
+             {
+              "frame": {
+               "duration": 0,
+               "redraw": true
+              },
+              "fromcurrent": true,
+              "mode": "immediate",
+              "transition": {
+               "duration": 0,
+               "easing": "linear"
+              }
+             }
+            ],
+            "label": "04/12/2019, 16:28:41",
+            "method": "animate"
+           },
+           {
+            "args": [
+             [
+              "1"
+             ],
+             {
+              "frame": {
+               "duration": 0,
+               "redraw": true
+              },
+              "fromcurrent": true,
+              "mode": "immediate",
+              "transition": {
+               "duration": 0,
+               "easing": "linear"
+              }
+             }
+            ],
+            "label": "04/12/2022, 16:28:41",
+            "method": "animate"
+           }
+          ],
+          "x": 0.1,
+          "xanchor": "left",
+          "y": 0,
+          "yanchor": "top"
+         }
+        ],
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "heatmapgl": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmapgl"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "#E5ECF6",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "white"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "#E5ECF6",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "radialaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "yaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "zaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "caxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "updatemenus": [
+         {
+          "buttons": [
+           {
+            "args": [
+             null,
+             {
+              "frame": {
+               "duration": 500,
+               "redraw": true
+              },
+              "fromcurrent": true,
+              "mode": "immediate",
+              "transition": {
+               "duration": 500,
+               "easing": "linear"
+              }
+             }
+            ],
+            "label": "&#9654;",
+            "method": "animate"
+           },
+           {
+            "args": [
+             [
+              null
+             ],
+             {
+              "frame": {
+               "duration": 0,
+               "redraw": true
+              },
+              "fromcurrent": true,
+              "mode": "immediate",
+              "transition": {
+               "duration": 0,
+               "easing": "linear"
+              }
+             }
+            ],
+            "label": "&#9724;",
+            "method": "animate"
+           }
+          ],
+          "direction": "left",
+          "pad": {
+           "r": 10,
+           "t": 70
+          },
+          "showactive": false,
+          "type": "buttons",
+          "x": 0.1,
+          "xanchor": "right",
+          "y": 0,
+          "yanchor": "top"
+         }
+        ],
+        "xaxis": {
+         "anchor": "y",
+         "domain": [
+          0,
+          1
+         ],
+         "showticklabels": false
+        },
+        "yaxis": {
+         "anchor": "x",
+         "domain": [
+          0,
+          1
+         ],
+         "showticklabels": false
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
-    "import rasterio\n",
-    "with rasterio.open(r\"C:\\Users\\Sieger.Falkena\\Documents\\torchgeo\\tests\\data\\sentinel2\\S2A_MSIL2A_20220414T110751_N0400_R108_T26EMU_20220414T165533.SAFE\\GRANULE\\L2A_T26EMU_A035569_20220414T110747\\IMG_DATA\\R10m\\T26EMU_20190414T110751_B02_10m.jp2\") as src:\n",
-    "    print(src.nodata)"
+    "plot(sample, show=False, indices_to_plot=[2, 1, 0])"
    ]
   }
  ],

--- a/test.ipynb
+++ b/test.ipynb
@@ -1,0 +1,137 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Populating index\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 16/16 [00:00<00:00, 76.25it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "from torchgeo.datasets import Sentinel2\n",
+    "\n",
+    "data_dir = r\"tests\\data\\sentinel2\"\n",
+    "\n",
+    "ds = Sentinel2(data_dir, bands=[\"B02\", \"B03\", \"B04\", \"B08\"], cache=False, res=10)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "BoundingBox(minx=399960.0, maxx=401240.0, miny=4498720.0, maxy=4500000.0, mint=1555079321.0, maxt=1649927271.999999)"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ds.bounds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "torch.Size([1, 4, 13, 13])\n",
+      "[[datetime.datetime(2022, 4, 12, 16, 28, 41), datetime.datetime(2019, 4, 12, 16, 28, 41), datetime.datetime(2019, 4, 14, 11, 7, 51), datetime.datetime(2022, 4, 14, 11, 7, 51)]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "from torchgeo.datasets.utils import BoundingBox\n",
+    "full_t_query = BoundingBox(minx=399960.0, maxx=400088.0, miny=4498720.0, maxy=4498848.0, mint=1555079321.0, maxt=1649927271.999999)\n",
+    "sample = ds[[full_t_query]]\n",
+    "print(sample[\"image\"].shape)\n",
+    "print(sample[\"dates\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "torch.Size([2, 4, 13, 13])\n",
+      "[[datetime.datetime(2019, 4, 12, 16, 28, 41), datetime.datetime(2019, 4, 14, 11, 7, 51)], [datetime.datetime(2022, 4, 12, 16, 28, 41), datetime.datetime(2022, 4, 14, 11, 7, 51)]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "multi_t_query = [BoundingBox(minx=399960.0, maxx=400088.0, miny=4498720.0, maxy=4498848.0, mint=1555079321.0, maxt=1605264929),\n",
+    "                 BoundingBox(minx=399960.0, maxx=400088.0, miny=4498720.0, maxy=4498848.0, mint=1605264929.0, maxt=1649927272),\n",
+    "                 ]\n",
+    "sample = ds[multi_t_query]\n",
+    "print(sample[\"image\"].shape)\n",
+    "print(sample[\"dates\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "None\n"
+     ]
+    }
+   ],
+   "source": [
+    "import rasterio\n",
+    "with rasterio.open(r\"C:\\Users\\Sieger.Falkena\\Documents\\torchgeo\\tests\\data\\sentinel2\\S2A_MSIL2A_20220414T110751_N0400_R108_T26EMU_20220414T165533.SAFE\\GRANULE\\L2A_T26EMU_A035569_20220414T110747\\IMG_DATA\\R10m\\T26EMU_20190414T110751_B02_10m.jp2\") as src:\n",
+    "    print(src.nodata)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "cca",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -649,7 +649,9 @@ class RasterDataset(GeoDataset):
 
         return pd.DataFrame(file_metadata)
 
-    def __merge_single_bbox(self, query: BoundingBox) -> tuple[torch.Tensor | None, list[str]]:
+    def __merge_single_bbox(
+        self, query: BoundingBox
+    ) -> tuple[torch.Tensor | None, list[str]]:
         """Merge all files that intersect with a single bounding box.
 
         Args:
@@ -687,7 +689,9 @@ class RasterDataset(GeoDataset):
 
         if res_single_bbox is not None:
             # Check if res_single_date contains nodata values and only append if it doesn't
-            if not self.drop_nodata or not torch.any(res_single_bbox == self.nodata_value):
+            if not self.drop_nodata or not torch.any(
+                res_single_bbox == self.nodata_value
+            ):
                 return res_single_bbox, dates
         return None, []
 

--- a/torchgeo/datasets/sentinel.py
+++ b/torchgeo/datasets/sentinel.py
@@ -266,7 +266,7 @@ class Sentinel2(Sentinel):
 
     # https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-2-msi/naming-convention
     # https://sentinel.esa.int/documents/247904/685211/Sentinel-2-MSI-L2A-Product-Format-Specifications.pdf
-    filename_glob = 'T*_*_{}*.*'
+    filename_glob = 'T*_*_*.*'
     filename_regex = r"""
         ^T(?P<tile>\d{{2}}[A-Z]{{3}})
         _(?P<date>\d{{8}}T\d{{6}})
@@ -295,6 +295,7 @@ class Sentinel2(Sentinel):
     rgb_bands = ('B04', 'B03', 'B02')
 
     separate_files = True
+    nodata_value = 0
 
     def __init__(
         self,
@@ -325,7 +326,7 @@ class Sentinel2(Sentinel):
             *root* was renamed to *paths*
         """
         bands = bands or self.all_bands
-        self.filename_glob = self.filename_glob.format(bands[0])
+        # self.filename_glob = self.filename_glob.format(bands[0])
         self.filename_regex = self.filename_regex.format(res)
 
         super().__init__(paths, crs, res, bands, transforms, cache)


### PR DESCRIPTION
This is a PR that is part of TorchGeo Timeseries support (#2382 - Return time series). The goal is to provide an interface that allows for the following options for querying: 

`sample = dataset[bbox]`
`sample = dataset[[bbox1, bbox2, bbox3]]`
`sample = dataset[([dataset1_bbox1], [dataset2_bbox1, dataset2_bbox2])]`

The idea is that anything within a single bbox get's merged into a single raster, and that any query with multiple bboxes will stack along the time dimension. Querying with a tuple of (iterable) bboxes would split the subqueries to different datasets.

As long as this PR is in draft mode, I will keep `test.ipynb` for anyone interested in helping to try out the new method. 

**Current status:** The first two ways of querying has been implemented for the RasterDataset and tested with a small example.

What has changed:
- I've refactored quite a bit to reduce the complexity of  `__init__` and `__get_item__` methods. `try_set_metadata, _get_bounds, _compile_and_check_filename_regex` and `_populate_index` are examples of this.
- Existing functionality to merge everything within a bbox has been moved in `__merge_single_bbox`, where the biggest difference is that I keep track of a dataframe for all regex metadata instead of `lists` and `dicts`. The main reason is that it allows to group filepaths per band easily, as well of keeping track of which dates went into which merged raster. More about that later.
- Multi-bbox queries are stacked across a new dimension (t, c, h, w) by `__merge_query`. We need to agree if we want to go for timedimension 1 with non-temporal datasets.
- Apart from the tensor with timeseries imagery, I am returning sample['dates'] in datetime format too. This is a list of dates that went into every single bbox. So in the multi-bbox case this will be `[[bbox1_t1, bbox1_t2, ...], [bbox2_t1]]`. I chose datetime format for now since that worked well for me in practice, but this can be converted to any format by the transforms. I was thinking that instead of a list of dates, maybe we could return a daterange or something, but that mostly depends on the downstream use.
- The `filename_glob` has been relaxed, so that all files/bands end up in the dataset index.
- A new class variable `nodata_value` has been added, and `drop_nodata` has been added to the `init` of the class. Setting the value to True will ignore any merged raster that contains nodata values. This came from using the class in practice with Sentinel2, and seeing that some timestamps contained black (parts of) imagery, since some sentinel tiles are not square. In theory, this could become a separate PR, but I chose to add it here, because the effect of nodata pixels becomes more pronounced with timeseries.

What is still left to do:
- Implement method 3, query with tuple (or raise an error if trying to index a "single" dataset with a tuple).
- Implement/copy querying strategy to other datasets.
- Pass all pre-commit checks.