### PR TITLE
Models: fix features_only loading, avoid redundant weight tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -43,7 +43,7 @@ jobs:
         run: pip list
       - name: Run pytest checks
         run: |
-          pytest --cov=torchgeo --cov-report=xml
+          pytest --cov=torchgeo --cov-report=xml --durations=10
           python3 -m torchgeo --help
       - name: Report coverage
         uses: codecov/codecov-action@v5.4.0

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -43,7 +43,7 @@ jobs:
         run: pip list
       - name: Run pytest checks
         run: |
-          pytest --cov=torchgeo --cov-report=xml --durations=10
+          pytest --cov=torchgeo --cov-report=xml
           python3 -m torchgeo --help
       - name: Report coverage
         uses: codecov/codecov-action@v5.4.0

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -7,6 +7,7 @@ from _pytest.fixtures import SubRequest
 
 @pytest.fixture(params=[True, False])
 def features_only(request: SubRequest) -> bool:
-    # features_only arg in ViT supported only from timm 1.0.3
-    pytest.importorskip('timm', minversion='1.0.3')
+    if request.param:
+        # features_only arg in ViT supported only from timm 1.0.3
+        pytest.importorskip('timm', minversion='1.0.3')
     return bool(request.param)

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -7,7 +7,6 @@ from _pytest.fixtures import SubRequest
 
 @pytest.fixture(params=[True, False])
 def features_only(request: SubRequest) -> bool:
-    if request.param:
-        # features_only arg in ViT supported only from timm 1.0.3
-        pytest.importorskip('timm', minversion='1.0.3')
+    # features_only arg in ViT supported only from timm 1.0.3
+    pytest.importorskip('timm', minversion='1.0.3')
     return bool(request.param)

--- a/tests/models/test_copernicusfm.py
+++ b/tests/models/test_copernicusfm.py
@@ -125,19 +125,13 @@ class TestCopernicusFMBase:
 
     @pytest.fixture
     def mocked_weights(
-        self,
-        tmp_path: Path,
-        monkeypatch: MonkeyPatch,
-        weights: WeightsEnum,
-        load_state_dict_from_url: None,
+        self, tmp_path: Path, monkeypatch: MonkeyPatch, load_state_dict_from_url: None
     ) -> WeightsEnum:
+        weights = CopernicusFM_Base_Weights.CopernicusFM_ViT
         path = tmp_path / f'{weights}.pth'
         model = copernicusfm_base()
         torch.save(model.state_dict(), path)
-        try:
-            monkeypatch.setattr(weights.value, 'url', str(path))
-        except AttributeError:
-            monkeypatch.setattr(weights, 'url', str(path))
+        monkeypatch.setattr(weights.value, 'url', str(path))
         return weights
 
     def test_copernicusfm_spectral(self) -> None:

--- a/tests/models/test_croma.py
+++ b/tests/models/test_croma.py
@@ -60,19 +60,13 @@ class TestCROMABase:
 
     @pytest.fixture
     def mocked_weights(
-        self,
-        tmp_path: Path,
-        monkeypatch: MonkeyPatch,
-        weights: WeightsEnum,
-        load_state_dict_from_url: None,
+        self, tmp_path: Path, monkeypatch: MonkeyPatch, load_state_dict_from_url: None
     ) -> WeightsEnum:
+        weights = CROMABase_Weights.CROMA_VIT
         path = tmp_path / f'{weights}.pth'
         model = croma_base()
         save_model(model, path)
-        try:
-            monkeypatch.setattr(weights.value, 'url', str(path))
-        except AttributeError:
-            monkeypatch.setattr(weights, 'url', str(path))
+        monkeypatch.setattr(weights.value, 'url', str(path))
         return weights
 
     def test_croma(self) -> None:
@@ -93,19 +87,13 @@ class TestCROMALarge:
 
     @pytest.fixture
     def mocked_weights(
-        self,
-        tmp_path: Path,
-        monkeypatch: MonkeyPatch,
-        weights: WeightsEnum,
-        load_state_dict_from_url: None,
+        self, tmp_path: Path, monkeypatch: MonkeyPatch, load_state_dict_from_url: None
     ) -> WeightsEnum:
+        weights = CROMALarge_Weights.CROMA_VIT
         path = tmp_path / f'{weights}.pth'
         model = croma_large()
         save_model(model, path)
-        try:
-            monkeypatch.setattr(weights.value, 'url', str(path))
-        except AttributeError:
-            monkeypatch.setattr(weights, 'url', str(path))
+        monkeypatch.setattr(weights.value, 'url', str(path))
         return weights
 
     def test_croma(self) -> None:

--- a/tests/models/test_dofa.py
+++ b/tests/models/test_dofa.py
@@ -82,19 +82,13 @@ class TestDOFABase16:
 
     @pytest.fixture
     def mocked_weights(
-        self,
-        tmp_path: Path,
-        monkeypatch: MonkeyPatch,
-        weights: WeightsEnum,
-        load_state_dict_from_url: None,
+        self, tmp_path: Path, monkeypatch: MonkeyPatch, load_state_dict_from_url: None
     ) -> WeightsEnum:
+        weights = DOFABase16_Weights.DOFA_MAE
         path = tmp_path / f'{weights}.pth'
         model = dofa_base_patch16_224()
         torch.save(model.state_dict(), path)
-        try:
-            monkeypatch.setattr(weights.value, 'url', str(path))
-        except AttributeError:
-            monkeypatch.setattr(weights, 'url', str(path))
+        monkeypatch.setattr(weights.value, 'url', str(path))
         return weights
 
     def test_dofa(self) -> None:
@@ -106,12 +100,12 @@ class TestDOFABase16:
     def test_dofa_weights(self, mocked_weights: WeightsEnum) -> None:
         dofa_base_patch16_224(weights=mocked_weights)
 
-    def test_transforms(self, mocked_weights: WeightsEnum) -> None:
+    def test_transforms(self, weights: WeightsEnum) -> None:
         c = 4
         sample = {
             'image': torch.arange(c * 224 * 224, dtype=torch.float).view(c, 224, 224)
         }
-        mocked_weights.transforms(sample)
+        weights.transforms(sample)
 
     @pytest.mark.slow
     def test_dofa_download(self, weights: WeightsEnum) -> None:
@@ -125,19 +119,13 @@ class TestDOFALarge16:
 
     @pytest.fixture
     def mocked_weights(
-        self,
-        tmp_path: Path,
-        monkeypatch: MonkeyPatch,
-        weights: WeightsEnum,
-        load_state_dict_from_url: None,
+        self, tmp_path: Path, monkeypatch: MonkeyPatch, load_state_dict_from_url: None
     ) -> WeightsEnum:
+        weights = DOFALarge16_Weights.DOFA_MAE
         path = tmp_path / f'{weights}.pth'
         model = dofa_large_patch16_224()
         torch.save(model.state_dict(), path)
-        try:
-            monkeypatch.setattr(weights.value, 'url', str(path))
-        except AttributeError:
-            monkeypatch.setattr(weights, 'url', str(path))
+        monkeypatch.setattr(weights.value, 'url', str(path))
         return weights
 
     def test_dofa(self) -> None:
@@ -149,12 +137,12 @@ class TestDOFALarge16:
     def test_dofa_weights(self, mocked_weights: WeightsEnum) -> None:
         dofa_large_patch16_224(weights=mocked_weights)
 
