### PR TITLE
SemanticSegmentationTask: pretrained ViT weights are now supported

### DIFF
--- a/torchgeo/trainers/segmentation.py
+++ b/torchgeo/trainers/segmentation.py
@@ -53,8 +53,7 @@ class SemanticSegmentationTask(BaseTask):
             weights: Initial model weights. Either a weight enum, the string
                 representation of a weight enum, True for ImageNet weights, False or
                 None for random weights, or the path to a saved model state dict. FCN
-                model does not support pretrained weights. Pretrained ViT weight enums
-                are not supported yet.
+                model does not support pretrained weights.
             in_channels: Number of input channels to model.
             task: One of 'binary', 'multiclass', or 'multilabel'.
             num_classes: Number of prediction classes (only for ``task='multiclass'``).


### PR DESCRIPTION
Still needs to be tested, but SMP now supports ViT backbones, so there _should_ be no reason why this isn't true.