### PR TITLE
ObjectDetection/InstanceSegmentationTask: fix support for non-RGB images

### DIFF
--- a/tests/conf/vhr10_ins_seg.yaml
+++ b/tests/conf/vhr10_ins_seg.yaml
@@ -9,6 +9,6 @@ data:
   init_args:
     batch_size: 1
     num_workers: 0
-    patch_size: 4
+    patch_size: 256
   dict_kwargs:
     root: 'tests/data/vhr10'

--- a/tests/trainers/test_detection.py
+++ b/tests/trainers/test_detection.py
@@ -5,6 +5,7 @@ import os
 from typing import Any
 
 import pytest
+import torch
 from lightning.pytorch import Trainer
 from pytest import MonkeyPatch
 
@@ -122,3 +123,14 @@ class TestObjectDetectionTask:
             model=model_name, backbone='resnet18', freeze_backbone=True
         )
         assert not all([param.requires_grad for param in model.model.parameters()])
+
+    @pytest.mark.parametrize('model_name', ['faster-rcnn', 'fcos', 'retinanet'])
+    def test_multispectral_support(self, model_name: str) -> None:
+        channels = 4
+        model = ObjectDetectionTask(
+            model=model_name, backbone='resnet18', num_classes=2, in_channels=channels
+        )
+        model.eval()
+        sample = [torch.randn(channels, 224, 224)]
+        with torch.inference_mode():
+            model(sample)

--- a/tests/trainers/test_detection.py
+++ b/tests/trainers/test_detection.py
@@ -125,12 +125,15 @@ class TestObjectDetectionTask:
         assert not all([param.requires_grad for param in model.model.parameters()])
 
     @pytest.mark.parametrize('model_name', ['faster-rcnn', 'fcos', 'retinanet'])
-    def test_multispectral_support(self, model_name: str) -> None:
-        channels = 4
+    @pytest.mark.parametrize('in_channels', [1, 4])
+    def test_multispectral_support(self, model_name: str, in_channels: int) -> None:
         model = ObjectDetectionTask(
-            model=model_name, backbone='resnet18', num_classes=2, in_channels=channels
+            model=model_name,
+            backbone='resnet18',
+            num_classes=2,
+            in_channels=in_channels,
         )
         model.eval()
-        sample = [torch.randn(channels, 224, 224)]
+        sample = [torch.randn(in_channels, 224, 224)]
         with torch.inference_mode():
             model(sample)

--- a/tests/trainers/test_instance_segmentation.py
+++ b/tests/trainers/test_instance_segmentation.py
@@ -5,6 +5,7 @@ import os
 from typing import Any
 
 import pytest
+import torch
 from lightning.pytorch import Trainer
 from pytest import MonkeyPatch
 
@@ -123,3 +124,11 @@ class TestInstanceSegmentationTask:
         for head in ['rpn', 'roi_heads']:
             for param in getattr(task.model, head).parameters():
                 assert param.requires_grad is True
+
+    @pytest.mark.parametrize('in_channels', [1, 4])
+    def test_multispectral_support(self, in_channels: int) -> None:
+        model = InstanceSegmentationTask(in_channels=in_channels, num_classes=2)
+        model.eval()
+        sample = [torch.randn(in_channels, 224, 224)]
+        with torch.inference_mode():
+            model(sample)

--- a/torchgeo/trainers/detection.py
+++ b/torchgeo/trainers/detection.py
@@ -151,8 +151,8 @@ class ObjectDetectionTask(BaseTask):
                 num_classes,
                 rpn_anchor_generator=anchor_generator,
                 box_roi_pool=roi_pooler,
-                min_size=1,
-                max_size=4096,
+                min_size=800,
+                max_size=800,
                 image_mean=[0],
                 image_std=[1],
             )
@@ -176,8 +176,8 @@ class ObjectDetectionTask(BaseTask):
                 model_backbone,
                 num_classes,
                 anchor_generator=anchor_generator,
-                min_size=1,
-                max_size=4096,
+                min_size=800,
+                max_size=800,
                 image_mean=[0],
                 image_std=[1],
             )
@@ -214,8 +214,8 @@ class ObjectDetectionTask(BaseTask):
                 num_classes,
                 anchor_generator=anchor_generator,
                 head=head,
-                min_size=1,
-                max_size=4096,
+                min_size=800,
+                max_size=800,
                 image_mean=[0],
                 image_std=[1],
             )

