### PR TITLE
Fix Pretrained ResNet/ViT not working when features_only=True

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,6 @@ import matplotlib
 import pytest
 import torch
 import torchvision
-from _pytest.fixtures import SubRequest
 from pytest import MonkeyPatch
 
 
@@ -29,8 +28,3 @@ def matplotlib_backend() -> None:
 @pytest.fixture(autouse=True)
 def torch_hub(tmp_path: Path) -> None:
     torch.hub.set_dir(tmp_path)
-
-
-@pytest.fixture(params=[True, False])
-def features_only(request: SubRequest) -> bool:
-    return bool(request.param)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import matplotlib
 import pytest
 import torch
 import torchvision
+from _pytest.fixtures import SubRequest
 from pytest import MonkeyPatch
 
 
@@ -28,3 +29,8 @@ def matplotlib_backend() -> None:
 @pytest.fixture(autouse=True)
 def torch_hub(tmp_path: Path) -> None:
     torch.hub.set_dir(tmp_path)
+
+
+@pytest.fixture(params=[True, False])
+def features_only(request: SubRequest) -> bool:
+    return bool(request.param)

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -4,4 +4,6 @@ from _pytest.fixtures import SubRequest
 
 @pytest.fixture(params=[True, False])
 def features_only(request: SubRequest) -> bool:
+    if request.param:
+        pytest.importorskip('timm', minversion='1.0.3')
     return bool(request.param)

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
 import pytest
 from _pytest.fixtures import SubRequest
 

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+from _pytest.fixtures import SubRequest
+
+
+@pytest.fixture(params=[True, False])
+def features_only(request: SubRequest) -> bool:
+    return bool(request.param)

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -5,5 +5,6 @@ from _pytest.fixtures import SubRequest
 @pytest.fixture(params=[True, False])
 def features_only(request: SubRequest) -> bool:
     if request.param:
+        # features_only arg in ViT supported only from timm 1.0.3
         pytest.importorskip('timm', minversion='1.0.3')
     return bool(request.param)

--- a/tests/models/test_resnet.py
+++ b/tests/models/test_resnet.py
@@ -25,34 +25,22 @@ class TestResNet18:
     def weights(self, request: SubRequest) -> WeightsEnum:
         return request.param
 
+    @pytest.fixture(params=[True, False])
+    def features_only(self, request: SubRequest) -> bool:
+        return bool(request.param)
+
     @pytest.fixture
     def mocked_weights(
         self,
         tmp_path: Path,
         monkeypatch: MonkeyPatch,
         weights: WeightsEnum,
-        load_state_dict_from_url: None,
-    ) -> WeightsEnum:
-        path = tmp_path / f'{weights}.pth'
-        model = timm.create_model('resnet18', in_chans=weights.meta['in_chans'])
-        torch.save(model.state_dict(), path)
-        try:
-            monkeypatch.setattr(weights.value, 'url', str(path))
-        except AttributeError:
-            monkeypatch.setattr(weights, 'url', str(path))
-        return weights
-
-    @pytest.fixture
-    def mocked_weights_features_only(
-        self,
-        tmp_path: Path,
-        monkeypatch: MonkeyPatch,
-        weights: WeightsEnum,
+        features_only: bool,
         load_state_dict_from_url: None,
     ) -> WeightsEnum:
         path = tmp_path / f'{weights}.pth'
         model = timm.create_model(
-            'resnet18', in_chans=weights.meta['in_chans'], features_only=True
+            'resnet18', in_chans=weights.meta['in_chans'], features_only=features_only
         )
         torch.save(model.state_dict(), path)
         try:
@@ -64,13 +52,10 @@ class TestResNet18:
     def test_resnet(self) -> None:
         resnet18()
 
