### PR TITLE
Samplers: yield instead of return

### DIFF
--- a/torchgeo/samplers/batch.py
+++ b/torchgeo/samplers/batch.py
@@ -50,7 +50,7 @@ class BatchGeoSampler(Sampler[list[BoundingBox]], abc.ABC):
     def __iter__(self) -> Iterator[list[BoundingBox]]:
         """Return a batch of indices of a dataset.
 
-        Returns:
+        Yields:
             batch of (minx, maxx, miny, maxy, mint, maxt) coordinates to index a dataset
         """
 
@@ -139,7 +139,7 @@ class RandomBatchGeoSampler(BatchGeoSampler):
     def __iter__(self) -> Iterator[list[BoundingBox]]:
         """Return the indices of a dataset.
 
-        Returns:
+        Yields:
             batch of (minx, maxx, miny, maxy, mint, maxt) coordinates to index a dataset
         """
         for _ in range(len(self)):

--- a/torchgeo/samplers/single.py
+++ b/torchgeo/samplers/single.py
@@ -51,7 +51,7 @@ class GeoSampler(Sampler[BoundingBox], abc.ABC):
     def __iter__(self) -> Iterator[BoundingBox]:
         """Return the index of a dataset.
 
-        Returns:
+        Yields:
             (minx, maxx, miny, maxy, mint, maxt) coordinates to index a dataset
         """
 
@@ -140,7 +140,7 @@ class RandomGeoSampler(GeoSampler):
     def __iter__(self) -> Iterator[BoundingBox]:
         """Return the index of a dataset.
 
-        Returns:
+        Yields:
             (minx, maxx, miny, maxy, mint, maxt) coordinates to index a dataset
         """
         for _ in range(len(self)):
@@ -237,7 +237,7 @@ class GridGeoSampler(GeoSampler):
     def __iter__(self) -> Iterator[BoundingBox]:
         """Return the index of a dataset.
 
-        Returns:
+        Yields:
             (minx, maxx, miny, maxy, mint, maxt) coordinates to index a dataset
         """
         # For each tile...
@@ -315,7 +315,7 @@ class PreChippedGeoSampler(GeoSampler):
     def __iter__(self) -> Iterator[BoundingBox]:
         """Return the index of a dataset.
 
-        Returns:
+        Yields:
             (minx, maxx, miny, maxy, mint, maxt) coordinates to index a dataset
         """
         generator: Callable[[int], Iterable[int]] = range


### PR DESCRIPTION
The `__iter__` method does not "return", it "yields". Change the docstring to account for this.