--- a/torchgeo/trainers/detection.py
+++ b/torchgeo/trainers/detection.py
@@ -75,6 +75,9 @@ class ObjectDetectionTask(BaseTask):
     ) -> None:
         """Initialize a new ObjectDetectionTask instance.
 
+        Note that we disable the internal normalize+resize transform of the detection models.
+        Please ensure your images are appropriately resized before passing them to the model.
+
         Args:
             model: Name of the `torchvision
                 <https://pytorch.org/vision/stable/models.html#object-detection>`__

--- a/torchgeo/trainers/detection.py
+++ b/torchgeo/trainers/detection.py
@@ -24,6 +24,7 @@ from torchvision.ops import MultiScaleRoIAlign, feature_pyramid_network, misc
 
 from ..datasets import RGBBandsMissingError, unbind_samples
 from .base import BaseTask
+from .utils import GeneralizedRCNNTransformNoOp
 
 BACKBONE_LAT_DIM_MAP = {
     'resnet18': 512,
@@ -151,11 +152,8 @@ class ObjectDetectionTask(BaseTask):
                 num_classes,
                 rpn_anchor_generator=anchor_generator,
                 box_roi_pool=roi_pooler,
-                min_size=800,
-                max_size=800,
-                image_mean=[0],
-                image_std=[1],
             )
+            self.model.transform = GeneralizedRCNNTransformNoOp()
         elif model == 'fcos':
             kwargs['extra_blocks'] = feature_pyramid_network.LastLevelP6P7(256, 256)
             kwargs['norm_layer'] = (
@@ -173,14 +171,9 @@ class ObjectDetectionTask(BaseTask):
                     param.requires_grad = False
 
             self.model = torchvision.models.detection.FCOS(
-                model_backbone,
-                num_classes,
-                anchor_generator=anchor_generator,
-                min_size=800,
-                max_size=800,
-                image_mean=[0],
-                image_std=[1],
+                model_backbone, num_classes, anchor_generator=anchor_generator
             )
+            self.model.transform = GeneralizedRCNNTransformNoOp()
         elif model == 'retinanet':
             kwargs['extra_blocks'] = feature_pyramid_network.LastLevelP6P7(
                 latent_dim, 256
@@ -214,11 +207,8 @@ class ObjectDetectionTask(BaseTask):
                 num_classes,
                 anchor_generator=anchor_generator,
                 head=head,
-                min_size=800,
-                max_size=800,
-                image_mean=[0],
-                image_std=[1],
             )
+            self.model.transform = GeneralizedRCNNTransformNoOp()
         else:
             raise ValueError(f"Model type '{model}' is not valid.")
 

--- a/torchgeo/trainers/detection.py
+++ b/torchgeo/trainers/detection.py
@@ -151,6 +151,10 @@ class ObjectDetectionTask(BaseTask):
                 num_classes,
                 rpn_anchor_generator=anchor_generator,
                 box_roi_pool=roi_pooler,
+                min_size=1,
+                max_size=4096,
+                image_mean=[0],
+                image_std=[1],
             )
         elif model == 'fcos':
             kwargs['extra_blocks'] = feature_pyramid_network.LastLevelP6P7(256, 256)
@@ -169,7 +173,13 @@ class ObjectDetectionTask(BaseTask):
                     param.requires_grad = False
 
             self.model = torchvision.models.detection.FCOS(
-                model_backbone, num_classes, anchor_generator=anchor_generator
+                model_backbone,
+                num_classes,
+                anchor_generator=anchor_generator,
+                min_size=1,
+                max_size=4096,
+                image_mean=[0],
+                image_std=[1],
             )
         elif model == 'retinanet':
             kwargs['extra_blocks'] = feature_pyramid_network.LastLevelP6P7(
@@ -204,6 +214,10 @@ class ObjectDetectionTask(BaseTask):
                 num_classes,
                 anchor_generator=anchor_generator,
                 head=head,
+                min_size=1,
+                max_size=4096,
+                image_mean=[0],
+                image_std=[1],
             )
         else:
             raise ValueError(f"Model type '{model}' is not valid.")

--- a/torchgeo/trainers/instance_segmentation.py
+++ b/torchgeo/trainers/instance_segmentation.py
@@ -22,6 +22,7 @@ from torchvision.models.detection import (
 
 from ..datasets import RGBBandsMissingError, unbind_samples
 from .base import BaseTask
+from .utils import GeneralizedRCNNTransformNoOp
 
 
 class InstanceSegmentationTask(BaseTask):
@@ -46,6 +47,9 @@ class InstanceSegmentationTask(BaseTask):
         freeze_backbone: bool = False,
     ) -> None:
         """Initialize a new InstanceSegmentationTask instance.
+
+        Note that we disable the internal normalize+resize transform of the MaskRCNN model.
+        Please ensure your images are appropriately resized before passing them to the model.
 
         Args:
             model: Name of the model to use.
@@ -87,11 +91,10 @@ class InstanceSegmentationTask(BaseTask):
                     weights=weights,
                     num_classes=num_classes,
                     weights_backbone=weights_backbone,
-                    min_size=800,
-                    max_size=800,
                     image_mean=[0],
                     image_std=[1],
                 )
+                self.model.transform = GeneralizedRCNNTransformNoOp()
             else:
                 msg = f"Invalid backbone type '{backbone}'. Supported backbone: 'resnet50'"
                 raise ValueError(msg)

