### PR TITLE
Refactor _RandomNCrop to RandomCrop + ExtractPatches

### DIFF
--- a/tests/conf/reforestree.yaml
+++ b/tests/conf/reforestree.yaml
@@ -8,5 +8,6 @@ data:
   class_path: ReforesTreeDataModule
   init_args:
     batch_size: 1
+    patch_size: 8
   dict_kwargs:
     root: 'tests/data/reforestree/reforesTree'

--- a/tests/datamodules/test_levircd.py
+++ b/tests/datamodules/test_levircd.py
@@ -51,9 +51,9 @@ class TestLEVIRCDPlusDataModule:
         batch = next(iter(datamodule.train_dataloader()))
         batch = datamodule.on_after_batch_transfer(batch, 0)
         assert batch['image1'].shape[-2:] == batch['mask'].shape[-2:] == (256, 256)
-        assert batch['image1'].shape[0] == batch['mask'].shape[0] == 8
+        assert batch['image1'].shape[0] == batch['mask'].shape[0] == 1
         assert batch['image2'].shape[-2:] == batch['mask'].shape[-2:] == (256, 256)
-        assert batch['image2'].shape[0] == batch['mask'].shape[0] == 8
+        assert batch['image2'].shape[0] == batch['mask'].shape[0] == 1
         assert batch['image1'].shape[1] == 3
         assert batch['image2'].shape[1] == 3
 
@@ -64,14 +64,10 @@ class TestLEVIRCDPlusDataModule:
         batch = next(iter(datamodule.val_dataloader()))
         batch = datamodule.on_after_batch_transfer(batch, 0)
         if datamodule.val_split_pct > 0.0:
-            assert (
-                batch['image1'].shape[-2:] == batch['mask'].shape[-2:] == (1024, 1024)
-            )
-            assert batch['image1'].shape[0] == batch['mask'].shape[0] == 1
-            assert (
-                batch['image2'].shape[-2:] == batch['mask'].shape[-2:] == (1024, 1024)
-            )
-            assert batch['image2'].shape[0] == batch['mask'].shape[0] == 1
+            assert batch['image1'].shape[-2:] == batch['mask'].shape[-2:] == (256, 256)
+            assert batch['image1'].shape[0] == batch['mask'].shape[0] == 16
+            assert batch['image2'].shape[-2:] == batch['mask'].shape[-2:] == (256, 256)
+            assert batch['image2'].shape[0] == batch['mask'].shape[0] == 16
             assert batch['image1'].shape[1] == 3
             assert batch['image2'].shape[1] == 3
 
@@ -81,10 +77,10 @@ class TestLEVIRCDPlusDataModule:
             datamodule.trainer.testing = True
         batch = next(iter(datamodule.test_dataloader()))
         batch = datamodule.on_after_batch_transfer(batch, 0)
-        assert batch['image1'].shape[-2:] == batch['mask'].shape[-2:] == (1024, 1024)
-        assert batch['image1'].shape[0] == batch['mask'].shape[0] == 1
-        assert batch['image2'].shape[-2:] == batch['mask'].shape[-2:] == (1024, 1024)
-        assert batch['image2'].shape[0] == batch['mask'].shape[0] == 1
+        assert batch['image1'].shape[-2:] == batch['mask'].shape[-2:] == (256, 256)
+        assert batch['image1'].shape[0] == batch['mask'].shape[0] == 32
+        assert batch['image2'].shape[-2:] == batch['mask'].shape[-2:] == (256, 256)
+        assert batch['image2'].shape[0] == batch['mask'].shape[0] == 32
         assert batch['image1'].shape[1] == 3
         assert batch['image2'].shape[1] == 3
 
@@ -105,9 +101,9 @@ class TestLEVIRCDDataModule:
         batch = next(iter(datamodule.train_dataloader()))
         batch = datamodule.on_after_batch_transfer(batch, 0)
         assert batch['image1'].shape[-2:] == batch['mask'].shape[-2:] == (256, 256)
-        assert batch['image1'].shape[0] == batch['mask'].shape[0] == 8
+        assert batch['image1'].shape[0] == batch['mask'].shape[0] == 2
         assert batch['image2'].shape[-2:] == batch['mask'].shape[-2:] == (256, 256)
-        assert batch['image2'].shape[0] == batch['mask'].shape[0] == 8
+        assert batch['image2'].shape[0] == batch['mask'].shape[0] == 2
         assert batch['image1'].shape[1] == 3
         assert batch['image2'].shape[1] == 3
 
