### PR TITLE
Trainers: denormalize images before plotting

### DIFF
--- a/torchgeo/trainers/classification.py
+++ b/torchgeo/trainers/classification.py
@@ -6,6 +6,7 @@
 import os
 from typing import Any
 
+import kornia.augmentation as K
 import matplotlib.pyplot as plt
 import timm
 import torch
@@ -215,8 +216,12 @@ class ClassificationTask(BaseTask):
             and hasattr(self.logger.experiment, 'add_figure')
         ):
             datamodule = self.trainer.datamodule
-            aug = datamodule._valid_attribute('val_aug', 'aug')
-            batch = aug.inverse(batch)
+            aug = K.AugmentationSequential(
+                K.Denormalize(datamodule.mean, datamodule.std),
+                data_keys=None,
+                keepdim=True,
+            )
+            batch = aug(batch)
             batch['prediction'] = y_hat.argmax(dim=-1)
             for key in ['image', 'label', 'prediction']:
                 batch[key] = batch[key].cpu()
@@ -361,8 +366,12 @@ class MultiLabelClassificationTask(ClassificationTask):
             and hasattr(self.logger.experiment, 'add_figure')
         ):
             datamodule = self.trainer.datamodule
-            aug = datamodule._valid_attribute('val_aug', 'aug')
-            batch = aug.inverse(batch)
+            aug = K.AugmentationSequential(
+                K.Denormalize(datamodule.mean, datamodule.std),
+                data_keys=None,
+                keepdim=True,
+            )
+            batch = aug(batch)
             batch['prediction'] = y_hat_hard
             for key in ['image', 'label', 'prediction']:
                 batch[key] = batch[key].cpu()

--- a/torchgeo/trainers/detection.py
+++ b/torchgeo/trainers/detection.py
@@ -6,6 +6,7 @@
 from functools import partial
 from typing import Any
 
+import kornia.augmentation as K
 import matplotlib.pyplot as plt
 import torch
 import torchvision.models.detection
@@ -282,8 +283,12 @@ class ObjectDetectionTask(BaseTask):
             and hasattr(self.logger.experiment, 'add_figure')
         ):
             datamodule = self.trainer.datamodule
-            aug = datamodule._valid_attribute('val_aug', 'aug')
-            batch = aug.inverse(batch)
+            aug = K.AugmentationSequential(
+                K.Denormalize(datamodule.mean, datamodule.std),
+                data_keys=None,
+                keepdim=True,
+            )
+            batch = aug(batch)
             batch['prediction_bbox_xyxy'] = [b['boxes'].cpu() for b in y_hat]
             batch['prediction_labels'] = [b['labels'].cpu() for b in y_hat]
             batch['prediction_scores'] = [b['scores'].cpu() for b in y_hat]

--- a/torchgeo/trainers/regression.py
+++ b/torchgeo/trainers/regression.py
@@ -6,6 +6,7 @@
 import os
 from typing import Any
 
+import kornia.augmentation as K
 import matplotlib.pyplot as plt
 import segmentation_models_pytorch as smp
 import timm
@@ -203,8 +204,12 @@ class RegressionTask(BaseTask):
             and hasattr(self.logger.experiment, 'add_figure')
         ):
             datamodule = self.trainer.datamodule
-            aug = datamodule._valid_attribute('val_aug', 'aug')
-            batch = aug.inverse(batch)
+            aug = K.AugmentationSequential(
+                K.Denormalize(datamodule.mean, datamodule.std),
+                data_keys=None,
+                keepdim=True,
+            )
+            batch = aug(batch)
             if self.target_key == 'mask':
                 y = y.squeeze(dim=1)
                 y_hat = y_hat.squeeze(dim=1)

--- a/torchgeo/trainers/segmentation.py
+++ b/torchgeo/trainers/segmentation.py
@@ -6,6 +6,7 @@
 import os
 from typing import Any
 
+import kornia.augmentation as K
 import matplotlib.pyplot as plt
 import segmentation_models_pytorch as smp
 import torch.nn as nn
@@ -263,8 +264,12 @@ class SemanticSegmentationTask(BaseTask):
             and hasattr(self.logger.experiment, 'add_figure')
         ):
             datamodule = self.trainer.datamodule
-            aug = datamodule._valid_attribute('val_aug', 'aug')
-            batch = aug.inverse(batch)
+            aug = K.AugmentationSequential(
+                K.Denormalize(datamodule.mean, datamodule.std),
+                data_keys=None,
+                keepdim=True,
+            )
+            batch = aug(batch)
             batch['prediction'] = y_hat.argmax(dim=1)
             for key in ['image', 'mask', 'prediction']:
                 batch[key] = batch[key].cpu()


### PR DESCRIPTION
Closes #1263?
Closes #2557

This should (hopefully) resolve the issue where our normalized images cannot be plotted because they are in a different range than the original dataset.