### PR TITLE
I/O Bench: automatically download data

### DIFF
--- a/tests/conf/digital_typhoon_id.yaml
+++ b/tests/conf/digital_typhoon_id.yaml
@@ -12,7 +12,6 @@ data:
     split_by: 'typhoon_id'
   dict_kwargs:
     root: 'tests/data/digital_typhoon'
-    download: true
     min_feature_value:
       wind: 10
     sequence_length: 3

--- a/tests/conf/digital_typhoon_time.yaml
+++ b/tests/conf/digital_typhoon_time.yaml
@@ -12,7 +12,6 @@ data:
     split_by: 'time'
   dict_kwargs:
     root: 'tests/data/digital_typhoon'
-    download: true
     min_feature_value:
       wind: 10
     sequence_length: 3

--- a/tests/conf/io_preprocessed.yaml
+++ b/tests/conf/io_preprocessed.yaml
@@ -5,6 +5,7 @@ data:
   dict_kwargs:
     root: 'data/io'
     split: 'preprocessed'
+    download: true
     checksum: true
 trainer:
   max_epochs: 1

--- a/tests/conf/io_raw.yaml
+++ b/tests/conf/io_raw.yaml
@@ -5,6 +5,7 @@ data:
   dict_kwargs:
     root: 'data/io'
     split: 'raw'
+    download: true
     checksum: true
 trainer:
   max_epochs: 1


### PR DESCRIPTION
When following https://torchgeo.readthedocs.io/en/latest/user/contributing.html#i-o-benchmarking, the config files are supposed to download the data for you (hence `checksum: true`). At some point, this was removed (probably by me) to avoid our tests downloading data. This PR re-adds automatic downloads (and removes it from Digital Typhoon).