@@ -117,10 +113,10 @@ class TestLEVIRCDDataModule:
             datamodule.trainer.validating = True
         batch = next(iter(datamodule.val_dataloader()))
         batch = datamodule.on_after_batch_transfer(batch, 0)
-        assert batch['image1'].shape[-2:] == batch['mask'].shape[-2:] == (1024, 1024)
-        assert batch['image1'].shape[0] == batch['mask'].shape[0] == 1
-        assert batch['image2'].shape[-2:] == batch['mask'].shape[-2:] == (1024, 1024)
-        assert batch['image2'].shape[0] == batch['mask'].shape[0] == 1
+        assert batch['image1'].shape[-2:] == batch['mask'].shape[-2:] == (256, 256)
+        assert batch['image1'].shape[0] == batch['mask'].shape[0] == 32
+        assert batch['image2'].shape[-2:] == batch['mask'].shape[-2:] == (256, 256)
+        assert batch['image2'].shape[0] == batch['mask'].shape[0] == 32
         assert batch['image1'].shape[1] == 3
         assert batch['image2'].shape[1] == 3
 
@@ -130,9 +126,9 @@ class TestLEVIRCDDataModule:
             datamodule.trainer.testing = True
         batch = next(iter(datamodule.test_dataloader()))
         batch = datamodule.on_after_batch_transfer(batch, 0)
-        assert batch['image1'].shape[-2:] == batch['mask'].shape[-2:] == (1024, 1024)
-        assert batch['image1'].shape[0] == batch['mask'].shape[0] == 1
-        assert batch['image2'].shape[-2:] == batch['mask'].shape[-2:] == (1024, 1024)
-        assert batch['image2'].shape[0] == batch['mask'].shape[0] == 1
+        assert batch['image1'].shape[-2:] == batch['mask'].shape[-2:] == (256, 256)
+        assert batch['image1'].shape[0] == batch['mask'].shape[0] == 32
+        assert batch['image2'].shape[-2:] == batch['mask'].shape[-2:] == (256, 256)
+        assert batch['image2'].shape[0] == batch['mask'].shape[0] == 32
         assert batch['image1'].shape[1] == 3
         assert batch['image2'].shape[1] == 3

--- a/tests/datamodules/test_oscd.py
+++ b/tests/datamodules/test_oscd.py
@@ -20,8 +20,8 @@ class TestOSCDDataModule:
             root=root,
             download=True,
             bands=bands,
-            batch_size=1,
-            patch_size=2,
+            batch_size=2,
+            patch_size=8,
             val_split_pct=0.5,
             num_workers=0,
         )
@@ -35,9 +35,9 @@ class TestOSCDDataModule:
             datamodule.trainer.training = True
         batch = next(iter(datamodule.train_dataloader()))
         batch = datamodule.on_after_batch_transfer(batch, 0)
-        assert batch['image1'].shape[-2:] == batch['mask'].shape[-2:] == (2, 2)
+        assert batch['image1'].shape[-2:] == batch['mask'].shape[-2:] == (8, 8)
         assert batch['image1'].shape[0] == batch['mask'].shape[0] == 1
-        assert batch['image2'].shape[-2:] == batch['mask'].shape[-2:] == (2, 2)
+        assert batch['image2'].shape[-2:] == batch['mask'].shape[-2:] == (8, 8)
         assert batch['image2'].shape[0] == batch['mask'].shape[0] == 1
         if datamodule.bands == OSCD.all_bands:
             assert batch['image1'].shape[1] == 13
@@ -53,10 +53,10 @@ class TestOSCDDataModule:
         batch = next(iter(datamodule.val_dataloader()))
         batch = datamodule.on_after_batch_transfer(batch, 0)
         if datamodule.val_split_pct > 0.0:
-            assert batch['image1'].shape[-2:] == batch['mask'].shape[-2:] == (2, 2)
-            assert batch['image1'].shape[0] == batch['mask'].shape[0] == 1
-            assert batch['image2'].shape[-2:] == batch['mask'].shape[-2:] == (2, 2)
-            assert batch['image2'].shape[0] == batch['mask'].shape[0] == 1
+            assert batch['image1'].shape[-2:] == batch['mask'].shape[-2:] == (8, 8)
+            assert batch['image1'].shape[0] == batch['mask'].shape[0] == 64
+            assert batch['image2'].shape[-2:] == batch['mask'].shape[-2:] == (8, 8)
+            assert batch['image2'].shape[0] == batch['mask'].shape[0] == 64
             if datamodule.bands == OSCD.all_bands:
                 assert batch['image1'].shape[1] == 13
                 assert batch['image2'].shape[1] == 13
