### PR TITLE
CopernicusFM: ensure test metadata is always within range

### DIFF
--- a/tests/models/test_copernicusfm.py
+++ b/tests/models/test_copernicusfm.py
@@ -137,7 +137,7 @@ class TestCopernicusFMBase:
     def test_copernicusfm_spectral(self) -> None:
         model = copernicusfm_base()
         x = torch.rand(1, 4, 28, 28)
-        metadata = torch.rand(1, 4)
+        metadata = torch.rand(1, 4) + 1
         wavelengths = [664.6, 559.8, 492.4, 832.8]
         bandwidths = [31, 36, 66, 106]
         input_mode = 'spectral'
@@ -152,7 +152,7 @@ class TestCopernicusFMBase:
     def test_copernicusfm_variable(self) -> None:
         model = copernicusfm_base()
         x = torch.rand(1, 1, 96, 96)
-        metadata = torch.rand(1, 4)
+        metadata = torch.rand(1, 4) + 1
         language_embed = torch.rand(2048)
         input_mode = 'variable'
         model(x, metadata, language_embed=language_embed, input_mode=input_mode)


### PR DESCRIPTION
@robmarkcole encountered the following issue in #2707:
```
FAILED tests/models/test_copernicusfm.py::TestCopernicusFMBase::test_copernicusfm_variable - AssertionError: The input tensor is not within the configured range `[0.001, 510000000.0]`.
```
The problem is that random numbers between 0 and 1 are sometimes 0, which is outside the valid range. This PR adds 1 to ensure that it is always in range.