### PR TITLE
Enable branch coverage in pytest by updating pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,7 @@ show_missing = true
 
 [tool.coverage.run]
 source_pkgs = ["torchgeo"]
+branch = true
 
 # https://mypy.readthedocs.io/en/stable/config_file.html
 [tool.mypy]


### PR DESCRIPTION
Adds the following to 'pyproject.toml'

`[tool.coverage.run]
branch = true`

PR for Issue #2501 