### PR TITLE
EuroSAT: use percentile normalization during plotting

### DIFF
--- a/torchgeo/datasets/eurosat.py
+++ b/torchgeo/datasets/eurosat.py
@@ -15,7 +15,14 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError, RGBBandsMissingError
 from .geo import NonGeoClassificationDataset
-from .utils import Path, check_integrity, download_url, extract_archive, rasterio_loader
+from .utils import (
+    Path,
+    check_integrity,
+    download_url,
+    extract_archive,
+    percentile_normalization,
+    rasterio_loader,
+)
 
 
 class EuroSAT(NonGeoClassificationDataset):
@@ -268,7 +275,7 @@ class EuroSAT(NonGeoClassificationDataset):
 
         image = np.take(sample['image'].numpy(), indices=rgb_indices, axis=0)
         image = np.rollaxis(image, 0, 3)
-        image = np.clip(image / 3000, 0, 1)
+        image = percentile_normalization(image)
 
         label = cast(int, sample['label'].item())
         label_class = self.classes[label]


### PR DESCRIPTION
Related to #1263 

The current plotting method works great for our dataset, but fails as soon as normalization is added (e.g., via our data module). By using percentile normalization, both the dataset and data module should work.

P.S. We should do this for all datasets if anyone is ever bored and looking for an easy contribution. I only did EuroSAT because it's used throughout our tutorials.