-    def test_transforms(self, mocked_weights: WeightsEnum) -> None:
+    def test_transforms(self, weights: WeightsEnum) -> None:
         c = 4
         sample = {
             'image': torch.arange(c * 224 * 224, dtype=torch.float).view(c, 224, 224)
         }
-        mocked_weights.transforms(sample)
+        weights.transforms(sample)
 
     @pytest.mark.slow
     def test_dofa_download(self, weights: WeightsEnum) -> None:

--- a/tests/models/test_resnet.py
+++ b/tests/models/test_resnet.py
@@ -27,22 +27,13 @@ class TestResNet18:
 
     @pytest.fixture
     def mocked_weights(
-        self,
-        tmp_path: Path,
-        monkeypatch: MonkeyPatch,
-        weights: WeightsEnum,
-        features_only: bool,
-        load_state_dict_from_url: None,
+        self, tmp_path: Path, monkeypatch: MonkeyPatch, load_state_dict_from_url: None
     ) -> WeightsEnum:
+        weights = ResNet18_Weights.SENTINEL2_RGB_MOCO
         path = tmp_path / f'{weights}.pth'
-        model = timm.create_model(
-            'resnet18', in_chans=weights.meta['in_chans'], features_only=features_only
-        )
+        model = timm.create_model('resnet18', in_chans=weights.meta['in_chans'])
         torch.save(model.state_dict(), path)
-        try:
-            monkeypatch.setattr(weights.value, 'url', str(path))
-        except AttributeError:
-            monkeypatch.setattr(weights, 'url', str(path))
+        monkeypatch.setattr(weights.value, 'url', str(path))
         return weights
 
     def test_resnet(self) -> None:
@@ -53,16 +44,16 @@ class TestResNet18:
     ) -> None:
         resnet18(weights=mocked_weights, features_only=features_only)
 
-    def test_bands(self, mocked_weights: WeightsEnum) -> None:
-        if 'bands' in mocked_weights.meta:
-            assert len(mocked_weights.meta['bands']) == mocked_weights.meta['in_chans']
+    def test_bands(self, weights: WeightsEnum) -> None:
+        if 'bands' in weights.meta:
+            assert len(weights.meta['bands']) == weights.meta['in_chans']
 
-    def test_transforms(self, mocked_weights: WeightsEnum) -> None:
-        c = mocked_weights.meta['in_chans']
+    def test_transforms(self, weights: WeightsEnum) -> None:
+        c = weights.meta['in_chans']
         sample = {
             'image': torch.arange(c * 256 * 256, dtype=torch.float).view(c, 256, 256)
         }
-        mocked_weights.transforms(sample)
+        weights.transforms(sample)
 
     @pytest.mark.slow
     def test_resnet_download(self, weights: WeightsEnum) -> None:
@@ -76,22 +67,13 @@ class TestResNet50:
 
     @pytest.fixture
     def mocked_weights(
-        self,
-        tmp_path: Path,
-        monkeypatch: MonkeyPatch,
-        weights: WeightsEnum,
-        features_only: bool,
-        load_state_dict_from_url: None,
+        self, tmp_path: Path, monkeypatch: MonkeyPatch, load_state_dict_from_url: None
     ) -> WeightsEnum:
+        weights = ResNet50_Weights.SENTINEL2_RGB_MOCO
         path = tmp_path / f'{weights}.pth'
-        model = timm.create_model(
-            'resnet50', in_chans=weights.meta['in_chans'], features_only=features_only
-        )
+        model = timm.create_model('resnet50', in_chans=weights.meta['in_chans'])
         torch.save(model.state_dict(), path)
-        try:
-            monkeypatch.setattr(weights.value, 'url', str(path))
-        except AttributeError:
-            monkeypatch.setattr(weights, 'url', str(path))
+        monkeypatch.setattr(weights.value, 'url', str(path))
         return weights
 
     def test_resnet(self) -> None:
@@ -102,16 +84,16 @@ class TestResNet50:
     ) -> None:
         resnet50(weights=mocked_weights, features_only=features_only)
 
-    def test_bands(self, mocked_weights: WeightsEnum) -> None:
-        if 'bands' in mocked_weights.meta:
-            assert len(mocked_weights.meta['bands']) == mocked_weights.meta['in_chans']
+    def test_bands(self, weights: WeightsEnum) -> None:
+        if 'bands' in weights.meta:
+            assert len(weights.meta['bands']) == weights.meta['in_chans']
 
-    def test_transforms(self, mocked_weights: WeightsEnum) -> None:
-        c = mocked_weights.meta['in_chans']
+    def test_transforms(self, weights: WeightsEnum) -> None:
+        c = weights.meta['in_chans']
         sample = {
             'image': torch.arange(c * 256 * 256, dtype=torch.float).view(c, 256, 256)
         }
-        mocked_weights.transforms(sample)
+        weights.transforms(sample)
 
     @pytest.mark.slow
     def test_resnet_download(self, weights: WeightsEnum) -> None:
@@ -125,22 +107,13 @@ class TestResNet152:
 
     @pytest.fixture
     def mocked_weights(
-        self,
-        tmp_path: Path,
-        monkeypatch: MonkeyPatch,
-        weights: WeightsEnum,
-        features_only: bool,
-        load_state_dict_from_url: None,
+        self, tmp_path: Path, monkeypatch: MonkeyPatch, load_state_dict_from_url: None
     ) -> WeightsEnum:
+        weights = ResNet152_Weights.SENTINEL2_SI_RGB_SATLAS
         path = tmp_path / f'{weights}.pth'
-        model = timm.create_model(
-            'resnet152', in_chans=weights.meta['in_chans'], features_only=features_only
-        )
+        model = timm.create_model('resnet152', in_chans=weights.meta['in_chans'])
         torch.save(model.state_dict(), path)
-        try:
-            monkeypatch.setattr(weights.value, 'url', str(path))
-        except AttributeError:
-            monkeypatch.setattr(weights, 'url', str(path))
+        monkeypatch.setattr(weights.value, 'url', str(path))
         return weights
 
     def test_resnet(self) -> None:
@@ -151,16 +124,16 @@ class TestResNet152:
     ) -> None:
         resnet152(weights=mocked_weights, features_only=features_only)
 
-    def test_bands(self, mocked_weights: WeightsEnum) -> None:
-        if 'bands' in mocked_weights.meta:
-            assert len(mocked_weights.meta['bands']) == mocked_weights.meta['in_chans']
+    def test_bands(self, weights: WeightsEnum) -> None:
+        if 'bands' in weights.meta:
+            assert len(weights.meta['bands']) == weights.meta['in_chans']
 
-    def test_transforms(self, mocked_weights: WeightsEnum) -> None:
-        c = mocked_weights.meta['in_chans']
+    def test_transforms(self, weights: WeightsEnum) -> None:
+        c = weights.meta['in_chans']
         sample = {
             'image': torch.arange(c * 256 * 256, dtype=torch.float).view(c, 256, 256)
         }
-        mocked_weights.transforms(sample)
+        weights.transforms(sample)
 
     @pytest.mark.slow
     def test_resnet_download(self, weights: WeightsEnum) -> None:

--- a/tests/models/test_resnet.py
+++ b/tests/models/test_resnet.py
@@ -27,11 +27,19 @@ class TestResNet18:
 
     @pytest.fixture
     def mocked_weights(
-        self, tmp_path: Path, monkeypatch: MonkeyPatch, load_state_dict_from_url: None
+        self,
+        tmp_path: Path,
+        monkeypatch: MonkeyPatch,
+        features_only: bool,
+        load_state_dict_from_url: None,
     ) -> WeightsEnum:
         weights = ResNet18_Weights.SENTINEL2_RGB_MOCO
         path = tmp_path / f'{weights}.pth'
