### PR TITLE
ETCI2021: fix file list when 'vv' in directory name

### DIFF
--- a/torchgeo/datasets/etci2021.py
+++ b/torchgeo/datasets/etci2021.py
@@ -170,17 +170,15 @@ class ETCI2021(NonGeoDataset):
         folders = [os.path.join(folder, 'tiles') for folder in folders]
         for folder in folders:
             vvs = sorted(glob.glob(os.path.join(folder, 'vv', '*.png')))
-            vhs = [vv.replace('vv', 'vh') for vv in vvs]
-            water_masks = [
-                vv.replace('_vv.png', '.png').replace('vv', 'water_body_label')
-                for vv in vvs
-            ]
+            vhs = sorted(glob.glob(os.path.join(folder, 'vh', '*.png')))
+            water_masks = sorted(
+                glob.glob(os.path.join(folder, 'water_body_label', '*.png'))
+            )
 
             if split != 'test':
-                flood_masks = [
-                    vv.replace('_vv.png', '.png').replace('vv', 'flood_label')
-                    for vv in vvs
-                ]
+                flood_masks = sorted(
+                    glob.glob(os.path.join(folder, 'flood_masks', '*.png'))
+                )
 
                 for vv, vh, flood_mask, water_mask in zip(
                     vvs, vhs, flood_masks, water_masks

--- a/torchgeo/datasets/etci2021.py
+++ b/torchgeo/datasets/etci2021.py
@@ -177,7 +177,7 @@ class ETCI2021(NonGeoDataset):
 
             if split != 'test':
                 flood_masks = sorted(
-                    glob.glob(os.path.join(folder, 'flood_masks', '*.png'))
+                    glob.glob(os.path.join(folder, 'flood_label', '*.png'))
                 )
 
                 for vv, vh, flood_mask, water_mask in zip(


### PR DESCRIPTION
Well this was one of the weirder bugs I've encountered in CI. See if you can spot the difference:
```
/private/var/folders/2s/h6hvv9ps03xgz_krkkstvq_r0000gn/T/pytest-of-runner/pytest-0/test_getitem_train_0/train/bangladesh_20170314t115609/tiles/vh/bangladesh_20170314t115609_x-0_y-0_vh.png
/private/var/folders/2s/h6hvh9ps03xgz_krkkstvq_r0000gn/T/pytest-of-runner/pytest-0/test_getitem_train_0/train/bangladesh_20170314t115609/tiles/vh/bangladesh_20170314t115609_x-0_y-0_vh.png
```
No? The difference is that the first string contains a random hash which accidentally contains `vv`, and our dataset was replacing all occurrences of `vv` with `vh` to get the cross-polarization file path. This was causing the tests to fail only on macOS since the tmp path is different on each OS. This bug has been present since this dataset was first added 4 years ago.