@@ -70,10 +70,10 @@ class TestOSCDDataModule:
             datamodule.trainer.testing = True
         batch = next(iter(datamodule.test_dataloader()))
         batch = datamodule.on_after_batch_transfer(batch, 0)
-        assert batch['image1'].shape[-2:] == batch['mask'].shape[-2:] == (2, 2)
-        assert batch['image1'].shape[0] == batch['mask'].shape[0] == 1
-        assert batch['image2'].shape[-2:] == batch['mask'].shape[-2:] == (2, 2)
-        assert batch['image2'].shape[0] == batch['mask'].shape[0] == 1
+        assert batch['image1'].shape[-2:] == batch['mask'].shape[-2:] == (8, 8)
+        assert batch['image1'].shape[0] == batch['mask'].shape[0] == 64
+        assert batch['image2'].shape[-2:] == batch['mask'].shape[-2:] == (8, 8)
+        assert batch['image2'].shape[0] == batch['mask'].shape[0] == 64
         if datamodule.bands == OSCD.all_bands:
             assert batch['image1'].shape[1] == 13
             assert batch['image2'].shape[1] == 13

--- a/torchgeo/datamodules/inria.py
+++ b/torchgeo/datamodules/inria.py
@@ -6,10 +6,11 @@
 from typing import Any
 
 import kornia.augmentation as K
+from torch import Tensor
 
 from ..datasets import InriaAerialImageLabeling
 from ..samplers.utils import _to_tuple
-from ..transforms.transforms import _RandomNCrop
+from ..transforms.transforms import _ExtractPatches
 from .geo import NonGeoDataModule
 
 
@@ -39,7 +40,12 @@ class InriaAerialImageLabelingDataModule(NonGeoDataModule):
             **kwargs: Additional keyword arguments passed to
                 :class:`~torchgeo.datasets.InriaAerialImageLabeling`.
         """
-        super().__init__(InriaAerialImageLabeling, 1, num_workers, **kwargs)
+        super().__init__(
+            InriaAerialImageLabeling,
+            batch_size=batch_size,
+            num_workers=num_workers,
+            **kwargs,
+        )
 
         self.patch_size = _to_tuple(patch_size)
 
@@ -47,21 +53,23 @@ class InriaAerialImageLabelingDataModule(NonGeoDataModule):
             K.Normalize(mean=self.mean, std=self.std),
             K.RandomHorizontalFlip(p=0.5),
             K.RandomVerticalFlip(p=0.5),
-            _RandomNCrop(self.patch_size, batch_size),
+            K.RandomCrop(self.patch_size, pad_if_needed=True),
             data_keys=None,
             keepdim=True,
         )
         self.aug = K.AugmentationSequential(
             K.Normalize(mean=self.mean, std=self.std),
-            _RandomNCrop(self.patch_size, batch_size),
+            _ExtractPatches(window_size=self.patch_size),
             data_keys=None,
             keepdim=True,
+            same_on_batch=True,
         )
         self.predict_aug = K.AugmentationSequential(
             K.Normalize(mean=self.mean, std=self.std),
-            _RandomNCrop(self.patch_size, batch_size),
+            _ExtractPatches(window_size=self.patch_size),
             data_keys=None,
             keepdim=True,
+            same_on_batch=True,
         )
 
     def setup(self, stage: str) -> None:
@@ -77,3 +85,26 @@ class InriaAerialImageLabelingDataModule(NonGeoDataModule):
         if stage in ['predict']:
             # Test set masks are not public, use for prediction instead
             self.predict_dataset = InriaAerialImageLabeling(split='test', **self.kwargs)
+
+    def on_after_batch_transfer(
+        self, batch: dict[str, Tensor], dataloader_idx: int
+    ) -> dict[str, Tensor]:
+        """Apply batch augmentations to the batch after it is transferred to the device.
+
+        Args:
+            batch: A batch of data that needs to be altered or augmented.
+            dataloader_idx: The index of the dataloader to which the batch belongs.
+
+        Returns:
+            A batch of data.
+
+        .. versionadded:: 0.7
+        """
+        # This solves a special case where if batch_size=1 the mask won't be stacked correctly
+        if 'mask' in batch and batch['mask'].ndim == 3:
+            batch['mask'] = batch['mask'].unsqueeze(0)
+            batch = super().on_after_batch_transfer(batch, dataloader_idx)
+            batch['mask'] = batch['mask'].squeeze(dim=1)
+            return batch
+        else:
+            return super().on_after_batch_transfer(batch, dataloader_idx)

--- a/torchgeo/datamodules/levircd.py
+++ b/torchgeo/datamodules/levircd.py
@@ -11,7 +11,7 @@ from torch.utils.data import random_split
 
 from ..datasets import LEVIRCD, LEVIRCDPlus
 from ..samplers.utils import _to_tuple
-from ..transforms.transforms import _RandomNCrop
+from ..transforms.transforms import _ExtractPatches
 from .geo import NonGeoDataModule
 
 
@@ -38,21 +38,31 @@ class LEVIRCDDataModule(NonGeoDataModule):
             **kwargs: Additional keyword arguments passed to
                 :class:`~torchgeo.datasets.LEVIRCD`.
         """
