### PR TITLE
New Sentinel-2 collection name

### DIFF
--- a/experiments/ssl4eo/download_ssl4eo.py
+++ b/experiments/ssl4eo/download_ssl4eo.py
@@ -12,7 +12,7 @@
 ### match and download pre-sampled locations
 python download_ssl4eo.py \
     --save-path ./data \
-    --collection COPERNICUS/S2 \
+    --collection COPERNICUS/S2_HARMONIZED \
     --meta-cloud-name CLOUDY_PIXEL_PERCENTAGE \
     --cloud-pct 20 \
     --dates 2021-12-21 2021-09-22 2021-06-21 2021-03-20 \
@@ -319,7 +319,7 @@ if __name__ == '__main__':
     )
     # collection properties
     parser.add_argument(
-        '--collection', type=str, default='COPERNICUS/S2', help='GEE collection name'
+        '--collection', type=str, default='COPERNICUS/S2_HARMONIZED', help='GEE collection name'
     )
     parser.add_argument('--qa-band', type=str, default='QA60', help='qa band name')
     parser.add_argument(


### PR DESCRIPTION
The current `download_ssl4eo.py` execution shows the warning:
```
DeprecationWarning: 

Attention required for COPERNICUS/S2! You are using a deprecated asset.
To ensure continued functionality, please update it.
Learn more: https://developers.google.com/earth-engine/datasets/catalog/COPERNICUS_S2
```
Changing to the new collection name `S2_HARMONIZED` can eliminate the warning.

Previous: https://developers.google.com/earth-engine/datasets/catalog/COPERNICUS_S2
New: https://developers.google.com/earth-engine/datasets/catalog/COPERNICUS_S2_HARMONIZED