-        model = timm.create_model('resnet18', in_chans=weights.meta['in_chans'])
+        model = timm.create_model(
+            'resnet18',
+            in_chans=weights.meta['in_chans'],
+            features_only=not features_only,
+        )
         torch.save(model.state_dict(), path)
         monkeypatch.setattr(weights.value, 'url', str(path))
         return weights
@@ -67,11 +75,19 @@ class TestResNet50:
 
     @pytest.fixture
     def mocked_weights(
-        self, tmp_path: Path, monkeypatch: MonkeyPatch, load_state_dict_from_url: None
+        self,
+        tmp_path: Path,
+        monkeypatch: MonkeyPatch,
+        features_only: bool,
+        load_state_dict_from_url: None,
     ) -> WeightsEnum:
         weights = ResNet50_Weights.SENTINEL2_RGB_MOCO
         path = tmp_path / f'{weights}.pth'
-        model = timm.create_model('resnet50', in_chans=weights.meta['in_chans'])
+        model = timm.create_model(
+            'resnet50',
+            in_chans=weights.meta['in_chans'],
+            features_only=not features_only,
+        )
         torch.save(model.state_dict(), path)
         monkeypatch.setattr(weights.value, 'url', str(path))
         return weights
@@ -107,11 +123,19 @@ class TestResNet152:
 
     @pytest.fixture
     def mocked_weights(
-        self, tmp_path: Path, monkeypatch: MonkeyPatch, load_state_dict_from_url: None
+        self,
+        tmp_path: Path,
+        monkeypatch: MonkeyPatch,
+        features_only: bool,
+        load_state_dict_from_url: None,
     ) -> WeightsEnum:
         weights = ResNet152_Weights.SENTINEL2_SI_RGB_SATLAS
         path = tmp_path / f'{weights}.pth'
-        model = timm.create_model('resnet152', in_chans=weights.meta['in_chans'])
+        model = timm.create_model(
+            'resnet152',
+            in_chans=weights.meta['in_chans'],
+            features_only=not features_only,
+        )
         torch.save(model.state_dict(), path)
         monkeypatch.setattr(weights.value, 'url', str(path))
         return weights

--- a/tests/models/test_resnet.py
+++ b/tests/models/test_resnet.py
@@ -36,9 +36,7 @@ class TestResNet18:
         weights = ResNet18_Weights.SENTINEL2_RGB_MOCO
         path = tmp_path / f'{weights}.pth'
         model = timm.create_model(
-            'resnet18',
-            in_chans=weights.meta['in_chans'],
-            features_only=not features_only,
+            'resnet18', in_chans=weights.meta['in_chans'], features_only=features_only
         )
         torch.save(model.state_dict(), path)
         monkeypatch.setattr(weights.value, 'url', str(path))
@@ -50,7 +48,7 @@ class TestResNet18:
     def test_resnet_weights(
         self, mocked_weights: WeightsEnum, features_only: bool
     ) -> None:
-        resnet18(weights=mocked_weights, features_only=features_only)
+        resnet18(weights=mocked_weights, features_only=not features_only)
 
     def test_bands(self, weights: WeightsEnum) -> None:
         if 'bands' in weights.meta:
@@ -84,9 +82,7 @@ class TestResNet50:
         weights = ResNet50_Weights.SENTINEL2_RGB_MOCO
         path = tmp_path / f'{weights}.pth'
         model = timm.create_model(
-            'resnet50',
-            in_chans=weights.meta['in_chans'],
-            features_only=not features_only,
+            'resnet50', in_chans=weights.meta['in_chans'], features_only=features_only
         )
         torch.save(model.state_dict(), path)
         monkeypatch.setattr(weights.value, 'url', str(path))
@@ -98,7 +94,7 @@ class TestResNet50:
     def test_resnet_weights(
         self, mocked_weights: WeightsEnum, features_only: bool
     ) -> None:
-        resnet50(weights=mocked_weights, features_only=features_only)
+        resnet50(weights=mocked_weights, features_only=not features_only)
 
     def test_bands(self, weights: WeightsEnum) -> None:
         if 'bands' in weights.meta:
@@ -132,9 +128,7 @@ class TestResNet152:
         weights = ResNet152_Weights.SENTINEL2_SI_RGB_SATLAS
         path = tmp_path / f'{weights}.pth'
         model = timm.create_model(
-            'resnet152',
-            in_chans=weights.meta['in_chans'],
-            features_only=not features_only,
+            'resnet152', in_chans=weights.meta['in_chans'], features_only=features_only
         )
         torch.save(model.state_dict(), path)
         monkeypatch.setattr(weights.value, 'url', str(path))
@@ -146,7 +140,7 @@ class TestResNet152:
     def test_resnet_weights(
         self, mocked_weights: WeightsEnum, features_only: bool
     ) -> None:
-        resnet152(weights=mocked_weights, features_only=features_only)
+        resnet152(weights=mocked_weights, features_only=not features_only)
 
     def test_bands(self, weights: WeightsEnum) -> None:
         if 'bands' in weights.meta:

--- a/tests/models/test_scale_mae.py
+++ b/tests/models/test_scale_mae.py
@@ -19,19 +19,13 @@ class TestScaleMAE:
 
     @pytest.fixture
     def mocked_weights(
-        self,
-        tmp_path: Path,
-        monkeypatch: MonkeyPatch,
-        weights: WeightsEnum,
-        load_state_dict_from_url: None,
+        self, tmp_path: Path, monkeypatch: MonkeyPatch, load_state_dict_from_url: None
     ) -> WeightsEnum:
+        weights = ScaleMAELarge16_Weights.FMOW_RGB
         path = tmp_path / f'{weights}.pth'
         model = scalemae_large_patch16()
         torch.save(model.state_dict(), path)
-        try:
-            monkeypatch.setattr(weights.value, 'url', str(path))
-        except AttributeError:
-            monkeypatch.setattr(weights, 'url', str(path))
+        monkeypatch.setattr(weights.value, 'url', str(path))
         return weights
 
     def test_scalemae(self) -> None:
@@ -46,12 +40,12 @@ class TestScaleMAE:
     def test_scalemae_weights(self, mocked_weights: WeightsEnum) -> None:
         scalemae_large_patch16(weights=mocked_weights)
 
-    def test_transforms(self, mocked_weights: WeightsEnum) -> None:
-        c = mocked_weights.meta['in_chans']
+    def test_transforms(self, weights: WeightsEnum) -> None:
+        c = weights.meta['in_chans']
         sample = {
             'image': torch.arange(c * 224 * 224, dtype=torch.float).view(c, 224, 224)
         }
-        mocked_weights.transforms(sample)
+        weights.transforms(sample)
 
     def test_scalemae_weights_diff_image_size(
         self, mocked_weights: WeightsEnum

--- a/tests/models/test_swin.py
+++ b/tests/models/test_swin.py
@@ -20,12 +20,9 @@ class TestSwin_V2_T:
 
     @pytest.fixture
     def mocked_weights(
-        self,
-        tmp_path: Path,
-        monkeypatch: MonkeyPatch,
-        weights: WeightsEnum,
-        load_state_dict_from_url: None,
+        self, tmp_path: Path, monkeypatch: MonkeyPatch, load_state_dict_from_url: None
     ) -> WeightsEnum:
+        weights = Swin_V2_T_Weights.SENTINEL2_SI_RGB_SATLAS
         path = tmp_path / f'{weights}.pth'
         model = torchvision.models.swin_v2_t()
         num_channels = weights.meta['in_chans']
@@ -34,10 +31,7 @@ class TestSwin_V2_T:
             num_channels, out_channels, kernel_size=(4, 4), stride=(4, 4)
         )
         torch.save(model.state_dict(), path)
