### PR TITLE
ReforesTreeDataModule: use correct path

### DIFF
--- a/tests/conf/reforestree.yaml
+++ b/tests/conf/reforestree.yaml
@@ -9,4 +9,4 @@ data:
   init_args:
     batch_size: 1
   dict_kwargs:
-    root: 'tests/data/reforestree'
+    root: 'tests/data/reforestree/reforesTree'


### PR DESCRIPTION
Follow-up to #2642, changes the root directory of the data to avoid the dataset extracting the .zip file and leaving untracked files in git.

@lns-lns