### PR TITLE
Related Libraries: DeepForest used to support TensorFlow

### DIFF
--- a/docs/user/alternatives.rst
+++ b/docs/user/alternatives.rst
@@ -26,7 +26,7 @@ Features
    :header-rows: 1
    :widths: auto
 
-\*Support for TensorFlow was dropped in Raster Vision 0.12.
+\*Support was dropped in newer releases.
 
 **ML Backend**: The machine learning libraries used by the project. For example, if you are a scikit-learn user, eo-learn may be perfect for you, but if you need more advanced deep learning support, you may want to choose a different library.
 

--- a/docs/user/metrics/features.csv
+++ b/docs/user/metrics/features.csv
@@ -2,7 +2,7 @@ Library,ML Backend,I/O Backend,Spatial Backend,Transform Backend,Datasets,Weight
 `TorchGeo`_,PyTorch,"GDAL, h5py, laspy, NetCDF4, OpenCV, pandas, pillow, scipy, xarray",R-tree,Kornia,125,93,✅,❌,✅,❌,🚧
 `eo-learn`_,scikit-learn,"GDAL, OpenCV, pandas, scipy, Zarr",geopandas,numpy,0,0,❌,❌,✅,❌,🚧
 `Raster Vision`_,"PyTorch, TensorFlow*","GDAL, OpenCV, pandas, pillow, scipy, xarray",STAC,Albumentations,0,6,✅,❌,✅,✅,🚧
-`DeepForest`_,PyTorch,"GDAL, OpenCV, pandas, pillow, scipy",R-tree,Albumentations,0,4,❌,❌,❌,❌,❌
+`DeepForest`_,"PyTorch, TensorFlow*","GDAL, OpenCV, pandas, pillow, scipy",R-tree,Albumentations,0,4,❌,❌,❌,❌,❌
 `samgeo`_,PyTorch,"GDAL, OpenCV, pandas, xarray",geopandas,numpy,0,0,❌,✅,✅,❌,❌
 `TerraTorch`_,PyTorch,"GDAL, h5py, pandas, xarray",R-tree,Albumentations,27,1,✅,❌,✅,❌,🚧
 `SITS`_,R Torch,GDAL,-,tidyverse,22,0,❌,❌,✅,✅,✅


### PR DESCRIPTION
Just discovered that DeepForest 0.X was TensorFlow-based and transitioned to PyTorch in 1.X: https://github.com/weecology/DeepForest/releases/tag/1.0.0

Should we continue to document historical support, or should we only document the latest backend? For example, TorchGeo is planning on switching from R-tree to geopandas.