### PR TITLE
Improve numeric stability of QR losses

### DIFF
--- a/torchgeo/losses/qr.py
+++ b/torchgeo/losses/qr.py
@@ -31,7 +31,7 @@ class QRLoss(Module):
         q_bar = q.mean(dim=(0, 2, 3))
         qbar_log_S = (q_bar * torch.log(q_bar)).sum()
 
-        q_log_p = torch.einsum('bcxy,bcxy->bxy', q, torch.log(target)).mean()
+        q_log_p = torch.einsum('bcxy,bcxy->bxy', q, torch.log(target + 1e-12)).mean()
 
         loss = qbar_log_S - q_log_p
         return loss
@@ -62,6 +62,6 @@ class RQLoss(Module):
         z = q / q.norm(p=1, dim=(0, 2, 3), keepdim=True).clamp_min(1e-12).expand_as(q)
         r = F.normalize(z * target, p=1, dim=1)
 
-        loss = torch.einsum('bcxy,bcxy->bxy', r, torch.log(r) - torch.log(q)).mean()
+        loss = torch.einsum('bcxy,bcxy->bxy', r, torch.log(r + 1e-12) - torch.log(q + 1e-12)).mean()
 
         return loss


### PR DESCRIPTION
These loss functions sometimes return `nan` values when r or q are 0.

This adds a small epsilon before the log transform to prevent undefined values. 