### PR TITLE
Landsat 7: fix default bands

### DIFF
--- a/torchgeo/datasets/landsat.py
+++ b/torchgeo/datasets/landsat.py
@@ -196,7 +196,7 @@ class Landsat7(Landsat):
 
     filename_glob = 'LE07_*_{}.*'
 
-    default_bands = ('SR_B1', 'SR_B2', 'SR_B3', 'SR_B4', 'SR_B5', 'SR_B6', 'SR_B7')
+    default_bands = ('SR_B1', 'SR_B2', 'SR_B3', 'SR_B4', 'SR_B5', 'SR_B7')
     rgb_bands = ('SR_B3', 'SR_B2', 'SR_B1')
 
 


### PR DESCRIPTION
There is no SR_B6, this band is TOA-only.