### PR TITLE
Adopt PEP 639 license metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
-    # setuptools 77+ required for PEP 639 support
-    "setuptools>=77",
+    # setuptools 77.0.1+ required for PEP 639 support
+    "setuptools>=77.0.1",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
-    # setuptools 61+ required for pyproject.toml support
-    "setuptools>=61",
+    # setuptools 77+ required for PEP 639 support
+    "setuptools>=77",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -11,7 +11,7 @@ name = "torchgeo"
 description = "TorchGeo: datasets, samplers, transforms, and pre-trained models for geospatial data"
 readme = "README.md"
 requires-python = ">=3.11"
-license = {file = "LICENSE"}
+license = "MIT"
 authors = [
     {name = "Adam J. Stewart", email = "ajstewart426@gmail.com"},
 ]
@@ -26,7 +26,6 @@ keywords = ["pytorch", "deep learning", "machine learning", "remote sensing", "s
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",

--- a/requirements/min-reqs.old
+++ b/requirements/min-reqs.old
@@ -1,5 +1,5 @@
 # setup
-setuptools==61.0.0
+setuptools==77.0.0
 
 # install
 einops==0.3.0

--- a/requirements/min-reqs.old
+++ b/requirements/min-reqs.old
@@ -1,5 +1,5 @@
 # setup
-setuptools==77.0.0
+setuptools==77.0.1
 
 # install
 einops==0.3.0


### PR DESCRIPTION
[PEP 639](https://peps.python.org/pep-0639/) introduces a standard way of representing [licenses](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files) via their [SPDX identifiers](https://spdx.org/licenses/). [Setuptools 77](https://setuptools.pypa.io/en/stable/history.html#v77-0-0) adds support for this. The previous syntax is deprecated, and setuptools issues the following warnings:
```
********************************************************************************
Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

By 2026-Feb-18, you need to update your project and remove deprecated calls
or your builds will no longer be supported.

See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
********************************************************************************

********************************************************************************
Please consider removing the following classifiers in favor of a SPDX license expression:

License :: OSI Approved :: MIT License

See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
********************************************************************************
```
Note that setuptools 77 is extremely new (only a few weeks old). I don't think this will cause any issues since pip separately resolves build deps, but something to consider.