### PR TITLE
VHR-10 plot fix

### DIFF
--- a/torchgeo/datasets/vhr10.py
+++ b/torchgeo/datasets/vhr10.py
@@ -400,7 +400,6 @@ class VHR10(NonGeoDataset):
         if show_feats != 'boxes':
             skimage = lazy_import('skimage')
 
-        image = sample['image'].permute(1, 2, 0).numpy()
         boxes = sample['bbox_xyxy'].cpu().numpy()
         labels = sample['label'].cpu().numpy()
         if 'mask' in sample:


### PR DESCRIPTION
Previously if split was not 'negative', unnormalized image was shown. Had accidently introduced this bug in #1978 


Before:

![vhr10-plot-bug](https://github.com/user-attachments/assets/be71b351-71be-4cd4-8522-7ec1dd1748ad)


After:

![vhr10-plot-fix](https://github.com/user-attachments/assets/87033f6c-e8eb-49e4-9b97-a846ee3082fd)
