### PR TITLE
Plot Method Added to Western USA Live Fuel Moisture Dataset

### DIFF
--- a/tests/datasets/test_western_usa_live_fuel_moisture.py
+++ b/tests/datasets/test_western_usa_live_fuel_moisture.py
@@ -4,9 +4,11 @@
 import os
 from pathlib import Path
 
+import matplotlib.pyplot as plt
 import pytest
 import torch
 import torch.nn as nn
+from matplotlib.figure import Figure
 from pytest import MonkeyPatch
 
 from torchgeo.datasets import DatasetNotFoundError, WesternUSALiveFuelMoisture
@@ -40,3 +42,16 @@ class TestWesternUSALiveFuelMoisture:
     def test_not_downloaded(self, tmp_path: Path) -> None:
         with pytest.raises(DatasetNotFoundError, match='Dataset not found'):
             WesternUSALiveFuelMoisture(tmp_path)
+
+    def test_plot(self, dataset: WesternUSALiveFuelMoisture) -> None:
+        sample = dataset[0]
+
+        # Test with a single variable - likely one of the missing lines
+        fig = dataset.plot(sample, variables_to_plot=['vv'])
+        assert isinstance(fig, Figure)
+        plt.close()
+
+        # Test with both suptitle and show_titles=False
+        fig = dataset.plot(sample, show_titles=False, suptitle='Custom title')
+        assert isinstance(fig, Figure)
+        plt.close()

--- a/torchgeo/datasets/western_usa_live_fuel_moisture.py
+++ b/torchgeo/datasets/western_usa_live_fuel_moisture.py
@@ -359,16 +359,16 @@ class WesternUSALiveFuelMoisture(NonGeoDataset):
         lat = input_data[-1]
         lfmc_value = sample['label'].item()
 
-        axs[-1].text(
+        fig.text(
             x=0.5,
-            y=-0.6,
+            y=-0.05,
             s=f'Live Fuel Moisture Content\nat {lon:.4f}, {lat:.4f}: {lfmc_value:.2f}%',
             ha='center',
-            transform=axs[-1].transAxes,
+            transform=fig.transFigure,
         )
 
         if suptitle is not None:
-            fig.suptitle(t=suptitle, y=1.5, fontsize=12, transform=axs[0].transAxes)
+            fig.suptitle(t=suptitle, y=1, fontsize=12, transform=fig.transFigure)
 
         fig.tight_layout()
 


### PR DESCRIPTION
- Relevant issue: https://github.com/microsoft/torchgeo/issues/2377
- Added plot method to Western USA Live Fuel Moisture dataset.
- Added test case for the plot method

This is how the plot looks like
# Default plot
```python
from torchgeo.datasets import WesternUSALiveFuelMoisture
data = WesternUSALiveFuelMoisture('path/to/data')
sample = data[0]
f = data.plot(
    sample,
    show_titles=True, suptitle='test suptitle'
)
```
![image](https://github.com/user-attachments/assets/d8571c0a-0474-43b8-8d6e-f2a45a80fea0)

# Single variable defined
```python
f = data.plot(
    sample,
    variables_to_plot=['slope'],
    show_titles=True, suptitle='test suptitle'
)
```
![image](https://github.com/user-attachments/assets/2e775598-3a3b-4a08-9db0-5f4708211d1e)


# Multiple variables defined
```python
f = data.plot(
    sample,
    variables_to_plot=[
        'slope',
        'green',
        'swir'
    ],
    show_titles=True, suptitle='test suptitle'
)
```
![image](https://github.com/user-attachments/assets/995cb4e7-cfd2-4cb1-8664-b1d319fce28e)