-        super().__init__(LEVIRCD, 1, num_workers, **kwargs)
+        super().__init__(
+            LEVIRCD, batch_size=batch_size, num_workers=num_workers, **kwargs
+        )
 
         self.patch_size = _to_tuple(patch_size)
 
         self.train_aug = K.AugmentationSequential(
             K.Normalize(mean=self.mean, std=self.std),
-            _RandomNCrop(self.patch_size, batch_size),
+            K.RandomCrop(self.patch_size, pad_if_needed=True),
             data_keys=None,
             keepdim=True,
         )
         self.val_aug = K.AugmentationSequential(
-            K.Normalize(mean=self.mean, std=self.std), data_keys=None, keepdim=True
+            K.Normalize(mean=self.mean, std=self.std),
+            _ExtractPatches(window_size=self.patch_size),
+            data_keys=None,
+            keepdim=True,
+            same_on_batch=True,
         )
         self.test_aug = K.AugmentationSequential(
-            K.Normalize(mean=self.mean, std=self.std), data_keys=None, keepdim=True
+            K.Normalize(mean=self.mean, std=self.std),
+            _ExtractPatches(window_size=self.patch_size),
+            data_keys=None,
+            keepdim=True,
+            same_on_batch=True,
         )
 
 
@@ -84,22 +94,32 @@ class LEVIRCDPlusDataModule(NonGeoDataModule):
             **kwargs: Additional keyword arguments passed to
                 :class:`~torchgeo.datasets.LEVIRCDPlus`.
         """
-        super().__init__(LEVIRCDPlus, 1, num_workers, **kwargs)
+        super().__init__(
+            LEVIRCDPlus, batch_size=batch_size, num_workers=num_workers, **kwargs
+        )
 
         self.patch_size = _to_tuple(patch_size)
         self.val_split_pct = val_split_pct
 
         self.train_aug = K.AugmentationSequential(
             K.Normalize(mean=self.mean, std=self.std),
-            _RandomNCrop(self.patch_size, batch_size),
+            K.RandomCrop(self.patch_size, pad_if_needed=True),
             data_keys=None,
             keepdim=True,
         )
         self.val_aug = K.AugmentationSequential(
-            K.Normalize(mean=self.mean, std=self.std), data_keys=None, keepdim=True
+            K.Normalize(mean=self.mean, std=self.std),
+            _ExtractPatches(window_size=self.patch_size),
+            data_keys=None,
+            keepdim=True,
+            same_on_batch=True,
         )
         self.test_aug = K.AugmentationSequential(
-            K.Normalize(mean=self.mean, std=self.std), data_keys=None, keepdim=True
+            K.Normalize(mean=self.mean, std=self.std),
+            _ExtractPatches(window_size=self.patch_size),
+            data_keys=None,
+            keepdim=True,
+            same_on_batch=True,
         )
 
     def setup(self, stage: str) -> None:

--- a/torchgeo/datamodules/oscd.py
+++ b/torchgeo/datamodules/oscd.py
@@ -131,9 +131,7 @@ class OSCDDataModule(NonGeoDataModule):
         # This solves a special case where if batch_size=1 the mask won't be stacked correctly
         if batch['mask'].ndim == 3:
             batch['mask'] = batch['mask'].unsqueeze(dim=0)
-            batch = super().on_after_batch_transfer(batch, dataloader_idx)
-            batch['mask'] = batch['mask'].squeeze(dim=1)
-            return batch
-        else:
-            batch = super().on_after_batch_transfer(batch, dataloader_idx)
-            return batch
+
+        batch = super().on_after_batch_transfer(batch, dataloader_idx)
+        batch['mask'] = batch['mask'].squeeze(dim=1)
+        return batch

--- a/torchgeo/datamodules/reforestree.py
+++ b/torchgeo/datamodules/reforestree.py
@@ -10,7 +10,6 @@ from torch.utils.data import random_split
 
 from ..datasets import ReforesTree
 from ..samplers.utils import _to_tuple
-from ..transforms.transforms import _RandomNCrop
 from .geo import NonGeoDataModule
 
 
@@ -42,7 +41,9 @@ class ReforesTreeDataModule(NonGeoDataModule):
             **kwargs: Additional keyword arguments passed to
                 :class:`~torchgeo.datasets.ReforesTree`.
         """
