### PR TITLE
Datasets: always return sample = dict[str, Tensor]

### DIFF
--- a/tests/datamodules/test_geo.py
+++ b/tests/datamodules/test_geo.py
@@ -9,7 +9,6 @@ import torch
 from _pytest.fixtures import SubRequest
 from lightning.pytorch import Trainer
 from matplotlib.figure import Figure
-from rasterio.crs import CRS
 
 from torchgeo.datamodules import (
     GeoDataModule,
@@ -32,7 +31,7 @@ class CustomGeoDataset(GeoDataset):
 
     def __getitem__(self, query: BoundingBox) -> Sample:
         image = torch.arange(3 * 2 * 2, dtype=torch.float).view(3, 2, 2)
-        return {'image': image, 'crs': CRS.from_epsg(4326), 'bounds': query}
+        return {'image': image}
 
     def plot(self, *args: Any, **kwargs: Any) -> Figure:
         return plt.figure()

--- a/tests/datamodules/test_geo.py
+++ b/tests/datamodules/test_geo.py
@@ -10,7 +10,6 @@ from _pytest.fixtures import SubRequest
 from lightning.pytorch import Trainer
 from matplotlib.figure import Figure
 from rasterio.crs import CRS
-from torch import Tensor
 
 from torchgeo.datamodules import (
     GeoDataModule,
@@ -18,6 +17,7 @@ from torchgeo.datamodules import (
     NonGeoDataModule,
 )
 from torchgeo.datasets import BoundingBox, GeoDataset, NonGeoDataset
+from torchgeo.datasets.utils import Sample
 from torchgeo.samplers import RandomBatchGeoSampler, RandomGeoSampler
 
 
@@ -30,7 +30,7 @@ class CustomGeoDataset(GeoDataset):
             self.index.insert(i, (0, 1, 2, 3, 4, 5))
         self.res = 1
 
-    def __getitem__(self, query: BoundingBox) -> dict[str, Any]:
+    def __getitem__(self, query: BoundingBox) -> Sample:
         image = torch.arange(3 * 2 * 2, dtype=torch.float).view(3, 2, 2)
         return {'image': image, 'crs': CRS.from_epsg(4326), 'bounds': query}
 
@@ -67,7 +67,7 @@ class CustomNonGeoDataset(NonGeoDataset):
     ) -> None:
         self.length = length
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         return {'image': torch.arange(3 * 2 * 2, dtype=torch.float).view(3, 2, 2)}
 
     def __len__(self) -> int:

--- a/tests/datamodules/test_levircd.py
+++ b/tests/datamodules/test_levircd.py
@@ -6,13 +6,13 @@ import os
 import pytest
 import torchvision.transforms.functional as F
 from lightning.pytorch import Trainer
-from torch import Tensor
 from torchvision.transforms import InterpolationMode
 
 from torchgeo.datamodules import LEVIRCDDataModule, LEVIRCDPlusDataModule
+from torchgeo.datasets.utils import Sample
 
 
-def transforms(sample: dict[str, Tensor]) -> dict[str, Tensor]:
+def transforms(sample: Sample) -> Sample:
     sample['image1'] = F.resize(
         sample['image1'],
         size=[1024, 1024],

--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -78,7 +78,7 @@ class CustomSentinelDataset(Sentinel2):
 
 
 class CustomNonGeoDataset(NonGeoDataset):
-    def __getitem__(self, index: int) -> dict[str, int]:
+    def __getitem__(self, index: int) -> Sample:
         return {'index': index}
 
     def __len__(self) -> int:

--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -30,6 +30,7 @@ from torchgeo.datasets import (
     UnionDataset,
     VectorDataset,
 )
+from torchgeo.datasets.utils import Sample
 
 
 class CustomGeoDataset(GeoDataset):
@@ -46,7 +47,7 @@ class CustomGeoDataset(GeoDataset):
         self.res = res
         self.paths = paths or []
 
-    def __getitem__(self, query: BoundingBox) -> dict[str, BoundingBox]:
+    def __getitem__(self, query: BoundingBox) -> Sample:
         hits = self.index.intersection(tuple(query), objects=True)
         hit = next(iter(hits))
         bounds = BoundingBox(*hit.bounds)

--- a/tests/datasets/test_splits.py
+++ b/tests/datasets/test_splits.py
@@ -3,7 +3,6 @@
 
 from collections.abc import Sequence
 from math import floor, isclose
-from typing import Any
 
 import pytest
 from rasterio.crs import CRS
@@ -17,6 +16,7 @@ from torchgeo.datasets import (
     roi_split,
     time_series_split,
 )
+from torchgeo.datasets.utils import Sample
 
 
 def total_area(dataset: GeoDataset) -> float:
@@ -49,7 +49,7 @@ class CustomGeoDataset(GeoDataset):
         self._crs = crs
         self.res = res
 
-    def __getitem__(self, query: BoundingBox) -> dict[str, Any]:
+    def __getitem__(self, query: BoundingBox) -> Sample:
         hits = self.index.intersection(tuple(query), objects=True)
         hit = next(iter(hits))
         return {'content': hit.object}

--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -18,6 +18,7 @@ from rasterio.crs import CRS
 from torchgeo.datasets import BoundingBox, DependencyNotFoundError
 from torchgeo.datasets.utils import (
     Executable,
+    Sample,
     array_to_tensor,
     concat_samples,
     disambiguate_timestamp,
@@ -393,13 +394,13 @@ def test_disambiguate_timestamp(
 
 class TestCollateFunctionsMatchingKeys:
     @pytest.fixture(scope='class')
-    def samples(self) -> list[dict[str, Any]]:
+    def samples(self) -> list[Sample]:
         return [
             {'image': torch.tensor([1, 2, 0]), 'crs': CRS.from_epsg(2000)},
             {'image': torch.tensor([0, 0, 3]), 'crs': CRS.from_epsg(2001)},
         ]
 
-    def test_stack_unbind_samples(self, samples: list[dict[str, Any]]) -> None:
+    def test_stack_unbind_samples(self, samples: list[Sample]) -> None:
         sample = stack_samples(samples)
         assert sample['image'].size() == torch.Size([2, 3])
         assert torch.allclose(sample['image'], torch.tensor([[1, 2, 0], [0, 0, 3]]))
@@ -410,13 +411,13 @@ class TestCollateFunctionsMatchingKeys:
             assert torch.allclose(samples[i]['image'], new_samples[i]['image'])
             assert samples[i]['crs'] == new_samples[i]['crs']
 
-    def test_concat_samples(self, samples: list[dict[str, Any]]) -> None:
+    def test_concat_samples(self, samples: list[Sample]) -> None:
         sample = concat_samples(samples)
         assert sample['image'].size() == torch.Size([6])
         assert torch.allclose(sample['image'], torch.tensor([1, 2, 0, 0, 0, 3]))
         assert sample['crs'] == CRS.from_epsg(2000)
 
-    def test_merge_samples(self, samples: list[dict[str, Any]]) -> None:
+    def test_merge_samples(self, samples: list[Sample]) -> None:
         sample = merge_samples(samples)
         assert sample['image'].size() == torch.Size([3])
         assert torch.allclose(sample['image'], torch.tensor([1, 2, 3]))
@@ -425,13 +426,13 @@ class TestCollateFunctionsMatchingKeys:
 
 class TestCollateFunctionsDifferingKeys:
     @pytest.fixture(scope='class')
-    def samples(self) -> list[dict[str, Any]]:
+    def samples(self) -> list[Sample]:
         return [
             {'image': torch.tensor([1, 2, 0]), 'crs1': CRS.from_epsg(2000)},
             {'mask': torch.tensor([0, 0, 3]), 'crs2': CRS.from_epsg(2001)},
         ]
 
-    def test_stack_unbind_samples(self, samples: list[dict[str, Any]]) -> None:
+    def test_stack_unbind_samples(self, samples: list[Sample]) -> None:
         sample = stack_samples(samples)
         assert sample['image'].size() == torch.Size([1, 3])
         assert sample['mask'].size() == torch.Size([1, 3])
@@ -446,7 +447,7 @@ class TestCollateFunctionsDifferingKeys:
         assert torch.allclose(samples[1]['mask'], new_samples[0]['mask'])
         assert samples[1]['crs2'] == new_samples[0]['crs2']
 
-    def test_concat_samples(self, samples: list[dict[str, Any]]) -> None:
+    def test_concat_samples(self, samples: list[Sample]) -> None:
         sample = concat_samples(samples)
         assert sample['image'].size() == torch.Size([3])
         assert sample['mask'].size() == torch.Size([3])
@@ -455,7 +456,7 @@ class TestCollateFunctionsDifferingKeys:
         assert sample['crs1'] == CRS.from_epsg(2000)
         assert sample['crs2'] == CRS.from_epsg(2001)
 
-    def test_merge_samples(self, samples: list[dict[str, Any]]) -> None:
+    def test_merge_samples(self, samples: list[Sample]) -> None:
         sample = merge_samples(samples)
         assert sample['image'].size() == torch.Size([3])
         assert sample['mask'].size() == torch.Size([3])

--- a/tests/samplers/test_batch.py
+++ b/tests/samplers/test_batch.py
@@ -12,6 +12,7 @@ from rasterio.crs import CRS
 from torch.utils.data import DataLoader
 
 from torchgeo.datasets import BoundingBox, GeoDataset, stack_samples
+from torchgeo.datasets.utils import Sample
 from torchgeo.samplers import BatchGeoSampler, RandomBatchGeoSampler, Units
 
 
@@ -33,7 +34,7 @@ class CustomGeoDataset(GeoDataset):
         self._crs = crs
         self.res = res
 
-    def __getitem__(self, query: BoundingBox) -> dict[str, BoundingBox]:
+    def __getitem__(self, query: BoundingBox) -> Sample:
         return {'index': query}
 
 

--- a/tests/samplers/test_single.py
+++ b/tests/samplers/test_single.py
@@ -12,6 +12,7 @@ from rasterio.crs import CRS
 from torch.utils.data import DataLoader
 
 from torchgeo.datasets import BoundingBox, GeoDataset, stack_samples
+from torchgeo.datasets.utils import Sample
 from torchgeo.samplers import (
     GeoSampler,
     GridGeoSampler,
@@ -40,7 +41,7 @@ class CustomGeoDataset(GeoDataset):
         self._crs = crs
         self.res = res
 
-    def __getitem__(self, query: BoundingBox) -> dict[str, BoundingBox]:
+    def __getitem__(self, query: BoundingBox) -> Sample:
         return {'index': query}
 
 

--- a/tests/trainers/conftest.py
+++ b/tests/trainers/conftest.py
@@ -9,8 +9,9 @@ import pytest
 import torch
 import torchvision
 from _pytest.fixtures import SubRequest
-from torch import Tensor
 from torch.nn.modules import Module
+
+from torchgeo.datasets.utils import Sample
 
 
 @pytest.fixture(
@@ -28,14 +29,12 @@ def model() -> Module:
 
 
 @pytest.fixture(scope='package')
-def state_dict(model: Module) -> dict[str, Tensor]:
+def state_dict(model: Module) -> Sample:
     return model.state_dict()
 
 
 @pytest.fixture(params=['model', 'backbone'])
-def checkpoint(
-    state_dict: dict[str, Tensor], request: SubRequest, tmp_path: Path
-) -> str:
+def checkpoint(state_dict: Sample, request: SubRequest, tmp_path: Path) -> str:
     if request.param == 'model':
         state_dict = OrderedDict({'model.' + k: v for k, v in state_dict.items()})
     else:

--- a/tests/trainers/conftest.py
+++ b/tests/trainers/conftest.py
@@ -9,9 +9,8 @@ import pytest
 import torch
 import torchvision
 from _pytest.fixtures import SubRequest
+from torch import Tensor
 from torch.nn.modules import Module
-
-from torchgeo.datasets.utils import Sample
 
 
 @pytest.fixture(
@@ -29,12 +28,14 @@ def model() -> Module:
 
 
 @pytest.fixture(scope='package')
-def state_dict(model: Module) -> Sample:
+def state_dict(model: Module) -> dict[str, Tensor]:
     return model.state_dict()
 
 
 @pytest.fixture(params=['model', 'backbone'])
-def checkpoint(state_dict: Sample, request: SubRequest, tmp_path: Path) -> str:
+def checkpoint(
+    state_dict: dict[str, Tensor], request: SubRequest, tmp_path: Path
+) -> str:
     if request.param == 'model':
         state_dict = OrderedDict({'model.' + k: v for k, v in state_dict.items()})
     else:

--- a/tests/transforms/test_color.py
+++ b/tests/transforms/test_color.py
@@ -6,11 +6,12 @@ import pytest
 import torch
 from torch import Tensor
 
+from torchgeo.datasets.utils import Sample
 from torchgeo.transforms import RandomGrayscale
 
 
 @pytest.fixture
-def sample() -> dict[str, Tensor]:
+def sample() -> Sample:
     return {
         'image': torch.arange(3 * 4 * 4, dtype=torch.float).view(3, 4, 4),
         'mask': torch.arange(4 * 4, dtype=torch.long).view(1, 4, 4),
@@ -18,7 +19,7 @@ def sample() -> dict[str, Tensor]:
 
 
 @pytest.fixture
-def batch() -> dict[str, Tensor]:
+def batch() -> Sample:
     return {
         'image': torch.arange(2 * 3 * 4 * 4, dtype=torch.float).view(2, 3, 4, 4),
         'mask': torch.arange(2 * 4 * 4, dtype=torch.long).view(2, 1, 4, 4),
@@ -33,7 +34,7 @@ def batch() -> dict[str, Tensor]:
         torch.tensor([1.0, 2.0, 3.0]),
     ],
 )
-def test_random_grayscale_sample(weights: Tensor, sample: dict[str, Tensor]) -> None:
+def test_random_grayscale_sample(weights: Tensor, sample: Sample) -> None:
     aug = K.AugmentationSequential(
         RandomGrayscale(weights, p=1), keepdim=True, data_keys=None
     )
@@ -51,7 +52,7 @@ def test_random_grayscale_sample(weights: Tensor, sample: dict[str, Tensor]) -> 
         torch.tensor([1.0, 2.0, 3.0]),
     ],
 )
-def test_random_grayscale_batch(weights: Tensor, batch: dict[str, Tensor]) -> None:
+def test_random_grayscale_batch(weights: Tensor, batch: Sample) -> None:
     aug = K.AugmentationSequential(RandomGrayscale(weights, p=1), data_keys=None)
     output = aug(batch)
     assert output['image'].shape == batch['image'].shape

--- a/tests/transforms/test_indices.py
+++ b/tests/transforms/test_indices.py
@@ -4,8 +4,8 @@
 import kornia.augmentation as K
 import pytest
 import torch
-from torch import Tensor
 
+from torchgeo.datasets.utils import Sample
 from torchgeo.transforms import (
     AppendBNDVI,
     AppendGBNDVI,
@@ -25,7 +25,7 @@ from torchgeo.transforms import (
 
 
 @pytest.fixture
-def sample() -> dict[str, Tensor]:
+def sample() -> Sample:
     return {
         'image': torch.arange(3 * 4 * 4, dtype=torch.float).view(3, 4, 4),
         'mask': torch.arange(4 * 4, dtype=torch.long).view(1, 4, 4),
@@ -33,14 +33,14 @@ def sample() -> dict[str, Tensor]:
 
 
 @pytest.fixture
-def batch() -> dict[str, Tensor]:
+def batch() -> Sample:
     return {
         'image': torch.arange(2 * 3 * 4 * 4, dtype=torch.float).view(2, 3, 4, 4),
         'mask': torch.arange(2 * 4 * 4, dtype=torch.long).view(2, 1, 4, 4),
     }
 
 
-def test_append_index_sample(sample: dict[str, Tensor]) -> None:
+def test_append_index_sample(sample: Sample) -> None:
     c, h, w = sample['image'].shape
     aug = K.AugmentationSequential(
         AppendNormalizedDifferenceIndex(index_a=0, index_b=1), data_keys=None
@@ -49,7 +49,7 @@ def test_append_index_sample(sample: dict[str, Tensor]) -> None:
     assert output['image'].shape == (1, c + 1, h, w)
 
 
-def test_append_index_batch(batch: dict[str, Tensor]) -> None:
+def test_append_index_batch(batch: Sample) -> None:
     b, c, h, w = batch['image'].shape
     aug = K.AugmentationSequential(
         AppendNormalizedDifferenceIndex(index_a=0, index_b=1), data_keys=None
@@ -58,7 +58,7 @@ def test_append_index_batch(batch: dict[str, Tensor]) -> None:
     assert output['image'].shape == (b, c + 1, h, w)
 
 
-def test_append_triband_index_batch(batch: dict[str, Tensor]) -> None:
+def test_append_triband_index_batch(batch: Sample) -> None:
     b, c, h, w = batch['image'].shape
     aug = K.AugmentationSequential(
         AppendTriBandNormalizedDifferenceIndex(index_a=0, index_b=1, index_c=2),
@@ -83,7 +83,7 @@ def test_append_triband_index_batch(batch: dict[str, Tensor]) -> None:
     ],
 )
 def test_append_normalized_difference_indices(
-    sample: dict[str, Tensor], index: AppendNormalizedDifferenceIndex
+    sample: Sample, index: AppendNormalizedDifferenceIndex
 ) -> None:
     c, h, w = sample['image'].shape
     aug = K.AugmentationSequential(index(0, 1), data_keys=None)
@@ -93,7 +93,7 @@ def test_append_normalized_difference_indices(
 
 @pytest.mark.parametrize('index', [AppendGBNDVI, AppendGRNDVI, AppendRBNDVI])
 def test_append_tri_band_normalized_difference_indices(
-    sample: dict[str, Tensor], index: AppendTriBandNormalizedDifferenceIndex
+    sample: Sample, index: AppendTriBandNormalizedDifferenceIndex
 ) -> None:
     c, h, w = sample['image'].shape
     aug = K.AugmentationSequential(index(0, 1, 2), data_keys=None)

--- a/tests/transforms/test_transforms.py
+++ b/tests/transforms/test_transforms.py
@@ -4,8 +4,8 @@
 import kornia.augmentation as K
 import pytest
 import torch
-from torch import Tensor
 
+from torchgeo.datasets.utils import Sample
 from torchgeo.transforms import indices
 from torchgeo.transforms.transforms import _ExtractPatches
 
@@ -19,7 +19,7 @@ from torchgeo.transforms.transforms import _ExtractPatches
 
 
 @pytest.fixture
-def batch_gray() -> dict[str, Tensor]:
+def batch_gray() -> Sample:
     return {
         'image': torch.tensor([[[[1, 2, 3], [4, 5, 6], [7, 8, 9]]]], dtype=torch.float),
         'mask': torch.tensor([[[0, 0, 1], [0, 1, 1], [1, 1, 1]]], dtype=torch.long),
@@ -29,7 +29,7 @@ def batch_gray() -> dict[str, Tensor]:
 
 
 @pytest.fixture
-def batch_rgb() -> dict[str, Tensor]:
+def batch_rgb() -> Sample:
     return {
         'image': torch.tensor(
             [
@@ -48,7 +48,7 @@ def batch_rgb() -> dict[str, Tensor]:
 
 
 @pytest.fixture
-def batch_multispectral() -> dict[str, Tensor]:
+def batch_multispectral() -> Sample:
     return {
         'image': torch.tensor(
             [
@@ -68,14 +68,14 @@ def batch_multispectral() -> dict[str, Tensor]:
     }
 
 
-def assert_matching(output: dict[str, Tensor], expected: dict[str, Tensor]) -> None:
+def assert_matching(output: Sample, expected: Sample) -> None:
     for key in expected:
         err = f'output[{key}] != expected[{key}]'
         equal = torch.allclose(output[key], expected[key])
         assert equal, err
 
 
-def test_augmentation_sequential_gray(batch_gray: dict[str, Tensor]) -> None:
+def test_augmentation_sequential_gray(batch_gray: Sample) -> None:
     expected = {
         'image': torch.tensor([[[[3, 2, 1], [6, 5, 4], [9, 8, 7]]]], dtype=torch.float),
         'mask': torch.tensor([[[1, 0, 0], [1, 1, 0], [1, 1, 1]]], dtype=torch.long),
@@ -87,7 +87,7 @@ def test_augmentation_sequential_gray(batch_gray: dict[str, Tensor]) -> None:
     assert_matching(output, expected)
 
 
-def test_augmentation_sequential_rgb(batch_rgb: dict[str, Tensor]) -> None:
+def test_augmentation_sequential_rgb(batch_rgb: Sample) -> None:
     expected = {
         'image': torch.tensor(
             [
@@ -108,9 +108,7 @@ def test_augmentation_sequential_rgb(batch_rgb: dict[str, Tensor]) -> None:
     assert_matching(output, expected)
 
 
-def test_augmentation_sequential_multispectral(
-    batch_multispectral: dict[str, Tensor],
-) -> None:
+def test_augmentation_sequential_multispectral(batch_multispectral: Sample) -> None:
     expected = {
         'image': torch.tensor(
             [
@@ -133,9 +131,7 @@ def test_augmentation_sequential_multispectral(
     assert_matching(output, expected)
 
 
-def test_augmentation_sequential_image_only(
-    batch_multispectral: dict[str, Tensor],
-) -> None:
+def test_augmentation_sequential_image_only(batch_multispectral: Sample) -> None:
     expected_image = torch.tensor(
         [
             [
@@ -154,9 +150,7 @@ def test_augmentation_sequential_image_only(
     assert torch.allclose(aug_image, expected_image)
 
 
-def test_sequential_transforms_augmentations(
-    batch_multispectral: dict[str, Tensor],
-) -> None:
+def test_sequential_transforms_augmentations(batch_multispectral: Sample) -> None:
     expected = {
         'image': torch.tensor(
             [

--- a/torchgeo/datamodules/chesapeake.py
+++ b/torchgeo/datamodules/chesapeake.py
@@ -7,9 +7,9 @@ from typing import Any
 
 import kornia.augmentation as K
 import torch.nn.functional as F
-from torch import Tensor
 
 from ..datasets import ChesapeakeCVPR
+from ..datasets.utils import Sample
 from ..samplers import GridGeoSampler, RandomBatchGeoSampler
 from .geo import GeoDataModule
 
@@ -124,9 +124,7 @@ class ChesapeakeCVPRDataModule(GeoDataModule):
                 self.test_dataset, self.original_patch_size, self.original_patch_size
             )
 
-    def on_after_batch_transfer(
-        self, batch: dict[str, Tensor], dataloader_idx: int
-    ) -> dict[str, Tensor]:
+    def on_after_batch_transfer(self, batch: Sample, dataloader_idx: int) -> Sample:
         """Apply batch augmentations to the batch after it is transferred to the device.
 
         Args:

--- a/torchgeo/datamodules/etci2021.py
+++ b/torchgeo/datamodules/etci2021.py
@@ -6,9 +6,9 @@
 from typing import Any
 
 import torch
-from torch import Tensor
 
 from ..datasets import ETCI2021
+from ..datasets.utils import Sample
 from .geo import NonGeoDataModule
 
 
@@ -62,9 +62,7 @@ class ETCI2021DataModule(NonGeoDataModule):
             # Test set masks are not public, use for prediction instead
             self.predict_dataset = ETCI2021(split='test', **self.kwargs)
 
-    def on_after_batch_transfer(
-        self, batch: dict[str, Tensor], dataloader_idx: int
-    ) -> dict[str, Tensor]:
+    def on_after_batch_transfer(self, batch: Sample, dataloader_idx: int) -> Sample:
         """Apply batch augmentations to the batch after it is transferred to the device.
 
         Args:

--- a/torchgeo/datamodules/fair1m.py
+++ b/torchgeo/datamodules/fair1m.py
@@ -6,13 +6,13 @@
 from typing import Any
 
 import torch
-from torch import Tensor
 
 from ..datasets import FAIR1M
+from ..datasets.utils import Sample
 from .geo import NonGeoDataModule
 
 
-def collate_fn(batch: list[dict[str, Tensor]]) -> dict[str, Any]:
+def collate_fn(batch: list[Sample]) -> Sample:
     """Custom object detection collate fn to handle variable boxes.
 
     Args:
@@ -23,7 +23,7 @@ def collate_fn(batch: list[dict[str, Tensor]]) -> dict[str, Any]:
 
     .. versionadded:: 0.5
     """
-    output: dict[str, Any] = {}
+    output: Sample = {}
     output['image'] = torch.stack([sample['image'] for sample in batch])
 
     if 'bbox_xyxy' in batch[0]:

--- a/torchgeo/datamodules/geo.py
+++ b/torchgeo/datamodules/geo.py
@@ -335,28 +335,6 @@ class GeoDataModule(BaseDataModule):
         """
         return self._dataloader_factory('predict')
 
-    def transfer_batch_to_device(
-        self, batch: Sample, device: torch.device, dataloader_idx: int
-    ) -> Sample:
-        """Transfer batch to device.
-
-        Defines how custom data types are moved to the target device.
-
-        Args:
-            batch: A batch of data that needs to be transferred to a new device.
-            device: The target device as defined in PyTorch.
-            dataloader_idx: The index of the dataloader to which the batch belongs.
-
-        Returns:
-            A reference to the data on the new device.
-        """
-        # Non-Tensor values cannot be moved to a device
-        del batch['crs']
-        del batch['bounds']
-
-        batch = super().transfer_batch_to_device(batch, device, dataloader_idx)
-        return batch
-
 
 class NonGeoDataModule(BaseDataModule):
     """Base class for data modules lacking geospatial information.

--- a/torchgeo/datamodules/geo.py
+++ b/torchgeo/datamodules/geo.py
@@ -10,10 +10,10 @@ import kornia.augmentation as K
 import torch
 from lightning.pytorch import LightningDataModule
 from matplotlib.figure import Figure
-from torch import Tensor
 from torch.utils.data import DataLoader, Dataset, Subset, default_collate
 
 from ..datasets import GeoDataset, NonGeoDataset, stack_samples
+from ..datasets.utils import Sample
 from ..samplers import (
     BatchGeoSampler,
     GeoSampler,
@@ -34,7 +34,7 @@ class BaseDataModule(LightningDataModule):
 
     def __init__(
         self,
-        dataset_class: type[Dataset[dict[str, Tensor]]],
+        dataset_class: type[Dataset[Sample]],
         batch_size: int = 1,
         num_workers: int = 0,
         **kwargs: Any,
@@ -55,11 +55,11 @@ class BaseDataModule(LightningDataModule):
         self.kwargs = kwargs
 
         # Datasets
-        self.dataset: Dataset[dict[str, Tensor]] | None = None
-        self.train_dataset: Dataset[dict[str, Tensor]] | None = None
-        self.val_dataset: Dataset[dict[str, Tensor]] | None = None
-        self.test_dataset: Dataset[dict[str, Tensor]] | None = None
-        self.predict_dataset: Dataset[dict[str, Tensor]] | None = None
+        self.dataset: Dataset[Sample] | None = None
+        self.train_dataset: Dataset[Sample] | None = None
+        self.val_dataset: Dataset[Sample] | None = None
+        self.test_dataset: Dataset[Sample] | None = None
+        self.predict_dataset: Dataset[Sample] | None = None
 
         # Data loaders
         self.train_batch_size: int | None = None
@@ -68,7 +68,7 @@ class BaseDataModule(LightningDataModule):
         self.predict_batch_size: int | None = None
 
         # Data augmentation
-        Transform = Callable[[dict[str, Tensor]], dict[str, Tensor]]
+        Transform = Callable[[Sample], Sample]
         self.aug: Transform = K.AugmentationSequential(
             K.Normalize(mean=self.mean, std=self.std), data_keys=None, keepdim=True
         )
@@ -115,9 +115,7 @@ class BaseDataModule(LightningDataModule):
         msg = f'{self.__class__.__name__}.setup must define one of {args}.'
         raise MisconfigurationException(msg)
 
-    def on_after_batch_transfer(
-        self, batch: dict[str, Tensor], dataloader_idx: int
-    ) -> dict[str, Tensor]:
+    def on_after_batch_transfer(self, batch: Sample, dataloader_idx: int) -> Sample:
         """Apply batch augmentations to the batch after it is transferred to the device.
 
         Args:
@@ -253,7 +251,7 @@ class GeoDataModule(BaseDataModule):
                 self.test_dataset, self.patch_size, self.patch_size
             )
 
-    def _dataloader_factory(self, split: str) -> DataLoader[dict[str, Tensor]]:
+    def _dataloader_factory(self, split: str) -> DataLoader[Sample]:
         """Implement one or more PyTorch DataLoaders.
 
         Args:
@@ -289,7 +287,7 @@ class GeoDataModule(BaseDataModule):
             persistent_workers=self.num_workers > 0,
         )
 
-    def train_dataloader(self) -> DataLoader[dict[str, Tensor]]:
+    def train_dataloader(self) -> DataLoader[Sample]:
         """Implement one or more PyTorch DataLoaders for training.
 
         Returns:
@@ -301,7 +299,7 @@ class GeoDataModule(BaseDataModule):
         """
         return self._dataloader_factory('train')
 
-    def val_dataloader(self) -> DataLoader[dict[str, Tensor]]:
+    def val_dataloader(self) -> DataLoader[Sample]:
         """Implement one or more PyTorch DataLoaders for validation.
 
         Returns:
@@ -313,7 +311,7 @@ class GeoDataModule(BaseDataModule):
         """
         return self._dataloader_factory('val')
 
-    def test_dataloader(self) -> DataLoader[dict[str, Tensor]]:
+    def test_dataloader(self) -> DataLoader[Sample]:
         """Implement one or more PyTorch DataLoaders for testing.
 
         Returns:
@@ -325,7 +323,7 @@ class GeoDataModule(BaseDataModule):
         """
         return self._dataloader_factory('test')
 
-    def predict_dataloader(self) -> DataLoader[dict[str, Tensor]]:
+    def predict_dataloader(self) -> DataLoader[Sample]:
         """Implement one or more PyTorch DataLoaders for prediction.
 
         Returns:
@@ -338,8 +336,8 @@ class GeoDataModule(BaseDataModule):
         return self._dataloader_factory('predict')
 
     def transfer_batch_to_device(
-        self, batch: dict[str, Tensor], device: torch.device, dataloader_idx: int
-    ) -> dict[str, Tensor]:
+        self, batch: Sample, device: torch.device, dataloader_idx: int
+    ) -> Sample:
         """Transfer batch to device.
 
         Defines how custom data types are moved to the target device.
@@ -409,7 +407,7 @@ class NonGeoDataModule(BaseDataModule):
                 split='test', **self.kwargs
             )
 
-    def _dataloader_factory(self, split: str) -> DataLoader[dict[str, Tensor]]:
+    def _dataloader_factory(self, split: str) -> DataLoader[Sample]:
         """Implement one or more PyTorch DataLoaders.
 
         Args:
@@ -433,7 +431,7 @@ class NonGeoDataModule(BaseDataModule):
             persistent_workers=self.num_workers > 0,
         )
 
-    def train_dataloader(self) -> DataLoader[dict[str, Tensor]]:
+    def train_dataloader(self) -> DataLoader[Sample]:
         """Implement one or more PyTorch DataLoaders for training.
 
         Returns:
@@ -445,7 +443,7 @@ class NonGeoDataModule(BaseDataModule):
         """
         return self._dataloader_factory('train')
 
-    def val_dataloader(self) -> DataLoader[dict[str, Tensor]]:
+    def val_dataloader(self) -> DataLoader[Sample]:
         """Implement one or more PyTorch DataLoaders for validation.
 
         Returns:
@@ -457,7 +455,7 @@ class NonGeoDataModule(BaseDataModule):
         """
         return self._dataloader_factory('val')
 
-    def test_dataloader(self) -> DataLoader[dict[str, Tensor]]:
+    def test_dataloader(self) -> DataLoader[Sample]:
         """Implement one or more PyTorch DataLoaders for testing.
 
         Returns:
@@ -469,7 +467,7 @@ class NonGeoDataModule(BaseDataModule):
         """
         return self._dataloader_factory('test')
 
-    def predict_dataloader(self) -> DataLoader[dict[str, Tensor]]:
+    def predict_dataloader(self) -> DataLoader[Sample]:
         """Implement one or more PyTorch DataLoaders for prediction.
 
         Returns:

--- a/torchgeo/datamodules/sen12ms.py
+++ b/torchgeo/datamodules/sen12ms.py
@@ -6,10 +6,10 @@
 from typing import Any
 
 import torch
-from torch import Tensor
 from torch.utils.data import Subset
 
 from ..datasets import SEN12MS
+from ..datasets.utils import Sample
 from .geo import NonGeoDataModule
 from .utils import group_shuffle_split
 
@@ -96,9 +96,7 @@ class SEN12MSDataModule(NonGeoDataModule):
         if stage in ['test']:
             self.test_dataset = SEN12MS(split='test', **self.kwargs)
 
-    def on_after_batch_transfer(
-        self, batch: dict[str, Tensor], dataloader_idx: int
-    ) -> dict[str, Tensor]:
+    def on_after_batch_transfer(self, batch: Sample, dataloader_idx: int) -> Sample:
         """Apply batch augmentations to the batch after it is transferred to the device.
 
         Args:

--- a/torchgeo/datamodules/so2sat.py
+++ b/torchgeo/datamodules/so2sat.py
@@ -6,10 +6,11 @@
 from typing import Any, ClassVar
 
 import torch
-from torch import Generator, Tensor
+from torch import Generator
 from torch.utils.data import random_split
 
 from ..datasets import So2Sat
+from ..datasets.utils import Sample
 from .geo import NonGeoDataModule
 
 
@@ -21,7 +22,7 @@ class So2SatDataModule(NonGeoDataModule):
     "train" set and use the "test" set as the test set.
     """
 
-    means_per_version: ClassVar[dict[str, Tensor]] = {
+    means_per_version: ClassVar[Sample] = {
         '2': torch.tensor(
             [
                 -0.00003591224260,
@@ -91,7 +92,7 @@ class So2SatDataModule(NonGeoDataModule):
     }
     means_per_version['3_culture_10'] = means_per_version['2']
 
-    stds_per_version: ClassVar[dict[str, Tensor]] = {
+    stds_per_version: ClassVar[Sample] = {
         '2': torch.tensor(
             [
                 0.17555201,

--- a/torchgeo/datamodules/so2sat.py
+++ b/torchgeo/datamodules/so2sat.py
@@ -6,11 +6,10 @@
 from typing import Any, ClassVar
 
 import torch
-from torch import Generator
+from torch import Generator, Tensor
 from torch.utils.data import random_split
 
 from ..datasets import So2Sat
-from ..datasets.utils import Sample
 from .geo import NonGeoDataModule
 
 
@@ -22,7 +21,7 @@ class So2SatDataModule(NonGeoDataModule):
     "train" set and use the "test" set as the test set.
     """
 
-    means_per_version: ClassVar[Sample] = {
+    means_per_version: ClassVar[dict[str, Tensor]] = {
         '2': torch.tensor(
             [
                 -0.00003591224260,
@@ -92,7 +91,7 @@ class So2SatDataModule(NonGeoDataModule):
     }
     means_per_version['3_culture_10'] = means_per_version['2']
 
-    stds_per_version: ClassVar[Sample] = {
+    stds_per_version: ClassVar[dict[str, Tensor]] = {
         '2': torch.tensor(
             [
                 0.17555201,

--- a/torchgeo/datamodules/spacenet.py
+++ b/torchgeo/datamodules/spacenet.py
@@ -7,10 +7,10 @@ from typing import Any
 
 import kornia.augmentation as K
 import torch
-from torch import Tensor
 from torch.utils.data import random_split
 
 from ..datasets import SpaceNet, SpaceNet1, SpaceNet6
+from ..datasets.utils import Sample
 from .geo import NonGeoDataModule
 
 
@@ -71,9 +71,7 @@ class SpaceNetBaseDataModule(NonGeoDataModule):
         if stage in ['predict']:
             self.predict_dataset = self.spacenet_ds_class(split='test', **self.kwargs)
 
-    def on_after_batch_transfer(
-        self, batch: dict[str, Tensor], dataloader_idx: int
-    ) -> dict[str, Tensor]:
+    def on_after_batch_transfer(self, batch: Sample, dataloader_idx: int) -> Sample:
         """Apply batch augmentations to the batch after it is transferred to the device.
 
         Args:

--- a/torchgeo/datamodules/treesatai.py
+++ b/torchgeo/datamodules/treesatai.py
@@ -7,10 +7,10 @@ from typing import Any
 
 import kornia.augmentation as K
 import torch
-from torch import Tensor
 from torch.utils.data import random_split
 
 from ..datasets import TreeSatAI
+from ..datasets.utils import Sample
 from ..samplers.utils import _to_tuple
 from .geo import NonGeoDataModule
 
@@ -117,9 +117,7 @@ class TreeSatAIDataModule(NonGeoDataModule):
             generator=generator,
         )
 
-    def on_after_batch_transfer(
-        self, batch: dict[str, Tensor], dataloader_idx: int
-    ) -> dict[str, Tensor]:
+    def on_after_batch_transfer(self, batch: Sample, dataloader_idx: int) -> Sample:
         """Apply batch augmentations to the batch after it is transferred to the device.
 
         Args:

--- a/torchgeo/datamodules/utils.py
+++ b/torchgeo/datamodules/utils.py
@@ -9,7 +9,8 @@ from typing import Any
 
 import numpy as np
 import torch
-from torch import Tensor
+
+from ..datasets.utils import Sample
 
 
 # Based on lightning_lite.utilities.exceptions
@@ -17,7 +18,7 @@ class MisconfigurationException(Exception):
     """Exception used to inform users of misuse with Lightning."""
 
 
-def collate_fn_detection(batch: list[dict[str, Tensor]]) -> dict[str, Any]:
+def collate_fn_detection(batch: list[Sample]) -> Sample:
     """Custom collate fn for object detection and instance segmentation.
 
     Args:
@@ -28,7 +29,7 @@ def collate_fn_detection(batch: list[dict[str, Tensor]]) -> dict[str, Any]:
 
     .. versionadded:: 0.6
     """
-    output: dict[str, Any] = {}
+    output: Sample = {}
     output['image'] = torch.stack([sample['image'] for sample in batch])
     output['bbox_xyxy'] = [sample['bbox_xyxy'].float() for sample in batch]
     if 'label' in batch[0].keys():

--- a/torchgeo/datasets/advance.py
+++ b/torchgeo/datasets/advance.py
@@ -17,7 +17,7 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import Path, download_and_extract_archive, lazy_import
+from .utils import Path, Sample, download_and_extract_archive, lazy_import
 
 
 class ADVANCE(NonGeoDataset):
@@ -89,7 +89,7 @@ class ADVANCE(NonGeoDataset):
     def __init__(
         self,
         root: Path = 'data',
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -122,7 +122,7 @@ class ADVANCE(NonGeoDataset):
         self.classes = tuple(sorted({f['cls'] for f in self.files}))
         self.class_to_idx: dict[str, int] = {c: i for i, c in enumerate(self.classes)}
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -224,10 +224,7 @@ class ADVANCE(NonGeoDataset):
             )
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/agb_live_woody_density.py
+++ b/torchgeo/datasets/agb_live_woody_density.py
@@ -6,7 +6,6 @@
 import json
 import os
 from collections.abc import Callable, Iterable
-from typing import Any
 
 import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
@@ -14,7 +13,7 @@ from rasterio.crs import CRS
 
 from .errors import DatasetNotFoundError
 from .geo import RasterDataset
-from .utils import Path, download_url
+from .utils import Path, Sample, download_url
 
 
 class AbovegroundLiveWoodyBiomassDensity(RasterDataset):
@@ -60,7 +59,7 @@ class AbovegroundLiveWoodyBiomassDensity(RasterDataset):
         paths: Path | Iterable[Path] = 'data',
         crs: CRS | None = None,
         res: float | None = None,
-        transforms: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         cache: bool = True,
     ) -> None:
@@ -119,10 +118,7 @@ class AbovegroundLiveWoodyBiomassDensity(RasterDataset):
             )
 
     def plot(
-        self,
-        sample: dict[str, Any],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/agrifieldnet.py
+++ b/torchgeo/datasets/agrifieldnet.py
@@ -6,7 +6,7 @@
 import os
 import re
 from collections.abc import Callable, Iterable, Sequence
-from typing import Any, ClassVar, cast
+from typing import ClassVar, cast
 
 import matplotlib.pyplot as plt
 import torch
@@ -16,7 +16,7 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError, RGBBandsMissingError
 from .geo import RasterDataset
-from .utils import BoundingBox, Path, which
+from .utils import BoundingBox, Path, Sample, which
 
 
 class AgriFieldNet(RasterDataset):
@@ -128,7 +128,7 @@ class AgriFieldNet(RasterDataset):
         crs: CRS | None = None,
         classes: list[int] = list(cmap.keys()),
         bands: Sequence[str] = all_bands,
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         cache: bool = True,
         download: bool = False,
     ) -> None:
@@ -171,7 +171,7 @@ class AgriFieldNet(RasterDataset):
             self.ordinal_map[k] = v
             self.ordinal_cmap[v] = torch.tensor(self.cmap[k])
 
-    def __getitem__(self, query: BoundingBox) -> dict[str, Any]:
+    def __getitem__(self, query: BoundingBox) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -251,10 +251,7 @@ class AgriFieldNet(RasterDataset):
         azcopy('sync', f'{self.url}', self.paths, '--recursive=true')
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/airphen.py
+++ b/torchgeo/datasets/airphen.py
@@ -3,14 +3,12 @@
 
 """Airphen dataset."""
 
-from typing import Any
-
 import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
 
 from .errors import RGBBandsMissingError
 from .geo import RasterDataset
-from .utils import percentile_normalization
+from .utils import Sample, percentile_normalization
 
 
 class Airphen(RasterDataset):
@@ -44,10 +42,7 @@ class Airphen(RasterDataset):
     rgb_bands = ('B4', 'B3', 'B1')
 
     def plot(
-        self,
-        sample: dict[str, Any],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/astergdem.py
+++ b/torchgeo/datasets/astergdem.py
@@ -4,7 +4,6 @@
 """Aster Global Digital Elevation Model dataset."""
 
 from collections.abc import Callable
-from typing import Any
 
 import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
@@ -12,7 +11,7 @@ from rasterio.crs import CRS
 
 from .errors import DatasetNotFoundError
 from .geo import RasterDataset
-from .utils import Path
+from .utils import Path, Sample
 
 
 class AsterGDEM(RasterDataset):
@@ -51,7 +50,7 @@ class AsterGDEM(RasterDataset):
         paths: Path | list[Path] = 'data',
         crs: CRS | None = None,
         res: float | None = None,
-        transforms: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         cache: bool = True,
     ) -> None:
         """Initialize a new Dataset instance.
@@ -88,10 +87,7 @@ class AsterGDEM(RasterDataset):
         raise DatasetNotFoundError(self)
 
     def plot(
-        self,
-        sample: dict[str, Any],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/benin_cashews.py
+++ b/torchgeo/datasets/benin_cashews.py
@@ -19,7 +19,7 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError, RGBBandsMissingError
 from .geo import NonGeoDataset
-from .utils import Path, which
+from .utils import Path, Sample, which
 
 
 class BeninSmallHolderCashews(NonGeoDataset):
@@ -167,7 +167,7 @@ class BeninSmallHolderCashews(NonGeoDataset):
         chip_size: int = 256,
         stride: int = 128,
         bands: Sequence[str] = all_bands,
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
     ) -> None:
         """Initialize a new Benin Smallholder Cashew Plantations Dataset instance.
@@ -209,7 +209,7 @@ class BeninSmallHolderCashews(NonGeoDataset):
             ]:
                 self.chips_metadata.append((y, x))
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -348,7 +348,7 @@ class BeninSmallHolderCashews(NonGeoDataset):
 
     def plot(
         self,
-        sample: dict[str, Tensor],
+        sample: Sample,
         show_titles: bool = True,
         time_step: int = 0,
         suptitle: str | None = None,

--- a/torchgeo/datasets/bigearthnet.py
+++ b/torchgeo/datasets/bigearthnet.py
@@ -19,7 +19,7 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import Path, download_url, extract_archive, sort_sentinel2_bands
+from .utils import Path, Sample, download_url, extract_archive, sort_sentinel2_bands
 
 
 class BigEarthNet(NonGeoDataset):
@@ -272,7 +272,7 @@ class BigEarthNet(NonGeoDataset):
         split: str = 'train',
         bands: str = 'all',
         num_classes: int = 19,
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -305,7 +305,7 @@ class BigEarthNet(NonGeoDataset):
         self._verify()
         self.folders = self._load_folders()
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -316,7 +316,7 @@ class BigEarthNet(NonGeoDataset):
         """
         image = self._load_image(index)
         label = self._load_target(index)
-        sample: dict[str, Tensor] = {'image': image, 'label': label}
+        sample: Sample = {'image': image, 'label': label}
 
         if self.transforms is not None:
             sample = self.transforms(sample)
@@ -526,10 +526,7 @@ class BigEarthNet(NonGeoDataset):
         return labels
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/biomassters.py
+++ b/torchgeo/datasets/biomassters.py
@@ -16,7 +16,7 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import Path, percentile_normalization
+from .utils import Path, Sample, percentile_normalization
 
 
 class BioMassters(NonGeoDataset):
@@ -127,7 +127,7 @@ class BioMassters(NonGeoDataset):
 
             self.df['num_index'] = self.df.groupby(['chip_id', 'month']).ngroup()
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -147,7 +147,7 @@ class BioMassters(NonGeoDataset):
         )
 
         filepaths = sample_df['filename'].tolist()
-        sample: dict[str, Tensor] = {}
+        sample: Sample = {}
         for sens in self.sensors:
             sens_filepaths = [fp for fp in filepaths if sens in fp]
             sample[f'image_{sens}'] = self._load_input(sens_filepaths)
@@ -216,10 +216,7 @@ class BioMassters(NonGeoDataset):
         raise DatasetNotFoundError(self)
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/bright.py
+++ b/torchgeo/datasets/bright.py
@@ -20,7 +20,7 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import Path, check_integrity, download_url, extract_archive
+from .utils import Path, Sample, check_integrity, download_url, extract_archive
 
 
 class BRIGHTDFC2025(NonGeoDataset):
@@ -91,7 +91,7 @@ class BRIGHTDFC2025(NonGeoDataset):
         self,
         root: Path = 'data',
         split: str = 'train',
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -120,7 +120,7 @@ class BRIGHTDFC2025(NonGeoDataset):
 
         self.sample_paths = self._get_paths()
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -267,10 +267,7 @@ class BRIGHTDFC2025(NonGeoDataset):
         return tensor
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/cabuar.py
+++ b/torchgeo/datasets/cabuar.py
@@ -15,7 +15,7 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import Path, download_url, lazy_import, percentile_normalization
+from .utils import Path, Sample, download_url, lazy_import, percentile_normalization
 
 
 class CaBuAr(NonGeoDataset):
@@ -86,7 +86,7 @@ class CaBuAr(NonGeoDataset):
         root: Path = 'data',
         split: str = 'train',
         bands: tuple[str, ...] = all_bands,
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -127,7 +127,7 @@ class CaBuAr(NonGeoDataset):
 
         self.uuids = self._load_uuids()
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -242,10 +242,7 @@ class CaBuAr(NonGeoDataset):
                 )
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/caffe.py
+++ b/torchgeo/datasets/caffe.py
@@ -20,7 +20,7 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import Path, download_and_extract_archive, extract_archive
+from .utils import Path, Sample, download_and_extract_archive, extract_archive
 
 
 class CaFFe(NonGeoDataset):
@@ -85,7 +85,7 @@ class CaFFe(NonGeoDataset):
         self,
         root: Path = 'data',
         split: str = 'train',
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -139,7 +139,7 @@ class CaFFe(NonGeoDataset):
         """Return the number of images in the dataset."""
         return len(self.fpaths)
 
-    def __getitem__(self, idx: int) -> dict[str, Tensor]:
+    def __getitem__(self, idx: int) -> Sample:
         """Return the image and mask at the given index.
 
         Args:
@@ -237,10 +237,7 @@ class CaFFe(NonGeoDataset):
         extract_archive(os.path.join(self.root, self.zipfilename), self.root)
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/cbf.py
+++ b/torchgeo/datasets/cbf.py
@@ -5,7 +5,6 @@
 
 import os
 from collections.abc import Callable, Iterable
-from typing import Any
 
 import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
@@ -13,7 +12,7 @@ from rasterio.crs import CRS
 
 from .errors import DatasetNotFoundError
 from .geo import VectorDataset
-from .utils import Path, check_integrity, download_and_extract_archive
+from .utils import Path, Sample, check_integrity, download_and_extract_archive
 
 
 class CanadianBuildingFootprints(VectorDataset):
@@ -65,7 +64,7 @@ class CanadianBuildingFootprints(VectorDataset):
         paths: Path | Iterable[Path] = 'data',
         crs: CRS | None = None,
         res: float = 0.00001,
-        transforms: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -125,10 +124,7 @@ class CanadianBuildingFootprints(VectorDataset):
             )
 
     def plot(
-        self,
-        sample: dict[str, Any],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/cdl.py
+++ b/torchgeo/datasets/cdl.py
@@ -5,7 +5,7 @@
 
 import os
 from collections.abc import Callable, Iterable
-from typing import Any, ClassVar
+from typing import ClassVar
 
 import matplotlib.pyplot as plt
 import torch
@@ -14,7 +14,7 @@ from rasterio.crs import CRS
 
 from .errors import DatasetNotFoundError
 from .geo import RasterDataset
-from .utils import BoundingBox, Path, download_url, extract_archive
+from .utils import BoundingBox, Path, Sample, download_url, extract_archive
 
 
 class CDL(RasterDataset):
@@ -212,7 +212,7 @@ class CDL(RasterDataset):
         res: float | None = None,
         years: list[int] = [2023],
         classes: list[int] = list(cmap.keys()),
-        transforms: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         cache: bool = True,
         download: bool = False,
         checksum: bool = False,
@@ -270,7 +270,7 @@ class CDL(RasterDataset):
             self.ordinal_map[k] = v
             self.ordinal_cmap[v] = torch.tensor(self.cmap[k])
 
-    def __getitem__(self, query: BoundingBox) -> dict[str, Any]:
+    def __getitem__(self, query: BoundingBox) -> Sample:
         """Retrieve mask and metadata indexed by query.
 
         Args:
@@ -334,10 +334,7 @@ class CDL(RasterDataset):
             extract_archive(pathname, self.paths)
 
     def plot(
-        self,
-        sample: dict[str, Any],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/chabud.py
+++ b/torchgeo/datasets/chabud.py
@@ -15,7 +15,7 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import Path, download_url, lazy_import, percentile_normalization
+from .utils import Path, Sample, download_url, lazy_import, percentile_normalization
 
 
 class ChaBuD(NonGeoDataset):
@@ -79,7 +79,7 @@ class ChaBuD(NonGeoDataset):
         root: Path = 'data',
         split: str = 'train',
         bands: Sequence[str] = all_bands,
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -117,7 +117,7 @@ class ChaBuD(NonGeoDataset):
 
         self.uuids = self._load_uuids()
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -227,10 +227,7 @@ class ChaBuD(NonGeoDataset):
             )
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/chesapeake.py
+++ b/torchgeo/datasets/chesapeake.py
@@ -8,7 +8,7 @@ import os
 import sys
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable, Sequence
-from typing import Any, ClassVar, cast
+from typing import ClassVar, cast
 
 import fiona
 import matplotlib.pyplot as plt
@@ -22,12 +22,11 @@ import torch
 from matplotlib.colors import ListedColormap
 from matplotlib.figure import Figure
 from rasterio.crs import CRS
-from torch import Tensor
 
 from .errors import DatasetNotFoundError
 from .geo import GeoDataset, RasterDataset
 from .nlcd import NLCD
-from .utils import BoundingBox, Path, download_url, extract_archive
+from .utils import BoundingBox, Path, Sample, download_url, extract_archive
 
 
 class Chesapeake(RasterDataset, ABC):
@@ -129,7 +128,7 @@ class Chesapeake(RasterDataset, ABC):
         paths: Path | Iterable[Path] = 'data',
         crs: CRS | None = None,
         res: float | None = None,
-        transforms: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         cache: bool = True,
         download: bool = False,
         checksum: bool = False,
@@ -199,10 +198,7 @@ class Chesapeake(RasterDataset, ABC):
             extract_archive(file)
 
     def plot(
-        self,
-        sample: dict[str, Any],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 
@@ -436,7 +432,7 @@ class ChesapeakeCVPR(GeoDataset):
         root: Path = 'data',
         splits: Sequence[str] = ['de-train'],
         layers: Sequence[str] = ['naip-new', 'lc'],
-        transforms: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         cache: bool = True,
         download: bool = False,
         checksum: bool = False,
@@ -512,7 +508,7 @@ class ChesapeakeCVPR(GeoDataset):
                         },
                     )
 
-    def __getitem__(self, query: BoundingBox) -> dict[str, Any]:
+    def __getitem__(self, query: BoundingBox) -> Sample:
         """Retrieve image/mask and metadata indexed by query.
 
         Args:
@@ -630,10 +626,7 @@ class ChesapeakeCVPR(GeoDataset):
             extract_archive(os.path.join(self.root, self.filenames[subdataset]))
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/cloud_cover.py
+++ b/torchgeo/datasets/cloud_cover.py
@@ -17,7 +17,7 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError, RGBBandsMissingError
 from .geo import NonGeoDataset
-from .utils import Path, which
+from .utils import Path, Sample, which
 
 
 class CloudCoverDetection(NonGeoDataset):
@@ -65,7 +65,7 @@ class CloudCoverDetection(NonGeoDataset):
         root: Path = 'data',
         split: str = 'train',
         bands: Sequence[str] = all_bands,
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
     ) -> None:
         """Initiatlize a CloudCoverDetection instance.
@@ -104,7 +104,7 @@ class CloudCoverDetection(NonGeoDataset):
         """
         return len(self.metadata)
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Returns a sample from dataset.
 
         Args:
@@ -174,10 +174,7 @@ class CloudCoverDetection(NonGeoDataset):
         azcopy('sync', url, directory, '--recursive=true')
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/cms_mangrove_canopy.py
+++ b/torchgeo/datasets/cms_mangrove_canopy.py
@@ -5,7 +5,6 @@
 
 import os
 from collections.abc import Callable
-from typing import Any
 
 import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
@@ -13,7 +12,7 @@ from rasterio.crs import CRS
 
 from .errors import DatasetNotFoundError
 from .geo import RasterDataset
-from .utils import Path, check_integrity, extract_archive
+from .utils import Path, Sample, check_integrity, extract_archive
 
 
 class CMSGlobalMangroveCanopy(RasterDataset):
@@ -174,7 +173,7 @@ class CMSGlobalMangroveCanopy(RasterDataset):
         res: float | None = None,
         measurement: str = 'agb',
         country: str = all_countries[0],
-        transforms: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         cache: bool = True,
         checksum: bool = False,
     ) -> None:
@@ -245,10 +244,7 @@ class CMSGlobalMangroveCanopy(RasterDataset):
         extract_archive(pathname)
 
     def plot(
-        self,
-        sample: dict[str, Any],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/cowc.py
+++ b/torchgeo/datasets/cowc.py
@@ -18,7 +18,7 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import Path, check_integrity, download_and_extract_archive
+from .utils import Path, Sample, check_integrity, download_and_extract_archive
 
 
 class COWC(NonGeoDataset, abc.ABC):
@@ -67,7 +67,7 @@ class COWC(NonGeoDataset, abc.ABC):
         self,
         root: Path = 'data',
         split: str = 'train',
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -110,7 +110,7 @@ class COWC(NonGeoDataset, abc.ABC):
                 self.images.append(row[0])
                 self.targets.append(row[1])
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -191,10 +191,7 @@ class COWC(NonGeoDataset, abc.ABC):
             )
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/cropharvest.py
+++ b/torchgeo/datasets/cropharvest.py
@@ -18,7 +18,7 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import Path, download_url, extract_archive, lazy_import
+from .utils import Path, Sample, download_url, extract_archive, lazy_import
 
 
 class CropHarvest(NonGeoDataset):
@@ -98,7 +98,7 @@ class CropHarvest(NonGeoDataset):
     def __init__(
         self,
         root: Path = 'data',
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -130,7 +130,7 @@ class CropHarvest(NonGeoDataset):
         self.classes = self.classes[self.classes != np.array(None)]
         self.classes = np.insert(self.classes, 0, ['None', 'Other'])
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -289,7 +289,7 @@ class CropHarvest(NonGeoDataset):
         features_path = os.path.join(self.root, self.file_dict['features']['filename'])
         extract_archive(features_path)
 
-    def plot(self, sample: dict[str, Tensor], suptitle: str | None = None) -> Figure:
+    def plot(self, sample: Sample, suptitle: str | None = None) -> Figure:
         """Plot a sample from the dataset using bands for Agriculture RGB composite.
 
         Args:

--- a/torchgeo/datasets/cv4a_kenya_crop_type.py
+++ b/torchgeo/datasets/cv4a_kenya_crop_type.py
@@ -16,7 +16,7 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError, RGBBandsMissingError
 from .geo import NonGeoDataset
-from .utils import Path, which
+from .utils import Path, Sample, which
 
 
 class CV4AKenyaCropType(NonGeoDataset):
@@ -108,7 +108,7 @@ class CV4AKenyaCropType(NonGeoDataset):
         chip_size: int = 256,
         stride: int = 128,
         bands: Sequence[str] = all_bands,
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
     ) -> None:
         """Initialize a new CV4A Kenya Crop Type Dataset instance.
@@ -151,7 +151,7 @@ class CV4AKenyaCropType(NonGeoDataset):
                 ]:
                     self.chips_metadata.append((tile_index, y, x))
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -284,7 +284,7 @@ class CV4AKenyaCropType(NonGeoDataset):
 
     def plot(
         self,
-        sample: dict[str, Tensor],
+        sample: Sample,
         show_titles: bool = True,
         time_step: int = 0,
         suptitle: str | None = None,

--- a/torchgeo/datasets/cyclone.py
+++ b/torchgeo/datasets/cyclone.py
@@ -6,7 +6,6 @@
 import os
 from collections.abc import Callable
 from functools import lru_cache
-from typing import Any
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -18,7 +17,7 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import Path, which
+from .utils import Path, Sample, which
 
 
 class TropicalCyclone(NonGeoDataset):
@@ -55,7 +54,7 @@ class TropicalCyclone(NonGeoDataset):
         self,
         root: Path = 'data',
         split: str = 'train',
-        transforms: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
     ) -> None:
         """Initialize a new TropicalCyclone instance.
@@ -87,7 +86,7 @@ class TropicalCyclone(NonGeoDataset):
         self.features = pd.read_csv(os.path.join(root, f'{self.filename}_features.csv'))
         self.labels = pd.read_csv(os.path.join(root, f'{self.filename}_labels.csv'))
 
-    def __getitem__(self, index: int) -> dict[str, Any]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -168,10 +167,7 @@ class TropicalCyclone(NonGeoDataset):
             azcopy('copy', f'{self.url}/{file}', self.root)
 
     def plot(
-        self,
-        sample: dict[str, Any],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/deepglobelandcover.py
+++ b/torchgeo/datasets/deepglobelandcover.py
@@ -17,6 +17,7 @@ from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
 from .utils import (
     Path,
+    Sample,
     check_integrity,
     draw_semantic_segmentation_masks,
     extract_archive,
@@ -103,7 +104,7 @@ class DeepGlobeLandCover(NonGeoDataset):
         self,
         root: Path = 'data',
         split: str = 'train',
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         checksum: bool = False,
     ) -> None:
         """Initialize a new DeepGlobeLandCover dataset instance.
@@ -147,7 +148,7 @@ class DeepGlobeLandCover(NonGeoDataset):
                 self.image_fns.append(image_path)
                 self.mask_fns.append(mask_path)
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -228,7 +229,7 @@ class DeepGlobeLandCover(NonGeoDataset):
 
     def plot(
         self,
-        sample: dict[str, Tensor],
+        sample: Sample,
         show_titles: bool = True,
         suptitle: str | None = None,
         alpha: float = 0.5,

--- a/torchgeo/datasets/dfc2022.py
+++ b/torchgeo/datasets/dfc2022.py
@@ -19,7 +19,13 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import Path, check_integrity, extract_archive, percentile_normalization
+from .utils import (
+    Path,
+    Sample,
+    check_integrity,
+    extract_archive,
+    percentile_normalization,
+)
 
 
 class DFC2022(NonGeoDataset):
@@ -140,7 +146,7 @@ class DFC2022(NonGeoDataset):
         self,
         root: Path = 'data',
         split: str = 'train',
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         checksum: bool = False,
     ) -> None:
         """Initialize a new DFC2022 dataset instance.
@@ -167,7 +173,7 @@ class DFC2022(NonGeoDataset):
         self.class2idx = {c: i for i, c in enumerate(self.classes)}
         self.files = self._load_files()
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -289,10 +295,7 @@ class DFC2022(NonGeoDataset):
         raise DatasetNotFoundError(self)
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/digital_typhoon.py
+++ b/torchgeo/datasets/digital_typhoon.py
@@ -7,7 +7,7 @@ import glob
 import os
 import tarfile
 from collections.abc import Callable, Sequence
-from typing import Any, ClassVar, TypedDict
+from typing import ClassVar, TypedDict
 
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -17,7 +17,7 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import Path, download_url, lazy_import, percentile_normalization
+from .utils import Path, Sample, download_url, lazy_import, percentile_normalization
 
 
 class _SampleSequenceDict(TypedDict):
@@ -105,7 +105,7 @@ class DigitalTyphoon(NonGeoDataset):
         sequence_length: int = 3,
         min_feature_value: dict[str, float] | None = None,
         max_feature_value: dict[str, float] | None = None,
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -244,7 +244,7 @@ class DigitalTyphoon(NonGeoDataset):
             for item in sublist
         ]
 
-    def __getitem__(self, index: int) -> dict[str, Any]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -334,7 +334,7 @@ class DigitalTyphoon(NonGeoDataset):
         ).float()
         return tensor
 
-    def _load_features(self, filepath: str, image_path: str) -> dict[str, Any]:
+    def _load_features(self, filepath: str, image_path: str) -> Sample:
         """Load features for the corresponding image.
 
         Args:
@@ -410,10 +410,7 @@ class DigitalTyphoon(NonGeoDataset):
                 tar.extractall(path=self.root)
 
     def plot(
-        self,
-        sample: dict[str, Any],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/eddmaps.py
+++ b/torchgeo/datasets/eddmaps.py
@@ -5,7 +5,6 @@
 
 import os
 import sys
-from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -13,7 +12,7 @@ from rasterio.crs import CRS
 
 from .errors import DatasetNotFoundError
 from .geo import GeoDataset
-from .utils import BoundingBox, Path, disambiguate_timestamp
+from .utils import BoundingBox, Path, Sample, disambiguate_timestamp
 
 
 class EDDMapS(GeoDataset):
@@ -80,7 +79,7 @@ class EDDMapS(GeoDataset):
             self.index.insert(i, coords)
             i += 1
 
-    def __getitem__(self, query: BoundingBox) -> dict[str, Any]:
+    def __getitem__(self, query: BoundingBox) -> Sample:
         """Retrieve metadata indexed by query.
 
         Args:

--- a/torchgeo/datasets/enmap.py
+++ b/torchgeo/datasets/enmap.py
@@ -4,7 +4,7 @@
 """EnMAP dataset."""
 
 from collections.abc import Callable, Iterable, Sequence
-from typing import Any, ClassVar
+from typing import ClassVar
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -14,7 +14,7 @@ from rasterio.crs import CRS
 
 from .errors import RGBBandsMissingError
 from .geo import RasterDataset
-from .utils import Path, percentile_normalization
+from .utils import Path, Sample, percentile_normalization
 
 ALL_BANDS = list(range(1, 225))
 # Remove bands strongly affected by water vapor absorption due to presence of nodata:
@@ -303,7 +303,7 @@ class EnMAP(RasterDataset):
         crs: CRS | None = None,
         res: float | None = None,
         bands: Sequence[str] | None = None,
-        transforms: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         cache: bool = True,
     ) -> None:
         """Initialize a new EnMAP instance.
@@ -325,7 +325,7 @@ class EnMAP(RasterDataset):
         bands = bands or self.default_bands
         super().__init__(paths, crs, res, bands, transforms, cache)
 
-    def plot(self, sample: dict[str, Any], suptitle: str | None = None) -> Figure:
+    def plot(self, sample: Sample, suptitle: str | None = None) -> Figure:
         """Plot a sample from the dataset.
 
         Args:

--- a/torchgeo/datasets/enviroatlas.py
+++ b/torchgeo/datasets/enviroatlas.py
@@ -6,7 +6,7 @@
 import os
 import sys
 from collections.abc import Callable, Sequence
-from typing import Any, ClassVar, cast
+from typing import ClassVar, cast
 
 import fiona
 import matplotlib.pyplot as plt
@@ -23,7 +23,7 @@ from rasterio.crs import CRS
 
 from .errors import DatasetNotFoundError
 from .geo import GeoDataset
-from .utils import BoundingBox, Path, download_url, extract_archive
+from .utils import BoundingBox, Path, Sample, download_url, extract_archive
 
 
 class EnviroAtlas(GeoDataset):
@@ -257,7 +257,7 @@ class EnviroAtlas(GeoDataset):
         root: Path = 'data',
         splits: Sequence[str] = ['pittsburgh_pa-2010_1m-train'],
         layers: Sequence[str] = ['naip', 'prior'],
-        transforms: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         prior_as_input: bool = False,
         cache: bool = True,
         download: bool = False,
@@ -333,7 +333,7 @@ class EnviroAtlas(GeoDataset):
                         },
                     )
 
-    def __getitem__(self, query: BoundingBox) -> dict[str, Any]:
+    def __getitem__(self, query: BoundingBox) -> Sample:
         """Retrieve image/mask and metadata indexed by query.
 
         Args:
@@ -444,10 +444,7 @@ class EnviroAtlas(GeoDataset):
         extract_archive(os.path.join(self.root, self.filename))
 
     def plot(
-        self,
-        sample: dict[str, Any],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/esri2020.py
+++ b/torchgeo/datasets/esri2020.py
@@ -6,7 +6,6 @@
 import glob
 import os
 from collections.abc import Callable, Iterable
-from typing import Any
 
 import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
@@ -14,7 +13,7 @@ from rasterio.crs import CRS
 
 from .errors import DatasetNotFoundError
 from .geo import RasterDataset
-from .utils import Path, download_url, extract_archive
+from .utils import Path, Sample, download_url, extract_archive
 
 
 class Esri2020(RasterDataset):
@@ -72,7 +71,7 @@ class Esri2020(RasterDataset):
         paths: Path | Iterable[Path] = 'data',
         crs: CRS | None = None,
         res: float | None = None,
-        transforms: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         cache: bool = True,
         download: bool = False,
         checksum: bool = False,
@@ -136,10 +135,7 @@ class Esri2020(RasterDataset):
         extract_archive(os.path.join(self.paths, self.zipfile))
 
     def plot(
-        self,
-        sample: dict[str, Any],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/etci2021.py
+++ b/torchgeo/datasets/etci2021.py
@@ -17,7 +17,7 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import Path, download_and_extract_archive
+from .utils import Path, Sample, download_and_extract_archive
 
 
 class ETCI2021(NonGeoDataset):
@@ -84,7 +84,7 @@ class ETCI2021(NonGeoDataset):
         self,
         root: Path = 'data',
         split: str = 'train',
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -117,7 +117,7 @@ class ETCI2021(NonGeoDataset):
 
         self.files = self._load_files(self.root, self.split)
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -252,10 +252,7 @@ class ETCI2021(NonGeoDataset):
         )
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/eudem.py
+++ b/torchgeo/datasets/eudem.py
@@ -6,7 +6,7 @@
 import glob
 import os
 from collections.abc import Callable, Iterable
-from typing import Any, ClassVar
+from typing import ClassVar
 
 import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
@@ -14,7 +14,7 @@ from rasterio.crs import CRS
 
 from .errors import DatasetNotFoundError
 from .geo import RasterDataset
-from .utils import Path, check_integrity, extract_archive
+from .utils import Path, Sample, check_integrity, extract_archive
 
 
 class EUDEM(RasterDataset):
@@ -78,7 +78,7 @@ class EUDEM(RasterDataset):
         paths: Path | Iterable[Path] = 'data',
         crs: CRS | None = None,
         res: float | None = None,
-        transforms: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         cache: bool = True,
         checksum: bool = False,
     ) -> None:
@@ -129,10 +129,7 @@ class EUDEM(RasterDataset):
         raise DatasetNotFoundError(self)
 
     def plot(
-        self,
-        sample: dict[str, Any],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/eurocrops.py
+++ b/torchgeo/datasets/eurocrops.py
@@ -16,7 +16,13 @@ from rasterio.crs import CRS
 
 from .errors import DatasetNotFoundError
 from .geo import VectorDataset
-from .utils import Path, check_integrity, download_and_extract_archive, download_url
+from .utils import (
+    Path,
+    Sample,
+    check_integrity,
+    download_and_extract_archive,
+    download_url,
+)
 
 
 class EuroCrops(VectorDataset):
@@ -89,7 +95,7 @@ class EuroCrops(VectorDataset):
         crs: CRS = CRS.from_epsg(4326),
         res: float = 0.00001,
         classes: list[str] | None = None,
-        transforms: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -222,10 +228,7 @@ class EuroCrops(VectorDataset):
         return 0
 
     def plot(
-        self,
-        sample: dict[str, Any],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/eurosat.py
+++ b/torchgeo/datasets/eurosat.py
@@ -15,7 +15,14 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError, RGBBandsMissingError
 from .geo import NonGeoClassificationDataset
-from .utils import Path, check_integrity, download_url, extract_archive, rasterio_loader
+from .utils import (
+    Path,
+    Sample,
+    check_integrity,
+    download_url,
+    extract_archive,
+    rasterio_loader,
+)
 
 
 class EuroSAT(NonGeoClassificationDataset):
@@ -103,7 +110,7 @@ class EuroSAT(NonGeoClassificationDataset):
         root: Path = 'data',
         split: str = 'train',
         bands: Sequence[str] = BAND_SETS['all'],
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -155,7 +162,7 @@ class EuroSAT(NonGeoClassificationDataset):
             is_valid_file=is_in_split,
         )
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -239,10 +246,7 @@ class EuroSAT(NonGeoClassificationDataset):
                 raise ValueError(f"'{band}' is an invalid band name.")
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/fair1m.py
+++ b/torchgeo/datasets/fair1m.py
@@ -6,7 +6,7 @@
 import glob
 import os
 from collections.abc import Callable
-from typing import ClassVar, cast
+from typing import Any, ClassVar, cast
 from xml.etree.ElementTree import Element, parse
 
 import matplotlib.patches as patches
@@ -119,7 +119,7 @@ class FAIR1M(NonGeoDataset):
     .. versionadded:: 0.2
     """
 
-    classes: ClassVar[dict[str, Sample]] = {
+    classes: ClassVar[dict[str, dict[str, Any]]] = {
         'Passenger Ship': {'id': 0, 'category': 'Ship'},
         'Motorboat': {'id': 1, 'category': 'Ship'},
         'Fishing Boat': {'id': 2, 'category': 'Ship'},

--- a/torchgeo/datasets/fair1m.py
+++ b/torchgeo/datasets/fair1m.py
@@ -6,7 +6,7 @@
 import glob
 import os
 from collections.abc import Callable
-from typing import Any, ClassVar, cast
+from typing import ClassVar, cast
 from xml.etree.ElementTree import Element, parse
 
 import matplotlib.patches as patches
@@ -19,10 +19,10 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import Path, check_integrity, download_url, extract_archive
+from .utils import Path, Sample, check_integrity, download_url, extract_archive
 
 
-def parse_pascal_voc(path: Path) -> dict[str, Any]:
+def parse_pascal_voc(path: Path) -> Sample:
     """Read a PASCAL VOC annotation file.
 
     Args:
@@ -119,7 +119,7 @@ class FAIR1M(NonGeoDataset):
     .. versionadded:: 0.2
     """
 
-    classes: ClassVar[dict[str, dict[str, Any]]] = {
+    classes: ClassVar[dict[str, Sample]] = {
         'Passenger Ship': {'id': 0, 'category': 'Ship'},
         'Motorboat': {'id': 1, 'category': 'Ship'},
         'Fishing Boat': {'id': 2, 'category': 'Ship'},
@@ -232,7 +232,7 @@ class FAIR1M(NonGeoDataset):
         self,
         root: Path = 'data',
         split: str = 'train',
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -264,7 +264,7 @@ class FAIR1M(NonGeoDataset):
             glob.glob(os.path.join(self.root, self.filename_glob[split]))
         )
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -383,10 +383,7 @@ class FAIR1M(NonGeoDataset):
                 extract_archive(filepath)
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/fire_risk.py
+++ b/torchgeo/datasets/fire_risk.py
@@ -9,11 +9,10 @@ from typing import cast
 
 import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
-from torch import Tensor
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoClassificationDataset
-from .utils import Path, download_url, extract_archive
+from .utils import Path, Sample, download_url, extract_archive
 
 
 class FireRisk(NonGeoClassificationDataset):
@@ -70,7 +69,7 @@ class FireRisk(NonGeoClassificationDataset):
         self,
         root: Path = 'data',
         split: str = 'train',
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -135,10 +134,7 @@ class FireRisk(NonGeoClassificationDataset):
         extract_archive(filepath)
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/forestdamage.py
+++ b/torchgeo/datasets/forestdamage.py
@@ -6,7 +6,6 @@
 import glob
 import os
 from collections.abc import Callable
-from typing import Any
 from xml.etree import ElementTree
 
 import matplotlib.patches as patches
@@ -19,10 +18,16 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import Path, check_integrity, download_and_extract_archive, extract_archive
+from .utils import (
+    Path,
+    Sample,
+    check_integrity,
+    download_and_extract_archive,
+    extract_archive,
+)
 
 
-def parse_pascal_voc(path: Path) -> dict[str, Any]:
+def parse_pascal_voc(path: Path) -> Sample:
     """Read a PASCAL VOC annotation file.
 
     Args:
@@ -104,7 +109,7 @@ class ForestDamage(NonGeoDataset):
     def __init__(
         self,
         root: Path = 'data',
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -131,7 +136,7 @@ class ForestDamage(NonGeoDataset):
 
         self.class_to_idx: dict[str, int] = {c: i for i, c in enumerate(self.classes)}
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -246,10 +251,7 @@ class ForestDamage(NonGeoDataset):
         )
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/forestdamage.py
+++ b/torchgeo/datasets/forestdamage.py
@@ -6,6 +6,7 @@
 import glob
 import os
 from collections.abc import Callable
+from typing import Any
 from xml.etree import ElementTree
 
 import matplotlib.patches as patches
@@ -27,7 +28,7 @@ from .utils import (
 )
 
 
-def parse_pascal_voc(path: Path) -> Sample:
+def parse_pascal_voc(path: Path) -> dict[str, Any]:
     """Read a PASCAL VOC annotation file.
 
     Args:

--- a/torchgeo/datasets/ftw.py
+++ b/torchgeo/datasets/ftw.py
@@ -18,7 +18,13 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import Path, array_to_tensor, download_and_extract_archive, extract_archive
+from .utils import (
+    Path,
+    Sample,
+    array_to_tensor,
+    download_and_extract_archive,
+    extract_archive,
+)
 
 
 class FieldsOfTheWorld(NonGeoDataset):
@@ -121,7 +127,7 @@ class FieldsOfTheWorld(NonGeoDataset):
         split: str = 'train',
         target: str = '2-class',
         countries: str | Sequence[str] = ['austria'],
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -160,7 +166,7 @@ class FieldsOfTheWorld(NonGeoDataset):
 
         self.files = self._load_files()
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -306,10 +312,7 @@ class FieldsOfTheWorld(NonGeoDataset):
         return True
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/gbif.py
+++ b/torchgeo/datasets/gbif.py
@@ -7,7 +7,6 @@ import glob
 import os
 import sys
 from datetime import datetime, timedelta
-from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -15,7 +14,7 @@ from rasterio.crs import CRS
 
 from .errors import DatasetNotFoundError
 from .geo import GeoDataset
-from .utils import BoundingBox, Path
+from .utils import BoundingBox, Path, Sample
 
 
 def _disambiguate_timestamps(
@@ -117,7 +116,7 @@ class GBIF(GeoDataset):
             self.index.insert(i, coords)
             i += 1
 
-    def __getitem__(self, query: BoundingBox) -> dict[str, Any]:
+    def __getitem__(self, query: BoundingBox) -> Sample:
         """Retrieve metadata indexed by query.
 
         Args:

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -192,7 +192,7 @@ class GeoDataset(Dataset[Sample], abc.ABC):
     # NOTE: This hack should be removed once the following issue is fixed:
     # https://github.com/Toblerity/rtree/issues/87
 
-    def __getstate__(self) -> tuple[Sample, list[tuple[Any, Any, Any | None]]]:
+    def __getstate__(self) -> tuple[dict[str, Any], list[tuple[Any, Any, Any | None]]]:
         """Define how instances are pickled.
 
         Returns:
@@ -547,7 +547,7 @@ class RasterDataset(GeoDataset):
         else:
             data = self._merge_files(filepaths, query, self.band_indexes)
 
-        sample = {}
+        sample: Sample = {}
 
         data = data.to(self.dtype)
         if self.is_image:

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -547,7 +547,7 @@ class RasterDataset(GeoDataset):
         else:
             data = self._merge_files(filepaths, query, self.band_indexes)
 
-        sample = {'crs': self.crs, 'bounds': query}
+        sample = {}
 
         data = data.to(self.dtype)
         if self.is_image:

--- a/torchgeo/datasets/geonrw.py
+++ b/torchgeo/datasets/geonrw.py
@@ -14,12 +14,11 @@ import matplotlib.colors as mcolors
 import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
 from PIL import Image
-from torch import Tensor
 from torchvision import transforms
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import Path, download_and_extract_archive, extract_archive
+from .utils import Path, Sample, download_and_extract_archive, extract_archive
 
 
 class GeoNRW(NonGeoDataset):
@@ -166,7 +165,7 @@ class GeoNRW(NonGeoDataset):
         self,
         root: Path = 'data',
         split: str = 'train',
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -218,7 +217,7 @@ class GeoNRW(NonGeoDataset):
         """
         return len(self.file_list)
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -233,7 +232,7 @@ class GeoNRW(NonGeoDataset):
         utm_coords = os.path.basename(path).split('_')[:2]
         base_dir = os.path.dirname(path)
 
-        sample: dict[str, Tensor] = {}
+        sample: Sample = {}
         for modality in self.modalities:
             modality_path = os.path.join(
                 base_dir, self.modality_filenames[modality](utm_coords)
@@ -279,10 +278,7 @@ class GeoNRW(NonGeoDataset):
         )
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/gid15.py
+++ b/torchgeo/datasets/gid15.py
@@ -16,7 +16,7 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import Path, download_and_extract_archive
+from .utils import Path, Sample, download_and_extract_archive
 
 
 class GID15(NonGeoDataset):
@@ -90,7 +90,7 @@ class GID15(NonGeoDataset):
         self,
         root: Path = 'data',
         split: str = 'train',
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -123,7 +123,7 @@ class GID15(NonGeoDataset):
 
         self.files = self._load_files(self.root, self.split)
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -235,7 +235,7 @@ class GID15(NonGeoDataset):
             md5=self.md5 if self.checksum else None,
         )
 
-    def plot(self, sample: dict[str, Tensor], suptitle: str | None = None) -> Figure:
+    def plot(self, sample: Sample, suptitle: str | None = None) -> Figure:
         """Plot a sample from the dataset.
 
         Args:

--- a/torchgeo/datasets/globbiomass.py
+++ b/torchgeo/datasets/globbiomass.py
@@ -6,7 +6,7 @@
 import glob
 import os
 from collections.abc import Callable, Iterable
-from typing import Any, ClassVar, cast
+from typing import ClassVar, cast
 
 import matplotlib.pyplot as plt
 import torch
@@ -18,6 +18,7 @@ from .geo import RasterDataset
 from .utils import (
     BoundingBox,
     Path,
+    Sample,
     check_integrity,
     disambiguate_timestamp,
     extract_archive,
@@ -141,7 +142,7 @@ class GlobBiomass(RasterDataset):
         crs: CRS | None = None,
         res: float | None = None,
         measurement: str = 'agb',
-        transforms: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         cache: bool = True,
         checksum: bool = False,
     ) -> None:
@@ -178,7 +179,7 @@ class GlobBiomass(RasterDataset):
 
         super().__init__(paths, crs, res, transforms=transforms, cache=cache)
 
-    def __getitem__(self, query: BoundingBox) -> dict[str, Any]:
+    def __getitem__(self, query: BoundingBox) -> Sample:
         """Retrieve image/mask and metadata indexed by query.
 
         Args:
@@ -233,10 +234,7 @@ class GlobBiomass(RasterDataset):
         raise DatasetNotFoundError(self)
 
     def plot(
-        self,
-        sample: dict[str, Any],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/hyspecnet.py
+++ b/torchgeo/datasets/hyspecnet.py
@@ -12,11 +12,10 @@ import torch
 from einops import rearrange
 from matplotlib import pyplot as plt
 from matplotlib.figure import Figure
-from torch import Tensor
 
 from .errors import DatasetNotFoundError, RGBBandsMissingError
 from .geo import NonGeoDataset
-from .utils import Path, download_url, extract_archive, percentile_normalization
+from .utils import Path, Sample, download_url, extract_archive, percentile_normalization
 
 # https://git.tu-berlin.de/rsim/hyspecnet-tools/-/blob/main/tif_to_npy.ipynb
 invalid_channels = [
@@ -108,7 +107,7 @@ class HySpecNet11k(NonGeoDataset):
         split: str = 'train',
         strategy: str = 'easy',
         bands: Sequence[int] = all_bands,
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -150,7 +149,7 @@ class HySpecNet11k(NonGeoDataset):
         """
         return len(self.files)
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -195,7 +194,7 @@ class HySpecNet11k(NonGeoDataset):
 
             raise DatasetNotFoundError(self)
 
-    def plot(self, sample: dict[str, Tensor], suptitle: str | None = None) -> Figure:
+    def plot(self, sample: Sample, suptitle: str | None = None) -> Figure:
         """Plot a sample from the dataset.
 
         Args:

--- a/torchgeo/datasets/idtrees.py
+++ b/torchgeo/datasets/idtrees.py
@@ -284,7 +284,7 @@ class IDTReeS(NonGeoDataset):
             the bounding boxes
         """
         base_path = os.path.basename(path)
-        geometries = cast(dict[int, Sample], self.geometries)
+        geometries = cast(dict[int, dict[str, Any]], self.geometries)
 
         # Find object ids and geometries
         # The train set geometry->image mapping is contained
@@ -337,7 +337,9 @@ class IDTReeS(NonGeoDataset):
         tensor = torch.tensor(labels)
         return tensor
 
-    def _load(self, root: Path) -> tuple[list[str], dict[int, Sample] | None, Any]:
+    def _load(
+        self, root: Path
+    ) -> tuple[list[str], dict[int, dict[str, Any]] | None, Any]:
         """Load files, geometries, and labels.
 
         Args:
@@ -383,7 +385,7 @@ class IDTReeS(NonGeoDataset):
         df.reset_index()
         return df
 
-    def _load_geometries(self, directory: Path) -> dict[int, Sample]:
+    def _load_geometries(self, directory: Path) -> dict[int, dict[str, Any]]:
         """Load the shape files containing the geometries.
 
         Args:
@@ -395,7 +397,7 @@ class IDTReeS(NonGeoDataset):
         filepaths = glob.glob(os.path.join(directory, 'ITC', '*.shp'))
 
         i = 0
-        features: dict[int, Sample] = {}
+        features: dict[int, dict[str, Any]] = {}
         for path in filepaths:
             with fiona.open(path) as src:
                 for feature in src:

--- a/torchgeo/datasets/inaturalist.py
+++ b/torchgeo/datasets/inaturalist.py
@@ -6,14 +6,13 @@
 import glob
 import os
 import sys
-from typing import Any
 
 import pandas as pd
 from rasterio.crs import CRS
 
 from .errors import DatasetNotFoundError
 from .geo import GeoDataset
-from .utils import BoundingBox, Path, disambiguate_timestamp
+from .utils import BoundingBox, Path, Sample, disambiguate_timestamp
 
 
 class INaturalist(GeoDataset):
@@ -87,7 +86,7 @@ class INaturalist(GeoDataset):
             self.index.insert(i, coords)
             i += 1
 
-    def __getitem__(self, query: BoundingBox) -> dict[str, Any]:
+    def __getitem__(self, query: BoundingBox) -> Sample:
         """Retrieve metadata indexed by query.
 
         Args:

--- a/torchgeo/datasets/inria.py
+++ b/torchgeo/datasets/inria.py
@@ -7,7 +7,6 @@ import glob
 import os
 import re
 from collections.abc import Callable
-from typing import Any
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -18,7 +17,13 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import Path, check_integrity, extract_archive, percentile_normalization
+from .utils import (
+    Path,
+    Sample,
+    check_integrity,
+    extract_archive,
+    percentile_normalization,
+)
 
 
 class InriaAerialImageLabeling(NonGeoDataset):
@@ -61,7 +66,7 @@ class InriaAerialImageLabeling(NonGeoDataset):
         self,
         root: Path = 'data',
         split: str = 'train',
-        transforms: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         checksum: bool = False,
     ) -> None:
         """Initialize a new InriaAerialImageLabeling Dataset instance.
@@ -158,7 +163,7 @@ class InriaAerialImageLabeling(NonGeoDataset):
         """
         return len(self.files)
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -194,10 +199,7 @@ class InriaAerialImageLabeling(NonGeoDataset):
         extract_archive(archive_path)
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/iobench.py
+++ b/torchgeo/datasets/iobench.py
@@ -6,7 +6,7 @@
 import glob
 import os
 from collections.abc import Callable, Sequence
-from typing import Any, ClassVar
+from typing import ClassVar
 
 import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
@@ -16,7 +16,7 @@ from .cdl import CDL
 from .errors import DatasetNotFoundError, RGBBandsMissingError
 from .geo import IntersectionDataset
 from .landsat import Landsat9
-from .utils import Path, download_url, extract_archive
+from .utils import Path, Sample, download_url, extract_archive
 
 
 class IOBench(IntersectionDataset):
@@ -56,7 +56,7 @@ class IOBench(IntersectionDataset):
         res: float | None = None,
         bands: Sequence[str] | None = [*Landsat9.default_bands, 'SR_QA_AEROSOL'],
         classes: list[int] = [0],
-        transforms: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         cache: bool = True,
         download: bool = False,
         checksum: bool = False,
@@ -134,10 +134,7 @@ class IOBench(IntersectionDataset):
         extract_archive(os.path.join(self.root, f'{self.split}.tar.gz'), self.root)
 
     def plot(
-        self,
-        sample: dict[str, Any],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/l7irish.py
+++ b/torchgeo/datasets/l7irish.py
@@ -7,20 +7,20 @@ import glob
 import os
 import re
 from collections.abc import Callable, Iterable, Sequence
-from typing import Any, ClassVar, cast
+from typing import ClassVar, cast
 
 import matplotlib.pyplot as plt
 import torch
 from matplotlib.figure import Figure
 from rasterio.crs import CRS
 from rtree.index import Index, Property
-from torch import Tensor
 
 from .errors import DatasetNotFoundError, RGBBandsMissingError
 from .geo import IntersectionDataset, RasterDataset
 from .utils import (
     BoundingBox,
     Path,
+    Sample,
     disambiguate_timestamp,
     download_url,
     extract_archive,
@@ -71,7 +71,7 @@ class L7IrishMask(RasterDataset):
         crs: CRS | None = None,
         res: float | None = None,
         bands: Sequence[str] | None = None,
-        transforms: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         cache: bool = True,
     ) -> None:
         """Initialize a new L7IrishMask instance.
@@ -102,7 +102,7 @@ class L7IrishMask(RasterDataset):
             index.insert(hit.id, (minx, maxx, miny, maxy, mint, maxt), hit.object)
         self.index = index
 
-    def __getitem__(self, query: BoundingBox) -> dict[str, Any]:
+    def __getitem__(self, query: BoundingBox) -> Sample:
         """Retrieve image/mask and metadata indexed by query.
 
         Args:
@@ -179,7 +179,7 @@ class L7Irish(IntersectionDataset):
         crs: CRS | None = CRS.from_epsg(3857),
         res: float | None = None,
         bands: Sequence[str] = L7IrishImage.all_bands,
-        transforms: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         cache: bool = True,
         download: bool = False,
         checksum: bool = False,
@@ -267,10 +267,7 @@ class L7Irish(IntersectionDataset):
             extract_archive(tarfile)
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/l8biome.py
+++ b/torchgeo/datasets/l8biome.py
@@ -6,17 +6,16 @@
 import glob
 import os
 from collections.abc import Callable, Iterable, Sequence
-from typing import Any, ClassVar
+from typing import ClassVar
 
 import matplotlib.pyplot as plt
 import torch
 from matplotlib.figure import Figure
 from rasterio.crs import CRS
-from torch import Tensor
 
 from .errors import DatasetNotFoundError, RGBBandsMissingError
 from .geo import IntersectionDataset, RasterDataset
-from .utils import BoundingBox, Path, download_url, extract_archive
+from .utils import BoundingBox, Path, Sample, download_url, extract_archive
 
 
 class L8BiomeImage(RasterDataset):
@@ -63,7 +62,7 @@ class L8BiomeMask(RasterDataset):
     ordinal_map[192] = 3
     ordinal_map[255] = 4
 
-    def __getitem__(self, query: BoundingBox) -> dict[str, Any]:
+    def __getitem__(self, query: BoundingBox) -> Sample:
         """Retrieve image/mask and metadata indexed by query.
 
         Args:
@@ -136,7 +135,7 @@ class L8Biome(IntersectionDataset):
         crs: CRS | None = CRS.from_epsg(3857),
         res: float | None = None,
         bands: Sequence[str] = L8BiomeImage.all_bands,
-        transforms: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         cache: bool = True,
         download: bool = False,
         checksum: bool = False,
@@ -212,10 +211,7 @@ class L8Biome(IntersectionDataset):
             extract_archive(tarfile)
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/landcoverai.py
+++ b/torchgeo/datasets/landcoverai.py
@@ -23,10 +23,10 @@ from torch.utils.data import Dataset
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset, RasterDataset
-from .utils import BoundingBox, Path, download_url, extract_archive, working_dir
+from .utils import BoundingBox, Path, Sample, download_url, extract_archive, working_dir
 
 
-class LandCoverAIBase(Dataset[dict[str, Any]], abc.ABC):
+class LandCoverAIBase(Dataset[Sample], abc.ABC):
     r"""Abstract base class for LandCover.ai Geo and NonGeo datasets.
 
     The `LandCover.ai <https://landcover.ai.linuxpolska.com/>`__ (Land Cover from
@@ -119,7 +119,7 @@ class LandCoverAIBase(Dataset[dict[str, Any]], abc.ABC):
         self._extract()
 
     @abc.abstractmethod
-    def __getitem__(self, query: Any) -> dict[str, Any]:
+    def __getitem__(self, query: Any) -> Sample:
         """Retrieve image, mask and metadata indexed by index.
 
         Args:
@@ -145,10 +145,7 @@ class LandCoverAIBase(Dataset[dict[str, Any]], abc.ABC):
         extract_archive(os.path.join(self.root, self.filename))
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 
@@ -207,7 +204,7 @@ class LandCoverAIGeo(LandCoverAIBase, RasterDataset):
         root: Path = 'data',
         crs: CRS | None = None,
         res: float | None = None,
-        transforms: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         cache: bool = True,
         download: bool = False,
         checksum: bool = False,
@@ -240,7 +237,7 @@ class LandCoverAIGeo(LandCoverAIBase, RasterDataset):
         masks = glob.glob(mask_query)
         return len(images) > 0 and len(images) == len(masks)
 
-    def __getitem__(self, query: BoundingBox) -> dict[str, Any]:
+    def __getitem__(self, query: BoundingBox) -> Sample:
         """Retrieve image/mask and metadata indexed by query.
 
         Args:
@@ -297,7 +294,7 @@ class LandCoverAI(LandCoverAIBase, NonGeoDataset):
         self,
         root: Path = 'data',
         split: str = 'train',
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -324,7 +321,7 @@ class LandCoverAI(LandCoverAIBase, NonGeoDataset):
         with open(os.path.join(self.root, split + '.txt')) as f:
             self.ids = f.readlines()
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:

--- a/torchgeo/datasets/landsat.py
+++ b/torchgeo/datasets/landsat.py
@@ -5,7 +5,6 @@
 
 import abc
 from collections.abc import Callable, Iterable, Sequence
-from typing import Any
 
 import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
@@ -13,7 +12,7 @@ from rasterio.crs import CRS
 
 from .errors import RGBBandsMissingError
 from .geo import RasterDataset
-from .utils import Path
+from .utils import Path, Sample
 
 
 class Landsat(RasterDataset, abc.ABC):
@@ -64,7 +63,7 @@ class Landsat(RasterDataset, abc.ABC):
         crs: CRS | None = None,
         res: float | None = None,
         bands: Sequence[str] | None = None,
-        transforms: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         cache: bool = True,
     ) -> None:
         """Initialize a new Dataset instance.
@@ -92,10 +91,7 @@ class Landsat(RasterDataset, abc.ABC):
         super().__init__(paths, crs, res, bands, transforms, cache)
 
     def plot(
-        self,
-        sample: dict[str, Any],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/levircd.py
+++ b/torchgeo/datasets/levircd.py
@@ -18,7 +18,7 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import Path, download_and_extract_archive, percentile_normalization
+from .utils import Path, Sample, download_and_extract_archive, percentile_normalization
 
 
 class LEVIRCDBase(NonGeoDataset, abc.ABC):
@@ -34,7 +34,7 @@ class LEVIRCDBase(NonGeoDataset, abc.ABC):
         self,
         root: Path = 'data',
         split: str = 'train',
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -67,7 +67,7 @@ class LEVIRCDBase(NonGeoDataset, abc.ABC):
 
         self.files = self._load_files(self.root, self.split)
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -130,10 +130,7 @@ class LEVIRCDBase(NonGeoDataset, abc.ABC):
             return tensor
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/loveda.py
+++ b/torchgeo/datasets/loveda.py
@@ -17,7 +17,7 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import Path, download_and_extract_archive
+from .utils import Path, Sample, download_and_extract_archive
 
 
 class LoveDA(NonGeoDataset):
@@ -95,7 +95,7 @@ class LoveDA(NonGeoDataset):
         root: Path = 'data',
         split: str = 'train',
         scene: Sequence[str] = ['urban', 'rural'],
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -143,7 +143,7 @@ class LoveDA(NonGeoDataset):
 
         self.files = self._load_files(self.scene_paths, self.split)
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -256,7 +256,7 @@ class LoveDA(NonGeoDataset):
             md5=self.md5 if self.checksum else None,
         )
 
-    def plot(self, sample: dict[str, Tensor], suptitle: str | None = None) -> Figure:
+    def plot(self, sample: Sample, suptitle: str | None = None) -> Figure:
         """Plot a sample from the dataset.
 
         Args:

--- a/torchgeo/datasets/mapinwild.py
+++ b/torchgeo/datasets/mapinwild.py
@@ -21,6 +21,7 @@ from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
 from .utils import (
     Path,
+    Sample,
     check_integrity,
     download_url,
     extract_archive,
@@ -116,7 +117,7 @@ class MapInWild(NonGeoDataset):
         root: Path = 'data',
         modality: list[str] = ['mask', 'esa_wc', 'viirs', 's2_summer'],
         split: str = 'train',
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -173,7 +174,7 @@ class MapInWild(NonGeoDataset):
             self.ids = split_dataframe[split].dropna().values.tolist()
             self.ids = list(map(int, self.ids))
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -195,7 +196,7 @@ class MapInWild(NonGeoDataset):
 
         image = torch.cat(list_modalities, dim=0)
 
-        sample: dict[str, Tensor] = {'image': image, 'mask': mask}
+        sample: Sample = {'image': image, 'mask': mask}
 
         if self.transforms is not None:
             sample = self.transforms(sample)
@@ -332,10 +333,7 @@ class MapInWild(NonGeoDataset):
         return arr_3d
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/mdas.py
+++ b/torchgeo/datasets/mdas.py
@@ -5,7 +5,7 @@
 
 import os
 from collections.abc import Callable
-from typing import Any, ClassVar
+from typing import ClassVar
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -17,7 +17,7 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import Path, download_and_extract_archive, extract_archive
+from .utils import Path, Sample, download_and_extract_archive, extract_archive
 
 
 class MDAS(NonGeoDataset):
@@ -141,7 +141,7 @@ class MDAS(NonGeoDataset):
         root: Path = 'data',
         subareas: list[str] = ['sub_area_1'],
         modalities: list[str] = ['3K_RGB', 'HySpex', 'Sentinel_2'],
-        transforms: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -232,7 +232,7 @@ class MDAS(NonGeoDataset):
 
             return torch.from_numpy(img)
 
-    def __getitem__(self, idx: int) -> dict[str, Tensor]:
+    def __getitem__(self, idx: int) -> Sample:
         """Return the dataset sample at the given index.
 
         Args:
@@ -242,7 +242,7 @@ class MDAS(NonGeoDataset):
             a dictionary containing the data of chosen modalities
         """
         sample_files = self.files[idx]
-        sample: dict[str, Any] = {}
+        sample: Sample = {}
         for modality, path in sample_files.items():
             if 'osm' in modality:
                 sample[f'{modality}_mask'] = self._load_image(path).long()
@@ -297,10 +297,7 @@ class MDAS(NonGeoDataset):
         )
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/millionaid.py
+++ b/torchgeo/datasets/millionaid.py
@@ -6,7 +6,7 @@
 import glob
 import os
 from collections.abc import Callable
-from typing import Any, ClassVar, cast
+from typing import ClassVar, cast
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -17,7 +17,7 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import Path, check_integrity, extract_archive
+from .utils import Path, Sample, check_integrity, extract_archive
 
 
 class MillionAID(NonGeoDataset):
@@ -193,7 +193,7 @@ class MillionAID(NonGeoDataset):
         root: Path = 'data',
         task: str = 'multi-class',
         split: str = 'train',
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         checksum: bool = False,
     ) -> None:
         """Initialize a new MillionAID dataset instance.
@@ -232,7 +232,7 @@ class MillionAID(NonGeoDataset):
         """
         return len(self.files)
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -252,7 +252,7 @@ class MillionAID(NonGeoDataset):
 
         return sample
 
-    def _load_files(self, root: Path) -> list[dict[str, Any]]:
+    def _load_files(self, root: Path) -> list[Sample]:
         """Return the paths of the files in the dataset.
 
         Args:
@@ -327,10 +327,7 @@ class MillionAID(NonGeoDataset):
         raise DatasetNotFoundError(self)
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/millionaid.py
+++ b/torchgeo/datasets/millionaid.py
@@ -6,7 +6,7 @@
 import glob
 import os
 from collections.abc import Callable
-from typing import ClassVar, cast
+from typing import Any, ClassVar, cast
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -252,7 +252,7 @@ class MillionAID(NonGeoDataset):
 
         return sample
 
-    def _load_files(self, root: Path) -> list[Sample]:
+    def _load_files(self, root: Path) -> list[dict[str, Any]]:
         """Return the paths of the files in the dataset.
 
         Args:

--- a/torchgeo/datasets/mmearth.py
+++ b/torchgeo/datasets/mmearth.py
@@ -368,7 +368,9 @@ class MMEarth(NonGeoDataset):
 
         return sample
 
-    def get_sample_specific_band_names(self, tile_info: Sample) -> dict[str, list[str]]:
+    def get_sample_specific_band_names(
+        self, tile_info: dict[str, Any]
+    ) -> dict[str, list[str]]:
         """Retrieve the sample specific band names.
 
         Args:
@@ -394,7 +396,7 @@ class MMEarth(NonGeoDataset):
 
         return specific_modality_bands
 
-    def get_intersection_dict(self, tile_info: Sample) -> dict[str, list[str]]:
+    def get_intersection_dict(self, tile_info: dict[str, Any]) -> dict[str, list[str]]:
         """Get intersection of requested and available bands.
 
         Args:
@@ -418,7 +420,7 @@ class MMEarth(NonGeoDataset):
 
         return intersection_dict
 
-    def _retrieve_sample(self, ds_index: int) -> Sample:
+    def _retrieve_sample(self, ds_index: int) -> dict[str, Any]:
         """Retrieve a sample from the dataset.
 
         Args:
@@ -435,7 +437,7 @@ class MMEarth(NonGeoDataset):
             'r',
         ) as f:
             name = f['metadata'][ds_index][0].decode('utf-8')
-            tile_info: Sample = self.tile_info[name]
+            tile_info: dict[str, Any] = self.tile_info[name]
             # need to find the intersection of requested and available bands
             intersection_dict = self.get_intersection_dict(tile_info)
             for modality, bands in intersection_dict.items():
@@ -493,7 +495,7 @@ class MMEarth(NonGeoDataset):
         self,
         data: 'np.typing.NDArray[Any]',
         modality: str,
-        tile_info: Sample,
+        tile_info: dict[str, Any],
         bands: list[str],
     ) -> Tensor:
         """Preprocess a single modality.

--- a/torchgeo/datasets/mmflood.py
+++ b/torchgeo/datasets/mmflood.py
@@ -15,11 +15,10 @@ import numpy as np
 import pandas as pd
 from matplotlib.figure import Figure
 from rasterio.crs import CRS
-from torch import Tensor
 
 from .errors import DatasetNotFoundError
 from .geo import IntersectionDataset, RasterDataset
-from .utils import BoundingBox, Path, download_url, extract_archive
+from .utils import BoundingBox, Path, Sample, download_url, extract_archive
 
 
 class MMFloodComponent(RasterDataset):
@@ -32,7 +31,7 @@ class MMFloodComponent(RasterDataset):
         root: Path = 'data',
         crs: CRS | None = None,
         res: float | None = None,
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         cache: bool = False,
     ) -> None:
         """Initialize MMFloodComponent dataset instance.
@@ -149,7 +148,7 @@ class MMFlood(IntersectionDataset):
         split: str = 'train',
         include_dem: bool = False,
         include_hydro: bool = False,
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
         cache: bool = False,
@@ -227,7 +226,7 @@ class MMFlood(IntersectionDataset):
                 with open(part_path, 'rb') as part_fp:
                     dst_fp.write(part_fp.read())
 
-    def __getitem__(self, query: BoundingBox) -> dict[str, Tensor]:
+    def __getitem__(self, query: BoundingBox) -> Sample:
         """Retrieve image/mask and metadata indexed by query.
 
         Args:
@@ -295,10 +294,7 @@ class MMFlood(IntersectionDataset):
         self._extract()
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/naip.py
+++ b/torchgeo/datasets/naip.py
@@ -3,12 +3,11 @@
 
 """National Agriculture Imagery Program (NAIP) dataset."""
 
-from typing import Any
-
 import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
 
 from .geo import RasterDataset
+from .utils import Sample
 
 
 class NAIP(RasterDataset):
@@ -49,10 +48,7 @@ class NAIP(RasterDataset):
     rgb_bands = ('R', 'G', 'B')
 
     def plot(
-        self,
-        sample: dict[str, Any],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/nasa_marine_debris.py
+++ b/torchgeo/datasets/nasa_marine_debris.py
@@ -12,12 +12,11 @@ import numpy as np
 import rasterio
 import torch
 from matplotlib.figure import Figure
-from torch import Tensor
 from torchvision.utils import draw_bounding_boxes
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import Path, which
+from .utils import Path, Sample, which
 
 
 class NASAMarineDebris(NonGeoDataset):
@@ -59,7 +58,7 @@ class NASAMarineDebris(NonGeoDataset):
     def __init__(
         self,
         root: Path = 'data',
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
     ) -> None:
         """Initialize a new NASA Marine Debris Dataset instance.
@@ -82,7 +81,7 @@ class NASAMarineDebris(NonGeoDataset):
         self.source = sorted(glob.glob(os.path.join(self.root, 'source', '*.tif')))
         self.labels = sorted(glob.glob(os.path.join(self.root, 'labels', '*.npy')))
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -142,10 +141,7 @@ class NASAMarineDebris(NonGeoDataset):
         azcopy('sync', self.url, self.root, '--recursive=true')
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/nccm.py
+++ b/torchgeo/datasets/nccm.py
@@ -4,7 +4,7 @@
 """Northeastern China Crop Map Dataset."""
 
 from collections.abc import Callable, Iterable
-from typing import Any, ClassVar
+from typing import ClassVar
 
 import matplotlib.pyplot as plt
 import torch
@@ -13,7 +13,7 @@ from rasterio.crs import CRS
 
 from .errors import DatasetNotFoundError
 from .geo import RasterDataset
-from .utils import BoundingBox, Path, download_url
+from .utils import BoundingBox, Path, Sample, download_url
 
 
 class NCCM(RasterDataset):
@@ -87,7 +87,7 @@ class NCCM(RasterDataset):
         crs: CRS | None = None,
         res: float | None = None,
         years: list[int] = [2019],
-        transforms: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         cache: bool = True,
         download: bool = False,
         checksum: bool = False,
@@ -128,7 +128,7 @@ class NCCM(RasterDataset):
             self.ordinal_map[k] = i
             self.ordinal_cmap[i] = torch.tensor(v)
 
-    def __getitem__(self, query: BoundingBox) -> dict[str, Any]:
+    def __getitem__(self, query: BoundingBox) -> Sample:
         """Retrieve mask and metadata indexed by query.
 
         Args:
@@ -168,10 +168,7 @@ class NCCM(RasterDataset):
             )
 
     def plot(
-        self,
-        sample: dict[str, Any],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/nlcd.py
+++ b/torchgeo/datasets/nlcd.py
@@ -5,7 +5,7 @@
 
 import os
 from collections.abc import Callable, Iterable
-from typing import Any, ClassVar
+from typing import ClassVar
 
 import matplotlib.pyplot as plt
 import torch
@@ -14,7 +14,7 @@ from rasterio.crs import CRS
 
 from .errors import DatasetNotFoundError
 from .geo import RasterDataset
-from .utils import BoundingBox, Path, download_url
+from .utils import BoundingBox, Path, Sample, download_url
 
 
 class NLCD(RasterDataset):
@@ -137,7 +137,7 @@ class NLCD(RasterDataset):
         res: float | None = None,
         years: list[int] = [2023],
         classes: list[int] = list(cmap.keys()),
-        transforms: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         cache: bool = True,
         download: bool = False,
         checksum: bool = False,
@@ -189,7 +189,7 @@ class NLCD(RasterDataset):
             self.ordinal_map[k] = v
             self.ordinal_cmap[v] = torch.tensor(self.cmap[k])
 
-    def __getitem__(self, query: BoundingBox) -> dict[str, Any]:
+    def __getitem__(self, query: BoundingBox) -> Sample:
         """Retrieve mask and metadata indexed by query.
 
         Args:
@@ -238,10 +238,7 @@ class NLCD(RasterDataset):
             )
 
     def plot(
-        self,
-        sample: dict[str, Any],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/openbuildings.py
+++ b/torchgeo/datasets/openbuildings.py
@@ -8,7 +8,7 @@ import json
 import os
 import sys
 from collections.abc import Callable, Iterable
-from typing import Any, ClassVar, cast
+from typing import ClassVar, cast
 
 import fiona
 import fiona.transform
@@ -24,7 +24,7 @@ from rtree.index import Index, Property
 
 from .errors import DatasetNotFoundError
 from .geo import VectorDataset
-from .utils import BoundingBox, Path, check_integrity
+from .utils import BoundingBox, Path, Sample, check_integrity
 
 
 class OpenBuildings(VectorDataset):
@@ -210,7 +210,7 @@ class OpenBuildings(VectorDataset):
         paths: Path | Iterable[Path] = 'data',
         crs: CRS | None = None,
         res: float = 0.0001,
-        transforms: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         checksum: bool = False,
     ) -> None:
         """Initialize a new Dataset instance.
@@ -290,7 +290,7 @@ class OpenBuildings(VectorDataset):
         self._crs = crs
         self._source_crs = source_crs
 
-    def __getitem__(self, query: BoundingBox) -> dict[str, Any]:
+    def __getitem__(self, query: BoundingBox) -> Sample:
         """Retrieve image/mask and metadata indexed by query.
 
         Args:
@@ -336,7 +336,7 @@ class OpenBuildings(VectorDataset):
 
     def _filter_geometries(
         self, query: BoundingBox, filepaths: list[str]
-    ) -> list[dict[str, Any]]:
+    ) -> list[Sample]:
         """Filters a df read from the polygon csv file based on query and conf thresh.
 
         Args:
@@ -369,7 +369,7 @@ class OpenBuildings(VectorDataset):
 
         return shapes
 
-    def _wkt_fiona_geom_transform(self, x: str) -> dict[str, Any]:
+    def _wkt_fiona_geom_transform(self, x: str) -> Sample:
         """Function to transform a geometry string into new crs.
 
         Args:
@@ -389,7 +389,7 @@ class OpenBuildings(VectorDataset):
             geom = fiona.model.Geometry(**x)
         else:
             geom = x
-        transformed: dict[str, Any] = fiona.transform.transform_geom(
+        transformed: Sample = fiona.transform.transform_geom(
             self._source_crs.to_dict(), self._crs.to_dict(), geom
         )
         return transformed
@@ -412,10 +412,7 @@ class OpenBuildings(VectorDataset):
         raise DatasetNotFoundError(self)
 
     def plot(
-        self,
-        sample: dict[str, Any],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/openbuildings.py
+++ b/torchgeo/datasets/openbuildings.py
@@ -8,7 +8,7 @@ import json
 import os
 import sys
 from collections.abc import Callable, Iterable
-from typing import ClassVar, cast
+from typing import Any, ClassVar, cast
 
 import fiona
 import fiona.transform
@@ -336,7 +336,7 @@ class OpenBuildings(VectorDataset):
 
     def _filter_geometries(
         self, query: BoundingBox, filepaths: list[str]
-    ) -> list[Sample]:
+    ) -> list[dict[str, Any]]:
         """Filters a df read from the polygon csv file based on query and conf thresh.
 
         Args:
@@ -369,7 +369,7 @@ class OpenBuildings(VectorDataset):
 
         return shapes
 
-    def _wkt_fiona_geom_transform(self, x: str) -> Sample:
+    def _wkt_fiona_geom_transform(self, x: str) -> dict[str, Any]:
         """Function to transform a geometry string into new crs.
 
         Args:
@@ -389,7 +389,7 @@ class OpenBuildings(VectorDataset):
             geom = fiona.model.Geometry(**x)
         else:
             geom = x
-        transformed: Sample = fiona.transform.transform_geom(
+        transformed: dict[str, Any] = fiona.transform.transform_geom(
             self._source_crs.to_dict(), self._crs.to_dict(), geom
         )
         return transformed

--- a/torchgeo/datasets/oscd.py
+++ b/torchgeo/datasets/oscd.py
@@ -19,6 +19,7 @@ from .errors import DatasetNotFoundError, RGBBandsMissingError
 from .geo import NonGeoDataset
 from .utils import (
     Path,
+    Sample,
     download_url,
     draw_semantic_segmentation_masks,
     extract_archive,
@@ -103,7 +104,7 @@ class OSCD(NonGeoDataset):
         root: Path = 'data',
         split: str = 'train',
         bands: Sequence[str] = all_bands,
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -137,7 +138,7 @@ class OSCD(NonGeoDataset):
 
         self.files = self._load_files()
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -283,7 +284,7 @@ class OSCD(NonGeoDataset):
 
     def plot(
         self,
-        sample: dict[str, Tensor],
+        sample: Sample,
         show_titles: bool = True,
         suptitle: str | None = None,
         alpha: float = 0.5,

--- a/torchgeo/datasets/pastis.py
+++ b/torchgeo/datasets/pastis.py
@@ -17,7 +17,7 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import Path, check_integrity, download_url, extract_archive
+from .utils import Path, Sample, check_integrity, download_url, extract_archive
 
 
 class PASTIS(NonGeoDataset):
@@ -133,7 +133,7 @@ class PASTIS(NonGeoDataset):
         folds: Sequence[int] = (1, 2, 3, 4, 5),
         bands: str = 's2',
         mode: str = 'semantic',
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -179,7 +179,7 @@ class PASTIS(NonGeoDataset):
             )
         self._cmap = ListedColormap(colors)
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -345,10 +345,7 @@ class PASTIS(NonGeoDataset):
         extract_archive(os.path.join(self.root, self.filename), self.root)
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/patternnet.py
+++ b/torchgeo/datasets/patternnet.py
@@ -9,11 +9,10 @@ from typing import cast
 
 import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
-from torch import Tensor
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoClassificationDataset
-from .utils import Path, download_url, extract_archive
+from .utils import Path, Sample, download_url, extract_archive
 
 
 class PatternNet(NonGeoClassificationDataset):
@@ -86,7 +85,7 @@ class PatternNet(NonGeoClassificationDataset):
     def __init__(
         self,
         root: Path = 'data',
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -144,10 +143,7 @@ class PatternNet(NonGeoClassificationDataset):
         extract_archive(filepath)
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/potsdam.py
+++ b/torchgeo/datasets/potsdam.py
@@ -19,6 +19,7 @@ from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
 from .utils import (
     Path,
+    Sample,
     check_integrity,
     draw_semantic_segmentation_masks,
     extract_archive,
@@ -125,7 +126,7 @@ class Potsdam2D(NonGeoDataset):
         self,
         root: Path = 'data',
         split: str = 'train',
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         checksum: bool = False,
     ) -> None:
         """Initialize a new Potsdam dataset instance.
@@ -156,7 +157,7 @@ class Potsdam2D(NonGeoDataset):
             if os.path.exists(image) and os.path.exists(mask):
                 self.files.append(dict(image=image, mask=mask))
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -240,7 +241,7 @@ class Potsdam2D(NonGeoDataset):
 
     def plot(
         self,
-        sample: dict[str, Tensor],
+        sample: Sample,
         show_titles: bool = True,
         suptitle: str | None = None,
         alpha: float = 0.5,

--- a/torchgeo/datasets/prisma.py
+++ b/torchgeo/datasets/prisma.py
@@ -3,13 +3,11 @@
 
 """PRISMA datasets."""
 
-from typing import Any
-
 import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
 
 from .geo import RasterDataset
-from .utils import percentile_normalization
+from .utils import Sample, percentile_normalization
 
 
 class PRISMA(RasterDataset):
@@ -78,10 +76,7 @@ class PRISMA(RasterDataset):
     date_format = '%Y%m%d%H%M%S'
 
     def plot(
-        self,
-        sample: dict[str, Any],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/quakeset.py
+++ b/torchgeo/datasets/quakeset.py
@@ -5,7 +5,7 @@
 
 import os
 from collections.abc import Callable
-from typing import Any, ClassVar, cast
+from typing import ClassVar, cast
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -15,7 +15,7 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import Path, download_url, lazy_import, percentile_normalization
+from .utils import Path, Sample, download_url, lazy_import, percentile_normalization
 
 
 class QuakeSet(NonGeoDataset):
@@ -72,7 +72,7 @@ class QuakeSet(NonGeoDataset):
         self,
         root: Path = 'data',
         split: str = 'train',
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -104,7 +104,7 @@ class QuakeSet(NonGeoDataset):
         self._verify()
         self.data = self._load_data()
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -132,7 +132,7 @@ class QuakeSet(NonGeoDataset):
         """
         return len(self.data)
 
-    def _load_data(self) -> list[dict[str, Any]]:
+    def _load_data(self) -> list[Sample]:
         """Return the metadata for a given split.
 
         Returns:
@@ -224,10 +224,7 @@ class QuakeSet(NonGeoDataset):
             )
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/quakeset.py
+++ b/torchgeo/datasets/quakeset.py
@@ -5,7 +5,7 @@
 
 import os
 from collections.abc import Callable
-from typing import ClassVar, cast
+from typing import Any, ClassVar, cast
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -132,7 +132,7 @@ class QuakeSet(NonGeoDataset):
         """
         return len(self.data)
 
-    def _load_data(self) -> list[Sample]:
+    def _load_data(self) -> list[dict[str, Any]]:
         """Return the metadata for a given split.
 
         Returns:

--- a/torchgeo/datasets/reforestree.py
+++ b/torchgeo/datasets/reforestree.py
@@ -18,7 +18,13 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import Path, check_integrity, download_and_extract_archive, extract_archive
+from .utils import (
+    Path,
+    Sample,
+    check_integrity,
+    download_and_extract_archive,
+    extract_archive,
+)
 
 
 class ReforesTree(NonGeoDataset):
@@ -65,7 +71,7 @@ class ReforesTree(NonGeoDataset):
     def __init__(
         self,
         root: Path = 'data',
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -94,7 +100,7 @@ class ReforesTree(NonGeoDataset):
 
         self.class2idx: dict[str, int] = {c: i for i, c in enumerate(self.classes)}
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -202,10 +208,7 @@ class ReforesTree(NonGeoDataset):
         )
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/resisc45.py
+++ b/torchgeo/datasets/resisc45.py
@@ -10,11 +10,10 @@ from typing import ClassVar, cast
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.figure import Figure
-from torch import Tensor
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoClassificationDataset
-from .utils import Path, download_url, extract_archive
+from .utils import Path, Sample, download_url, extract_archive
 
 
 class RESISC45(NonGeoClassificationDataset):
@@ -114,7 +113,7 @@ class RESISC45(NonGeoClassificationDataset):
         self,
         root: Path = 'data',
         split: str = 'train',
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -194,10 +193,7 @@ class RESISC45(NonGeoClassificationDataset):
         extract_archive(filepath)
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/rwanda_field_boundary.py
+++ b/torchgeo/datasets/rwanda_field_boundary.py
@@ -15,11 +15,10 @@ import rasterio.features
 import torch
 from einops import rearrange
 from matplotlib.figure import Figure
-from torch import Tensor
 
 from .errors import DatasetNotFoundError, RGBBandsMissingError
 from .geo import NonGeoDataset
-from .utils import Path, which
+from .utils import Path, Sample, which
 
 
 class RwandaFieldBoundary(NonGeoDataset):
@@ -68,7 +67,7 @@ class RwandaFieldBoundary(NonGeoDataset):
         root: Path = 'data',
         split: str = 'train',
         bands: Sequence[str] = all_bands,
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
     ) -> None:
         """Initialize a new RwandaFieldBoundary instance.
@@ -104,7 +103,7 @@ class RwandaFieldBoundary(NonGeoDataset):
         """
         return self.splits[self.split]
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -156,7 +155,7 @@ class RwandaFieldBoundary(NonGeoDataset):
 
     def plot(
         self,
-        sample: dict[str, Tensor],
+        sample: Sample,
         show_titles: bool = True,
         time_step: int = 0,
         suptitle: str | None = None,

--- a/torchgeo/datasets/satlas.py
+++ b/torchgeo/datasets/satlas.py
@@ -14,11 +14,10 @@ from einops import rearrange
 from matplotlib import pyplot as plt
 from matplotlib.figure import Figure
 from PIL import Image
-from torch import Tensor
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import Path, check_integrity, extract_archive, which
+from .utils import Path, Sample, check_integrity, extract_archive, which
 
 
 class _Task(TypedDict, total=False):
@@ -541,7 +540,7 @@ class SatlasPretrain(NonGeoDataset):
         image_times: str = 'image_times',
         images: Iterable[str] = ('sentinel1', 'sentinel2', 'landsat'),
         labels: Iterable[str] = ('land_cover',),
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -597,7 +596,7 @@ class SatlasPretrain(NonGeoDataset):
         """
         return len(self.split)
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -609,7 +608,7 @@ class SatlasPretrain(NonGeoDataset):
         col, row = self.split.iloc[index]
         directories = self.good_images.get_group((col, row))['directory']
 
-        sample: dict[str, Tensor] = {}
+        sample: Sample = {}
 
         for image in self.images:
             self._load_image(sample, image, col, row, directories)
@@ -623,12 +622,7 @@ class SatlasPretrain(NonGeoDataset):
         return sample
 
     def _load_image(
-        self,
-        sample: dict[str, Tensor],
-        image: str,
-        col: int,
-        row: int,
-        directories: pd.Series,
+        self, sample: Sample, image: str, col: int, row: int, directories: pd.Series
     ) -> None:
         """Load a single image.
 
@@ -669,9 +663,7 @@ class SatlasPretrain(NonGeoDataset):
         raster = rearrange(torch.cat(channels, dim=-1), 'h w c -> c h w')
         sample[f'image_{image}'] = raster
 
-    def _load_label(
-        self, sample: dict[str, Tensor], label: str, col: int, row: int
-    ) -> None:
+    def _load_label(self, sample: Sample, label: str, col: int, row: int) -> None:
         """Load a single label.
 
         Args:
@@ -720,10 +712,7 @@ class SatlasPretrain(NonGeoDataset):
                 extract_archive(path)
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/seasonet.py
+++ b/torchgeo/datasets/seasonet.py
@@ -21,7 +21,7 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError, RGBBandsMissingError
 from .geo import NonGeoDataset
-from .utils import Path, download_url, extract_archive, percentile_normalization
+from .utils import Path, Sample, download_url, extract_archive, percentile_normalization
 
 
 class SeasoNet(NonGeoDataset):
@@ -219,7 +219,7 @@ class SeasoNet(NonGeoDataset):
         bands: Iterable[str] = all_bands,
         grids: Iterable[int] = [1, 2],
         concat_seasons: int = 1,
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -292,7 +292,7 @@ class SeasoNet(NonGeoDataset):
         else:
             self.files = csv['Path']
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -402,7 +402,7 @@ class SeasoNet(NonGeoDataset):
 
     def plot(
         self,
-        sample: dict[str, Tensor],
+        sample: Sample,
         show_titles: bool = True,
         show_legend: bool = True,
         suptitle: str | None = None,

--- a/torchgeo/datasets/seco.py
+++ b/torchgeo/datasets/seco.py
@@ -18,7 +18,7 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError, RGBBandsMissingError
 from .geo import NonGeoDataset
-from .utils import Path, download_url, extract_archive, percentile_normalization
+from .utils import Path, Sample, download_url, extract_archive, percentile_normalization
 
 
 class SeasonalContrastS2(NonGeoDataset):
@@ -75,7 +75,7 @@ class SeasonalContrastS2(NonGeoDataset):
         version: str = '100k',
         seasons: int = 1,
         bands: Sequence[str] = rgb_bands,
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -113,7 +113,7 @@ class SeasonalContrastS2(NonGeoDataset):
 
         self._verify()
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -222,10 +222,7 @@ class SeasonalContrastS2(NonGeoDataset):
         )
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/sen12ms.py
+++ b/torchgeo/datasets/sen12ms.py
@@ -16,7 +16,7 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError, RGBBandsMissingError
 from .geo import NonGeoDataset
-from .utils import Path, check_integrity, percentile_normalization
+from .utils import Path, Sample, check_integrity, percentile_normalization
 
 
 class SEN12MS(NonGeoDataset):
@@ -169,7 +169,7 @@ class SEN12MS(NonGeoDataset):
         root: Path = 'data',
         split: str = 'train',
         bands: Sequence[str] = BAND_SETS['all'],
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         checksum: bool = False,
     ) -> None:
         """Initialize a new SEN12MS dataset instance.
@@ -213,7 +213,7 @@ class SEN12MS(NonGeoDataset):
         with open(os.path.join(self.root, split + '_list.txt')) as f:
             self.ids = [line.rstrip() for line in f.readlines()]
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -231,7 +231,7 @@ class SEN12MS(NonGeoDataset):
         image = torch.cat(tensors=[s1, s2], dim=0)
         image = torch.index_select(image, dim=0, index=self.band_indices)
 
-        sample: dict[str, Tensor] = {'image': image, 'mask': lc[0]}
+        sample: Sample = {'image': image, 'mask': lc[0]}
 
         if self.transforms is not None:
             sample = self.transforms(sample)
@@ -313,10 +313,7 @@ class SEN12MS(NonGeoDataset):
         return True
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/sentinel.py
+++ b/torchgeo/datasets/sentinel.py
@@ -4,7 +4,6 @@
 """Sentinel datasets."""
 
 from collections.abc import Callable, Iterable, Sequence
-from typing import Any
 
 import matplotlib.pyplot as plt
 import torch
@@ -13,7 +12,7 @@ from rasterio.crs import CRS
 
 from .errors import RGBBandsMissingError
 from .geo import RasterDataset
-from .utils import Path
+from .utils import Path, Sample
 
 
 class Sentinel(RasterDataset):
@@ -146,7 +145,7 @@ class Sentinel1(Sentinel):
         crs: CRS | None = None,
         res: float = 10,
         bands: Sequence[str] = ['VV', 'VH'],
-        transforms: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         cache: bool = True,
     ) -> None:
         """Initialize a new Dataset instance.
@@ -192,10 +191,7 @@ To create a dataset containing both, use:
         super().__init__(paths, crs, res, bands, transforms, cache)
 
     def plot(
-        self,
-        sample: dict[str, Any],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 
@@ -302,7 +298,7 @@ class Sentinel2(Sentinel):
         crs: CRS | None = None,
         res: float = 10,
         bands: Sequence[str] | None = None,
-        transforms: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         cache: bool = True,
     ) -> None:
         """Initialize a new Dataset instance.
@@ -331,10 +327,7 @@ class Sentinel2(Sentinel):
         super().__init__(paths, crs, res, bands, transforms, cache)
 
     def plot(
-        self,
-        sample: dict[str, Any],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/skippd.py
+++ b/torchgeo/datasets/skippd.py
@@ -134,7 +134,7 @@ class SKIPPD(NonGeoDataset):
 
         return num_datapoints
 
-    def __getitem__(self, index: int) -> dict[str, str | Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -143,7 +143,7 @@ class SKIPPD(NonGeoDataset):
         Returns:
             data and label at that index
         """
-        sample: dict[str, str | Tensor] = {'image': self._load_image(index)}
+        sample = {'image': self._load_image(index)}
         sample.update(self._load_features(index))
 
         if self.transforms is not None:

--- a/torchgeo/datasets/skippd.py
+++ b/torchgeo/datasets/skippd.py
@@ -5,7 +5,7 @@
 
 import os
 from collections.abc import Callable
-from typing import Any, ClassVar
+from typing import ClassVar
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -16,7 +16,7 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import Path, download_url, extract_archive, lazy_import
+from .utils import Path, Sample, download_url, extract_archive, lazy_import
 
 
 class SKIPPD(NonGeoDataset):
@@ -82,7 +82,7 @@ class SKIPPD(NonGeoDataset):
         root: Path = 'data',
         split: str = 'trainval',
         task: str = 'nowcast',
-        transforms: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -237,10 +237,7 @@ class SKIPPD(NonGeoDataset):
         extract_archive(zipfile_path, self.root)
 
     def plot(
-        self,
-        sample: dict[str, Any],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/skyscript.py
+++ b/torchgeo/datasets/skyscript.py
@@ -5,7 +5,7 @@
 
 import os
 from collections.abc import Callable
-from typing import Any, ClassVar
+from typing import ClassVar
 
 import numpy as np
 import pandas as pd
@@ -14,11 +14,16 @@ from einops import rearrange
 from matplotlib import pyplot as plt
 from matplotlib.figure import Figure
 from PIL import Image
-from torch import Tensor
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import Path, download_and_extract_archive, download_url, extract_archive
+from .utils import (
+    Path,
+    Sample,
+    download_and_extract_archive,
+    download_url,
+    extract_archive,
+)
 
 
 class SkyScript(NonGeoDataset):
@@ -64,7 +69,7 @@ class SkyScript(NonGeoDataset):
         self,
         root: Path = 'data',
         split: str = 'train',
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -102,7 +107,7 @@ class SkyScript(NonGeoDataset):
         """
         return len(self.captions)
 
-    def __getitem__(self, index: int) -> dict[str, Any]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -154,10 +159,7 @@ class SkyScript(NonGeoDataset):
             download_url(url, self.root, md5=md5)
 
     def plot(
-        self,
-        sample: dict[str, Any],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/so2sat.py
+++ b/torchgeo/datasets/so2sat.py
@@ -11,11 +11,10 @@ import matplotlib.pyplot as plt
 import numpy as np
 import torch
 from matplotlib.figure import Figure
-from torch import Tensor
 
 from .errors import DatasetNotFoundError, RGBBandsMissingError
 from .geo import NonGeoDataset
-from .utils import Path, check_integrity, lazy_import, percentile_normalization
+from .utils import Path, Sample, check_integrity, lazy_import, percentile_normalization
 
 
 class So2Sat(NonGeoDataset):
@@ -198,7 +197,7 @@ class So2Sat(NonGeoDataset):
         version: str = '2',
         split: str = 'train',
         bands: Sequence[str] = BAND_SETS['all'],
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         checksum: bool = False,
     ) -> None:
         """Initialize a new So2Sat dataset instance.
@@ -266,7 +265,7 @@ class So2Sat(NonGeoDataset):
         with h5py.File(self.fn, 'r') as f:
             self.size: int = f['label'].shape[0]
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -335,10 +334,7 @@ class So2Sat(NonGeoDataset):
                 raise ValueError(f"'{band}' is an invalid band name.")
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/south_africa_crop_type.py
+++ b/torchgeo/datasets/south_africa_crop_type.py
@@ -6,7 +6,7 @@
 import os
 import re
 from collections.abc import Callable, Iterable, Sequence
-from typing import Any, ClassVar, cast
+from typing import ClassVar, cast
 
 import matplotlib.pyplot as plt
 import torch
@@ -16,7 +16,7 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError, RGBBandsMissingError
 from .geo import RasterDataset
-from .utils import BoundingBox, Path, which
+from .utils import BoundingBox, Path, Sample, which
 
 
 class SouthAfricaCropType(RasterDataset):
@@ -114,7 +114,7 @@ class SouthAfricaCropType(RasterDataset):
         crs: CRS | None = None,
         classes: Sequence[int] = list(cmap.keys()),
         bands: Sequence[str] = s2_bands,
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
     ) -> None:
         """Initialize a new South Africa Crop Type dataset instance.
@@ -151,7 +151,7 @@ class SouthAfricaCropType(RasterDataset):
             self.ordinal_map[k] = v
             self.ordinal_cmap[v] = torch.tensor(self.cmap[k])
 
-    def __getitem__(self, query: BoundingBox) -> dict[str, Any]:
+    def __getitem__(self, query: BoundingBox) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -258,10 +258,7 @@ class SouthAfricaCropType(RasterDataset):
         azcopy('sync', f'{self.url}', self.paths, '--recursive=true')
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/south_america_soybean.py
+++ b/torchgeo/datasets/south_america_soybean.py
@@ -5,7 +5,7 @@
 
 import os
 from collections.abc import Callable, Iterable
-from typing import Any, ClassVar
+from typing import ClassVar
 
 import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
@@ -13,7 +13,7 @@ from rasterio.crs import CRS
 
 from .errors import DatasetNotFoundError
 from .geo import RasterDataset
-from .utils import Path, download_url
+from .utils import Path, Sample, download_url
 
 
 class SouthAmericaSoybean(RasterDataset):
@@ -77,7 +77,7 @@ class SouthAmericaSoybean(RasterDataset):
         crs: CRS | None = None,
         res: float | None = None,
         years: list[int] = [2021],
-        transforms: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         cache: bool = True,
         download: bool = False,
         checksum: bool = False,
@@ -132,10 +132,7 @@ class SouthAmericaSoybean(RasterDataset):
             )
 
     def plot(
-        self,
-        sample: dict[str, Any],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/spacenet.py
+++ b/torchgeo/datasets/spacenet.py
@@ -28,6 +28,7 @@ from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
 from .utils import (
     Path,
+    Sample,
     check_integrity,
     extract_archive,
     percentile_normalization,
@@ -108,7 +109,7 @@ class SpaceNet(NonGeoDataset, ABC):
         aois: list[int] = [],
         image: str | None = None,
         mask: str | None = None,
-        transforms: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -217,7 +218,7 @@ class SpaceNet(NonGeoDataset, ABC):
 
         return torch.from_numpy(mask)
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -339,10 +340,7 @@ class SpaceNet(NonGeoDataset, ABC):
                 self.masks.extend(masks)
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/ssl4eo.py
+++ b/torchgeo/datasets/ssl4eo.py
@@ -14,11 +14,10 @@ import numpy as np
 import rasterio
 import torch
 from matplotlib.figure import Figure
-from torch import Tensor
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import Path, check_integrity, download_url, extract_archive
+from .utils import Path, Sample, check_integrity, download_url, extract_archive
 
 
 class SSL4EO(NonGeoDataset):
@@ -165,7 +164,7 @@ class SSL4EOL(NonGeoDataset):
         root: Path = 'data',
         split: str = 'oli_sr',
         seasons: int = 1,
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -199,7 +198,7 @@ class SSL4EOL(NonGeoDataset):
 
         self.scenes = sorted(os.listdir(self.subdir))
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -284,10 +283,7 @@ class SSL4EOL(NonGeoDataset):
         extract_archive(path)
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 
@@ -407,7 +403,7 @@ class SSL4EOS12(NonGeoDataset):
         root: Path = 'data',
         split: str = 's2c',
         seasons: int = 1,
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         checksum: bool = False,
     ) -> None:
         """Initialize a new SSL4EOS12 instance.
@@ -439,7 +435,7 @@ class SSL4EOS12(NonGeoDataset):
 
         self._verify()
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -499,10 +495,7 @@ class SSL4EOS12(NonGeoDataset):
         extract_archive(os.path.join(self.root, filename))
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/ssl4eo_benchmark.py
+++ b/torchgeo/datasets/ssl4eo_benchmark.py
@@ -19,7 +19,7 @@ from .cdl import CDL
 from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
 from .nlcd import NLCD
-from .utils import Path, download_url, extract_archive
+from .utils import Path, Sample, download_url, extract_archive
 
 
 class SSL4EOLBenchmark(NonGeoDataset):
@@ -116,7 +116,7 @@ class SSL4EOLBenchmark(NonGeoDataset):
         product: str = 'cdl',
         split: str = 'train',
         classes: list[int] | None = None,
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -257,7 +257,7 @@ class SSL4EOLBenchmark(NonGeoDataset):
         mask_pathname = os.path.join(self.root, f'{self.mask_dir_name}.tar.gz')
         extract_archive(mask_pathname)
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -329,10 +329,7 @@ class SSL4EOLBenchmark(NonGeoDataset):
         return mask
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/sustainbench_crop_yield.py
+++ b/torchgeo/datasets/sustainbench_crop_yield.py
@@ -5,17 +5,15 @@
 
 import os
 from collections.abc import Callable
-from typing import Any
 
 import matplotlib.pyplot as plt
 import numpy as np
 import torch
 from matplotlib.figure import Figure
-from torch import Tensor
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import Path, download_url, extract_archive
+from .utils import Path, Sample, download_url, extract_archive
 
 
 class SustainBenchCropYield(NonGeoDataset):
@@ -62,7 +60,7 @@ class SustainBenchCropYield(NonGeoDataset):
         root: Path = 'data',
         split: str = 'train',
         countries: list[str] = ['usa'],
-        transforms: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -139,7 +137,7 @@ class SustainBenchCropYield(NonGeoDataset):
         """
         return len(self.images)
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -148,7 +146,7 @@ class SustainBenchCropYield(NonGeoDataset):
         Returns:
             data and label at that index
         """
-        sample: dict[str, Tensor] = {'image': self.images[index]}
+        sample: Sample = {'image': self.images[index]}
         sample.update(self.features[index])
 
         if self.transforms is not None:
@@ -194,7 +192,7 @@ class SustainBenchCropYield(NonGeoDataset):
 
     def plot(
         self,
-        sample: dict[str, Any],
+        sample: Sample,
         band_idx: int = 0,
         show_titles: bool = True,
         suptitle: str | None = None,

--- a/torchgeo/datasets/treesatai.py
+++ b/torchgeo/datasets/treesatai.py
@@ -17,7 +17,7 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import Path, download_url, extract_archive, percentile_normalization
+from .utils import Path, Sample, download_url, extract_archive, percentile_normalization
 
 
 class TreeSatAI(NonGeoDataset):
@@ -128,7 +128,7 @@ class TreeSatAI(NonGeoDataset):
         root: Path = 'data',
         split: str = 'train',
         sensors: Sequence[str] = all_sensors,
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -174,7 +174,7 @@ class TreeSatAI(NonGeoDataset):
         """
         return len(self.files)
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -239,7 +239,7 @@ class TreeSatAI(NonGeoDataset):
 
         extract_archive(os.path.join(self.root, file), to_path)
 
-    def plot(self, sample: dict[str, Tensor], show_titles: bool = True) -> Figure:
+    def plot(self, sample: Sample, show_titles: bool = True) -> Figure:
         """Plot a sample from the dataset.
 
         Args:

--- a/torchgeo/datasets/ucmerced.py
+++ b/torchgeo/datasets/ucmerced.py
@@ -15,7 +15,7 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoClassificationDataset
-from .utils import Path, check_integrity, download_url, extract_archive
+from .utils import Path, Sample, check_integrity, download_url, extract_archive
 
 
 class UCMerced(NonGeoClassificationDataset):
@@ -88,7 +88,7 @@ class UCMerced(NonGeoClassificationDataset):
         self,
         root: Path = 'data',
         split: str = 'train',
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -188,10 +188,7 @@ class UCMerced(NonGeoClassificationDataset):
         extract_archive(filepath)
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_titles: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_titles: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/usavars.py
+++ b/torchgeo/datasets/usavars.py
@@ -18,7 +18,7 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import Path, download_url, extract_archive
+from .utils import Path, Sample, download_url, extract_archive
 
 
 class USAVars(NonGeoDataset):
@@ -90,7 +90,7 @@ class USAVars(NonGeoDataset):
         root: Path = 'data',
         split: str = 'train',
         labels: Sequence[str] = ALL_LABELS,
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -131,7 +131,7 @@ class USAVars(NonGeoDataset):
             for lab in self.labels
         }
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -228,10 +228,7 @@ class USAVars(NonGeoDataset):
         extract_archive(os.path.join(self.root, self.dirname + '.zip'))
 
     def plot(
-        self,
-        sample: dict[str, Tensor],
-        show_labels: bool = True,
-        suptitle: str | None = None,
+        self, sample: Sample, show_labels: bool = True, suptitle: str | None = None
     ) -> Figure:
         """Plot a sample from the dataset.
 

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -42,6 +42,7 @@ __all__ = (
 
 
 Path: TypeAlias = str | os.PathLike[str]
+Sample: TypeAlias = dict[str, Tensor]
 
 
 @dataclass(frozen=True)

--- a/torchgeo/datasets/vaihingen.py
+++ b/torchgeo/datasets/vaihingen.py
@@ -18,6 +18,7 @@ from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
 from .utils import (
     Path,
+    Sample,
     check_integrity,
     draw_semantic_segmentation_masks,
     extract_archive,
@@ -124,7 +125,7 @@ class Vaihingen2D(NonGeoDataset):
         self,
         root: Path = 'data',
         split: str = 'train',
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         checksum: bool = False,
     ) -> None:
         """Initialize a new Vaihingen2D dataset instance.
@@ -155,7 +156,7 @@ class Vaihingen2D(NonGeoDataset):
             if os.path.exists(image) and os.path.exists(mask):
                 self.files.append(dict(image=image, mask=mask))
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -241,7 +242,7 @@ class Vaihingen2D(NonGeoDataset):
 
     def plot(
         self,
-        sample: dict[str, Tensor],
+        sample: Sample,
         show_titles: bool = True,
         suptitle: str | None = None,
         alpha: float = 0.5,

--- a/torchgeo/datasets/vhr10.py
+++ b/torchgeo/datasets/vhr10.py
@@ -5,7 +5,7 @@
 
 import os
 from collections.abc import Callable
-from typing import ClassVar
+from typing import Any, ClassVar
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -63,7 +63,7 @@ class ConvertCocoAnnotations:
     https://github.com/pytorch/vision/blob/v0.14.0/references/detection/coco_utils.py
     """
 
-    def __call__(self, sample: Sample) -> Sample:
+    def __call__(self, sample: dict[str, Any]) -> dict[str, Any]:
         """Converts MS COCO fields (boxes, masks & labels) from list of ints to tensors.
 
         Args:
@@ -293,7 +293,7 @@ class VHR10(NonGeoDataset):
             tensor = tensor.permute((2, 0, 1))
             return tensor
 
-    def _load_target(self, id_: int) -> Sample:
+    def _load_target(self, id_: int) -> dict[str, Any]:
         """Load the annotations for a single image.
 
         Args:

--- a/torchgeo/datasets/vhr10.py
+++ b/torchgeo/datasets/vhr10.py
@@ -5,7 +5,7 @@
 
 import os
 from collections.abc import Callable
-from typing import Any, ClassVar
+from typing import ClassVar
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -19,6 +19,7 @@ from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
 from .utils import (
     Path,
+    Sample,
     check_integrity,
     download_and_extract_archive,
     download_url,
@@ -62,7 +63,7 @@ class ConvertCocoAnnotations:
     https://github.com/pytorch/vision/blob/v0.14.0/references/detection/coco_utils.py
     """
 
-    def __call__(self, sample: dict[str, Any]) -> dict[str, Any]:
+    def __call__(self, sample: Sample) -> Sample:
         """Converts MS COCO fields (boxes, masks & labels) from list of ints to tensors.
 
         Args:
@@ -187,7 +188,7 @@ class VHR10(NonGeoDataset):
         self,
         root: Path = 'data',
         split: str = 'positive',
-        transforms: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -230,7 +231,7 @@ class VHR10(NonGeoDataset):
             self.coco_convert = ConvertCocoAnnotations()
             self.ids = list(sorted(self.coco.imgs.keys()))
 
-    def __getitem__(self, index: int) -> dict[str, Any]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -241,7 +242,7 @@ class VHR10(NonGeoDataset):
         """
         id_ = index % len(self) + 1
 
-        sample: dict[str, Any] = {
+        sample: Sample = {
             'image': self._load_image(id_),
             'label': self._load_target(id_),
         }
@@ -292,7 +293,7 @@ class VHR10(NonGeoDataset):
             tensor = tensor.permute((2, 0, 1))
             return tensor
 
-    def _load_target(self, id_: int) -> dict[str, Any]:
+    def _load_target(self, id_: int) -> Sample:
         """Load the annotations for a single image.
 
         Args:
@@ -359,7 +360,7 @@ class VHR10(NonGeoDataset):
 
     def plot(
         self,
-        sample: dict[str, Tensor],
+        sample: Sample,
         show_titles: bool = True,
         suptitle: str | None = None,
         show_feats: str | None = 'both',

--- a/torchgeo/datasets/western_usa_live_fuel_moisture.py
+++ b/torchgeo/datasets/western_usa_live_fuel_moisture.py
@@ -7,14 +7,13 @@ import glob
 import json
 import os
 from collections.abc import Callable, Iterable
-from typing import Any
 
 import pandas as pd
 import torch
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
-from .utils import Path, which
+from .utils import Path, Sample, which
 
 
 class WesternUSALiveFuelMoisture(NonGeoDataset):
@@ -199,7 +198,7 @@ class WesternUSALiveFuelMoisture(NonGeoDataset):
         self,
         root: Path = 'data',
         input_features: Iterable[str] = all_variable_names,
-        transforms: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
     ) -> None:
         """Initialize a new Western USA Live Fuel Moisture Dataset.
@@ -234,7 +233,7 @@ class WesternUSALiveFuelMoisture(NonGeoDataset):
         """
         return len(self.dataframe)
 
-    def __getitem__(self, index: int) -> dict[str, Any]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:

--- a/torchgeo/datasets/xview.py
+++ b/torchgeo/datasets/xview.py
@@ -19,6 +19,7 @@ from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset
 from .utils import (
     Path,
+    Sample,
     check_integrity,
     draw_semantic_segmentation_masks,
     extract_archive,
@@ -74,7 +75,7 @@ class XView2(NonGeoDataset):
         self,
         root: Path = 'data',
         split: str = 'train',
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         checksum: bool = False,
     ) -> None:
         """Initialize a new xView2 dataset instance.
@@ -101,7 +102,7 @@ class XView2(NonGeoDataset):
         self.class2idx = {c: i for i, c in enumerate(self.classes)}
         self.files = self._load_files(root, split)
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -225,7 +226,7 @@ class XView2(NonGeoDataset):
 
     def plot(
         self,
-        sample: dict[str, Tensor],
+        sample: Sample,
         show_titles: bool = True,
         suptitle: str | None = None,
         alpha: float = 0.5,

--- a/torchgeo/datasets/zuericrop.py
+++ b/torchgeo/datasets/zuericrop.py
@@ -13,7 +13,7 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError, RGBBandsMissingError
 from .geo import NonGeoDataset
-from .utils import Path, download_url, lazy_import, percentile_normalization
+from .utils import Path, Sample, download_url, lazy_import, percentile_normalization
 
 
 class ZueriCrop(NonGeoDataset):
@@ -63,7 +63,7 @@ class ZueriCrop(NonGeoDataset):
         self,
         root: Path = 'data',
         bands: Sequence[str] = band_names,
-        transforms: Callable[[dict[str, Tensor]], dict[str, Tensor]] | None = None,
+        transforms: Callable[[Sample], Sample] | None = None,
         download: bool = False,
         checksum: bool = False,
     ) -> None:
@@ -97,7 +97,7 @@ class ZueriCrop(NonGeoDataset):
 
         self._verify()
 
-    def __getitem__(self, index: int) -> dict[str, Tensor]:
+    def __getitem__(self, index: int) -> Sample:
         """Return an index within the dataset.
 
         Args:
@@ -247,7 +247,7 @@ class ZueriCrop(NonGeoDataset):
 
     def plot(
         self,
-        sample: dict[str, Tensor],
+        sample: Sample,
         time_step: int = 0,
         show_titles: bool = True,
         suptitle: str | None = None,

--- a/torchgeo/models/changestar.py
+++ b/torchgeo/models/changestar.py
@@ -9,7 +9,6 @@ from einops import rearrange
 from torch import Tensor
 from torch.nn.modules import Module
 
-from ..datasets.utils import Sample
 from .farseg import FarSeg
 
 
@@ -128,7 +127,7 @@ class ChangeStar(Module):
             raise ValueError(f'Unknown inference_mode: {inference_mode}')
         self.inference_mode = inference_mode
 
-    def forward(self, x: Tensor) -> Sample:
+    def forward(self, x: Tensor) -> dict[str, Tensor]:
         """Forward pass of the model.
 
         Args:
@@ -150,7 +149,7 @@ class ChangeStar(Module):
         # change detection
         c12, c21 = self.changemixin(bi_feature)
 
-        results: Sample = {}
+        results: dict[str, Tensor] = {}
         if not self.training:
             results.update({'bi_seg_logit': bi_seg_logit})
             if self.inference_mode == 't1t2':

--- a/torchgeo/models/changestar.py
+++ b/torchgeo/models/changestar.py
@@ -9,6 +9,7 @@ from einops import rearrange
 from torch import Tensor
 from torch.nn.modules import Module
 
+from ..datasets.utils import Sample
 from .farseg import FarSeg
 
 
@@ -127,7 +128,7 @@ class ChangeStar(Module):
             raise ValueError(f'Unknown inference_mode: {inference_mode}')
         self.inference_mode = inference_mode
 
-    def forward(self, x: Tensor) -> dict[str, Tensor]:
+    def forward(self, x: Tensor) -> Sample:
         """Forward pass of the model.
 
         Args:
@@ -149,7 +150,7 @@ class ChangeStar(Module):
         # change detection
         c12, c21 = self.changemixin(bi_feature)
 
-        results: dict[str, Tensor] = {}
+        results: Sample = {}
         if not self.training:
             results.update({'bi_seg_logit': bi_seg_logit})
             if self.inference_mode == 't1t2':

--- a/torchgeo/models/croma.py
+++ b/torchgeo/models/croma.py
@@ -15,6 +15,8 @@ from einops import rearrange
 from torch import Tensor, einsum, nn
 from torchvision.models._api import Weights, WeightsEnum
 
+from ..datasets.utils import Sample
+
 
 class CROMA(nn.Module):
     """Pretrained CROMA model.
@@ -115,14 +117,14 @@ class CROMA(nn.Module):
 
     def forward(
         self, x_sar: Tensor | None = None, x_optical: Tensor | None = None
-    ) -> dict[str, Tensor]:
+    ) -> Sample:
         """Forward pass of the CROMA model.
 
         Args:
             x_sar: Input mini-batch of SAR images [B, 2, H, W].
             x_optical: Input mini-batch of optical images [B, 12, H, W].
         """
-        return_dict: dict[str, Tensor] = {}
+        return_dict: Sample = {}
 
         if 'sar' in self.modalities and x_sar is not None:
             sar_encodings = self.s1_encoder(imgs=x_sar, attn_bias=self.attn_bias)

--- a/torchgeo/models/croma.py
+++ b/torchgeo/models/croma.py
@@ -15,8 +15,6 @@ from einops import rearrange
 from torch import Tensor, einsum, nn
 from torchvision.models._api import Weights, WeightsEnum
 
-from ..datasets.utils import Sample
-
 
 class CROMA(nn.Module):
     """Pretrained CROMA model.
@@ -117,14 +115,14 @@ class CROMA(nn.Module):
 
     def forward(
         self, x_sar: Tensor | None = None, x_optical: Tensor | None = None
-    ) -> Sample:
+    ) -> dict[str, Tensor]:
         """Forward pass of the CROMA model.
 
         Args:
             x_sar: Input mini-batch of SAR images [B, 2, H, W].
             x_optical: Input mini-batch of optical images [B, 12, H, W].
         """
-        return_dict: Sample = {}
+        return_dict: dict[str, Tensor] = {}
 
         if 'sar' in self.modalities and x_sar is not None:
             sar_encodings = self.s1_encoder(imgs=x_sar, attn_bias=self.attn_bias)

--- a/torchgeo/trainers/byol.py
+++ b/torchgeo/trainers/byol.py
@@ -14,6 +14,7 @@ from kornia import augmentation as K
 from torch import Tensor
 from torchvision.models._api import WeightsEnum
 
+from ..datasets.utils import Sample
 from ..models import get_weight
 from . import utils
 from .base import BaseTask
@@ -349,7 +350,7 @@ class BYOLTask(BaseTask):
         self.model = BYOL(backbone, in_channels=in_channels, image_size=(224, 224))
 
     def training_step(
-        self, batch: Any, batch_idx: int, dataloader_idx: int = 0
+        self, batch: Sample, batch_idx: int, dataloader_idx: int = 0
     ) -> Tensor:
         """Compute the training loss and additional metrics.
 
@@ -395,12 +396,14 @@ class BYOLTask(BaseTask):
         return loss
 
     def validation_step(
-        self, batch: Any, batch_idx: int, dataloader_idx: int = 0
+        self, batch: Sample, batch_idx: int, dataloader_idx: int = 0
     ) -> None:
         """No-op, does nothing."""
 
-    def test_step(self, batch: Any, batch_idx: int, dataloader_idx: int = 0) -> None:
+    def test_step(self, batch: Sample, batch_idx: int, dataloader_idx: int = 0) -> None:
         """No-op, does nothing."""
 
-    def predict_step(self, batch: Any, batch_idx: int, dataloader_idx: int = 0) -> None:
+    def predict_step(
+        self, batch: Sample, batch_idx: int, dataloader_idx: int = 0
+    ) -> None:
         """No-op, does nothing."""

--- a/torchgeo/trainers/classification.py
+++ b/torchgeo/trainers/classification.py
@@ -4,7 +4,6 @@
 """Trainers for image classification."""
 
 import os
-from typing import Any
 
 import matplotlib.pyplot as plt
 import timm
@@ -24,6 +23,7 @@ from torchmetrics.classification import (
 from torchvision.models._api import WeightsEnum
 
 from ..datasets import RGBBandsMissingError, unbind_samples
+from ..datasets.utils import Sample
 from ..models import get_weight
 from . import utils
 from .base import BaseTask
@@ -164,7 +164,7 @@ class ClassificationTask(BaseTask):
         self.test_metrics = metrics.clone(prefix='test_')
 
     def training_step(
-        self, batch: Any, batch_idx: int, dataloader_idx: int = 0
+        self, batch: Sample, batch_idx: int, dataloader_idx: int = 0
     ) -> Tensor:
         """Compute the training loss and additional metrics.
 
@@ -188,7 +188,7 @@ class ClassificationTask(BaseTask):
         return loss
 
     def validation_step(
-        self, batch: Any, batch_idx: int, dataloader_idx: int = 0
+        self, batch: Sample, batch_idx: int, dataloader_idx: int = 0
     ) -> None:
         """Compute the validation loss and additional metrics.
 
@@ -233,7 +233,7 @@ class ClassificationTask(BaseTask):
                 )
                 plt.close()
 
-    def test_step(self, batch: Any, batch_idx: int, dataloader_idx: int = 0) -> None:
+    def test_step(self, batch: Sample, batch_idx: int, dataloader_idx: int = 0) -> None:
         """Compute the test loss and additional metrics.
 
         Args:
@@ -251,7 +251,7 @@ class ClassificationTask(BaseTask):
         self.log_dict(self.test_metrics, batch_size=batch_size)
 
     def predict_step(
-        self, batch: Any, batch_idx: int, dataloader_idx: int = 0
+        self, batch: Sample, batch_idx: int, dataloader_idx: int = 0
     ) -> Tensor:
         """Compute the predicted class probabilities.
 
@@ -306,7 +306,7 @@ class MultiLabelClassificationTask(ClassificationTask):
         self.test_metrics = metrics.clone(prefix='test_')
 
     def training_step(
-        self, batch: Any, batch_idx: int, dataloader_idx: int = 0
+        self, batch: Sample, batch_idx: int, dataloader_idx: int = 0
     ) -> Tensor:
         """Compute the training loss and additional metrics.
 
@@ -331,7 +331,7 @@ class MultiLabelClassificationTask(ClassificationTask):
         return loss
 
     def validation_step(
-        self, batch: Any, batch_idx: int, dataloader_idx: int = 0
+        self, batch: Sample, batch_idx: int, dataloader_idx: int = 0
     ) -> None:
         """Compute the validation loss and additional metrics.
 
@@ -376,7 +376,7 @@ class MultiLabelClassificationTask(ClassificationTask):
                     f'image/{batch_idx}', fig, global_step=self.global_step
                 )
 
-    def test_step(self, batch: Any, batch_idx: int, dataloader_idx: int = 0) -> None:
+    def test_step(self, batch: Sample, batch_idx: int, dataloader_idx: int = 0) -> None:
         """Compute the test loss and additional metrics.
 
         Args:
@@ -395,7 +395,7 @@ class MultiLabelClassificationTask(ClassificationTask):
         self.log_dict(self.test_metrics, batch_size=batch_size)
 
     def predict_step(
-        self, batch: Any, batch_idx: int, dataloader_idx: int = 0
+        self, batch: Sample, batch_idx: int, dataloader_idx: int = 0
     ) -> Tensor:
         """Compute the predicted class probabilities.
 

--- a/torchgeo/trainers/detection.py
+++ b/torchgeo/trainers/detection.py
@@ -4,7 +4,6 @@
 """Trainers for object detection."""
 
 from functools import partial
-from typing import Any
 
 import matplotlib.pyplot as plt
 import torch
@@ -225,7 +224,7 @@ class ObjectDetectionTask(BaseTask):
         self.test_metrics = metrics.clone(prefix='test_')
 
     def training_step(
-        self, batch: Any, batch_idx: int, dataloader_idx: int = 0
+        self, batch: Sample, batch_idx: int, dataloader_idx: int = 0
     ) -> Tensor:
         """Compute the training loss.
 
@@ -250,7 +249,7 @@ class ObjectDetectionTask(BaseTask):
         return train_loss
 
     def validation_step(
-        self, batch: Any, batch_idx: int, dataloader_idx: int = 0
+        self, batch: Sample, batch_idx: int, dataloader_idx: int = 0
     ) -> None:
         """Compute the validation metrics.
 
@@ -306,7 +305,7 @@ class ObjectDetectionTask(BaseTask):
                 )
                 plt.close()
 
-    def test_step(self, batch: Any, batch_idx: int, dataloader_idx: int = 0) -> None:
+    def test_step(self, batch: Sample, batch_idx: int, dataloader_idx: int = 0) -> None:
         """Compute the test metrics.
 
         Args:
@@ -330,7 +329,7 @@ class ObjectDetectionTask(BaseTask):
         self.log_dict(metrics, batch_size=batch_size)
 
     def predict_step(
-        self, batch: Any, batch_idx: int, dataloader_idx: int = 0
+        self, batch: Sample, batch_idx: int, dataloader_idx: int = 0
     ) -> list[Sample]:
         """Compute the predicted bounding boxes.
 

--- a/torchgeo/trainers/detection.py
+++ b/torchgeo/trainers/detection.py
@@ -20,6 +20,7 @@ from torchvision.models.detection.rpn import AnchorGenerator
 from torchvision.ops import MultiScaleRoIAlign, feature_pyramid_network, misc
 
 from ..datasets import RGBBandsMissingError, unbind_samples
+from ..datasets.utils import Sample
 from .base import BaseTask
 
 BACKBONE_LAT_DIM_MAP = {
@@ -330,7 +331,7 @@ class ObjectDetectionTask(BaseTask):
 
     def predict_step(
         self, batch: Any, batch_idx: int, dataloader_idx: int = 0
-    ) -> list[dict[str, Tensor]]:
+    ) -> list[Sample]:
         """Compute the predicted bounding boxes.
 
         Args:
@@ -342,5 +343,5 @@ class ObjectDetectionTask(BaseTask):
             Output predicted probabilities.
         """
         x = batch['image']
-        y_hat: list[dict[str, Tensor]] = self(x)
+        y_hat: list[Sample] = self(x)
         return y_hat

--- a/torchgeo/trainers/detection.py
+++ b/torchgeo/trainers/detection.py
@@ -330,7 +330,7 @@ class ObjectDetectionTask(BaseTask):
 
     def predict_step(
         self, batch: Sample, batch_idx: int, dataloader_idx: int = 0
-    ) -> list[Sample]:
+    ) -> list[dict[str, Tensor]]:
         """Compute the predicted bounding boxes.
 
         Args:
@@ -342,5 +342,5 @@ class ObjectDetectionTask(BaseTask):
             Output predicted probabilities.
         """
         x = batch['image']
-        y_hat: list[Sample] = self(x)
+        y_hat: list[dict[str, Tensor]] = self(x)
         return y_hat

--- a/torchgeo/trainers/iobench.py
+++ b/torchgeo/trainers/iobench.py
@@ -3,13 +3,12 @@
 
 """Trainers for I/O benchmarking."""
 
-from typing import Any
-
 import lightning
 import torch
 from torch import Tensor
 from torch.optim import SGD
 
+from ..datasets.utils import Sample
 from .base import BaseTask
 
 
@@ -34,7 +33,7 @@ class IOBenchTask(BaseTask):
         return {'optimizer': optimizer}
 
     def training_step(
-        self, batch: Any, batch_idx: int, dataloader_idx: int = 0
+        self, batch: Sample, batch_idx: int, dataloader_idx: int = 0
     ) -> Tensor:
         """No-op.
 
@@ -49,7 +48,7 @@ class IOBenchTask(BaseTask):
         return torch.tensor(0.0, requires_grad=True)
 
     def validation_step(
-        self, batch: Any, batch_idx: int, dataloader_idx: int = 0
+        self, batch: Sample, batch_idx: int, dataloader_idx: int = 0
     ) -> None:
         """No-op.
 
@@ -59,7 +58,7 @@ class IOBenchTask(BaseTask):
             dataloader_idx: Index of the current dataloader.
         """
 
-    def test_step(self, batch: Any, batch_idx: int, dataloader_idx: int = 0) -> None:
+    def test_step(self, batch: Sample, batch_idx: int, dataloader_idx: int = 0) -> None:
         """No-op.
 
         Args:
@@ -68,7 +67,9 @@ class IOBenchTask(BaseTask):
             dataloader_idx: Index of the current dataloader.
         """
 
-    def predict_step(self, batch: Any, batch_idx: int, dataloader_idx: int = 0) -> None:
+    def predict_step(
+        self, batch: Sample, batch_idx: int, dataloader_idx: int = 0
+    ) -> None:
         """No-op.
 
         Args:

--- a/torchgeo/trainers/moco.py
+++ b/torchgeo/trainers/moco.py
@@ -6,7 +6,6 @@
 import os
 import warnings
 from collections.abc import Sequence
-from typing import Any
 
 import kornia.augmentation as K
 import lightning
@@ -30,6 +29,7 @@ from torchvision.models._api import WeightsEnum
 
 import torchgeo.transforms as T
 
+from ..datasets.utils import Sample
 from ..models import get_weight
 from . import utils
 from .base import BaseTask
@@ -368,7 +368,7 @@ class MoCoTask(BaseTask):
         return k
 
     def training_step(
-        self, batch: Any, batch_idx: int, dataloader_idx: int = 0
+        self, batch: Sample, batch_idx: int, dataloader_idx: int = 0
     ) -> Tensor:
         """Compute the training loss and additional metrics.
 
@@ -436,12 +436,14 @@ class MoCoTask(BaseTask):
         return loss
 
     def validation_step(
-        self, batch: Any, batch_idx: int, dataloader_idx: int = 0
+        self, batch: Sample, batch_idx: int, dataloader_idx: int = 0
     ) -> None:
         """No-op, does nothing."""
 
-    def test_step(self, batch: Any, batch_idx: int, dataloader_idx: int = 0) -> None:
+    def test_step(self, batch: Sample, batch_idx: int, dataloader_idx: int = 0) -> None:
         """No-op, does nothing."""
 
-    def predict_step(self, batch: Any, batch_idx: int, dataloader_idx: int = 0) -> None:
+    def predict_step(
+        self, batch: Sample, batch_idx: int, dataloader_idx: int = 0
+    ) -> None:
         """No-op, does nothing."""

--- a/torchgeo/trainers/regression.py
+++ b/torchgeo/trainers/regression.py
@@ -4,7 +4,6 @@
 """Trainers for regression."""
 
 import os
-from typing import Any
 
 import matplotlib.pyplot as plt
 import segmentation_models_pytorch as smp
@@ -17,6 +16,7 @@ from torchmetrics import MeanAbsoluteError, MeanSquaredError, MetricCollection
 from torchvision.models._api import WeightsEnum
 
 from ..datasets import RGBBandsMissingError, unbind_samples
+from ..datasets.utils import Sample
 from ..models import FCN, get_weight
 from . import utils
 from .base import BaseTask
@@ -146,7 +146,7 @@ class RegressionTask(BaseTask):
         self.test_metrics = metrics.clone(prefix='test_')
 
     def training_step(
-        self, batch: Any, batch_idx: int, dataloader_idx: int = 0
+        self, batch: Sample, batch_idx: int, dataloader_idx: int = 0
     ) -> Tensor:
         """Compute the training loss and additional metrics.
 
@@ -173,7 +173,7 @@ class RegressionTask(BaseTask):
         return loss
 
     def validation_step(
-        self, batch: Any, batch_idx: int, dataloader_idx: int = 0
+        self, batch: Sample, batch_idx: int, dataloader_idx: int = 0
     ) -> None:
         """Compute the validation loss and additional metrics.
 
@@ -224,7 +224,7 @@ class RegressionTask(BaseTask):
                 )
                 plt.close()
 
-    def test_step(self, batch: Any, batch_idx: int, dataloader_idx: int = 0) -> None:
+    def test_step(self, batch: Sample, batch_idx: int, dataloader_idx: int = 0) -> None:
         """Compute the test loss and additional metrics.
 
         Args:
@@ -245,7 +245,7 @@ class RegressionTask(BaseTask):
         self.log_dict(self.test_metrics, batch_size=batch_size)
 
     def predict_step(
-        self, batch: Any, batch_idx: int, dataloader_idx: int = 0
+        self, batch: Sample, batch_idx: int, dataloader_idx: int = 0
     ) -> Tensor:
         """Compute the predicted regression values.
 

--- a/torchgeo/trainers/segmentation.py
+++ b/torchgeo/trainers/segmentation.py
@@ -4,7 +4,6 @@
 """Trainers for semantic segmentation."""
 
 import os
-from typing import Any
 
 import matplotlib.pyplot as plt
 import segmentation_models_pytorch as smp
@@ -16,6 +15,7 @@ from torchmetrics.classification import MulticlassAccuracy, MulticlassJaccardInd
 from torchvision.models._api import WeightsEnum
 
 from ..datasets import RGBBandsMissingError, unbind_samples
+from ..datasets.utils import Sample
 from ..models import FCN, get_weight
 from . import utils
 from .base import BaseTask
@@ -213,7 +213,7 @@ class SemanticSegmentationTask(BaseTask):
         self.test_metrics = metrics.clone(prefix='test_')
 
     def training_step(
-        self, batch: Any, batch_idx: int, dataloader_idx: int = 0
+        self, batch: Sample, batch_idx: int, dataloader_idx: int = 0
     ) -> Tensor:
         """Compute the training loss and additional metrics.
 
@@ -236,7 +236,7 @@ class SemanticSegmentationTask(BaseTask):
         return loss
 
     def validation_step(
-        self, batch: Any, batch_idx: int, dataloader_idx: int = 0
+        self, batch: Sample, batch_idx: int, dataloader_idx: int = 0
     ) -> None:
         """Compute the validation loss and additional metrics.
 
@@ -281,7 +281,7 @@ class SemanticSegmentationTask(BaseTask):
                 )
                 plt.close()
 
-    def test_step(self, batch: Any, batch_idx: int, dataloader_idx: int = 0) -> None:
+    def test_step(self, batch: Sample, batch_idx: int, dataloader_idx: int = 0) -> None:
         """Compute the test loss and additional metrics.
 
         Args:
@@ -299,7 +299,7 @@ class SemanticSegmentationTask(BaseTask):
         self.log_dict(self.test_metrics, batch_size=batch_size)
 
     def predict_step(
-        self, batch: Any, batch_idx: int, dataloader_idx: int = 0
+        self, batch: Sample, batch_idx: int, dataloader_idx: int = 0
     ) -> Tensor:
         """Compute the predicted class probabilities.
 

--- a/torchgeo/trainers/simclr.py
+++ b/torchgeo/trainers/simclr.py
@@ -5,7 +5,6 @@
 
 import os
 import warnings
-from typing import Any
 
 import kornia.augmentation as K
 import lightning
@@ -22,6 +21,7 @@ from torchvision.models._api import WeightsEnum
 
 import torchgeo.transforms as T
 
+from ..datasets.utils import Sample
 from ..models import get_weight
 from . import utils
 from .base import BaseTask
@@ -221,7 +221,7 @@ class SimCLRTask(BaseTask):
         return z, h
 
     def training_step(
-        self, batch: Any, batch_idx: int, dataloader_idx: int = 0
+        self, batch: Sample, batch_idx: int, dataloader_idx: int = 0
     ) -> Tensor:
         """Compute the training loss and additional metrics.
 
@@ -272,16 +272,18 @@ class SimCLRTask(BaseTask):
         return loss
 
     def validation_step(
-        self, batch: Any, batch_idx: int, dataloader_idx: int = 0
+        self, batch: Sample, batch_idx: int, dataloader_idx: int = 0
     ) -> None:
         """No-op, does nothing."""
 
-    def test_step(self, batch: Any, batch_idx: int, dataloader_idx: int = 0) -> None:
+    def test_step(self, batch: Sample, batch_idx: int, dataloader_idx: int = 0) -> None:
         """No-op, does nothing."""
         # TODO
         # v2: add distillation step
 
-    def predict_step(self, batch: Any, batch_idx: int, dataloader_idx: int = 0) -> None:
+    def predict_step(
+        self, batch: Sample, batch_idx: int, dataloader_idx: int = 0
+    ) -> None:
         """No-op, does nothing."""
 
     def configure_optimizers(

--- a/torchgeo/transforms/color.py
+++ b/torchgeo/transforms/color.py
@@ -6,8 +6,6 @@
 from kornia.augmentation import IntensityAugmentationBase2D
 from torch import Tensor
 
-from ..datasets.utils import Sample
-
 
 class RandomGrayscale(IntensityAugmentationBase2D):
     r"""Apply random transformation to grayscale according to a probability p value.
@@ -55,8 +53,8 @@ class RandomGrayscale(IntensityAugmentationBase2D):
     def apply_transform(
         self,
         input: Tensor,
-        params: Sample,
-        flags: Sample,
+        params: dict[str, Tensor],
+        flags: dict[str, Tensor],
         transform: Tensor | None = None,
     ) -> Tensor:
         """Apply the transform.

--- a/torchgeo/transforms/color.py
+++ b/torchgeo/transforms/color.py
@@ -6,6 +6,8 @@
 from kornia.augmentation import IntensityAugmentationBase2D
 from torch import Tensor
 
+from ..datasets.utils import Sample
+
 
 class RandomGrayscale(IntensityAugmentationBase2D):
     r"""Apply random transformation to grayscale according to a probability p value.
@@ -53,8 +55,8 @@ class RandomGrayscale(IntensityAugmentationBase2D):
     def apply_transform(
         self,
         input: Tensor,
-        params: dict[str, Tensor],
-        flags: dict[str, Tensor],
+        params: Sample,
+        flags: Sample,
         transform: Tensor | None = None,
     ) -> Tensor:
         """Apply the transform.

--- a/torchgeo/transforms/indices.py
+++ b/torchgeo/transforms/indices.py
@@ -12,6 +12,8 @@ import torch
 from kornia.augmentation import IntensityAugmentationBase2D
 from torch import Tensor
 
+from ..datasets.utils import Sample
+
 _EPSILON = 1e-10
 
 
@@ -40,7 +42,7 @@ class AppendNormalizedDifferenceIndex(IntensityAugmentationBase2D):
     def apply_transform(
         self,
         input: Tensor,
-        params: dict[str, Tensor],
+        params: Sample,
         flags: dict[str, int],
         transform: Tensor | None = None,
     ) -> Tensor:
@@ -315,7 +317,7 @@ class AppendTriBandNormalizedDifferenceIndex(IntensityAugmentationBase2D):
     def apply_transform(
         self,
         input: Tensor,
-        params: dict[str, Tensor],
+        params: Sample,
         flags: dict[str, int],
         transform: Tensor | None = None,
     ) -> Tensor:

--- a/torchgeo/transforms/indices.py
+++ b/torchgeo/transforms/indices.py
@@ -12,8 +12,6 @@ import torch
 from kornia.augmentation import IntensityAugmentationBase2D
 from torch import Tensor
 
-from ..datasets.utils import Sample
-
 _EPSILON = 1e-10
 
 
@@ -42,7 +40,7 @@ class AppendNormalizedDifferenceIndex(IntensityAugmentationBase2D):
     def apply_transform(
         self,
         input: Tensor,
-        params: Sample,
+        params: dict[str, Tensor],
         flags: dict[str, int],
         transform: Tensor | None = None,
     ) -> Tensor:
@@ -317,7 +315,7 @@ class AppendTriBandNormalizedDifferenceIndex(IntensityAugmentationBase2D):
     def apply_transform(
         self,
         input: Tensor,
-        params: Sample,
+        params: dict[str, Tensor],
         flags: dict[str, int],
         transform: Tensor | None = None,
     ) -> Tensor:

--- a/torchgeo/transforms/transforms.py
+++ b/torchgeo/transforms/transforms.py
@@ -11,8 +11,6 @@ from kornia.contrib import extract_tensor_patches
 from kornia.geometry import crop_by_indices
 from torch import Tensor
 
-from ..datasets.utils import Sample
-
 # Only include import redirects
 __all__ = ('AugmentationSequential',)
 
@@ -32,7 +30,7 @@ class _RandomNCrop(K.GeometricAugmentationBase2D):
         self.flags = {'size': size, 'num': num}
 
     def compute_transformation(
-        self, input: Tensor, params: Sample, flags: Sample
+        self, input: Tensor, params: dict[str, Tensor], flags: dict[str, Tensor]
     ) -> Tensor:
         """Compute the transformation.
 
@@ -50,8 +48,8 @@ class _RandomNCrop(K.GeometricAugmentationBase2D):
     def apply_transform(
         self,
         input: Tensor,
-        params: Sample,
-        flags: Sample,
+        params: dict[str, Tensor],
+        flags: dict[str, Tensor],
         transform: Tensor | None = None,
     ) -> Tensor:
         """Apply the transform.
@@ -86,7 +84,7 @@ class _NCropGenerator(K.random_generator.CropGenerator):
 
     def forward(
         self, batch_shape: tuple[int, ...], same_on_batch: bool = False
-    ) -> Sample:
+    ) -> dict[str, Tensor]:
         """Generate the crops.
 
         Args:
@@ -135,7 +133,7 @@ class _ExtractPatches(K.GeometricAugmentationBase2D):
         }
 
     def compute_transformation(
-        self, input: Tensor, params: Sample, flags: Sample
+        self, input: Tensor, params: dict[str, Tensor], flags: dict[str, Tensor]
     ) -> Tensor:
         """Compute the transformation.
 
@@ -153,8 +151,8 @@ class _ExtractPatches(K.GeometricAugmentationBase2D):
     def apply_transform(
         self,
         input: Tensor,
-        params: Sample,
-        flags: Sample,
+        params: dict[str, Tensor],
+        flags: dict[str, Tensor],
         transform: Tensor | None = None,
     ) -> Tensor:
         """Apply the transform.
@@ -214,8 +212,8 @@ class _Clamp(K.IntensityAugmentationBase2D):
     def apply_transform(
         self,
         input: Tensor,
-        params: Sample,
-        flags: Sample,
+        params: dict[str, Tensor],
+        flags: dict[str, Tensor],
         transform: Tensor | None = None,
     ) -> Tensor:
         """Apply the transform.

--- a/torchgeo/transforms/transforms.py
+++ b/torchgeo/transforms/transforms.py
@@ -3,8 +3,6 @@
 
 """TorchGeo transforms."""
 
-from typing import Any
-
 import kornia.augmentation as K
 import torch
 from einops import rearrange
@@ -12,6 +10,8 @@ from kornia.augmentation import AugmentationSequential
 from kornia.contrib import extract_tensor_patches
 from kornia.geometry import crop_by_indices
 from torch import Tensor
+
+from ..datasets.utils import Sample
 
 # Only include import redirects
 __all__ = ('AugmentationSequential',)
@@ -32,7 +32,7 @@ class _RandomNCrop(K.GeometricAugmentationBase2D):
         self.flags = {'size': size, 'num': num}
 
     def compute_transformation(
-        self, input: Tensor, params: dict[str, Tensor], flags: dict[str, Any]
+        self, input: Tensor, params: Sample, flags: Sample
     ) -> Tensor:
         """Compute the transformation.
 
@@ -50,8 +50,8 @@ class _RandomNCrop(K.GeometricAugmentationBase2D):
     def apply_transform(
         self,
         input: Tensor,
-        params: dict[str, Tensor],
-        flags: dict[str, Any],
+        params: Sample,
+        flags: Sample,
         transform: Tensor | None = None,
     ) -> Tensor:
         """Apply the transform.
@@ -86,7 +86,7 @@ class _NCropGenerator(K.random_generator.CropGenerator):
 
     def forward(
         self, batch_shape: tuple[int, ...], same_on_batch: bool = False
-    ) -> dict[str, Tensor]:
+    ) -> Sample:
         """Generate the crops.
 
         Args:
@@ -135,7 +135,7 @@ class _ExtractPatches(K.GeometricAugmentationBase2D):
         }
 
     def compute_transformation(
-        self, input: Tensor, params: dict[str, Tensor], flags: dict[str, Any]
+        self, input: Tensor, params: Sample, flags: Sample
     ) -> Tensor:
         """Compute the transformation.
 
@@ -153,8 +153,8 @@ class _ExtractPatches(K.GeometricAugmentationBase2D):
     def apply_transform(
         self,
         input: Tensor,
-        params: dict[str, Tensor],
-        flags: dict[str, Any],
+        params: Sample,
+        flags: Sample,
         transform: Tensor | None = None,
     ) -> Tensor:
         """Apply the transform.
@@ -214,8 +214,8 @@ class _Clamp(K.IntensityAugmentationBase2D):
     def apply_transform(
         self,
         input: Tensor,
-        params: dict[str, Tensor],
-        flags: dict[str, Any],
+        params: Sample,
+        flags: Sample,
         transform: Tensor | None = None,
     ) -> Tensor:
         """Apply the transform.


### PR DESCRIPTION
This PR introduces a new `Sample` type alias defined as:
```python
Sample = dict[str, Tensor]
```
All dataset `__getitem__` methods return a `Sample`, and all transforms operate on a `Sample`.

This PR supersedes #2249 with a simpler approach (can be expanded later).

### Pros

* Compatibility with PyTorch's `default_collate` function
* Compatibility with Lightning's `transfer_batch_to_device`
* Uniform type hints across all TorchGeo subpackages
* Avoids most uses of dynamic typing (`typing.Any`)
* Allows arbitrary key names (unlike #2249)

### Cons

* Datasets can no longer return non-Tensor types
* Does not enforce standard key names (unlike #2249)
* Backwards-incompatible changes (removing CRS/bounds)

Closes #2249 
See #985 for discussion