-        try:
-            monkeypatch.setattr(weights.value, 'url', str(path))
-        except AttributeError:
-            monkeypatch.setattr(weights, 'url', str(path))
+        monkeypatch.setattr(weights.value, 'url', str(path))
         return weights
 
     def test_swin_v2_t(self) -> None:
@@ -46,16 +40,16 @@ class TestSwin_V2_T:
     def test_swin_v2_t_weights(self, mocked_weights: WeightsEnum) -> None:
         swin_v2_t(weights=mocked_weights)
 
-    def test_bands(self, mocked_weights: WeightsEnum) -> None:
-        if 'bands' in mocked_weights.meta:
-            assert len(mocked_weights.meta['bands']) == mocked_weights.meta['in_chans']
+    def test_bands(self, weights: WeightsEnum) -> None:
+        if 'bands' in weights.meta:
+            assert len(weights.meta['bands']) == weights.meta['in_chans']
 
-    def test_transforms(self, mocked_weights: WeightsEnum) -> None:
-        c = mocked_weights.meta['in_chans']
+    def test_transforms(self, weights: WeightsEnum) -> None:
+        c = weights.meta['in_chans']
         sample = {
             'image': torch.arange(c * 256 * 256, dtype=torch.float).view(c, 256, 256)
         }
-        mocked_weights.transforms(sample)
+        weights.transforms(sample)
 
     @pytest.mark.slow
     def test_swin_v2_t_download(self, weights: WeightsEnum) -> None:
@@ -69,12 +63,9 @@ class TestSwin_V2_B:
 
     @pytest.fixture
     def mocked_weights(
-        self,
-        tmp_path: Path,
-        monkeypatch: MonkeyPatch,
-        weights: WeightsEnum,
-        load_state_dict_from_url: None,
+        self, tmp_path: Path, monkeypatch: MonkeyPatch, load_state_dict_from_url: None
     ) -> WeightsEnum:
+        weights = Swin_V2_B_Weights.SENTINEL1_SI_SATLAS
         path = tmp_path / f'{weights}.pth'
         model = torchvision.models.swin_v2_b()
         num_channels = weights.meta['in_chans']
@@ -83,10 +74,7 @@ class TestSwin_V2_B:
             num_channels, out_channels, kernel_size=(4, 4), stride=(4, 4)
         )
         torch.save(model.state_dict(), path)
-        try:
-            monkeypatch.setattr(weights.value, 'url', str(path))
-        except AttributeError:
-            monkeypatch.setattr(weights, 'url', str(path))
+        monkeypatch.setattr(weights.value, 'url', str(path))
         return weights
 
     def test_swin_v2_b(self) -> None:
@@ -95,16 +83,16 @@ class TestSwin_V2_B:
     def test_swin_v2_b_weights(self, mocked_weights: WeightsEnum) -> None:
         swin_v2_b(weights=mocked_weights)
 
-    def test_bands(self, mocked_weights: WeightsEnum) -> None:
-        if 'bands' in mocked_weights.meta:
-            assert len(mocked_weights.meta['bands']) == mocked_weights.meta['in_chans']
+    def test_bands(self, weights: WeightsEnum) -> None:
+        if 'bands' in weights.meta:
+            assert len(weights.meta['bands']) == weights.meta['in_chans']
 
-    def test_transforms(self, mocked_weights: WeightsEnum) -> None:
-        c = mocked_weights.meta['in_chans']
+    def test_transforms(self, weights: WeightsEnum) -> None:
+        c = weights.meta['in_chans']
         sample = {
             'image': torch.arange(c * 256 * 256, dtype=torch.float).view(c, 256, 256)
         }
-        mocked_weights.transforms(sample)
+        weights.transforms(sample)
 
     @pytest.mark.slow
     def test_swin_v2_b_download(self, weights: WeightsEnum) -> None:

--- a/tests/models/test_vit.py
+++ b/tests/models/test_vit.py
@@ -33,13 +33,20 @@ class TestViTSmall16:
 
     @pytest.fixture
     def mocked_weights(
-        self, tmp_path: Path, monkeypatch: MonkeyPatch, load_state_dict_from_url: None
+        self,
+        tmp_path: Path,
+        monkeypatch: MonkeyPatch,
+        features_only: bool,
+        load_state_dict_from_url: None,
     ) -> WeightsEnum:
         weights = ViTSmall16_Weights.SENTINEL1_GRD_MAE
         path = tmp_path / f'{weights}.pth'
         model = timm.create_model(
-            weights.meta['model'], in_chans=weights.meta['in_chans']
+            weights.meta['model'],
+            in_chans=weights.meta['in_chans'],
+            features_only=not features_only,
         )
+        model = model if features_only else model.model
         torch.save(model.state_dict(), path)
         monkeypatch.setattr(weights.value, 'url', str(path))
         return weights
@@ -75,13 +82,20 @@ class TestViTBase16:
 
     @pytest.fixture
     def mocked_weights(
-        self, tmp_path: Path, monkeypatch: MonkeyPatch, load_state_dict_from_url: None
+        self,
+        tmp_path: Path,
+        monkeypatch: MonkeyPatch,
+        features_only: bool,
+        load_state_dict_from_url: None,
     ) -> WeightsEnum:
         weights = ViTBase16_Weights.SENTINEL1_GRD_MAE
         path = tmp_path / f'{weights}.pth'
         model = timm.create_model(
-            weights.meta['model'], in_chans=weights.meta['in_chans']
+            weights.meta['model'],
+            in_chans=weights.meta['in_chans'],
+            features_only=not features_only,
         )
+        model = model if features_only else model.model
         torch.save(model.state_dict(), path)
         monkeypatch.setattr(weights.value, 'url', str(path))
         return weights
@@ -117,13 +131,20 @@ class TestViTLarge16:
 
     @pytest.fixture
     def mocked_weights(
-        self, tmp_path: Path, monkeypatch: MonkeyPatch, load_state_dict_from_url: None
+        self,
+        tmp_path: Path,
+        monkeypatch: MonkeyPatch,
+        features_only: bool,
+        load_state_dict_from_url: None,
     ) -> WeightsEnum:
         weights = ViTLarge16_Weights.SENTINEL1_GRD_MAE
         path = tmp_path / f'{weights}.pth'
         model = timm.create_model(
-            weights.meta['model'], in_chans=weights.meta['in_chans']
+            weights.meta['model'],
+            in_chans=weights.meta['in_chans'],
+            features_only=not features_only,
         )
+        model = model if features_only else model.model
         torch.save(model.state_dict(), path)
         monkeypatch.setattr(weights.value, 'url', str(path))
         return weights
