### PR TITLE
MDAS: silence matplotlib deprecation warning

### DIFF
--- a/torchgeo/datasets/mdas.py
+++ b/torchgeo/datasets/mdas.py
@@ -7,11 +7,11 @@ import os
 from collections.abc import Callable
 from typing import Any, ClassVar
 
-import matplotlib.cm as cm
 import matplotlib.pyplot as plt
 import numpy as np
 import rasterio as rio
 import torch
+from matplotlib.colormaps import get_cmap
 from matplotlib.colors import ListedColormap
 from matplotlib.figure import Figure
 from torch import Tensor
@@ -356,7 +356,7 @@ class MDAS(NonGeoDataset):
                     axs[idx].imshow(img)
                 case 'osm_landuse_mask':
                     img = data.numpy().squeeze(0)
-                    cmap = ListedColormap([cm.get_cmap('tab20')(i) for i in range(20)])
+                    cmap = ListedColormap([get_cmap('tab20')(i) for i in range(20)])
                     im = axs[idx].imshow(img, cmap=cmap)
                     cbar = plt.colorbar(im, ax=axs[idx], ticks=range(19))
                     cbar.ax.set_yticklabels(

--- a/torchgeo/datasets/mdas.py
+++ b/torchgeo/datasets/mdas.py
@@ -11,7 +11,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import rasterio as rio
 import torch
-from matplotlib.colormaps import get_cmap
 from matplotlib.colors import ListedColormap
 from matplotlib.figure import Figure
 from torch import Tensor
@@ -356,7 +355,7 @@ class MDAS(NonGeoDataset):
                     axs[idx].imshow(img)
                 case 'osm_landuse_mask':
                     img = data.numpy().squeeze(0)
-                    cmap = ListedColormap([get_cmap('tab20')(i) for i in range(20)])
+                    cmap = ListedColormap([plt.get_cmap('tab20')(i) for i in range(20)])
                     im = axs[idx].imshow(img, cmap=cmap)
                     cbar = plt.colorbar(im, ax=axs[idx], ticks=range(19))
                     cbar.ax.set_yticklabels(


### PR DESCRIPTION
Silences the following warning in CI:
```
tests/datasets/test_mdas.py: 40 warnings
  /home/runner/work/torchgeo/torchgeo/torchgeo/datasets/mdas.py:359: MatplotlibDeprecationWarning: The get_cmap function was deprecated in Matplotlib 3.7 and will be removed in 3.11. Use ``matplotlib.colormaps[name]`` or ``matplotlib.colormaps.get_cmap()`` or ``pyplot.get_cmap()`` instead.
    cmap = ListedColormap([cm.get_cmap('tab20')(i) for i in range(20)])
```