### PR TITLE
Bump TorchGeo version to 0.8.0.dev0

### DIFF
--- a/torchgeo/__init__.py
+++ b/torchgeo/__init__.py
@@ -11,4 +11,4 @@ common image transformations for geospatial data.
 """
 
 __author__ = 'Adam J. Stewart'
-__version__ = '0.7.0'
+__version__ = '0.8.0.dev0'


### PR DESCRIPTION
With a little luck (and a lot of planning), this next release may be 1.0.0 instead of 0.8.0 🙂 