@@ -159,13 +180,20 @@ class TestViTHuge14:
 
     @pytest.fixture
     def mocked_weights(
-        self, tmp_path: Path, monkeypatch: MonkeyPatch, load_state_dict_from_url: None
+        self,
+        tmp_path: Path,
+        monkeypatch: MonkeyPatch,
+        features_only: bool,
+        load_state_dict_from_url: None,
     ) -> WeightsEnum:
         weights = ViTHuge14_Weights.SENTINEL1_GRD_MAE
         path = tmp_path / f'{weights}.pth'
         model = timm.create_model(
-            weights.meta['model'], in_chans=weights.meta['in_chans']
+            weights.meta['model'],
+            in_chans=weights.meta['in_chans'],
+            features_only=not features_only,
         )
+        model = model if features_only else model.model
         torch.save(model.state_dict(), path)
         monkeypatch.setattr(weights.value, 'url', str(path))
         return weights
@@ -201,7 +229,11 @@ class TestViTSmall14_DINOv2:
 
     @pytest.fixture
     def mocked_weights(
-        self, tmp_path: Path, monkeypatch: MonkeyPatch, load_state_dict_from_url: None
+        self,
+        tmp_path: Path,
+        monkeypatch: MonkeyPatch,
+        features_only: bool,
+        load_state_dict_from_url: None,
     ) -> WeightsEnum:
         weights = ViTSmall14_DINOv2_Weights.SENTINEL1_GRD_SOFTCON
         path = tmp_path / f'{weights}.pth'
@@ -209,7 +241,9 @@ class TestViTSmall14_DINOv2:
             weights.meta['model'],
             in_chans=weights.meta['in_chans'],
             img_size=weights.meta['img_size'],
+            features_only=not features_only,
         )
+        model = model if features_only else model.model
         torch.save(model.state_dict(), path)
         monkeypatch.setattr(weights.value, 'url', str(path))
         return weights
@@ -248,7 +282,11 @@ class TestViTBase14_DINOv2:
 
     @pytest.fixture
     def mocked_weights(
-        self, tmp_path: Path, monkeypatch: MonkeyPatch, load_state_dict_from_url: None
+        self,
+        tmp_path: Path,
+        monkeypatch: MonkeyPatch,
+        features_only: bool,
+        load_state_dict_from_url: None,
     ) -> WeightsEnum:
         weights = ViTBase14_DINOv2_Weights.SENTINEL1_GRD_SOFTCON
         path = tmp_path / f'{weights}.pth'
@@ -256,7 +294,9 @@ class TestViTBase14_DINOv2:
             weights.meta['model'],
             in_chans=weights.meta['in_chans'],
             img_size=weights.meta['img_size'],
+            features_only=not features_only,
         )
+        model = model if features_only else model.model
         torch.save(model.state_dict(), path)
         monkeypatch.setattr(weights.value, 'url', str(path))
         return weights

--- a/tests/models/test_vit.py
+++ b/tests/models/test_vit.py
@@ -44,9 +44,9 @@ class TestViTSmall16:
         model = timm.create_model(
             weights.meta['model'],
             in_chans=weights.meta['in_chans'],
-            features_only=not features_only,
+            features_only=features_only,
         )
-        model = model if features_only else model.model
+        model = model.model if features_only else model
         torch.save(model.state_dict(), path)
         monkeypatch.setattr(weights.value, 'url', str(path))
         return weights
@@ -57,7 +57,7 @@ class TestViTSmall16:
     def test_vit_weights(
         self, mocked_weights: WeightsEnum, features_only: bool
     ) -> None:
-        vit_small_patch16_224(weights=mocked_weights, features_only=features_only)
+        vit_small_patch16_224(weights=mocked_weights, features_only=not features_only)
 
     def test_bands(self, weights: WeightsEnum) -> None:
         if 'bands' in weights.meta:
@@ -93,9 +93,9 @@ class TestViTBase16:
         model = timm.create_model(
             weights.meta['model'],
             in_chans=weights.meta['in_chans'],
-            features_only=not features_only,
+            features_only=features_only,
         )
-        model = model if features_only else model.model
+        model = model.model if features_only else model
         torch.save(model.state_dict(), path)
         monkeypatch.setattr(weights.value, 'url', str(path))
         return weights
@@ -106,7 +106,7 @@ class TestViTBase16:
     def test_vit_weights(
         self, mocked_weights: WeightsEnum, features_only: bool
     ) -> None:
-        vit_base_patch16_224(weights=mocked_weights, features_only=features_only)
+        vit_base_patch16_224(weights=mocked_weights, features_only=not features_only)
 
     def test_bands(self, weights: WeightsEnum) -> None:
         if 'bands' in weights.meta:
@@ -142,9 +142,9 @@ class TestViTLarge16:
         model = timm.create_model(
             weights.meta['model'],
             in_chans=weights.meta['in_chans'],
-            features_only=not features_only,
+            features_only=features_only,
         )
-        model = model if features_only else model.model
+        model = model.model if features_only else model
         torch.save(model.state_dict(), path)
         monkeypatch.setattr(weights.value, 'url', str(path))
         return weights
@@ -155,7 +155,7 @@ class TestViTLarge16:
     def test_vit_weights(
         self, mocked_weights: WeightsEnum, features_only: bool
     ) -> None:
-        vit_large_patch16_224(weights=mocked_weights, features_only=features_only)
+        vit_large_patch16_224(weights=mocked_weights, features_only=not features_only)
 
     def test_bands(self, weights: WeightsEnum) -> None:
         if 'bands' in weights.meta:
@@ -191,9 +191,9 @@ class TestViTHuge14:
         model = timm.create_model(
             weights.meta['model'],
             in_chans=weights.meta['in_chans'],
-            features_only=not features_only,
+            features_only=features_only,
         )
-        model = model if features_only else model.model
+        model = model.model if features_only else model
         torch.save(model.state_dict(), path)
         monkeypatch.setattr(weights.value, 'url', str(path))
         return weights
@@ -204,7 +204,7 @@ class TestViTHuge14:
     def test_vit_weights(
         self, mocked_weights: WeightsEnum, features_only: bool
     ) -> None:
-        vit_huge_patch14_224(weights=mocked_weights, features_only=features_only)
+        vit_huge_patch14_224(weights=mocked_weights, features_only=not features_only)
 
     def test_bands(self, weights: WeightsEnum) -> None:
         if 'bands' in weights.meta:
@@ -241,9 +241,9 @@ class TestViTSmall14_DINOv2:
             weights.meta['model'],
             in_chans=weights.meta['in_chans'],
             img_size=weights.meta['img_size'],
-            features_only=not features_only,
+            features_only=features_only,
         )
-        model = model if features_only else model.model
+        model = model.model if features_only else model
         torch.save(model.state_dict(), path)
         monkeypatch.setattr(weights.value, 'url', str(path))
         return weights
@@ -254,7 +254,9 @@ class TestViTSmall14_DINOv2:
     def test_vit_weights(
         self, mocked_weights: WeightsEnum, features_only: bool
     ) -> None:
-        vit_small_patch14_dinov2(weights=mocked_weights, features_only=features_only)
+        vit_small_patch14_dinov2(
+            weights=mocked_weights, features_only=not features_only
+        )
 
     def test_bands(self, weights: WeightsEnum) -> None:
         if 'bands' in weights.meta:
@@ -294,9 +296,9 @@ class TestViTBase14_DINOv2:
             weights.meta['model'],
             in_chans=weights.meta['in_chans'],
             img_size=weights.meta['img_size'],
-            features_only=not features_only,
+            features_only=features_only,
         )
