### PR TITLE
CLI: silence jsonargparse deprecation warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -258,7 +258,7 @@ filterwarnings = [
     # https://github.com/pydantic/pydantic/pull/11377
     "ignore:Failing to pass a value to the 'type_params' parameter of 'typing.*' is deprecated:DeprecationWarning:pydantic",
     # https://github.com/Lightning-AI/pytorch-lightning/pull/20802
-    "ignore:set_config_read_mode was deprecated in v4.39.0 and will be removed in v5.0.0:jsonargparse.JsonargparseDeprecationWarning:lightning.pytorch.cli",
+    "ignore:set_config_read_mode was deprecated in v4.39.0 and will be removed in v5.0.0:DeprecationWarning",
 
     # Expected warnings
     # Lightning warns us about using num_workers=0, but it's faster on macOS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -258,7 +258,7 @@ filterwarnings = [
     # https://github.com/pydantic/pydantic/pull/11377
     "ignore:Failing to pass a value to the 'type_params' parameter of 'typing.*' is deprecated:DeprecationWarning:pydantic",
     # https://github.com/Lightning-AI/pytorch-lightning/pull/20802
-    "ignore:set_config_read_mode was deprecated in v4.39.0 and will be removed in v5.0.0:DeprecationWarning",
+    "ignore::jsonargparse._deprecated.JsonargparseDeprecationWarning:lightning.pytorch.cli",
 
     # Expected warnings
     # Lightning warns us about using num_workers=0, but it's faster on macOS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,6 +257,8 @@ filterwarnings = [
     "ignore:__array_wrap__ must accept context and return_scalar arguments:DeprecationWarning",
     # https://github.com/pydantic/pydantic/pull/11377
     "ignore:Failing to pass a value to the 'type_params' parameter of 'typing.*' is deprecated:DeprecationWarning:pydantic",
+    # https://github.com/Lightning-AI/pytorch-lightning/pull/20802
+    "ignore:set_config_read_mode was deprecated in v4.39.0 and will be removed in v5.0.0:DeprecationWarning:lightning.pytorch.cli",
 
     # Expected warnings
     # Lightning warns us about using num_workers=0, but it's faster on macOS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -258,7 +258,7 @@ filterwarnings = [
     # https://github.com/pydantic/pydantic/pull/11377
     "ignore:Failing to pass a value to the 'type_params' parameter of 'typing.*' is deprecated:DeprecationWarning:pydantic",
     # https://github.com/Lightning-AI/pytorch-lightning/pull/20802
-    "ignore:set_config_read_mode was deprecated in v4.39.0 and will be removed in v5.0.0:DeprecationWarning:lightning.pytorch.cli",
+    "ignore:set_config_read_mode was deprecated in v4.39.0 and will be removed in v5.0.0:jsonargparse.JsonargparseDeprecationWarning:lightning.pytorch.cli",
 
     # Expected warnings
     # Lightning warns us about using num_workers=0, but it's faster on macOS


### PR DESCRIPTION
Silences the following CI warning in main:
```
../../../../../opt/hostedtoolcache/Python/3.13.3/x64/lib/python3.13/site-packages/lightning/pytorch/cli.py:52
  /opt/hostedtoolcache/Python/3.13.3/x64/lib/python3.13/site-packages/lightning/pytorch/cli.py:52: 
      By default only one JsonargparseDeprecationWarning per type is shown. To see all warnings set environment
      variable JSONARGPARSE_DEPRECATION_WARNINGS=all and to disable the warnings set
      JSONARGPARSE_DEPRECATION_WARNINGS=off.

../../../../../opt/hostedtoolcache/Python/3.13.3/x64/lib/python3.13/site-packages/lightning/pytorch/cli.py:52
  /opt/hostedtoolcache/Python/3.13.3/x64/lib/python3.13/site-packages/lightning/pytorch/cli.py:52: 
      set_config_read_mode was deprecated in v4.39.0 and will be removed in v5.0.0. Optional config read modes
      should now be set using function set_parsing_settings.
```