### PR TITLE
TorchGeo development status: alpha -> beta

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ maintainers = [
 ]
 keywords = ["pytorch", "deep learning", "machine learning", "remote sensing", "satellite imagery", "earth observation", "geospatial"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",


### PR DESCRIPTION
I propose the following development status schedule:

- TorchGeo 0.1–0.6: alpha, backwards-incompatible changes without warning
- TorchGeo 0.7–0.Y: beta, backwards-incompatible changes with 1 minor release warning
- TorchGeo 1.0–X.Y: production/stable, backwards-incompatible changes with 2 minor releases warning

Here, "warning" specifically means `DeprecationWarning`. See #2396 for how to do this. A "2 minor release warning" means that a deprecation that first appears in 1.0 would be removed in 1.2 (approximately 1 year later). This is also how Python handles deprecations. This may prove difficult for some changes, but let's do the best we can from now on.

Note that 0.7 will likely be the last 0.Y release, we expect 1.0 to follow (but no promises).

See https://pypi.org/classifiers/ for details.