-        model = model if features_only else model.model
+        model = model.model if features_only else model
         torch.save(model.state_dict(), path)
         monkeypatch.setattr(weights.value, 'url', str(path))
         return weights
@@ -307,7 +309,7 @@ class TestViTBase14_DINOv2:
     def test_vit_weights(
         self, mocked_weights: WeightsEnum, features_only: bool
     ) -> None:
-        vit_base_patch14_dinov2(weights=mocked_weights, features_only=features_only)
+        vit_base_patch14_dinov2(weights=mocked_weights, features_only=not features_only)
 
     def test_bands(self, weights: WeightsEnum) -> None:
         if 'bands' in weights.meta:

--- a/tests/models/test_vit.py
+++ b/tests/models/test_vit.py
@@ -33,25 +33,15 @@ class TestViTSmall16:
 
     @pytest.fixture
     def mocked_weights(
-        self,
-        tmp_path: Path,
-        monkeypatch: MonkeyPatch,
-        weights: WeightsEnum,
-        features_only: bool,
-        load_state_dict_from_url: None,
+        self, tmp_path: Path, monkeypatch: MonkeyPatch, load_state_dict_from_url: None
     ) -> WeightsEnum:
+        weights = ViTSmall16_Weights.SENTINEL1_GRD_MAE
         path = tmp_path / f'{weights}.pth'
         model = timm.create_model(
-            weights.meta['model'],
-            in_chans=weights.meta['in_chans'],
-            features_only=features_only,
+            weights.meta['model'], in_chans=weights.meta['in_chans']
         )
-        target_model = model.model if features_only else model
-        torch.save(target_model.state_dict(), path)
-        try:
-            monkeypatch.setattr(weights.value, 'url', str(path))
-        except AttributeError:
-            monkeypatch.setattr(weights, 'url', str(path))
+        torch.save(model.state_dict(), path)
+        monkeypatch.setattr(weights.value, 'url', str(path))
         return weights
 
     def test_vit(self) -> None:
@@ -62,16 +52,16 @@ class TestViTSmall16:
     ) -> None:
         vit_small_patch16_224(weights=mocked_weights, features_only=features_only)
 
-    def test_bands(self, mocked_weights: WeightsEnum) -> None:
-        if 'bands' in mocked_weights.meta:
-            assert len(mocked_weights.meta['bands']) == mocked_weights.meta['in_chans']
+    def test_bands(self, weights: WeightsEnum) -> None:
+        if 'bands' in weights.meta:
+            assert len(weights.meta['bands']) == weights.meta['in_chans']
 
-    def test_transforms(self, mocked_weights: WeightsEnum) -> None:
-        c = mocked_weights.meta['in_chans']
+    def test_transforms(self, weights: WeightsEnum) -> None:
+        c = weights.meta['in_chans']
         sample = {
             'image': torch.arange(c * 224 * 224, dtype=torch.float).view(c, 224, 224)
         }
-        mocked_weights.transforms(sample)
+        weights.transforms(sample)
 
     @pytest.mark.slow
     def test_vit_download(self, weights: WeightsEnum) -> None:
@@ -85,25 +75,15 @@ class TestViTBase16:
 
     @pytest.fixture
     def mocked_weights(
-        self,
-        tmp_path: Path,
-        monkeypatch: MonkeyPatch,
-        weights: WeightsEnum,
-        features_only: bool,
-        load_state_dict_from_url: None,
+        self, tmp_path: Path, monkeypatch: MonkeyPatch, load_state_dict_from_url: None
     ) -> WeightsEnum:
+        weights = ViTBase16_Weights.SENTINEL1_GRD_MAE
         path = tmp_path / f'{weights}.pth'
         model = timm.create_model(
-            weights.meta['model'],
-            in_chans=weights.meta['in_chans'],
-            features_only=features_only,
+            weights.meta['model'], in_chans=weights.meta['in_chans']
         )
-        target_model = model.model if features_only else model
-        torch.save(target_model.state_dict(), path)
-        try:
-            monkeypatch.setattr(weights.value, 'url', str(path))
-        except AttributeError:
-            monkeypatch.setattr(weights, 'url', str(path))
+        torch.save(model.state_dict(), path)
+        monkeypatch.setattr(weights.value, 'url', str(path))
         return weights
 
     def test_vit(self) -> None:
@@ -114,16 +94,16 @@ class TestViTBase16:
     ) -> None:
         vit_base_patch16_224(weights=mocked_weights, features_only=features_only)
 
-    def test_bands(self, mocked_weights: WeightsEnum) -> None:
-        if 'bands' in mocked_weights.meta:
-            assert len(mocked_weights.meta['bands']) == mocked_weights.meta['in_chans']
+    def test_bands(self, weights: WeightsEnum) -> None:
+        if 'bands' in weights.meta:
+            assert len(weights.meta['bands']) == weights.meta['in_chans']
 
-    def test_transforms(self, mocked_weights: WeightsEnum) -> None:
-        c = mocked_weights.meta['in_chans']
+    def test_transforms(self, weights: WeightsEnum) -> None:
+        c = weights.meta['in_chans']
         sample = {
             'image': torch.arange(c * 224 * 224, dtype=torch.float).view(c, 224, 224)
         }
-        mocked_weights.transforms(sample)
+        weights.transforms(sample)
 
     @pytest.mark.slow
     def test_vit_download(self, weights: WeightsEnum) -> None:
@@ -137,25 +117,15 @@ class TestViTLarge16:
 
     @pytest.fixture
     def mocked_weights(
-        self,
-        tmp_path: Path,
-        monkeypatch: MonkeyPatch,
-        weights: WeightsEnum,
-        features_only: bool,
-        load_state_dict_from_url: None,
+        self, tmp_path: Path, monkeypatch: MonkeyPatch, load_state_dict_from_url: None
     ) -> WeightsEnum:
+        weights = ViTLarge16_Weights.SENTINEL1_GRD_MAE
         path = tmp_path / f'{weights}.pth'
         model = timm.create_model(
-            weights.meta['model'],
-            in_chans=weights.meta['in_chans'],
-            features_only=features_only,
+            weights.meta['model'], in_chans=weights.meta['in_chans']
         )
-        target_model = model.model if features_only else model
-        torch.save(target_model.state_dict(), path)
-        try:
-            monkeypatch.setattr(weights.value, 'url', str(path))
-        except AttributeError:
-            monkeypatch.setattr(weights, 'url', str(path))
+        torch.save(model.state_dict(), path)
+        monkeypatch.setattr(weights.value, 'url', str(path))
         return weights
 
     def test_vit(self) -> None:
@@ -166,16 +136,16 @@ class TestViTLarge16:
     ) -> None:
         vit_large_patch16_224(weights=mocked_weights, features_only=features_only)
 
-    def test_bands(self, mocked_weights: WeightsEnum) -> None:
-        if 'bands' in mocked_weights.meta:
-            assert len(mocked_weights.meta['bands']) == mocked_weights.meta['in_chans']
+    def test_bands(self, weights: WeightsEnum) -> None:
+        if 'bands' in weights.meta:
+            assert len(weights.meta['bands']) == weights.meta['in_chans']
 
-    def test_transforms(self, mocked_weights: WeightsEnum) -> None:
-        c = mocked_weights.meta['in_chans']
+    def test_transforms(self, weights: WeightsEnum) -> None:
+        c = weights.meta['in_chans']
         sample = {
             'image': torch.arange(c * 224 * 224, dtype=torch.float).view(c, 224, 224)
         }