-        super().__init__(ReforesTree, 1, num_workers, **kwargs)
+        super().__init__(
+            ReforesTree, batch_size=batch_size, num_workers=num_workers, **kwargs
+        )
 
         self.val_split_pct = val_split_pct
         self.test_split_pct = test_split_pct
@@ -50,7 +51,7 @@ class ReforesTreeDataModule(NonGeoDataModule):
 
         self.train_aug = K.AugmentationSequential(
             K.Normalize(self.mean, self.std),
-            _RandomNCrop(self.patch_size, batch_size),
+            K.RandomCrop(self.patch_size, pad_if_needed=True),
             K.RandomHorizontalFlip(p=0.5),
             K.RandomVerticalFlip(p=0.5),
             data_keys=None,
@@ -59,7 +60,7 @@ class ReforesTreeDataModule(NonGeoDataModule):
 
         self.aug = K.AugmentationSequential(
             K.Normalize(mean=self.mean, std=self.std),
-            _RandomNCrop(self.patch_size, batch_size),
+            K.CenterCrop(self.patch_size),
             data_keys=None,
             keepdim=True,
         )

--- a/torchgeo/datamodules/vaihingen.py
+++ b/torchgeo/datamodules/vaihingen.py
@@ -11,7 +11,7 @@ from torch.utils.data import random_split
 
 from ..datasets import Vaihingen2D
 from ..samplers.utils import _to_tuple
-from ..transforms.transforms import _RandomNCrop
+from ..transforms.transforms import _ExtractPatches
 from .geo import NonGeoDataModule
 
 
@@ -42,16 +42,25 @@ class Vaihingen2DDataModule(NonGeoDataModule):
             **kwargs: Additional keyword arguments passed to
                 :class:`~torchgeo.datasets.Vaihingen2D`.
         """
-        super().__init__(Vaihingen2D, 1, num_workers, **kwargs)
+        super().__init__(
+            Vaihingen2D, batch_size=batch_size, num_workers=num_workers, **kwargs
+        )
 
         self.patch_size = _to_tuple(patch_size)
         self.val_split_pct = val_split_pct
 
-        self.aug = K.AugmentationSequential(
+        self.train_aug = K.AugmentationSequential(
             K.Normalize(mean=self.mean, std=self.std),
-            _RandomNCrop(self.patch_size, batch_size),
+            K.RandomCrop(self.patch_size, pad_if_needed=True),
             data_keys=None,
             keepdim=True,
+        )
+        self.aug = K.AugmentationSequential(
+            K.Normalize(mean=self.mean, std=self.std),
+            _ExtractPatches(window_size=self.patch_size),
+            data_keys=None,
+            keepdim=True,
+            same_on_batch=True,
         )
 
     def setup(self, stage: str) -> None:

--- a/torchgeo/transforms/transforms.py
+++ b/torchgeo/transforms/transforms.py
@@ -19,7 +19,9 @@ class AugmentationSequential(K.AugmentationSequential):
     """Deprecated wrapper around kornia.augmentation.AugmentationSequential."""
 
 
-# TODO: contribute these to Kornia and delete this file
+@deprecated(
+    'Use kornia.augmentation.RandomCrop and torchgeo.transforms._ExtractPatches instead'
+)
 class _RandomNCrop(K.GeometricAugmentationBase2D):
     """Take N random crops of a tensor."""
 
@@ -74,6 +76,9 @@ class _RandomNCrop(K.GeometricAugmentationBase2D):
         return torch.cat(out)
 
 
+@deprecated(
+    'Use kornia.augmentation.RandomCrop and torchgeo.transforms._ExtractPatches instead'
+)
 class _NCropGenerator(K.random_generator.CropGenerator):
     """Generate N random crops."""
 
@@ -110,6 +115,7 @@ class _NCropGenerator(K.random_generator.CropGenerator):
         }
 
 
+# TODO: contribute these to Kornia and delete this file
 class _ExtractPatches(K.GeometricAugmentationBase2D):
     """Extract patches from an image or mask."""
 

--- a/torchgeo/transforms/transforms.py
+++ b/torchgeo/transforms/transforms.py
@@ -9,7 +9,6 @@ import kornia.augmentation as K
 import torch
 from einops import rearrange
 from kornia.contrib import extract_tensor_patches
-from kornia.geometry import crop_by_indices
 from torch import Tensor
 from typing_extensions import deprecated
 
@@ -17,102 +16,6 @@ from typing_extensions import deprecated
 @deprecated('Use kornia.augmentation.AugmentationSequential instead')
 class AugmentationSequential(K.AugmentationSequential):
     """Deprecated wrapper around kornia.augmentation.AugmentationSequential."""
-
-
-@deprecated(
-    'Use kornia.augmentation.RandomCrop and torchgeo.transforms._ExtractPatches instead'
-)
-class _RandomNCrop(K.GeometricAugmentationBase2D):
-    """Take N random crops of a tensor."""
-
-    def __init__(self, size: tuple[int, int], num: int) -> None:
-        """Initialize a new _RandomNCrop instance.
-
-        Args:
-            size: desired output size (out_h, out_w) of the crop
-            num: number of crops to take
-        """
-        super().__init__(p=1)
-        self._param_generator: _NCropGenerator = _NCropGenerator(size, num)
-        self.flags = {'size': size, 'num': num}
-
-    def compute_transformation(
-        self, input: Tensor, params: dict[str, Tensor], flags: dict[str, Any]
-    ) -> Tensor:
-        """Compute the transformation.
-
-        Args:
-            input: the input tensor
-            params: generated parameters
-            flags: static parameters
-
-        Returns:
-            the transformation
-        """
-        out: Tensor = self.identity_matrix(input)
-        return out
-
-    def apply_transform(
-        self,
-        input: Tensor,
-        params: dict[str, Tensor],
-        flags: dict[str, Any],
-        transform: Tensor | None = None,
-    ) -> Tensor:
-        """Apply the transform.
-
-        Args:
-            input: the input tensor
-            params: generated parameters
-            flags: static parameters
-            transform: the geometric transformation tensor
-
-        Returns:
-            the augmented input
-        """
-        out = []
-        for i in range(flags['num']):
-            out.append(crop_by_indices(input, params['src'][i], flags['size']))
-        return torch.cat(out)
-
-
-@deprecated(
-    'Use kornia.augmentation.RandomCrop and torchgeo.transforms._ExtractPatches instead'
-)
-class _NCropGenerator(K.random_generator.CropGenerator):
-    """Generate N random crops."""
-
-    def __init__(self, size: tuple[int, int] | Tensor, num: int) -> None:
-        """Initialize a new _NCropGenerator instance.
-
-        Args:
-            size: desired output size (out_h, out_w) of the crop
-            num: number of crops to generate
-        """
-        super().__init__(size)
-        self.num = num
-
-    def forward(
-        self, batch_shape: tuple[int, ...], same_on_batch: bool = False
-    ) -> dict[str, Tensor]:
-        """Generate the crops.
-
-        Args:
-            batch_shape: input size (b, c?, in_h, in_w)
-            same_on_batch: apply the same transformation across the batch
-
-        Returns:
-            the randomly generated parameters
-        """
-        out = []
-        for _ in range(self.num):
-            out.append(super().forward(batch_shape, same_on_batch))
-        return {
-            'src': torch.stack([x['src'] for x in out]),
-            'dst': torch.stack([x['dst'] for x in out]),
-            'input_size': out[0]['input_size'],
-            'output_size': out[0]['output_size'],
-        }
 
 
 # TODO: contribute these to Kornia and delete this file


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/torchgeo/issues/2667 and refactors `_RandomNCrop` out of segmentation and change detection datamodules in favor of `K.RandomCrop` during training and `ExtractPatches` for val/test/predicting.