-    def test_resnet_weights(self, mocked_weights: WeightsEnum) -> None:
-        resnet18(weights=mocked_weights)
-
-    def test_resnet_weights_features_only(
-        self, mocked_weights_features_only: WeightsEnum
+    def test_resnet_weights(
+        self, mocked_weights: WeightsEnum, features_only: bool
     ) -> None:
-        resnet18(weights=mocked_weights_features_only, features_only=True)
+        resnet18(weights=mocked_weights, features_only=features_only)
 
     def test_bands(self, mocked_weights: WeightsEnum) -> None:
         if 'bands' in mocked_weights.meta:
@@ -93,34 +78,22 @@ class TestResNet50:
     def weights(self, request: SubRequest) -> WeightsEnum:
         return request.param
 
+    @pytest.fixture(params=[True, False])
+    def features_only(self, request: SubRequest) -> bool:
+        return bool(request.param)
+
     @pytest.fixture
     def mocked_weights(
         self,
         tmp_path: Path,
         monkeypatch: MonkeyPatch,
         weights: WeightsEnum,
-        load_state_dict_from_url: None,
-    ) -> WeightsEnum:
-        path = tmp_path / f'{weights}.pth'
-        model = timm.create_model('resnet50', in_chans=weights.meta['in_chans'])
-        torch.save(model.state_dict(), path)
-        try:
-            monkeypatch.setattr(weights.value, 'url', str(path))
-        except AttributeError:
-            monkeypatch.setattr(weights, 'url', str(path))
-        return weights
-
-    @pytest.fixture
-    def mocked_weights_features_only(
-        self,
-        tmp_path: Path,
-        monkeypatch: MonkeyPatch,
-        weights: WeightsEnum,
+        features_only: bool,
         load_state_dict_from_url: None,
     ) -> WeightsEnum:
         path = tmp_path / f'{weights}.pth'
         model = timm.create_model(
-            'resnet50', in_chans=weights.meta['in_chans'], features_only=True
+            'resnet50', in_chans=weights.meta['in_chans'], features_only=features_only
         )
         torch.save(model.state_dict(), path)
         try:
@@ -132,13 +105,10 @@ class TestResNet50:
     def test_resnet(self) -> None:
         resnet50()
 
-    def test_resnet_weights(self, mocked_weights: WeightsEnum) -> None:
-        resnet50(weights=mocked_weights)
-
-    def test_resnet_weights_features_only(
-        self, mocked_weights_features_only: WeightsEnum
+    def test_resnet_weights(
+        self, mocked_weights: WeightsEnum, features_only: bool
     ) -> None:
-        resnet50(weights=mocked_weights_features_only, features_only=True)
+        resnet50(weights=mocked_weights, features_only=features_only)
 
     def test_bands(self, mocked_weights: WeightsEnum) -> None:
         if 'bands' in mocked_weights.meta:
@@ -161,34 +131,22 @@ class TestResNet152:
     def weights(self, request: SubRequest) -> WeightsEnum:
         return request.param
 
+    @pytest.fixture(params=[True, False])
+    def features_only(self, request: SubRequest) -> bool:
+        return bool(request.param)
+
     @pytest.fixture
     def mocked_weights(
         self,
         tmp_path: Path,
         monkeypatch: MonkeyPatch,
         weights: WeightsEnum,
-        load_state_dict_from_url: None,
-    ) -> WeightsEnum:
-        path = tmp_path / f'{weights}.pth'
-        model = timm.create_model('resnet152', in_chans=weights.meta['in_chans'])
-        torch.save(model.state_dict(), path)
-        try:
-            monkeypatch.setattr(weights.value, 'url', str(path))
-        except AttributeError:
-            monkeypatch.setattr(weights, 'url', str(path))
-        return weights
-
-    @pytest.fixture
-    def mocked_weights_features_only(
-        self,
-        tmp_path: Path,
-        monkeypatch: MonkeyPatch,
-        weights: WeightsEnum,
+        features_only: bool,
         load_state_dict_from_url: None,
     ) -> WeightsEnum:
         path = tmp_path / f'{weights}.pth'
         model = timm.create_model(
-            'resnet152', in_chans=weights.meta['in_chans'], features_only=True
+            'resnet152', in_chans=weights.meta['in_chans'], features_only=features_only
         )
         torch.save(model.state_dict(), path)
         try:
@@ -200,13 +158,10 @@ class TestResNet152:
     def test_resnet(self) -> None:
         resnet152()
 
-    def test_resnet_weights(self, mocked_weights: WeightsEnum) -> None:
-        resnet152(weights=mocked_weights)
-
-    def test_resnet_weights_features_only(
-        self, mocked_weights_features_only: WeightsEnum
+    def test_resnet_weights(
+        self, mocked_weights: WeightsEnum, features_only: bool
     ) -> None:
-        resnet152(weights=mocked_weights_features_only, features_only=True)
+        resnet152(weights=mocked_weights, features_only=features_only)
 
     def test_bands(self, mocked_weights: WeightsEnum) -> None:
         if 'bands' in mocked_weights.meta:

--- a/tests/models/test_resnet.py
+++ b/tests/models/test_resnet.py
@@ -47,6 +47,7 @@ class TestResNet18:
 
     def test_resnet_weights(self, mocked_weights: WeightsEnum) -> None:
         resnet18(weights=mocked_weights)
+        resnet18(weights=mocked_weights, features_only=True)
 
     def test_bands(self, mocked_weights: WeightsEnum) -> None:
         if 'bands' in mocked_weights.meta:
@@ -91,6 +92,7 @@ class TestResNet50:
 
     def test_resnet_weights(self, mocked_weights: WeightsEnum) -> None:
         resnet50(weights=mocked_weights)
+        resnet50(weights=mocked_weights, features_only=True)
 
     def test_bands(self, mocked_weights: WeightsEnum) -> None:
         if 'bands' in mocked_weights.meta:
@@ -135,6 +137,7 @@ class TestResNet152:
 
     def test_resnet_weights(self, mocked_weights: WeightsEnum) -> None:
         resnet152(weights=mocked_weights)
+        resnet152(weights=mocked_weights, features_only=True)
 
     def test_bands(self, mocked_weights: WeightsEnum) -> None:
         if 'bands' in mocked_weights.meta:

--- a/tests/models/test_resnet.py
+++ b/tests/models/test_resnet.py
@@ -42,12 +42,35 @@ class TestResNet18:
             monkeypatch.setattr(weights, 'url', str(path))
         return weights
 
+    @pytest.fixture
+    def mocked_weights_features_only(
+        self,
+        tmp_path: Path,
+        monkeypatch: MonkeyPatch,
+        weights: WeightsEnum,
+        load_state_dict_from_url: None,
+    ) -> WeightsEnum:
+        path = tmp_path / f'{weights}.pth'
+        model = timm.create_model(
+            'resnet18', in_chans=weights.meta['in_chans'], features_only=True
+        )
+        torch.save(model.state_dict(), path)
+        try:
+            monkeypatch.setattr(weights.value, 'url', str(path))
+        except AttributeError:
+            monkeypatch.setattr(weights, 'url', str(path))
+        return weights
+
     def test_resnet(self) -> None:
         resnet18()
 
     def test_resnet_weights(self, mocked_weights: WeightsEnum) -> None:
         resnet18(weights=mocked_weights)
-        resnet18(weights=mocked_weights, features_only=True)
+
+    def test_resnet_weights_features_only(
+        self, mocked_weights_features_only: WeightsEnum
+    ) -> None:
+        resnet18(weights=mocked_weights_features_only, features_only=True)
 
     def test_bands(self, mocked_weights: WeightsEnum) -> None:
         if 'bands' in mocked_weights.meta:
@@ -87,12 +110,35 @@ class TestResNet50:
             monkeypatch.setattr(weights, 'url', str(path))
         return weights
 
+    @pytest.fixture
+    def mocked_weights_features_only(
+        self,
+        tmp_path: Path,
+        monkeypatch: MonkeyPatch,
+        weights: WeightsEnum,
+        load_state_dict_from_url: None,
+    ) -> WeightsEnum:
+        path = tmp_path / f'{weights}.pth'
+        model = timm.create_model(
+            'resnet50', in_chans=weights.meta['in_chans'], features_only=True
+        )
+        torch.save(model.state_dict(), path)
+        try:
+            monkeypatch.setattr(weights.value, 'url', str(path))
+        except AttributeError:
+            monkeypatch.setattr(weights, 'url', str(path))
+        return weights
+
     def test_resnet(self) -> None:
         resnet50()
 
     def test_resnet_weights(self, mocked_weights: WeightsEnum) -> None:
         resnet50(weights=mocked_weights)
-        resnet50(weights=mocked_weights, features_only=True)
+
+    def test_resnet_weights_features_only(
+        self, mocked_weights_features_only: WeightsEnum
+    ) -> None:
+        resnet50(weights=mocked_weights_features_only, features_only=True)
 
     def test_bands(self, mocked_weights: WeightsEnum) -> None:
         if 'bands' in mocked_weights.meta:
@@ -132,12 +178,35 @@ class TestResNet152:
             monkeypatch.setattr(weights, 'url', str(path))
         return weights
 
+    @pytest.fixture
+    def mocked_weights_features_only(
+        self,
+        tmp_path: Path,
+        monkeypatch: MonkeyPatch,
+        weights: WeightsEnum,
+        load_state_dict_from_url: None,
+    ) -> WeightsEnum:
+        path = tmp_path / f'{weights}.pth'
+        model = timm.create_model(
+            'resnet152', in_chans=weights.meta['in_chans'], features_only=True
+        )
+        torch.save(model.state_dict(), path)
+        try:
+            monkeypatch.setattr(weights.value, 'url', str(path))
+        except AttributeError:
+            monkeypatch.setattr(weights, 'url', str(path))
+        return weights
+
     def test_resnet(self) -> None:
         resnet152()
 
     def test_resnet_weights(self, mocked_weights: WeightsEnum) -> None:
         resnet152(weights=mocked_weights)
-        resnet152(weights=mocked_weights, features_only=True)
+
+    def test_resnet_weights_features_only(
+        self, mocked_weights_features_only: WeightsEnum
+    ) -> None:
+        resnet152(weights=mocked_weights_features_only, features_only=True)
 
     def test_bands(self, mocked_weights: WeightsEnum) -> None:
         if 'bands' in mocked_weights.meta:

--- a/tests/models/test_resnet.py
+++ b/tests/models/test_resnet.py
@@ -25,10 +25,6 @@ class TestResNet18:
     def weights(self, request: SubRequest) -> WeightsEnum:
         return request.param
 
-    @pytest.fixture(params=[True, False])
-    def features_only(self, request: SubRequest) -> bool:
-        return bool(request.param)
-
     @pytest.fixture
     def mocked_weights(
         self,
@@ -78,10 +74,6 @@ class TestResNet50:
     def weights(self, request: SubRequest) -> WeightsEnum:
         return request.param
 
-    @pytest.fixture(params=[True, False])
-    def features_only(self, request: SubRequest) -> bool:
-        return bool(request.param)
-
     @pytest.fixture
     def mocked_weights(
         self,
@@ -130,10 +122,6 @@ class TestResNet152:
     @pytest.fixture(params=[*ResNet152_Weights])
     def weights(self, request: SubRequest) -> WeightsEnum:
         return request.param
-
-    @pytest.fixture(params=[True, False])
-    def features_only(self, request: SubRequest) -> bool:
-        return bool(request.param)
 
     @pytest.fixture
     def mocked_weights(

--- a/tests/models/test_vit.py
+++ b/tests/models/test_vit.py
@@ -42,6 +42,7 @@ class TestViTSmall16:
 
     def test_vit_weights(self, mocked_weights: WeightsEnum) -> None:
         vit_small_patch16_224(weights=mocked_weights)
+        vit_small_patch16_224(weights=mocked_weights, features_only=True)
 
     def test_bands(self, mocked_weights: WeightsEnum) -> None:
         if 'bands' in mocked_weights.meta:

--- a/tests/models/test_vit.py
+++ b/tests/models/test_vit.py
@@ -18,41 +18,29 @@ class TestViTSmall16:
     def weights(self, request: SubRequest) -> WeightsEnum:
         return request.param
 
+    @pytest.fixture(params=[True, False])
+    def features_only(self, request: SubRequest) -> bool:
+        if request.param:
+            # features_only arg in ViT supported only from timm 1.0.3
+            pytest.importorskip('timm', minversion='1.0.3')
+        return bool(request.param)
+
     @pytest.fixture
     def mocked_weights(
         self,
         tmp_path: Path,
         monkeypatch: MonkeyPatch,
         weights: WeightsEnum,
+        features_only: bool,
         load_state_dict_from_url: None,
     ) -> WeightsEnum:
         path = tmp_path / f'{weights}.pth'
         model = timm.create_model(
-            weights.meta['model'], in_chans=weights.meta['in_chans']
+            weights.meta['model'],
+            in_chans=weights.meta['in_chans'],
+            features_only=features_only,
         )
         torch.save(model.state_dict(), path)
-        try:
-            monkeypatch.setattr(weights.value, 'url', str(path))
-        except AttributeError:
-            monkeypatch.setattr(weights, 'url', str(path))
-        return weights
-
-    @pytest.fixture
-    def mocked_weights_features_only(
-        self,
-        tmp_path: Path,
-        monkeypatch: MonkeyPatch,
-        weights: WeightsEnum,
-        load_state_dict_from_url: None,
-    ) -> WeightsEnum:
-        # features_only args implemented in timm 1.0.3
-        pytest.importorskip('timm', minversion='1.0.3')
-        path = tmp_path / f'{weights}.pth'
-        model = timm.create_model(
-            weights.meta['model'], in_chans=weights.meta['in_chans'], features_only=True
-        )
-        # the actual ViT is stored in model attribute
-        torch.save(model.model.state_dict(), path)
         try:
             monkeypatch.setattr(weights.value, 'url', str(path))
         except AttributeError:
@@ -62,13 +50,10 @@ class TestViTSmall16:
     def test_vit(self) -> None:
         vit_small_patch16_224()
 
-    def test_vit_weights(self, mocked_weights: WeightsEnum) -> None:
-        vit_small_patch16_224(weights=mocked_weights)
-
-    def test_vit_weights_features_only(
-        self, mocked_weights_features_only: WeightsEnum
+    def test_vit_weights(
+        self, mocked_weights: WeightsEnum, features_only: bool
     ) -> None:
-        vit_small_patch16_224(weights=mocked_weights_features_only, features_only=True)
+        vit_small_patch16_224(weights=mocked_weights, features_only=features_only)
 
     def test_bands(self, mocked_weights: WeightsEnum) -> None:
         if 'bands' in mocked_weights.meta:

--- a/tests/models/test_vit.py
+++ b/tests/models/test_vit.py
@@ -18,13 +18,6 @@ class TestViTSmall16:
     def weights(self, request: SubRequest) -> WeightsEnum:
         return request.param
 
-    @pytest.fixture(params=[True, False])
-    def features_only(self, request: SubRequest) -> bool:
-        if request.param:
-            # features_only arg in ViT supported only from timm 1.0.3
-            pytest.importorskip('timm', minversion='1.0.3')
-        return bool(request.param)
-
     @pytest.fixture
     def mocked_weights(
         self,

--- a/tests/models/test_vit.py
+++ b/tests/models/test_vit.py
@@ -45,6 +45,8 @@ class TestViTSmall16:
         weights: WeightsEnum,
         load_state_dict_from_url: None,
     ) -> WeightsEnum:
+        # features_only args implemented in timm 1.0.3
+        pytest.importorskip('timm', minversion='1.0.3')
         path = tmp_path / f'{weights}.pth'
         model = timm.create_model(
             weights.meta['model'], in_chans=weights.meta['in_chans'], features_only=True

--- a/tests/models/test_vit.py
+++ b/tests/models/test_vit.py
@@ -40,7 +40,8 @@ class TestViTSmall16:
             in_chans=weights.meta['in_chans'],
             features_only=features_only,
         )
-        torch.save(model.state_dict(), path)
+        target_model = model.model if features_only else model
+        torch.save(target_model.state_dict(), path)
         try:
             monkeypatch.setattr(weights.value, 'url', str(path))
         except AttributeError:

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -8,7 +8,7 @@ from typing import Any
 import kornia.augmentation as K
 import timm
 import torch
-from timm.models import ResNet, FeatureListNet
+from timm.models import FeatureListNet, ResNet
 from torchvision.models._api import Weights, WeightsEnum
 
 from .swin import (

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -8,7 +8,8 @@ from typing import Any
 import kornia.augmentation as K
 import timm
 import torch
-from timm.models import FeatureListNet, ResNet
+from timm.models import ResNet
+from torch import nn
 from torchvision.models._api import Weights, WeightsEnum
 
 from .swin import (
@@ -748,7 +749,7 @@ class ResNet152_Weights(WeightsEnum):  # type: ignore[misc]
 
 def resnet18(
     weights: ResNet18_Weights | None = None, *args: Any, **kwargs: Any
-) -> ResNet | FeatureListNet:
+) -> ResNet | nn.ModuleDict:
     """ResNet-18 model.
 
     If you use this model in your research, please cite the following paper:
@@ -768,7 +769,7 @@ def resnet18(
     if weights:
         kwargs['in_chans'] = weights.meta['in_chans']
 
-    model: ResNet | FeatureListNet = timm.create_model('resnet18', *args, **kwargs)
+    model: ResNet | nn.ModuleDict = timm.create_model('resnet18', *args, **kwargs)
 
     if weights:
         missing_keys, unexpected_keys = model.load_state_dict(
@@ -782,7 +783,7 @@ def resnet18(
 
 def resnet50(
     weights: ResNet50_Weights | None = None, *args: Any, **kwargs: Any
-) -> ResNet | FeatureListNet:
+) -> ResNet | nn.ModuleDict:
     """ResNet-50 model.
 
     If you use this model in your research, please cite the following paper:
@@ -803,7 +804,7 @@ def resnet50(
     if weights:
         kwargs['in_chans'] = weights.meta['in_chans']
 
-    model: ResNet | FeatureListNet = timm.create_model('resnet50', *args, **kwargs)
+    model: ResNet | nn.ModuleDict = timm.create_model('resnet50', *args, **kwargs)
 
     if weights:
         missing_keys, unexpected_keys = model.load_state_dict(
@@ -818,7 +819,7 @@ def resnet50(
 
 def resnet152(
     weights: ResNet152_Weights | None = None, *args: Any, **kwargs: Any
-) -> ResNet | FeatureListNet:
+) -> ResNet | nn.ModuleDict:
     """ResNet-152 model.
 
     If you use this model in your research, please cite the following paper:
@@ -838,7 +839,7 @@ def resnet152(
     if weights:
         kwargs['in_chans'] = weights.meta['in_chans']
 
-    model: ResNet | FeatureListNet = timm.create_model('resnet152', *args, **kwargs)
+    model: ResNet | nn.ModuleDict = timm.create_model('resnet152', *args, **kwargs)
 
     if weights:
         missing_keys, unexpected_keys = model.load_state_dict(

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -846,6 +846,7 @@ def resnet152(
             weights.get_state_dict(progress=True), strict=False
         )
         assert set(missing_keys) <= {'fc.weight', 'fc.bias'}
+        # used when features_only = True
         assert set(unexpected_keys) <= {'fc.weight', 'fc.bias'}
 
     return model

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -8,8 +8,7 @@ from typing import Any
 import kornia.augmentation as K
 import timm
 import torch
-from timm.models import ResNet
-from timm.models._features import FeatureListNet
+from timm.models import ResNet, FeatureListNet
 from torchvision.models._api import Weights, WeightsEnum
 
 from .swin import (

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -9,6 +9,7 @@ import kornia.augmentation as K
 import timm
 import torch
 from timm.models import ResNet
+from timm.models._features import FeatureListNet
 from torchvision.models._api import Weights, WeightsEnum
 
 from .swin import (
@@ -748,7 +749,7 @@ class ResNet152_Weights(WeightsEnum):  # type: ignore[misc]
 
 def resnet18(
     weights: ResNet18_Weights | None = None, *args: Any, **kwargs: Any
-) -> ResNet:
+) -> ResNet | FeatureListNet:
     """ResNet-18 model.
 
     If you use this model in your research, please cite the following paper:
@@ -768,7 +769,7 @@ def resnet18(
     if weights:
         kwargs['in_chans'] = weights.meta['in_chans']
 
-    model: ResNet = timm.create_model('resnet18', *args, **kwargs)
+    model: ResNet | FeatureListNet = timm.create_model('resnet18', *args, **kwargs)
 
     if weights:
         missing_keys, unexpected_keys = model.load_state_dict(
@@ -782,7 +783,7 @@ def resnet18(
 
 def resnet50(
     weights: ResNet50_Weights | None = None, *args: Any, **kwargs: Any
-) -> ResNet:
+) -> ResNet | FeatureListNet:
     """ResNet-50 model.
 
     If you use this model in your research, please cite the following paper:
@@ -803,21 +804,22 @@ def resnet50(
     if weights:
         kwargs['in_chans'] = weights.meta['in_chans']
 
-    model: ResNet = timm.create_model('resnet50', *args, **kwargs)
+    model: ResNet | FeatureListNet = timm.create_model('resnet50', *args, **kwargs)
 
     if weights:
         missing_keys, unexpected_keys = model.load_state_dict(
             weights.get_state_dict(progress=True), strict=False
         )
         assert set(missing_keys) <= {'fc.weight', 'fc.bias'}
-        assert not unexpected_keys
+        # used when features_only = True
+        assert set(unexpected_keys) <= {'fc.weight', 'fc.bias'}
 
     return model
 
 
 def resnet152(
     weights: ResNet152_Weights | None = None, *args: Any, **kwargs: Any
-) -> ResNet:
+) -> ResNet | FeatureListNet:
     """ResNet-152 model.
 
     If you use this model in your research, please cite the following paper:
@@ -837,13 +839,13 @@ def resnet152(
     if weights:
         kwargs['in_chans'] = weights.meta['in_chans']
 
-    model: ResNet = timm.create_model('resnet152', *args, **kwargs)
+    model: ResNet | FeatureListNet = timm.create_model('resnet152', *args, **kwargs)
 
     if weights:
         missing_keys, unexpected_keys = model.load_state_dict(
             weights.get_state_dict(progress=True), strict=False
         )
         assert set(missing_keys) <= {'fc.weight', 'fc.bias'}
-        assert not unexpected_keys
+        assert set(unexpected_keys) <= {'fc.weight', 'fc.bias'}
 
     return model

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -839,6 +839,7 @@ def resnet152(
     if weights:
         kwargs['in_chans'] = weights.meta['in_chans']
 
+    # FeatureListNet (extends nn.ModuleDict) is returned when features_only=True
     model: ResNet | nn.ModuleDict = timm.create_model('resnet152', *args, **kwargs)
 
     if weights:

--- a/torchgeo/models/vit.py
+++ b/torchgeo/models/vit.py
@@ -8,8 +8,8 @@ from typing import Any, cast
 import kornia.augmentation as K
 import timm
 import torch
-from timm.models._features import FeatureGetterNet
 from timm.models.vision_transformer import VisionTransformer
+from torch import nn
 from torchvision.models._api import Weights, WeightsEnum
 
 from .resnet import (
@@ -224,7 +224,7 @@ class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
 
 def vit_small_patch16_224(
     weights: ViTSmall16_Weights | None = None, *args: Any, **kwargs: Any
-) -> VisionTransformer | FeatureGetterNet:
+) -> VisionTransformer | nn.ModuleDict:
     """Vision Transform (ViT) small patch size 16 model.
 
     If you use this model in your research, please cite the following paper:
@@ -243,13 +243,13 @@ def vit_small_patch16_224(
     """
     if weights:
         kwargs['in_chans'] = weights.meta['in_chans']
-
-    model: VisionTransformer | FeatureGetterNet = timm.create_model(
+    # FeatureGetterNet (extends nn.ModuleDict) is returned when features_only=True
+    model: VisionTransformer | nn.ModuleDict = timm.create_model(
         'vit_small_patch16_224', *args, **kwargs
     )
 
     if kwargs.get('features_only', False):
-        model = cast(FeatureGetterNet, model)
+        model = cast(nn.ModuleDict, model)
         target_model = cast(VisionTransformer, model.model)
     else:
         model = cast(VisionTransformer, model)

--- a/torchgeo/models/vit.py
+++ b/torchgeo/models/vit.py
@@ -250,7 +250,7 @@ def vit_small_patch16_224(
 
     if 'features_only' in kwargs:
         model = cast(FeatureGetterNet, model)
-        target_model: VisionTransformer = cast(VisionTransformer, model.model)
+        target_model = cast(VisionTransformer, model.model)
     else:
         model = cast(VisionTransformer, model)
         target_model = model

--- a/torchgeo/models/vit.py
+++ b/torchgeo/models/vit.py
@@ -248,7 +248,7 @@ def vit_small_patch16_224(
         'vit_small_patch16_224', *args, **kwargs
     )
 
-    if 'features_only' in kwargs:
+    if kwargs.get('features_only', False):
         model = cast(FeatureGetterNet, model)
         target_model = cast(VisionTransformer, model.model)
     else:


### PR DESCRIPTION
Fix the AssertionError raised when pretrained ResNet/ViT models (from timm) were created with `features_only = True`.

ResNet18 and Swin models were not affected by the issue (Swin models are created with torchvision instead of timm).

Closes [#2640](https://github.com/microsoft/torchgeo/issues/2640).