--- a/torchgeo/trainers/instance_segmentation.py
+++ b/torchgeo/trainers/instance_segmentation.py
@@ -91,8 +91,6 @@ class InstanceSegmentationTask(BaseTask):
                     weights=weights,
                     num_classes=num_classes,
                     weights_backbone=weights_backbone,
-                    image_mean=[0],
-                    image_std=[1],
                 )
                 self.model.transform = GeneralizedRCNNTransformNoOp()
             else:

--- a/torchgeo/trainers/instance_segmentation.py
+++ b/torchgeo/trainers/instance_segmentation.py
@@ -87,6 +87,10 @@ class InstanceSegmentationTask(BaseTask):
                     weights=weights,
                     num_classes=num_classes,
                     weights_backbone=weights_backbone,
+                    min_size=1,
+                    max_size=4096,
+                    image_mean=[0],
+                    image_std=[1],
                 )
             else:
                 msg = f"Invalid backbone type '{backbone}'. Supported backbone: 'resnet50'"

--- a/torchgeo/trainers/instance_segmentation.py
+++ b/torchgeo/trainers/instance_segmentation.py
@@ -87,8 +87,8 @@ class InstanceSegmentationTask(BaseTask):
                     weights=weights,
                     num_classes=num_classes,
                     weights_backbone=weights_backbone,
-                    min_size=1,
-                    max_size=4096,
+                    min_size=800,
+                    max_size=800,
                     image_mean=[0],
                     image_std=[1],
                 )

--- a/torchgeo/trainers/utils.py
+++ b/torchgeo/trainers/utils.py
@@ -14,7 +14,7 @@ from torch.nn.modules import Conv2d, Module
 from torchvision.models.detection.transform import GeneralizedRCNNTransform
 
 
-class GeneralizedRCNNTransformNoOp(GeneralizedRCNNTransform):
+class GeneralizedRCNNTransformNoOp(GeneralizedRCNNTransform):  # type: ignore[misc]
     """GeneralizedRCNNTransform without the normalize and resize ops.
 
     .. versionadded:: 0.8

--- a/torchgeo/trainers/utils.py
+++ b/torchgeo/trainers/utils.py
@@ -17,7 +17,7 @@ from torchvision.models.detection.transform import GeneralizedRCNNTransform
 class GeneralizedRCNNTransformNoOp(GeneralizedRCNNTransform):  # type: ignore[misc]
     """GeneralizedRCNNTransform without the normalize and resize ops.
 
-    .. versionadded:: 0.7.1
+    .. versionadded:: 0.8
     """
 
     def __init__(self) -> None:

--- a/torchgeo/trainers/utils.py
+++ b/torchgeo/trainers/utils.py
@@ -17,7 +17,7 @@ from torchvision.models.detection.transform import GeneralizedRCNNTransform
 class GeneralizedRCNNTransformNoOp(GeneralizedRCNNTransform):  # type: ignore[misc]
     """GeneralizedRCNNTransform without the normalize and resize ops.
 
-    .. versionadded:: 0.8
+    .. versionadded:: 0.7.1
     """
 
     def __init__(self) -> None:

--- a/torchgeo/trainers/utils.py
+++ b/torchgeo/trainers/utils.py
@@ -11,6 +11,24 @@ import torch
 import torch.nn as nn
 from torch import Tensor
 from torch.nn.modules import Conv2d, Module
+from torchvision.models.detection.transform import GeneralizedRCNNTransform
+
+
+class GeneralizedRCNNTransformNoOp(GeneralizedRCNNTransform):
+    """GeneralizedRCNNTransform without the normalize and resize ops.
+
+    .. versionadded:: 0.8
+    """
+
+    def __init__(self) -> None:
+        """Initialize a new GeneralizedRCNNTransformNoOp instance."""
+        super().__init__(min_size=0, max_size=0, image_mean=[0], image_std=[1])
+
+    def resize(
+        self, image: Tensor, target: dict[str, Tensor] | None = None
+    ) -> tuple[Tensor, dict[str, Tensor] | None]:
+        """Skip resizing and return the image and target."""
+        return image, target
 
 
 def extract_backbone(path: str) -> tuple[str, 'OrderedDict[str, Tensor]']:


### PR DESCRIPTION
One of the wonderful surprises of torchvision's detector models is that a `GeneralizedRCNNTransform` gets added under the hood which defaults to ImageNet RGB mean/std normalize + dynamic resizing in the range of (800, 1333).

This PR fixes this by loading pretrained weights but overriding this transform to simply subtract 0 and divide by 1 which is a no-op and changes the dynamic resize to allow for a min/max input shape in the range of (1, 4096).


#### Alternatives considered:
I attempted to simply replace `model.transform` with `nn.Identity()` but this doesn't work because the detection models pass multiple args to the transform which will throw an error.

Fixes #2749