### PR TITLE
fix inconsistent patch size in dofa huge model

### DIFF
--- a/docs/api/models.rst
+++ b/docs/api/models.rst
@@ -26,7 +26,7 @@ DOFA
 .. autofunction:: dofa_small_patch16_224
 .. autofunction:: dofa_base_patch16_224
 .. autofunction:: dofa_large_patch16_224
-.. autofunction:: dofa_huge_patch16_224
+.. autofunction:: dofa_huge_patch14_224
 .. autoclass:: DOFABase16_Weights
 .. autoclass:: DOFALarge16_Weights
 

--- a/tests/models/test_dofa.py
+++ b/tests/models/test_dofa.py
@@ -69,7 +69,10 @@ class TestDOFA:
 
 class TestDOFASmall16:
     def test_dofa(self) -> None:
-        dofa_small_patch16_224()
+        model = dofa_small_patch16_224()
+        x = torch.rand(1, 4, 224, 224)
+        wavelengths = [664.6, 559.8, 492.4, 832.8]
+        model(x, wavelengths)
 
 
 class TestDOFABase16:
@@ -95,7 +98,10 @@ class TestDOFABase16:
         return weights
 
     def test_dofa(self) -> None:
-        dofa_base_patch16_224()
+        model = dofa_base_patch16_224()
+        x = torch.rand(1, 4, 224, 224)
+        wavelengths = [664.6, 559.8, 492.4, 832.8]
+        model(x, wavelengths)
 
     def test_dofa_weights(self, mocked_weights: WeightsEnum) -> None:
         dofa_base_patch16_224(weights=mocked_weights)
@@ -135,7 +141,10 @@ class TestDOFALarge16:
         return weights
 
     def test_dofa(self) -> None:
-        dofa_large_patch16_224()
+        model = dofa_large_patch16_224()
+        x = torch.rand(1, 4, 224, 224)
+        wavelengths = [664.6, 559.8, 492.4, 832.8]
+        model(x, wavelengths)
 
     def test_dofa_weights(self, mocked_weights: WeightsEnum) -> None:
         dofa_large_patch16_224(weights=mocked_weights)
@@ -152,6 +161,9 @@ class TestDOFALarge16:
         dofa_large_patch16_224(weights=weights)
 
 
-class TestDOFAHuge16:
+class TestDOFAHuge14:
     def test_dofa(self) -> None:
-        dofa_huge_patch14_224()
+        model = dofa_huge_patch14_224()
+        x = torch.rand(1, 4, 224, 224)
+        wavelengths = [664.6, 559.8, 492.4, 832.8]
+        model(x, wavelengths)

--- a/tests/models/test_dofa.py
+++ b/tests/models/test_dofa.py
@@ -14,7 +14,7 @@ from torchgeo.models import (
     DOFABase16_Weights,
     DOFALarge16_Weights,
     dofa_base_patch16_224,
-    dofa_huge_patch16_224,
+    dofa_huge_patch14_224,
     dofa_large_patch16_224,
     dofa_small_patch16_224,
 )
@@ -154,4 +154,4 @@ class TestDOFALarge16:
 
 class TestDOFAHuge16:
     def test_dofa(self) -> None:
-        dofa_huge_patch16_224()
+        dofa_huge_patch14_224()

--- a/torchgeo/models/__init__.py
+++ b/torchgeo/models/__init__.py
@@ -11,7 +11,7 @@ from .dofa import (
     DOFABase16_Weights,
     DOFALarge16_Weights,
     dofa_base_patch16_224,
-    dofa_huge_patch16_224,
+    dofa_huge_patch14_224,
     dofa_large_patch16_224,
     dofa_small_patch16_224,
 )
@@ -57,7 +57,7 @@ __all__ = (
     'croma_base',
     'croma_large',
     'dofa_base_patch16_224',
-    'dofa_huge_patch16_224',
+    'dofa_huge_patch14_224',
     'dofa_large_patch16_224',
     'dofa_small_patch16_224',
     'get_model',

--- a/torchgeo/models/dofa.py
+++ b/torchgeo/models/dofa.py
@@ -295,7 +295,7 @@ class DOFA(nn.Module):
         # --------------------------------------------------------------------------
         # MAE encoder specifics
         self.patch_embed = DOFAEmbedding(
-            dynamic_embed_dim=128, kernel_size=16, embed_dim=embed_dim
+            dynamic_embed_dim=128, kernel_size=patch_size, embed_dim=embed_dim
         )
         self.num_patches = (img_size // patch_size) ** 2
         self.cls_token = nn.Parameter(torch.zeros(1, 1, embed_dim))
@@ -531,7 +531,7 @@ def dofa_large_patch16_224(
 
 
 def dofa_huge_patch14_224(*args: Any, **kwargs: Any) -> DOFA:
-    """Dynamic One-For-All (DOFA) huge patch size 16 model.
+    """Dynamic One-For-All (DOFA) huge patch size 14 model.
 
     If you use this model in your research, please cite the following paper:
 
@@ -544,7 +544,7 @@ def dofa_huge_patch14_224(*args: Any, **kwargs: Any) -> DOFA:
         **kwargs: Additional keyword arguments to pass to :class:`DOFA`.
 
     Returns:
-        A DOFA huge 16 model.
+        A DOFA huge 14 model.
     """
     kwargs |= {'patch_size': 14, 'embed_dim': 1280, 'depth': 32, 'num_heads': 16}
     model = DOFA(*args, **kwargs)

--- a/torchgeo/models/dofa.py
+++ b/torchgeo/models/dofa.py
@@ -530,7 +530,7 @@ def dofa_large_patch16_224(
     return model
 
 
-def dofa_huge_patch16_224(*args: Any, **kwargs: Any) -> DOFA:
+def dofa_huge_patch14_224(*args: Any, **kwargs: Any) -> DOFA:
     """Dynamic One-For-All (DOFA) huge patch size 16 model.
 
     If you use this model in your research, please cite the following paper:


### PR DESCRIPTION
Fix the inconsistent patch size of DOFA huge model, specifically:

docs/api/models.rst:.. autofunction:: dofa_huge_patch16_224, changed to autofunction:: dofa_huge_patch14_224
tests/models/test_dofa.py: dofa_huge_patch16_224, changed to dofa_huge_patch14_224
tests/models/test_dofa.py: dofa_huge_patch16_224() changed to dofa_huge_patch14_224()
torchgeo/models/init.py: dofa_huge_patch16_224, changed to dofa_huge_patch14_224
torchgeo/models/init.py: 'dofa_huge_patch16_224', changed to dofa_huge_patch14_224
torchgeo/models/dofa.py: def dofa_huge_patch16_224(*args: Any, **kwargs: Any) -> DOFA: changed to dofa_huge_patch14_224(*args: Any, **kwargs: Any)

Closes #2618