-        mocked_weights.transforms(sample)
+        weights.transforms(sample)
 
     @pytest.mark.slow
     def test_vit_download(self, weights: WeightsEnum) -> None:
@@ -189,25 +159,15 @@ class TestViTHuge14:
 
     @pytest.fixture
     def mocked_weights(
-        self,
-        tmp_path: Path,
-        monkeypatch: MonkeyPatch,
-        weights: WeightsEnum,
-        features_only: bool,
-        load_state_dict_from_url: None,
+        self, tmp_path: Path, monkeypatch: MonkeyPatch, load_state_dict_from_url: None
     ) -> WeightsEnum:
+        weights = ViTHuge14_Weights.SENTINEL1_GRD_MAE
         path = tmp_path / f'{weights}.pth'
         model = timm.create_model(
-            weights.meta['model'],
-            in_chans=weights.meta['in_chans'],
-            features_only=features_only,
+            weights.meta['model'], in_chans=weights.meta['in_chans']
         )
-        target_model = model.model if features_only else model
-        torch.save(target_model.state_dict(), path)
-        try:
-            monkeypatch.setattr(weights.value, 'url', str(path))
-        except AttributeError:
-            monkeypatch.setattr(weights, 'url', str(path))
+        torch.save(model.state_dict(), path)
+        monkeypatch.setattr(weights.value, 'url', str(path))
         return weights
 
     def test_vit(self) -> None:
@@ -218,16 +178,16 @@ class TestViTHuge14:
     ) -> None:
         vit_huge_patch14_224(weights=mocked_weights, features_only=features_only)
 
-    def test_bands(self, mocked_weights: WeightsEnum) -> None:
-        if 'bands' in mocked_weights.meta:
-            assert len(mocked_weights.meta['bands']) == mocked_weights.meta['in_chans']
+    def test_bands(self, weights: WeightsEnum) -> None:
+        if 'bands' in weights.meta:
+            assert len(weights.meta['bands']) == weights.meta['in_chans']
 
-    def test_transforms(self, mocked_weights: WeightsEnum) -> None:
-        c = mocked_weights.meta['in_chans']
+    def test_transforms(self, weights: WeightsEnum) -> None:
+        c = weights.meta['in_chans']
         sample = {
             'image': torch.arange(c * 224 * 224, dtype=torch.float).view(c, 224, 224)
         }
-        mocked_weights.transforms(sample)
+        weights.transforms(sample)
 
     @pytest.mark.slow
     def test_vit_download(self, weights: WeightsEnum) -> None:
@@ -241,26 +201,17 @@ class TestViTSmall14_DINOv2:
 
     @pytest.fixture
     def mocked_weights(
-        self,
-        tmp_path: Path,
-        monkeypatch: MonkeyPatch,
-        weights: WeightsEnum,
-        features_only: bool,
-        load_state_dict_from_url: None,
+        self, tmp_path: Path, monkeypatch: MonkeyPatch, load_state_dict_from_url: None
     ) -> WeightsEnum:
+        weights = ViTSmall14_DINOv2_Weights.SENTINEL1_GRD_SOFTCON
         path = tmp_path / f'{weights}.pth'
         model = timm.create_model(
             weights.meta['model'],
             in_chans=weights.meta['in_chans'],
             img_size=weights.meta['img_size'],
-            features_only=features_only,
         )
-        target_model = model.model if features_only else model
-        torch.save(target_model.state_dict(), path)
-        try:
-            monkeypatch.setattr(weights.value, 'url', str(path))
-        except AttributeError:
-            monkeypatch.setattr(weights, 'url', str(path))
+        torch.save(model.state_dict(), path)
+        monkeypatch.setattr(weights.value, 'url', str(path))
         return weights
 
     def test_vit(self) -> None:
@@ -271,19 +222,19 @@ class TestViTSmall14_DINOv2:
     ) -> None:
         vit_small_patch14_dinov2(weights=mocked_weights, features_only=features_only)
 
-    def test_bands(self, mocked_weights: WeightsEnum) -> None:
-        if 'bands' in mocked_weights.meta:
-            assert len(mocked_weights.meta['bands']) == mocked_weights.meta['in_chans']
+    def test_bands(self, weights: WeightsEnum) -> None:
+        if 'bands' in weights.meta:
+            assert len(weights.meta['bands']) == weights.meta['in_chans']
 
-    def test_transforms(self, mocked_weights: WeightsEnum) -> None:
-        c = mocked_weights.meta['in_chans']
-        img_size = mocked_weights.meta['img_size']
+    def test_transforms(self, weights: WeightsEnum) -> None:
+        c = weights.meta['in_chans']
+        img_size = weights.meta['img_size']
         if isinstance(img_size, int):
             h = w = img_size
         else:
             h, w = img_size
         sample = {'image': torch.arange(c * h * w, dtype=torch.float).view(c, h, w)}
-        mocked_weights.transforms(sample)
+        weights.transforms(sample)
 
     @pytest.mark.slow
     def test_vit_download(self, weights: WeightsEnum) -> None:
@@ -297,26 +248,17 @@ class TestViTBase14_DINOv2:
 
     @pytest.fixture
     def mocked_weights(
-        self,
-        tmp_path: Path,
-        monkeypatch: MonkeyPatch,
-        weights: WeightsEnum,
-        features_only: bool,
-        load_state_dict_from_url: None,
+        self, tmp_path: Path, monkeypatch: MonkeyPatch, load_state_dict_from_url: None
     ) -> WeightsEnum:
+        weights = ViTBase14_DINOv2_Weights.SENTINEL1_GRD_SOFTCON
         path = tmp_path / f'{weights}.pth'
         model = timm.create_model(
             weights.meta['model'],
             in_chans=weights.meta['in_chans'],
             img_size=weights.meta['img_size'],
-            features_only=features_only,
         )
-        target_model = model.model if features_only else model
-        torch.save(target_model.state_dict(), path)
-        try:
-            monkeypatch.setattr(weights.value, 'url', str(path))
-        except AttributeError:
-            monkeypatch.setattr(weights, 'url', str(path))
+        torch.save(model.state_dict(), path)
+        monkeypatch.setattr(weights.value, 'url', str(path))
         return weights
 
     def test_vit(self) -> None:
@@ -327,19 +269,19 @@ class TestViTBase14_DINOv2:
     ) -> None:
         vit_base_patch14_dinov2(weights=mocked_weights, features_only=features_only)
 
-    def test_bands(self, mocked_weights: WeightsEnum) -> None:
-        if 'bands' in mocked_weights.meta:
-            assert len(mocked_weights.meta['bands']) == mocked_weights.meta['in_chans']
+    def test_bands(self, weights: WeightsEnum) -> None:
+        if 'bands' in weights.meta:
+            assert len(weights.meta['bands']) == weights.meta['in_chans']
 
-    def test_transforms(self, mocked_weights: WeightsEnum) -> None:
-        c = mocked_weights.meta['in_chans']
-        img_size = mocked_weights.meta['img_size']
+    def test_transforms(self, weights: WeightsEnum) -> None:
+        c = weights.meta['in_chans']
+        img_size = weights.meta['img_size']
         if isinstance(img_size, int):
             h = w = img_size
         else:
             h, w = img_size
         sample = {'image': torch.arange(c * h * w, dtype=torch.float).view(c, h, w)}
