### PR TITLE
CI: do not cancel runs on main branch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,4 +67,4 @@ jobs:
         run: pytest --nbmake --durations=10 docs/tutorials
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.head.label || github.head_ref || github.ref }}
-  cancel-in-progress: ${{ ! contains(github.ref, 'main')}}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,4 +67,4 @@ jobs:
         run: pytest --nbmake --durations=10 docs/tutorials
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.head.label || github.head_ref || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ ! contains(github.ref, 'main')}}

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -88,4 +88,4 @@ jobs:
         run: npx prettier --check .
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.head.label || github.head_ref || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ ! contains(github.ref, 'main')}}

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -88,4 +88,4 @@ jobs:
         run: npx prettier --check .
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.head.label || github.head_ref || github.ref }}
-  cancel-in-progress: ${{ ! contains(github.ref, 'main')}}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -115,4 +115,4 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.head.label || github.head_ref || github.ref }}
-  cancel-in-progress: ${{ ! contains(github.ref, 'main')}}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -115,4 +115,4 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.head.label || github.head_ref || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ ! contains(github.ref, 'main')}}

--- a/.github/workflows/tutorials.yaml
+++ b/.github/workflows/tutorials.yaml
@@ -42,4 +42,4 @@ jobs:
         run: pytest --nbmake --durations=10 docs/tutorials
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.head.label || github.head_ref || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ ! contains(github.ref, 'main')}}

--- a/.github/workflows/tutorials.yaml
+++ b/.github/workflows/tutorials.yaml
@@ -42,4 +42,4 @@ jobs:
         run: pytest --nbmake --durations=10 docs/tutorials
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.head.label || github.head_ref || github.ref }}
-  cancel-in-progress: ${{ ! contains(github.ref, 'main')}}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}


### PR DESCRIPTION
The main branch is special, as all of our:

[![docs](https://readthedocs.org/projects/torchgeo/badge/?version=latest)](https://torchgeo.readthedocs.io/en/stable/)
[![style](https://github.com/microsoft/torchgeo/actions/workflows/style.yaml/badge.svg)](https://github.com/microsoft/torchgeo/actions/workflows/style.yaml)
[![tests](https://github.com/microsoft/torchgeo/actions/workflows/tests.yaml/badge.svg)](https://github.com/microsoft/torchgeo/actions/workflows/tests.yaml)
[![codecov](https://codecov.io/gh/microsoft/torchgeo/branch/main/graph/badge.svg?token=oa3Z3PMVOg)](https://codecov.io/gh/microsoft/torchgeo)

buttons display current test results and code coverage on main. We should not skip in-progress CI runs on the main branch just because a newer commit has been pushed. This will keep our buttons stably green.

### References

* https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-on-specific-branches
* https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context