-        mocked_weights.transforms(sample)
+        weights.transforms(sample)
 
     @pytest.mark.slow
     def test_vit_download(self, weights: WeightsEnum) -> None:

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -806,7 +806,7 @@ def resnet18(
             weights.get_state_dict(progress=True), strict=False
         )
         assert set(missing_keys) <= {'fc.weight', 'fc.bias'}
-        assert not unexpected_keys
+        assert set(unexpected_keys) <= {'fc.weight', 'fc.bias'}
 
     return model
 

--- a/torchgeo/models/vit.py
+++ b/torchgeo/models/vit.py
@@ -598,7 +598,12 @@ def vit_small_patch16_224(
         )
         assert set(missing_keys) <= {'head.weight', 'head.bias'}
         # used when features_only = True
-        assert set(unexpected_keys) <= {'norm.weight', 'norm.bias'}
+        assert set(unexpected_keys) <= {
+            'norm.weight',
+            'norm.bias',
+            'head.weight',
+            'head.bias',
+        }
 
     return model
 
@@ -641,7 +646,12 @@ def vit_base_patch16_224(
             weights.get_state_dict(progress=True), strict=False
         )
         assert set(missing_keys) <= {'head.weight', 'head.bias'}
-        assert set(unexpected_keys) <= {'norm.weight', 'norm.bias'}
+        assert set(unexpected_keys) <= {
+            'norm.weight',
+            'norm.bias',
+            'head.weight',
+            'head.bias',
+        }
 
     return model
 
@@ -684,7 +694,12 @@ def vit_large_patch16_224(
             weights.get_state_dict(progress=True), strict=False
         )
         assert set(missing_keys) <= {'head.weight', 'head.bias'}
-        assert set(unexpected_keys) <= {'norm.weight', 'norm.bias'}
+        assert set(unexpected_keys) <= {
+            'norm.weight',
+            'norm.bias',
+            'head.weight',
+            'head.bias',
+        }
 
     return model
 
@@ -727,7 +742,12 @@ def vit_huge_patch14_224(
             weights.get_state_dict(progress=True), strict=False
         )
         assert set(missing_keys) <= {'head.weight', 'head.bias'}
-        assert set(unexpected_keys) <= {'norm.weight', 'norm.bias'}
+        assert set(unexpected_keys) <= {
+            'norm.weight',
+            'norm.bias',
+            'head.weight',
+            'head.bias',
+        }
 
     return model
 

--- a/torchgeo/models/vit.py
+++ b/torchgeo/models/vit.py
@@ -46,6 +46,8 @@ _ssl4eo_l_transforms = K.AugmentationSequential(
 # Can be removed once torchvision>=0.15 is required
 Weights.__deepcopy__ = lambda *args, **kwargs: args[0]
 
+KEYS = {'norm.weight', 'norm.bias', 'head.weight', 'head.bias'}
+
 
 class ViTSmall16_Weights(WeightsEnum):  # type: ignore[misc]
     """Vision Transformer Small Patch Size 16 weights.
@@ -596,14 +598,9 @@ def vit_small_patch16_224(
         missing_keys, unexpected_keys = target_model.load_state_dict(
             weights.get_state_dict(progress=True), strict=False
         )
-        assert set(missing_keys) <= {'head.weight', 'head.bias'}
+        assert set(missing_keys) <= KEYS
         # used when features_only = True
-        assert set(unexpected_keys) <= {
-            'norm.weight',
-            'norm.bias',
-            'head.weight',
-            'head.bias',
-        }
+        assert set(unexpected_keys) <= KEYS
 
     return model
 
@@ -645,13 +642,8 @@ def vit_base_patch16_224(
         missing_keys, unexpected_keys = target_model.load_state_dict(
             weights.get_state_dict(progress=True), strict=False
         )
-        assert set(missing_keys) <= {'head.weight', 'head.bias'}
-        assert set(unexpected_keys) <= {
-            'norm.weight',
-            'norm.bias',
-            'head.weight',
-            'head.bias',
-        }
+        assert set(missing_keys) <= KEYS
+        assert set(unexpected_keys) <= KEYS
 
     return model
 
@@ -693,13 +685,8 @@ def vit_large_patch16_224(
         missing_keys, unexpected_keys = target_model.load_state_dict(
             weights.get_state_dict(progress=True), strict=False
         )
-        assert set(missing_keys) <= {'head.weight', 'head.bias'}
-        assert set(unexpected_keys) <= {
-            'norm.weight',
-            'norm.bias',
-            'head.weight',
-            'head.bias',
-        }
+        assert set(missing_keys) <= KEYS
+        assert set(unexpected_keys) <= KEYS
 
     return model
 
@@ -741,13 +728,8 @@ def vit_huge_patch14_224(
         missing_keys, unexpected_keys = target_model.load_state_dict(
             weights.get_state_dict(progress=True), strict=False
         )
-        assert set(missing_keys) <= {'head.weight', 'head.bias'}
-        assert set(unexpected_keys) <= {
-            'norm.weight',
-            'norm.bias',
-            'head.weight',
-            'head.bias',
-        }
+        assert set(missing_keys) <= KEYS
+        assert set(unexpected_keys) <= KEYS
 
     return model
 
@@ -790,8 +772,8 @@ def vit_small_patch14_dinov2(
         missing_keys, unexpected_keys = target_model.load_state_dict(
             weights.get_state_dict(progress=True), strict=False
         )
-        assert set(missing_keys) <= {'head.weight', 'head.bias'}
-        assert set(unexpected_keys) <= {'norm.weight', 'norm.bias'}
+        assert set(missing_keys) <= KEYS
+        assert set(unexpected_keys) <= KEYS
 
     return model
 
@@ -834,7 +816,7 @@ def vit_base_patch14_dinov2(
         missing_keys, unexpected_keys = target_model.load_state_dict(
             weights.get_state_dict(progress=True), strict=False
         )
-        assert set(missing_keys) <= {'head.weight', 'head.bias'}
-        assert set(unexpected_keys) <= {'norm.weight', 'norm.bias'}
+        assert set(missing_keys) <= KEYS
+        assert set(unexpected_keys) <= KEYS
 
     return model


### PR DESCRIPTION
TorchGeo now has a whopping 93 builtin pre-trained model weights. These weights have become prohibitively expensive to test, resulting in a significant slowdown and intermittent test failures. This PR is designed to resolve this issue.

### Before

At the moment, we test all model weights roughly 6 times: with `features_only` True and False, and for weight-loading, bands, and transforms. This means we are instantiating and saving large models to disk (sometimes as large as ViT-H) $$93 \times 6 = 576$$ times per OS, per Python version, and per commit. This adds up very quickly:

```console
> pytest tests/models/
...
==== 666 passed, 93 deselected in 926.76s (0:15:26) ====
```

### After

We apply the following changes to reduce the amount of testing:

- [x] We only test a single weight per enum instead of all weights (93 -> 17)
- [x] We use the builtin weights instead of mocked weights when testing bands and transforms (6 -> 2)

The result is still 100% test coverage, with all weights still being tested on the release branch, but significantly less compute time and storage requirements for the average CI run:

```console
> pytest tests/models/
...
==== 380 passed, 93 deselected in 200.63s (0:03:20) ====
```
That's an 80% decrease, and shaves off 12 min from every test run!

One other change is to create our test weights without considering `features_only` but test that those weights can be loaded with or without `features_only`. This caught several bugs in #2659 @lccol

P.S. There is likely still opportunity to further speed this up by converting the fixtures from function to class scope, but `monkeypatch` and `tmp_path` do not support this.