### PR TITLE
GeoDataset: add support for slicing

### DIFF
--- a/docs/api/datasets.rst
+++ b/docs/api/datasets.rst
@@ -660,8 +660,6 @@ UnionDataset
 Utilities
 ---------
 
-.. autoclass:: BoundingBox
-
 Collation Functions
 ^^^^^^^^^^^^^^^^^^^
 

--- a/docs/api/datasets.rst
+++ b/docs/api/datasets.rst
@@ -660,6 +660,8 @@ UnionDataset
 Utilities
 ---------
 
+.. autoclass:: BoundingBox
+
 Collation Functions
 ^^^^^^^^^^^^^^^^^^^
 

--- a/docs/tutorials/torchgeo.ipynb
+++ b/docs/tutorials/torchgeo.ipynb
@@ -71,11 +71,10 @@
     "import os\n",
     "import tempfile\n",
     "\n",
-    "import pandas as pd\n",
     "from matplotlib import pyplot as plt\n",
     "from torch.utils.data import DataLoader\n",
     "\n",
-    "from torchgeo.datasets import CDL, BoundingBox, Landsat7, Landsat8, stack_samples\n",
+    "from torchgeo.datasets import CDL, Landsat7, Landsat8, stack_samples\n",
     "from torchgeo.datasets.utils import download_and_extract_archive\n",
     "from torchgeo.samplers import GridGeoSampler, RandomGeoSampler"
    ]
@@ -289,11 +288,8 @@
     "xmax = xmin + size * 30\n",
     "ymin = 4470000\n",
     "ymax = ymin + size * 30\n",
-    "tmin = pd.Timestamp(2023, 1, 1)\n",
-    "tmax = pd.Timestamp(2023, 12, 31)\n",
     "\n",
-    "bbox = BoundingBox(xmin, xmax, ymin, ymax, tmin, tmax)\n",
-    "sample = dataset[bbox]\n",
+    "sample = dataset[xmin:xmax, ymin:ymax]\n",
     "\n",
     "landsat8.plot(sample)\n",
     "cdl.plot(sample)\n",
@@ -315,7 +311,7 @@
    "source": [
     "## Samplers\n",
     "\n",
-    "The above `BoundingBox` makes it easy to index into complex datasets consisting of hundreds of files. However, it is a bit cumbersome to manually construct these queries every time, especially if we want thousands or even millions of bounding boxes. Luckily, TorchGeo provides a `GeoSampler` class to construct these for us."
+    "The above slice makes it easy to index into complex datasets consisting of hundreds of files. However, it is a bit cumbersome to manually construct these queries every time, especially if we want thousands or even millions of bounding boxes. Luckily, TorchGeo provides a `GeoSampler` class to construct these for us."
    ]
   },
   {

--- a/tests/datamodules/test_geo.py
+++ b/tests/datamodules/test_geo.py
@@ -20,7 +20,8 @@ from torchgeo.datamodules import (
     MisconfigurationException,
     NonGeoDataModule,
 )
-from torchgeo.datasets import BoundingBox, GeoDataset, NonGeoDataset
+from torchgeo.datasets import GeoDataset, NonGeoDataset
+from torchgeo.datasets.utils import GeoSlice
 from torchgeo.samplers import RandomBatchGeoSampler, RandomGeoSampler
 
 MINT = pd.Timestamp(2025, 4, 24)
@@ -37,7 +38,7 @@ class CustomGeoDataset(GeoDataset):
         self.index = GeoDataFrame(index=index, geometry=geometry, crs=crs)
         self.res = (1, 1)
 
-    def __getitem__(self, query: BoundingBox) -> dict[str, Any]:
+    def __getitem__(self, query: GeoSlice) -> dict[str, Any]:
         image = torch.arange(3 * 2 * 2, dtype=torch.float).view(3, 2, 2)
         return {'image': image, 'crs': self.index.crs, 'bounds': query}
 

--- a/tests/datasets/test_agrifieldnet.py
+++ b/tests/datasets/test_agrifieldnet.py
@@ -72,7 +72,9 @@ class TestAgriFieldNet:
         plt.close()
 
     def test_invalid_query(self, dataset: AgriFieldNet) -> None:
-        with pytest.raises(IndexError, match='key: .* not found in index with bounds:'):
+        with pytest.raises(
+            IndexError, match='query: .* not found in index with bounds:'
+        ):
             dataset[0:0, 0:0, pd.Timestamp.min : pd.Timestamp.min]
 
     def test_rgb_bands_absent_plot(self, dataset: AgriFieldNet) -> None:

--- a/tests/datasets/test_agrifieldnet.py
+++ b/tests/datasets/test_agrifieldnet.py
@@ -33,8 +33,7 @@ class TestAgriFieldNet:
         return AgriFieldNet(tmp_path, transforms=transforms, download=True)
 
     def test_getitem(self, dataset: AgriFieldNet) -> None:
-        xmin, xmax, ymin, ymax, tmin, tmax = dataset.bounds
-        x = dataset[xmin:xmax, ymin:ymax, tmin:tmax]
+        x = dataset[dataset.bounds]
         assert isinstance(x, dict)
         assert isinstance(x['crs'], CRS)
         assert isinstance(x['image'], torch.Tensor)
@@ -59,14 +58,12 @@ class TestAgriFieldNet:
             AgriFieldNet(tmp_path)
 
     def test_plot(self, dataset: AgriFieldNet) -> None:
-        xmin, xmax, ymin, ymax, tmin, tmax = dataset.bounds
-        x = dataset[xmin:xmax, ymin:ymax, tmin:tmax]
+        x = dataset[dataset.bounds]
         dataset.plot(x, suptitle='Test')
         plt.close()
 
     def test_plot_prediction(self, dataset: AgriFieldNet) -> None:
-        xmin, xmax, ymin, ymax, tmin, tmax = dataset.bounds
-        x = dataset[xmin:xmax, ymin:ymax, tmin:tmax]
+        x = dataset[dataset.bounds]
         x['prediction'] = x['mask'].clone()
         dataset.plot(x, suptitle='Prediction')
         plt.close()
@@ -82,7 +79,6 @@ class TestAgriFieldNet:
             RGBBandsMissingError, match='Dataset does not contain some of the RGB bands'
         ):
             ds = AgriFieldNet(dataset.paths, bands=['B01', 'B02', 'B05'])
-            xmin, xmax, ymin, ymax, tmin, tmax = dataset.bounds
-            x = dataset[xmin:xmax, ymin:ymax, tmin:tmax]
+            x = ds[ds.bounds]
             ds.plot(x, suptitle='Test')
             plt.close()

--- a/tests/datasets/test_airphen.py
+++ b/tests/datasets/test_airphen.py
@@ -13,7 +13,6 @@ from pyproj import CRS
 
 from torchgeo.datasets import (
     Airphen,
-    BoundingBox,
     DatasetNotFoundError,
     IntersectionDataset,
     RGBBandsMissingError,
@@ -56,11 +55,10 @@ class TestAirphen:
             Airphen(tmp_path)
 
     def test_invalid_query(self, dataset: Airphen) -> None:
-        query = BoundingBox(0, 0, 0, 0, pd.Timestamp.min, pd.Timestamp.min)
         with pytest.raises(
             IndexError, match='query: .* not found in index with bounds:'
         ):
-            dataset[query]
+            dataset[0:0, 0:0, pd.Timestamp.min : pd.Timestamp.min]
 
     def test_plot_wrong_bands(self, dataset: Airphen) -> None:
         bands = ('B1', 'B2', 'B3')

--- a/tests/datasets/test_astergdem.py
+++ b/tests/datasets/test_astergdem.py
@@ -14,7 +14,6 @@ from pyproj import CRS
 
 from torchgeo.datasets import (
     AsterGDEM,
-    BoundingBox,
     DatasetNotFoundError,
     IntersectionDataset,
     UnionDataset,
@@ -67,8 +66,7 @@ class TestAsterGDEM:
         plt.close()
 
     def test_invalid_query(self, dataset: AsterGDEM) -> None:
-        query = BoundingBox(100, 100, 100, 100, pd.Timestamp.min, pd.Timestamp.min)
         with pytest.raises(
             IndexError, match='query: .* not found in index with bounds:'
         ):
-            dataset[query]
+            dataset[100:100, 100:100, pd.Timestamp.min : pd.Timestamp.min]

--- a/tests/datasets/test_cbf.py
+++ b/tests/datasets/test_cbf.py
@@ -13,7 +13,6 @@ from pyproj import CRS
 from pytest import MonkeyPatch
 
 from torchgeo.datasets import (
-    BoundingBox,
     CanadianBuildingFootprints,
     DatasetNotFoundError,
     IntersectionDataset,
@@ -77,8 +76,7 @@ class TestCanadianBuildingFootprints:
             CanadianBuildingFootprints(tmp_path)
 
     def test_invalid_query(self, dataset: CanadianBuildingFootprints) -> None:
-        query = BoundingBox(2, 2, 2, 2, pd.Timestamp.min, pd.Timestamp.min)
         with pytest.raises(
             IndexError, match='query: .* not found in index with bounds:'
         ):
-            dataset[query]
+            dataset[2:2, 2:2, pd.Timestamp.min : pd.Timestamp.min]

--- a/tests/datasets/test_cdl.py
+++ b/tests/datasets/test_cdl.py
@@ -16,7 +16,6 @@ from pytest import MonkeyPatch
 
 from torchgeo.datasets import (
     CDL,
-    BoundingBox,
     DatasetNotFoundError,
     IntersectionDataset,
     UnionDataset,
@@ -70,9 +69,8 @@ class TestCDL:
         assert isinstance(ds, UnionDataset)
 
     def test_full_year(self, dataset: CDL) -> None:
-        bbox = dataset.bounds
         time = pd.Timestamp(2023, 6, 1)
-        query = BoundingBox(bbox.minx, bbox.maxx, bbox.miny, bbox.maxy, time, time)
+        query = (dataset.bounds[0], dataset.bounds[1], slice(time, time))
         dataset[query]
 
     def test_already_extracted(self, dataset: CDL) -> None:
@@ -117,8 +115,7 @@ class TestCDL:
             CDL(tmp_path)
 
     def test_invalid_query(self, dataset: CDL) -> None:
-        query = BoundingBox(0, 0, 0, 0, pd.Timestamp.min, pd.Timestamp.min)
         with pytest.raises(
             IndexError, match='query: .* not found in index with bounds:'
         ):
-            dataset[query]
+            dataset[0:0, 0:0, pd.Timestamp.min : pd.Timestamp.min]

--- a/tests/datasets/test_chesapeake.py
+++ b/tests/datasets/test_chesapeake.py
@@ -15,7 +15,6 @@ from pyproj import CRS
 from pytest import MonkeyPatch
 
 from torchgeo.datasets import (
-    BoundingBox,
     ChesapeakeCVPR,
     ChesapeakeDC,
     DatasetNotFoundError,
@@ -84,11 +83,10 @@ class TestChesapeakeDC:
         plt.close()
 
     def test_invalid_query(self, dataset: ChesapeakeDC) -> None:
-        query = BoundingBox(0, 0, 0, 0, pd.Timestamp.min, pd.Timestamp.min)
         with pytest.raises(
             IndexError, match='query: .* not found in index with bounds:'
         ):
-            dataset[query]
+            dataset[0:0, 0:0, pd.Timestamp.min : pd.Timestamp.min]
 
 
 class TestChesapeakeCVPR:
@@ -192,11 +190,10 @@ class TestChesapeakeCVPR:
             ChesapeakeCVPR(tmp_path, checksum=True)
 
     def test_out_of_bounds_query(self, dataset: ChesapeakeCVPR) -> None:
-        query = BoundingBox(0, 0, 0, 0, pd.Timestamp.min, pd.Timestamp.min)
         with pytest.raises(
             IndexError, match='query: .* not found in index with bounds:'
         ):
-            dataset[query]
+            dataset[0:0, 0:0, pd.Timestamp.min : pd.Timestamp.min]
 
     def test_multiple_hits_query(self, dataset: ChesapeakeCVPR) -> None:
         ds = ChesapeakeCVPR(

--- a/tests/datasets/test_eddmaps.py
+++ b/tests/datasets/test_eddmaps.py
@@ -10,7 +10,6 @@ import pytest
 from matplotlib.figure import Figure
 
 from torchgeo.datasets import (
-    BoundingBox,
     DatasetNotFoundError,
     EDDMapS,
     IntersectionDataset,
@@ -44,11 +43,10 @@ class TestEDDMapS:
             EDDMapS(tmp_path)
 
     def test_invalid_query(self, dataset: EDDMapS) -> None:
-        query = BoundingBox(0, 0, 0, 0, pd.Timestamp.min, pd.Timestamp.min)
         with pytest.raises(
             IndexError, match='query: .* not found in index with bounds:'
         ):
-            dataset[query]
+            dataset[0:0, 0:0, pd.Timestamp.min : pd.Timestamp.min]
 
     def test_plot(self, dataset: EDDMapS) -> None:
         sample = dataset[dataset.bounds]

--- a/tests/datasets/test_enmap.py
+++ b/tests/datasets/test_enmap.py
@@ -12,7 +12,6 @@ import torch.nn as nn
 from pyproj import CRS
 
 from torchgeo.datasets import (
-    BoundingBox,
     DatasetNotFoundError,
     EnMAP,
     IntersectionDataset,
@@ -64,8 +63,7 @@ class TestEnMAP:
             EnMAP(tmp_path)
 
     def test_invalid_query(self, dataset: EnMAP) -> None:
-        query = BoundingBox(0, 0, 0, 0, pd.Timestamp.min, pd.Timestamp.min)
         with pytest.raises(
             IndexError, match='query: .* not found in index with bounds:'
         ):
-            dataset[query]
+            dataset[0:0, 0:0, pd.Timestamp.min : pd.Timestamp.min]

--- a/tests/datasets/test_enviroatlas.py
+++ b/tests/datasets/test_enviroatlas.py
@@ -20,7 +20,6 @@ from torchgeo.datasets import (
     IntersectionDataset,
     UnionDataset,
 )
-from torchgeo.samplers import RandomGeoSampler
 
 
 class TestEnviroAtlas:
@@ -57,9 +56,7 @@ class TestEnviroAtlas:
         )
 
     def test_getitem(self, dataset: EnviroAtlas) -> None:
-        sampler = RandomGeoSampler(dataset, size=16, length=32)
-        bb = next(iter(sampler))
-        x = dataset[bb]
+        x = dataset[dataset.bounds]
         assert isinstance(x, dict)
         assert isinstance(x['crs'], CRS)
         assert isinstance(x['mask'], torch.Tensor)
@@ -107,9 +104,7 @@ class TestEnviroAtlas:
             ds[dataset.bounds]
 
     def test_plot(self, dataset: EnviroAtlas) -> None:
-        sampler = RandomGeoSampler(dataset, size=16, length=1)
-        bb = next(iter(sampler))
-        x = dataset[bb]
+        x = dataset[dataset.bounds]
         if 'naip' not in dataset.layers or 'lc' not in dataset.layers:
             with pytest.raises(ValueError, match="The 'naip' and"):
                 dataset.plot(x)

--- a/tests/datasets/test_enviroatlas.py
+++ b/tests/datasets/test_enviroatlas.py
@@ -15,7 +15,6 @@ from pyproj import CRS
 from pytest import MonkeyPatch
 
 from torchgeo.datasets import (
-    BoundingBox,
     DatasetNotFoundError,
     EnviroAtlas,
     IntersectionDataset,
@@ -91,11 +90,10 @@ class TestEnviroAtlas:
             EnviroAtlas(tmp_path, checksum=True)
 
     def test_out_of_bounds_query(self, dataset: EnviroAtlas) -> None:
-        query = BoundingBox(0, 0, 0, 0, pd.Timestamp.min, pd.Timestamp.min)
         with pytest.raises(
             IndexError, match='query: .* not found in index with bounds:'
         ):
-            dataset[query]
+            dataset[0:0, 0:0, pd.Timestamp.min : pd.Timestamp.min]
 
     def test_multiple_hits_query(self, dataset: EnviroAtlas) -> None:
         ds = EnviroAtlas(

--- a/tests/datasets/test_esri2020.py
+++ b/tests/datasets/test_esri2020.py
@@ -14,7 +14,6 @@ from pyproj import CRS
 from pytest import MonkeyPatch
 
 from torchgeo.datasets import (
-    BoundingBox,
     DatasetNotFoundError,
     Esri2020,
     IntersectionDataset,
@@ -93,8 +92,7 @@ class TestEsri2020:
         assert 'ai4edataeuwest.blob.core.windows.net' in ds.url
 
     def test_invalid_query(self, dataset: Esri2020) -> None:
-        query = BoundingBox(0, 0, 0, 0, pd.Timestamp.min, pd.Timestamp.min)
         with pytest.raises(
             IndexError, match='query: .* not found in index with bounds:'
         ):
-            dataset[query]
+            dataset[0:0, 0:0, pd.Timestamp.min : pd.Timestamp.min]

--- a/tests/datasets/test_eudem.py
+++ b/tests/datasets/test_eudem.py
@@ -15,7 +15,6 @@ from pytest import MonkeyPatch
 
 from torchgeo.datasets import (
     EUDEM,
-    BoundingBox,
     DatasetNotFoundError,
     IntersectionDataset,
     UnionDataset,
@@ -82,8 +81,7 @@ class TestEUDEM:
         plt.close()
 
     def test_invalid_query(self, dataset: EUDEM) -> None:
-        query = BoundingBox(100, 100, 100, 100, pd.Timestamp.min, pd.Timestamp.min)
         with pytest.raises(
             IndexError, match='query: .* not found in index with bounds:'
         ):
-            dataset[query]
+            dataset[100:100, 100:100, pd.Timestamp.min : pd.Timestamp.min]

--- a/tests/datasets/test_eurocrops.py
+++ b/tests/datasets/test_eurocrops.py
@@ -14,7 +14,6 @@ from pyproj import CRS
 from pytest import MonkeyPatch
 
 from torchgeo.datasets import (
-    BoundingBox,
     DatasetNotFoundError,
     EuroCrops,
     IntersectionDataset,
@@ -77,11 +76,10 @@ class TestEuroCrops:
             EuroCrops(tmp_path)
 
     def test_invalid_query(self, dataset: EuroCrops) -> None:
-        query = BoundingBox(200, 200, 200, 200, pd.Timestamp.min, pd.Timestamp.min)
         with pytest.raises(
             IndexError, match='query: .* not found in index with bounds:'
         ):
-            dataset[query]
+            dataset[200:200, 200:200, pd.Timestamp.min : pd.Timestamp.min]
 
     def test_get_label_with_none_hcat_code(self, dataset: EuroCrops) -> None:
         mock_feature = {'properties': {dataset.label_name: None}}

--- a/tests/datasets/test_gbif.py
+++ b/tests/datasets/test_gbif.py
@@ -46,7 +46,7 @@ class TestGBIF:
         with pytest.raises(
             IndexError, match='query: .* not found in index with bounds:'
         ):
-            dataset[0:0, 0:0, pd.Timestamp.min:pd.Timestamp.min]
+            dataset[0:0, 0:0, pd.Timestamp.min : pd.Timestamp.min]
 
     def test_plot(self, dataset: GBIF) -> None:
         sample = dataset[dataset.bounds]

--- a/tests/datasets/test_gbif.py
+++ b/tests/datasets/test_gbif.py
@@ -11,7 +11,6 @@ from matplotlib.figure import Figure
 
 from torchgeo.datasets import (
     GBIF,
-    BoundingBox,
     DatasetNotFoundError,
     IntersectionDataset,
     UnionDataset,
@@ -44,11 +43,10 @@ class TestGBIF:
             GBIF(tmp_path)
 
     def test_invalid_query(self, dataset: GBIF) -> None:
-        query = BoundingBox(0, 0, 0, 0, pd.Timestamp.min, pd.Timestamp.min)
         with pytest.raises(
             IndexError, match='query: .* not found in index with bounds:'
         ):
-            dataset[query]
+            dataset[0:0, 0:0, pd.Timestamp.min:pd.Timestamp.min]
 
     def test_plot(self, dataset: GBIF) -> None:
         sample = dataset[dataset.bounds]

--- a/tests/datasets/test_gbm.py
+++ b/tests/datasets/test_gbm.py
@@ -11,7 +11,6 @@ import torch
 from pyproj import CRS
 
 from torchgeo.datasets import (
-    BoundingBox,
     DatasetNotFoundError,
     GlobalBuildingMap,
     IntersectionDataset,
@@ -53,8 +52,7 @@ class TestGlobalBuildingMap:
             GlobalBuildingMap(tmp_path)
 
     def test_invalid_query(self, dataset: GlobalBuildingMap) -> None:
-        query = BoundingBox(0, 0, 0, 0, pd.Timestamp.min, pd.Timestamp.min)
         with pytest.raises(
             IndexError, match='query: .* not found in index with bounds:'
         ):
-            dataset[query]
+            dataset[0:0, 0:0, pd.Timestamp.min : pd.Timestamp.min]

--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -5,7 +5,6 @@ import math
 import os
 import pickle
 from collections.abc import Iterable, Sequence
-from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -903,8 +902,8 @@ class TestUnionDataset:
         return UnionDataset(ds1, ds2, transforms=transforms)
 
     def test_getitem(self, dataset: UnionDataset) -> None:
-        query = dataset.bounds
-        sample = dataset[query]
+        xmin, xmax, ymin, ymax, tmin, tmax = dataset.bounds
+        sample = dataset[xmin:xmax, ymin:ymax, tmin:tmax]
         assert isinstance(sample['image'], torch.Tensor)
 
     def test_len(self, dataset: UnionDataset) -> None:
@@ -924,7 +923,8 @@ class TestUnionDataset:
             os.path.join('tests', 'data', 'raster', 'res_2-2_epsg_4326')
         )
         ds = UnionDataset(ds1, ds2)
-        sample = ds[ds.bounds]
+        xmin, xmax, ymin, ymax, tmin, tmax = ds.bounds
+        sample = ds[xmin:xmax, ymin:ymax, tmin:tmax]
         assert ds1.crs == ds2.crs == ds.crs == CRS.from_epsg(4087)
         assert ds1.res == ds2.res == ds.res == (2, 2)
         assert len(ds1) == len(ds2) == 1
@@ -942,7 +942,8 @@ class TestUnionDataset:
             os.path.join('tests', 'data', 'raster', 'res_2-2_epsg_32631')
         )
         ds = (ds1 | ds2) | ds3
-        sample = ds[ds.bounds]
+        xmin, xmax, ymin, ymax, tmin, tmax = ds.bounds
+        sample = ds[xmin:xmax, ymin:ymax, tmin:tmax]
         assert ds1.crs == ds2.crs == ds3.crs == ds.crs == CRS.from_epsg(4087)
         assert ds1.res == ds2.res == ds3.res == ds.res == (2, 2)
         assert len(ds1) == len(ds2) == len(ds3) == 1
@@ -960,7 +961,8 @@ class TestUnionDataset:
             os.path.join('tests', 'data', 'raster', 'res_2-2_epsg_32631')
         )
         ds = ds1 | (ds2 | ds3)
-        sample = ds[ds.bounds]
+        xmin, xmax, ymin, ymax, tmin, tmax = ds.bounds
+        sample = ds[xmin:xmax, ymin:ymax, tmin:tmax]
         assert ds1.crs == ds2.crs == ds3.crs == ds.crs == CRS.from_epsg(4087)
         assert ds1.res == ds2.res == ds3.res == ds.res == (2, 2)
         assert len(ds1) == len(ds2) == len(ds3) == 1
@@ -975,7 +977,8 @@ class TestUnionDataset:
             os.path.join('tests', 'data', 'raster', 'res_4-4_epsg_4087')
         )
         ds = UnionDataset(ds1, ds2)
-        sample = ds[ds.bounds]
+        xmin, xmax, ymin, ymax, tmin, tmax = ds.bounds
+        sample = ds[xmin:xmax, ymin:ymax, tmin:tmax]
         assert ds1.crs == ds2.crs == ds.crs == CRS.from_epsg(4087)
         assert ds1.res == ds2.res == ds.res == (2, 2)
         assert len(ds1) == len(ds2) == 1
@@ -993,7 +996,8 @@ class TestUnionDataset:
             os.path.join('tests', 'data', 'raster', 'res_8-8_epsg_4087')
         )
         ds = (ds1 | ds2) | ds3
-        sample = ds[ds.bounds]
+        xmin, xmax, ymin, ymax, tmin, tmax = ds.bounds
+        sample = ds[xmin:xmax, ymin:ymax, tmin:tmax]
         assert ds1.crs == ds2.crs == ds3.crs == ds.crs == CRS.from_epsg(4087)
         assert ds1.res == ds2.res == ds3.res == ds.res == (2, 2)
         assert len(ds1) == len(ds2) == len(ds3) == 1
@@ -1011,7 +1015,8 @@ class TestUnionDataset:
             os.path.join('tests', 'data', 'raster', 'res_8-8_epsg_4087')
         )
         ds = ds1 | (ds2 | ds3)
-        sample = ds[ds.bounds]
+        xmin, xmax, ymin, ymax, tmin, tmax = ds.bounds
+        sample = ds[xmin:xmax, ymin:ymax, tmin:tmax]
         assert ds1.crs == ds2.crs == ds3.crs == ds.crs == CRS.from_epsg(4087)
         assert ds1.res == ds2.res == ds3.res == ds.res == (2, 2)
         assert len(ds1) == len(ds2) == len(ds3) == 1
@@ -1022,8 +1027,8 @@ class TestUnionDataset:
         ds1 = CustomGeoDataset([(0, 1, 0, 1, MINT, MAXT)])
         ds2 = CustomGeoDataset([(2, 3, 2, 3, MINT, MAXT)])
         ds = UnionDataset(ds1, ds2)
-        ds[(0, 1, 0, 1, MINT, MAXT)]
-        ds[(2, 3, 2, 3, MINT, MAXT)]
+        ds[0:1, 0:1, MINT:MAXT]
+        ds[2:3, 2:3, MINT:MAXT]
 
     def test_single_res(self) -> None:
         ds1 = RasterDataset(
@@ -1049,6 +1054,5 @@ class TestUnionDataset:
             UnionDataset(ds3, ds1)  # type: ignore[arg-type]
 
     def test_invalid_key(self, dataset: UnionDataset) -> None:
-        key = (-1, -1, -1, -1, datetime.min, datetime.min)
         with pytest.raises(IndexError, match='key: .* not found in index with bounds:'):
-            dataset[key]
+            dataset[-1:-1, -1:-1, pd.Timestamp.min : pd.Timestamp.min]

--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -59,7 +59,7 @@ class CustomGeoDataset(GeoDataset):
         x, y, t = self._disambiguate_slice(query)
         interval = pd.Interval(t.start, t.stop)
         index = self.index.iloc[self.index.index.overlaps(interval)]
-        index = index.cx[x.start : x.stop, y.start : y.stop]  # type: ignore[misc]
+        index = index.cx[x.start : x.stop, y.start : y.stop]
 
         if index.empty:
             raise IndexError(
@@ -524,7 +524,7 @@ class TestVectorDataset:
         )
 
     def test_empty_shapes(self, dataset: CustomVectorDataset) -> None:
-        x = dataset[1.1:1.9, 1.1:1.9, pd.Timestamp.min : pd.Timestamp.max]
+        x = dataset[1.1:1.9, 1.1:1.9, pd.Timestamp.min : pd.Timestamp.max]  # type: ignore[misc]
         assert torch.equal(x['mask'], torch.zeros(8, 8, dtype=torch.uint8))
 
     def test_invalid_query(self, dataset: CustomVectorDataset) -> None:

--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -518,12 +518,12 @@ class TestVectorDataset:
         )
 
     def test_empty_shapes(self, dataset: CustomVectorDataset) -> None:
-        x = dataset[1.1:1.9, 1.1:1.9, pd.Timestamp.min:pd.Timestamp.max]
+        x = dataset[1.1:1.9, 1.1:1.9, pd.Timestamp.min : pd.Timestamp.max]
         assert torch.equal(x['mask'], torch.zeros(8, 8, dtype=torch.uint8))
 
     def test_invalid_key(self, dataset: CustomVectorDataset) -> None:
         with pytest.raises(IndexError, match='key: .* not found in index with bounds:'):
-            dataset[3:3, 3:3, pd.Timestamp.min:pd.Timestamp.min]
+            dataset[3:3, 3:3, pd.Timestamp.min : pd.Timestamp.min]
 
     def test_no_data(self, tmp_path: Path) -> None:
         with pytest.raises(DatasetNotFoundError, match='Dataset not found'):
@@ -642,8 +642,8 @@ class TestIntersectionDataset:
         return IntersectionDataset(ds1, ds2, transforms=transforms)
 
     def test_getitem(self, dataset: IntersectionDataset) -> None:
-        query = dataset.bounds
-        sample = dataset[query]
+        xmin, xmax, ymin, ymax, tmin, tmax = dataset.bounds
+        sample = dataset[xmin:xmax, ymin:ymax, tmin:tmax]
         assert isinstance(sample['image'], torch.Tensor)
 
     def test_len(self, dataset: IntersectionDataset) -> None:
@@ -671,7 +671,8 @@ class TestIntersectionDataset:
             os.path.join('tests', 'data', 'raster', 'res_2-2_epsg_4087')
         )
         ds = IntersectionDataset(ds1, ds2)
-        sample = ds[ds.bounds]
+        xmin, xmax, ymin, ymax, tmin, tmax = ds.bounds
+        sample = ds[xmin:xmax, ymin:ymax, tmin:tmax]
         assert ds1.crs == ds2.crs == ds.crs == CRS.from_epsg(4087)
         assert ds1.res == ds2.res == ds.res == (2, 1)
         assert len(ds1) == len(ds2) == len(ds) == 1
@@ -685,7 +686,8 @@ class TestIntersectionDataset:
             os.path.join('tests', 'data', 'raster', 'res_2-2_epsg_4087')
         )
         ds = IntersectionDataset(ds2, ds1)
-        sample = ds[ds.bounds]
+        xmin, xmax, ymin, ymax, tmin, tmax = ds.bounds
+        sample = ds[xmin:xmax, ymin:ymax, tmin:tmax]
         assert ds1.crs == ds2.crs == ds.crs == CRS.from_epsg(4087)
         assert ds1.res == ds2.res == ds.res == (2, 2)
         assert len(ds1) == len(ds2) == len(ds) == 1
@@ -699,7 +701,8 @@ class TestIntersectionDataset:
             os.path.join('tests', 'data', 'raster', 'res_2-2_epsg_4326')
         )
         ds = IntersectionDataset(ds1, ds2)
-        sample = ds[ds.bounds]
+        xmin, xmax, ymin, ymax, tmin, tmax = ds.bounds
+        sample = ds[xmin:xmax, ymin:ymax, tmin:tmax]
         assert ds1.crs == ds2.crs == ds.crs == CRS.from_epsg(4087)
         assert ds1.res == ds2.res == ds.res == (2, 2)
         assert len(ds1) == len(ds2) == len(ds) == 1
@@ -716,7 +719,8 @@ class TestIntersectionDataset:
             os.path.join('tests', 'data', 'raster', 'res_2-2_epsg_32631')
         )
         ds = (ds1 & ds2) & ds3
-        sample = ds[ds.bounds]
+        xmin, xmax, ymin, ymax, tmin, tmax = ds.bounds
+        sample = ds[xmin:xmax, ymin:ymax, tmin:tmax]
         assert ds1.crs == ds2.crs == ds3.crs == ds.crs == CRS.from_epsg(4087)
         assert ds1.res == ds2.res == ds3.res == ds.res == (2, 2)
         assert len(ds1) == len(ds2) == len(ds3) == len(ds) == 1
@@ -733,7 +737,8 @@ class TestIntersectionDataset:
             os.path.join('tests', 'data', 'raster', 'res_2-2_epsg_32631')
         )
         ds = ds1 & (ds2 & ds3)
-        sample = ds[ds.bounds]
+        xmin, xmax, ymin, ymax, tmin, tmax = ds.bounds
+        sample = ds[xmin:xmax, ymin:ymax, tmin:tmax]
         assert ds1.crs == ds2.crs == ds3.crs == ds.crs == CRS.from_epsg(4087)
         assert ds1.res == ds2.res == ds3.res == ds.res == (2, 2)
         assert len(ds1) == len(ds2) == len(ds3) == len(ds) == 1
@@ -747,7 +752,8 @@ class TestIntersectionDataset:
             os.path.join('tests', 'data', 'raster', 'res_4-4_epsg_4087')
         )
         ds = IntersectionDataset(ds1, ds2)
-        sample = ds[ds.bounds]
+        xmin, xmax, ymin, ymax, tmin, tmax = ds.bounds
+        sample = ds[xmin:xmax, ymin:ymax, tmin:tmax]
         assert ds1.crs == ds2.crs == ds.crs == CRS.from_epsg(4087)
         assert ds1.res == ds2.res == ds.res == (2, 2)
         assert len(ds1) == len(ds2) == len(ds) == 1
@@ -764,7 +770,8 @@ class TestIntersectionDataset:
             os.path.join('tests', 'data', 'raster', 'res_8-8_epsg_4087')
         )
         ds = (ds1 & ds2) & ds3
-        sample = ds[ds.bounds]
+        xmin, xmax, ymin, ymax, tmin, tmax = ds.bounds
+        sample = ds[xmin:xmax, ymin:ymax, tmin:tmax]
         assert ds1.crs == ds2.crs == ds3.crs == ds.crs == CRS.from_epsg(4087)
         assert ds1.res == ds2.res == ds3.res == ds.res == (2, 2)
         assert len(ds1) == len(ds2) == len(ds3) == len(ds) == 1
@@ -781,7 +788,8 @@ class TestIntersectionDataset:
             os.path.join('tests', 'data', 'raster', 'res_8-8_epsg_4087')
         )
         ds = ds1 & (ds2 & ds3)
-        sample = ds[ds.bounds]
+        xmin, xmax, ymin, ymax, tmin, tmax = ds.bounds
+        sample = ds[xmin:xmax, ymin:ymax, tmin:tmax]
         assert ds1.crs == ds2.crs == ds3.crs == ds.crs == CRS.from_epsg(4087)
         assert ds1.res == ds2.res == ds3.res == ds.res == (2, 2)
         assert len(ds1) == len(ds2) == len(ds3) == len(ds) == 1
@@ -878,9 +886,8 @@ class TestIntersectionDataset:
             IntersectionDataset(ds1, ds2)
 
     def test_invalid_key(self, dataset: IntersectionDataset) -> None:
-        key = (-1, -1, -1, -1, datetime.min, datetime.min)
         with pytest.raises(IndexError, match='key: .* not found in index with bounds:'):
-            dataset[key]
+            dataset[-1:-1, -1:-1, pd.Timestamp.min : pd.Timestamp.min]
 
 
 class TestUnionDataset:

--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -492,7 +492,8 @@ class TestVectorDataset:
         )
 
     def test_getitem(self, dataset: CustomVectorDataset) -> None:
-        x = dataset[dataset.bounds]
+        xmin, xmax, ymin, ymax, tmin, tmax = dataset.bounds
+        x = dataset[xmin:xmax, ymin:ymax, tmin:tmax]
         assert isinstance(x, dict)
         assert isinstance(x['crs'], CRS)
         assert isinstance(x['mask'], torch.Tensor)
@@ -506,7 +507,8 @@ class TestVectorDataset:
         assert dataset.bounds[5] < pd.Timestamp.max
 
     def test_getitem_multilabel(self, multilabel: CustomVectorDataset) -> None:
-        x = multilabel[multilabel.bounds]
+        xmin, xmax, ymin, ymax, tmin, tmax = multilabel.bounds
+        x = multilabel[xmin:xmax, ymin:ymax, tmin:tmax]
         assert isinstance(x, dict)
         assert isinstance(x['crs'], CRS)
         assert isinstance(x['mask'], torch.Tensor)
@@ -516,12 +518,12 @@ class TestVectorDataset:
         )
 
     def test_empty_shapes(self, dataset: CustomVectorDataset) -> None:
-        x = dataset[1.1:1.9, 1.1:1.9, pd.Timestamp.min, pd.Timestamp.max]
+        x = dataset[1.1:1.9, 1.1:1.9, pd.Timestamp.min:pd.Timestamp.max]
         assert torch.equal(x['mask'], torch.zeros(8, 8, dtype=torch.uint8))
 
     def test_invalid_key(self, dataset: CustomVectorDataset) -> None:
         with pytest.raises(IndexError, match='key: .* not found in index with bounds:'):
-            dataset[3:3, 3:3, pd.Timestamp.min, pd.Timestamp.min]
+            dataset[3:3, 3:3, pd.Timestamp.min:pd.Timestamp.min]
 
     def test_no_data(self, tmp_path: Path) -> None:
         with pytest.raises(DatasetNotFoundError, match='Dataset not found'):

--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -167,7 +167,7 @@ class TestGeoDataset:
     def test_str(self, dataset: GeoDataset) -> None:
         out = str(dataset)
         assert 'type: GeoDataset' in out
-        assert 'bbox: ' in out
+        assert 'bbox: (slice' in out
         assert 'size: 1' in out
 
     def test_picklable(self, dataset: GeoDataset) -> None:
@@ -659,7 +659,7 @@ class TestIntersectionDataset:
     def test_str(self, dataset: IntersectionDataset) -> None:
         out = str(dataset)
         assert 'type: IntersectionDataset' in out
-        assert 'bbox: ' in out
+        assert 'bbox: (slice' in out
         assert 'size: 1' in out
 
     def test_nongeo_dataset(self) -> None:
@@ -913,7 +913,7 @@ class TestUnionDataset:
     def test_str(self, dataset: UnionDataset) -> None:
         out = str(dataset)
         assert 'type: UnionDataset' in out
-        assert 'bbox: ' in out
+        assert 'bbox: (slice' in out
         assert 'size: 2' in out
 
     def test_different_crs_12(self) -> None:

--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -392,14 +392,16 @@ class TestRasterDataset:
         assert len(Sentinel2(paths, bands=Sentinel2.rgb_bands).files) == 2
 
     def test_getitem_single_file(self, naip: NAIP) -> None:
-        x = naip[naip.bounds]
+        xmin, xmax, ymin, ymax, tmin, tmax = naip.bounds
+        x = naip[xmin:xmax, ymin:ymax, tmin:tmax]
         assert isinstance(x, dict)
         assert isinstance(x['crs'], CRS)
         assert isinstance(x['image'], torch.Tensor)
         assert len(naip.bands) == x['image'].shape[0]
 
     def test_getitem_separate_files(self, sentinel: Sentinel2) -> None:
-        x = sentinel[sentinel.bounds]
+        xmin, xmax, ymin, ymax, tmin, tmax = sentinel.bounds
+        x = sentinel[xmin:xmax, ymin:ymax, tmin:tmax]
         assert isinstance(x, dict)
         assert isinstance(x['crs'], CRS)
         assert isinstance(x['image'], torch.Tensor)
@@ -415,7 +417,8 @@ class TestRasterDataset:
     def test_getitem_uint_dtype(self, dtype: str) -> None:
         root = os.path.join('tests', 'data', 'raster', dtype)
         ds = RasterDataset(root)
-        x = ds[ds.bounds]
+        xmin, xmax, ymin, ymax, tmin, tmax = ds.bounds
+        x = ds[xmin:xmax, ymin:ymax, tmin:tmax]
         assert isinstance(x, dict)
         assert isinstance(x['image'], torch.Tensor)
         assert x['image'].dtype == torch.float32
@@ -424,7 +427,8 @@ class TestRasterDataset:
     def test_resampling_float_dtype(self, dtype: torch.dtype) -> None:
         paths = os.path.join('tests', 'data', 'raster', 'uint16')
         ds = CustomRasterDataset(dtype, paths)
-        x = ds[ds.bounds]
+        xmin, xmax, ymin, ymax, tmin, tmax = ds.bounds
+        x = ds[xmin:xmax, ymin:ymax, tmin:tmax]
         assert x['image'].dtype == dtype
         assert ds.resampling == Resampling.bilinear
 
@@ -432,7 +436,8 @@ class TestRasterDataset:
     def test_resampling_int_dtype(self, dtype: torch.dtype) -> None:
         paths = os.path.join('tests', 'data', 'raster', 'uint16')
         ds = CustomRasterDataset(dtype, paths)
-        x = ds[ds.bounds]
+        xmin, xmax, ymin, ymax, tmin, tmax = ds.bounds
+        x = ds[xmin:xmax, ymin:ymax, tmin:tmax]
         assert x['image'].dtype == dtype
         assert ds.resampling == Resampling.nearest
 

--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -103,7 +103,7 @@ class CustomNonGeoDataset(NonGeoDataset):
 
 
 class TestGeoDataset:
-    @pytest.fixture(scope='class')
+    @pytest.fixture
     def dataset(self) -> GeoDataset:
         return CustomGeoDataset()
 

--- a/tests/datasets/test_globbiomass.py
+++ b/tests/datasets/test_globbiomass.py
@@ -14,7 +14,6 @@ from pyproj import CRS
 from pytest import MonkeyPatch
 
 from torchgeo.datasets import (
-    BoundingBox,
     DatasetNotFoundError,
     GlobBiomass,
     IntersectionDataset,
@@ -86,8 +85,7 @@ class TestGlobBiomass:
         plt.close()
 
     def test_invalid_query(self, dataset: GlobBiomass) -> None:
-        query = BoundingBox(100, 100, 100, 100, pd.Timestamp.min, pd.Timestamp.min)
         with pytest.raises(
             IndexError, match='query: .* not found in index with bounds:'
         ):
-            dataset[query]
+            dataset[100:100, 100:100, pd.Timestamp.min : pd.Timestamp.min]

--- a/tests/datasets/test_inaturalist.py
+++ b/tests/datasets/test_inaturalist.py
@@ -10,7 +10,6 @@ import pytest
 from matplotlib.figure import Figure
 
 from torchgeo.datasets import (
-    BoundingBox,
     DatasetNotFoundError,
     INaturalist,
     IntersectionDataset,
@@ -45,11 +44,10 @@ class TestINaturalist:
 
     def test_invalid_query(self, dataset: INaturalist) -> None:
         mint = pd.Timestamp('2022-05-07 11:02:53+01:00')
-        query = BoundingBox(0, 0, 0, 0, mint, mint)
         with pytest.raises(
             IndexError, match='query: .* not found in index with bounds:'
         ):
-            dataset[query]
+            dataset[0:0, 0:0, mint:mint]
 
     def test_plot(self, dataset: INaturalist) -> None:
         sample = dataset[dataset.bounds]

--- a/tests/datasets/test_iobench.py
+++ b/tests/datasets/test_iobench.py
@@ -15,7 +15,6 @@ from pyproj import CRS
 from pytest import MonkeyPatch
 
 from torchgeo.datasets import (
-    BoundingBox,
     DatasetNotFoundError,
     IntersectionDataset,
     IOBench,
@@ -73,11 +72,10 @@ class TestIOBench:
             IOBench(tmp_path)
 
     def test_invalid_query(self, dataset: IOBench) -> None:
-        query = BoundingBox(0, 0, 0, 0, pd.Timestamp.min, pd.Timestamp.min)
         with pytest.raises(
             IndexError, match='query: .* not found in index with bounds:'
         ):
-            dataset[query]
+            dataset[0:0, 0:0, pd.Timestamp.min : pd.Timestamp.min]
 
     def test_rgb_bands_absent_plot(self, dataset: IOBench) -> None:
         with pytest.raises(

--- a/tests/datasets/test_l7irish.py
+++ b/tests/datasets/test_l7irish.py
@@ -16,7 +16,6 @@ from pyproj import CRS
 from pytest import MonkeyPatch
 
 from torchgeo.datasets import (
-    BoundingBox,
     DatasetNotFoundError,
     IntersectionDataset,
     L7Irish,
@@ -86,11 +85,10 @@ class TestL7Irish:
         plt.close()
 
     def test_invalid_query(self, dataset: L7Irish) -> None:
-        query = BoundingBox(0, 0, 0, 0, pd.Timestamp.min, pd.Timestamp.min)
         with pytest.raises(
             IndexError, match='query: .* not found in index with bounds:'
         ):
-            dataset[query]
+            dataset[0:0, 0:0, pd.Timestamp.min : pd.Timestamp.min]
 
     def test_rgb_bands_absent_plot(self, dataset: L7Irish) -> None:
         with pytest.raises(

--- a/tests/datasets/test_l8biome.py
+++ b/tests/datasets/test_l8biome.py
@@ -16,7 +16,6 @@ from pyproj import CRS
 from pytest import MonkeyPatch
 
 from torchgeo.datasets import (
-    BoundingBox,
     DatasetNotFoundError,
     IntersectionDataset,
     L8Biome,
@@ -86,11 +85,10 @@ class TestL8Biome:
         plt.close()
 
     def test_invalid_query(self, dataset: L8Biome) -> None:
-        query = BoundingBox(0, 0, 0, 0, pd.Timestamp.min, pd.Timestamp.min)
         with pytest.raises(
             IndexError, match='query: .* not found in index with bounds:'
         ):
-            dataset[query]
+            dataset[0:0, 0:0, pd.Timestamp.min : pd.Timestamp.min]
 
     def test_rgb_bands_absent_plot(self, dataset: L8Biome) -> None:
         with pytest.raises(

--- a/tests/datasets/test_landcoverai.py
+++ b/tests/datasets/test_landcoverai.py
@@ -16,7 +16,6 @@ from pytest import MonkeyPatch
 from torch.utils.data import ConcatDataset
 
 from torchgeo.datasets import (
-    BoundingBox,
     DatasetNotFoundError,
     LandCoverAI,
     LandCoverAI100,
@@ -55,11 +54,10 @@ class TestLandCoverAIGeo:
             LandCoverAIGeo(tmp_path)
 
     def test_out_of_bounds_query(self, dataset: LandCoverAIGeo) -> None:
-        query = BoundingBox(0, 0, 0, 0, pd.Timestamp.min, pd.Timestamp.min)
         with pytest.raises(
             IndexError, match='query: .* not found in index with bounds:'
         ):
-            dataset[query]
+            dataset[0:0, 0:0, pd.Timestamp.min : pd.Timestamp.min]
 
     def test_plot(self, dataset: LandCoverAIGeo) -> None:
         x = dataset[dataset.bounds].copy()

--- a/tests/datasets/test_landsat.py
+++ b/tests/datasets/test_landsat.py
@@ -13,7 +13,6 @@ from _pytest.fixtures import SubRequest
 from pyproj import CRS
 
 from torchgeo.datasets import (
-    BoundingBox,
     DatasetNotFoundError,
     IntersectionDataset,
     Landsat8,
@@ -71,8 +70,7 @@ class TestLandsat8:
             Landsat8(tmp_path)
 
     def test_invalid_query(self, dataset: Landsat8) -> None:
-        query = BoundingBox(0, 0, 0, 0, pd.Timestamp.min, pd.Timestamp.min)
         with pytest.raises(
             IndexError, match='query: .* not found in index with bounds:'
         ):
-            dataset[query]
+            dataset[0:0, 0:0, pd.Timestamp.min : pd.Timestamp.min]

--- a/tests/datasets/test_mmflood.py
+++ b/tests/datasets/test_mmflood.py
@@ -15,7 +15,6 @@ from pyproj import CRS
 from pytest import MonkeyPatch
 
 from torchgeo.datasets import (
-    BoundingBox,
     DatasetNotFoundError,
     IntersectionDataset,
     MMFlood,
@@ -105,8 +104,7 @@ class TestMMFlood:
         plt.close()
 
     def test_invalid_query(self, dataset: MMFlood) -> None:
-        query = BoundingBox(0, 0, 0, 0, pd.Timestamp.min, pd.Timestamp.min)
         with pytest.raises(
             IndexError, match='query: .* not found in index with bounds:'
         ):
-            dataset[query]
+            dataset[0:0, 0:0, pd.Timestamp.min : pd.Timestamp.min]

--- a/tests/datasets/test_naip.py
+++ b/tests/datasets/test_naip.py
@@ -13,7 +13,6 @@ from pyproj import CRS
 
 from torchgeo.datasets import (
     NAIP,
-    BoundingBox,
     DatasetNotFoundError,
     IntersectionDataset,
     UnionDataset,
@@ -55,8 +54,7 @@ class TestNAIP:
             NAIP(tmp_path)
 
     def test_invalid_query(self, dataset: NAIP) -> None:
-        query = BoundingBox(0, 0, 0, 0, pd.Timestamp.min, pd.Timestamp.min)
         with pytest.raises(
             IndexError, match='query: .* not found in index with bounds:'
         ):
-            dataset[query]
+            dataset[0:0, 0:0, pd.Timestamp.min : pd.Timestamp.min]

--- a/tests/datasets/test_nccm.py
+++ b/tests/datasets/test_nccm.py
@@ -14,7 +14,6 @@ from pytest import MonkeyPatch
 
 from torchgeo.datasets import (
     NCCM,
-    BoundingBox,
     DatasetNotFoundError,
     IntersectionDataset,
     UnionDataset,
@@ -81,8 +80,7 @@ class TestNCCM:
             NCCM(tmp_path)
 
     def test_invalid_query(self, dataset: NCCM) -> None:
-        query = BoundingBox(0, 0, 0, 0, pd.Timestamp.min, pd.Timestamp.min)
         with pytest.raises(
             IndexError, match='query: .* not found in index with bounds:'
         ):
-            dataset[query]
+            dataset[0:0, 0:0, pd.Timestamp.min : pd.Timestamp.min]

--- a/tests/datasets/test_nlcd.py
+++ b/tests/datasets/test_nlcd.py
@@ -15,7 +15,6 @@ from pytest import MonkeyPatch
 
 from torchgeo.datasets import (
     NLCD,
-    BoundingBox,
     DatasetNotFoundError,
     IntersectionDataset,
     UnionDataset,
@@ -112,8 +111,7 @@ class TestNLCD:
             NLCD(tmp_path)
 
     def test_invalid_query(self, dataset: NLCD) -> None:
-        query = BoundingBox(0, 0, 0, 0, pd.Timestamp.min, pd.Timestamp.min)
         with pytest.raises(
             IndexError, match='query: .* not found in index with bounds:'
         ):
-            dataset[query]
+            dataset[0:0, 0:0, pd.Timestamp.min : pd.Timestamp.min]

--- a/tests/datasets/test_openbuildings.py
+++ b/tests/datasets/test_openbuildings.py
@@ -15,7 +15,6 @@ from pyproj import CRS
 from pytest import MonkeyPatch
 
 from torchgeo.datasets import (
-    BoundingBox,
     DatasetNotFoundError,
     IntersectionDataset,
     OpenBuildings,
@@ -93,11 +92,10 @@ class TestOpenBuildings:
         assert isinstance(ds, UnionDataset)
 
     def test_invalid_query(self, dataset: OpenBuildings) -> None:
-        query = BoundingBox(100, 100, 100, 100, pd.Timestamp.min, pd.Timestamp.min)
         with pytest.raises(
             IndexError, match='query: .* not found in index with bounds:'
         ):
-            dataset[query]
+            dataset[100:100, 100:100, pd.Timestamp.min : pd.Timestamp.min]
 
     def test_plot(self, dataset: OpenBuildings) -> None:
         x = dataset[dataset.bounds]

--- a/tests/datasets/test_prisma.py
+++ b/tests/datasets/test_prisma.py
@@ -13,7 +13,6 @@ from pyproj import CRS
 
 from torchgeo.datasets import (
     PRISMA,
-    BoundingBox,
     DatasetNotFoundError,
     IntersectionDataset,
     UnionDataset,
@@ -54,8 +53,7 @@ class TestPRISMA:
             PRISMA(tmp_path)
 
     def test_invalid_query(self, dataset: PRISMA) -> None:
-        query = BoundingBox(0, 0, 0, 0, pd.Timestamp.min, pd.Timestamp.min)
         with pytest.raises(
             IndexError, match='query: .* not found in index with bounds:'
         ):
-            dataset[query]
+            dataset[0:0, 0:0, pd.Timestamp.min : pd.Timestamp.min]

--- a/tests/datasets/test_sentinel.py
+++ b/tests/datasets/test_sentinel.py
@@ -13,7 +13,6 @@ from _pytest.fixtures import SubRequest
 from pyproj import CRS
 
 from torchgeo.datasets import (
-    BoundingBox,
     DatasetNotFoundError,
     IntersectionDataset,
     RGBBandsMissingError,
@@ -92,11 +91,10 @@ class TestSentinel1:
             Sentinel1(bands=bands)
 
     def test_invalid_query(self, dataset: Sentinel1) -> None:
-        query = BoundingBox(-1, -1, -1, -1, pd.Timestamp.min, pd.Timestamp.min)
         with pytest.raises(
             IndexError, match='query: .* not found in index with bounds:'
         ):
-            dataset[query]
+            dataset[-1:-1, -1:-1, pd.Timestamp.min : pd.Timestamp.min]
 
 
 class TestSentinel2:
@@ -144,11 +142,10 @@ class TestSentinel2:
             ds.plot(x)
 
     def test_invalid_query(self, dataset: Sentinel2) -> None:
-        query = BoundingBox(0, 0, 0, 0, pd.Timestamp.min, pd.Timestamp.min)
         with pytest.raises(
             IndexError, match='query: .* not found in index with bounds:'
         ):
-            dataset[query]
+            dataset[0:0, 0:0, pd.Timestamp.min : pd.Timestamp.min]
 
     def test_float_res(self, dataset: Sentinel2) -> None:
         Sentinel2(dataset.paths, res=10.0, bands=dataset.bands)

--- a/tests/datasets/test_south_africa_crop_type.py
+++ b/tests/datasets/test_south_africa_crop_type.py
@@ -14,7 +14,6 @@ from pyproj import CRS
 from pytest import MonkeyPatch
 
 from torchgeo.datasets import (
-    BoundingBox,
     DatasetNotFoundError,
     IntersectionDataset,
     RGBBandsMissingError,
@@ -82,11 +81,10 @@ class TestSouthAfricaCropType:
         plt.close()
 
     def test_invalid_query(self, dataset: SouthAfricaCropType) -> None:
-        query = BoundingBox(0, 0, 0, 0, pd.Timestamp.min, pd.Timestamp.min)
         with pytest.raises(
             IndexError, match='query: .* not found in index with bounds:'
         ):
-            dataset[query]
+            dataset[0:0, 0:0, pd.Timestamp.min : pd.Timestamp.min]
 
     def test_rgb_bands_absent_plot(self) -> None:
         path = os.path.join('tests', 'data', 'south_africa_crop_type')

--- a/tests/datasets/test_south_america_soybean.py
+++ b/tests/datasets/test_south_america_soybean.py
@@ -13,7 +13,6 @@ from pyproj import CRS
 from pytest import MonkeyPatch
 
 from torchgeo.datasets import (
-    BoundingBox,
     DatasetNotFoundError,
     IntersectionDataset,
     SouthAmericaSoybean,
@@ -85,8 +84,7 @@ class TestSouthAmericaSoybean:
             SouthAmericaSoybean(tmp_path)
 
     def test_invalid_query(self, dataset: SouthAmericaSoybean) -> None:
-        query = BoundingBox(0, 0, 0, 0, pd.Timestamp.min, pd.Timestamp.min)
         with pytest.raises(
             IndexError, match='query: .* not found in index with bounds:'
         ):
-            dataset[query]
+            dataset[0:0, 0:0, pd.Timestamp.min : pd.Timestamp.min]

--- a/tests/datasets/test_splits.py
+++ b/tests/datasets/test_splits.py
@@ -23,6 +23,7 @@ from torchgeo.datasets import (
     roi_split,
     time_series_split,
 )
+from torchgeo.datasets.utils import GeoSlice
 
 MINT = datetime(2025, 4, 24)
 MAXT = datetime(2025, 4, 25)
@@ -57,7 +58,7 @@ class CustomGeoDataset(GeoDataset):
         self.index = GeoDataFrame(index=index, geometry=geometry, crs=crs)
         self.res = (1, 1)
 
-    def __getitem__(self, query: BoundingBox) -> dict[str, Any]:
+    def __getitem__(self, query: GeoSlice) -> dict[str, Any]:
         return {'index': query}
 
 

--- a/tests/samplers/test_batch.py
+++ b/tests/samplers/test_batch.py
@@ -17,6 +17,7 @@ from shapely import Geometry
 from torch.utils.data import DataLoader
 
 from torchgeo.datasets import BoundingBox, GeoDataset, stack_samples
+from torchgeo.datasets.utils import GeoSlice
 from torchgeo.samplers import BatchGeoSampler, RandomBatchGeoSampler, Units
 
 MINT = datetime(2025, 4, 24)
@@ -24,9 +25,9 @@ MAXT = datetime(2025, 4, 25)
 
 
 class CustomBatchGeoSampler(BatchGeoSampler):
-    def __iter__(self) -> Iterator[list[BoundingBox]]:
+    def __iter__(self) -> Iterator[list[GeoSlice]]:
         for i in range(2):
-            yield [BoundingBox(j, j, j, j, MINT, MAXT) for j in range(2)]
+            yield [(slice(j, j), slice(j, j), slice(MINT, MAXT)) for j in range(2)]
 
 
 class CustomGeoDataset(GeoDataset):
@@ -39,7 +40,7 @@ class CustomGeoDataset(GeoDataset):
         self.index = GeoDataFrame(index=index, geometry=geometry, crs=crs)
         self.res = res
 
-    def __getitem__(self, query: BoundingBox) -> dict[str, BoundingBox]:
+    def __getitem__(self, query: GeoSlice) -> dict[str, GeoSlice]:
         return {'index': query}
 
 
@@ -55,8 +56,8 @@ class TestBatchGeoSampler:
 
     def test_iter(self, sampler: CustomBatchGeoSampler) -> None:
         expected = [
-            BoundingBox(0, 0, 0, 0, MINT, MAXT),
-            BoundingBox(1, 1, 1, 1, MINT, MAXT),
+            (slice(0, 0), slice(0, 0), slice(MINT, MAXT)),
+            (slice(1, 1), slice(1, 1), slice(MINT, MAXT)),
         ]
         assert next(iter(sampler)) == expected
 

--- a/tests/samplers/test_single.py
+++ b/tests/samplers/test_single.py
@@ -17,6 +17,7 @@ from shapely import Geometry, Point
 from torch.utils.data import DataLoader
 
 from torchgeo.datasets import BoundingBox, GeoDataset, stack_samples
+from torchgeo.datasets.utils import GeoSlice
 from torchgeo.samplers import (
     GeoSampler,
     GridGeoSampler,
@@ -31,9 +32,9 @@ MAXT = datetime(2025, 4, 25)
 
 
 class CustomGeoSampler(GeoSampler):
-    def __iter__(self) -> Iterator[BoundingBox]:
+    def __iter__(self) -> Iterator[GeoSlice]:
         for i in range(2):
-            yield BoundingBox(i, i, i, i, MINT, MAXT)
+            yield slice(i, i), slice(i, i), slice(MINT, MAXT)
 
 
 class CustomGeoDataset(GeoDataset):
@@ -46,7 +47,7 @@ class CustomGeoDataset(GeoDataset):
         self.index = GeoDataFrame(index=index, geometry=geometry, crs=crs)
         self.res = res
 
-    def __getitem__(self, query: BoundingBox) -> dict[str, BoundingBox]:
+    def __getitem__(self, query: GeoSlice) -> dict[str, GeoSlice]:
         return {'index': query}
 
 
@@ -61,7 +62,7 @@ class TestGeoSampler:
         return CustomGeoSampler(dataset)
 
     def test_iter(self, sampler: CustomGeoSampler) -> None:
-        assert next(iter(sampler)) == BoundingBox(0, 0, 0, 0, MINT, MAXT)
+        assert next(iter(sampler)) == (slice(0, 0), slice(0, 0), slice(MINT, MAXT))
 
     def test_abstract(self, dataset: CustomGeoDataset) -> None:
         with pytest.raises(TypeError, match="Can't instantiate abstract class"):

--- a/tests/samplers/test_single.py
+++ b/tests/samplers/test_single.py
@@ -283,8 +283,13 @@ class TestPreChippedGeoSampler:
     def test_roi(self, dataset: CustomGeoDataset) -> None:
         roi = BoundingBox(5, 15, 5, 15, MINT, MAXT)
         sampler = PreChippedGeoSampler(dataset, roi=roi)
-        for query in sampler:
-            assert query == roi
+        for x, y, t in sampler:
+            assert roi.minx == x.start
+            assert roi.maxx == x.stop
+            assert roi.miny == y.start
+            assert roi.maxy == y.stop
+            assert roi.mint == t.start
+            assert roi.maxt == t.stop
 
     def test_point_data(self) -> None:
         geometry = [shapely.Point(0, 0), shapely.Point(1, 1)]

--- a/tests/samplers/test_utils.py
+++ b/tests/samplers/test_utils.py
@@ -2,18 +2,13 @@
 # Licensed under the MIT License.
 
 import math
-from datetime import datetime
 
 import pytest
 
-from torchgeo.datasets import BoundingBox
 from torchgeo.samplers import tile_to_chips
 from torchgeo.samplers.utils import _to_tuple
 
 MAYBE_TUPLE = float | tuple[float, float]
-
-MINT = datetime(2025, 4, 24)
-MAXT = datetime(2025, 4, 25)
 
 
 @pytest.mark.parametrize(
@@ -38,7 +33,7 @@ MAXT = datetime(2025, 4, 25)
 def test_tile_to_chips(
     size: MAYBE_TUPLE, stride: MAYBE_TUPLE | None, expected: MAYBE_TUPLE
 ) -> None:
-    bounds = BoundingBox(0, 10, 20, 30, MINT, MAXT)
+    bounds = (0, 20, 10, 30)
     size = _to_tuple(size)
     if stride is not None:
         stride = _to_tuple(stride)

--- a/torchgeo/datamodules/naip.py
+++ b/torchgeo/datamodules/naip.py
@@ -82,24 +82,22 @@ class NAIPChesapeakeDataModule(GeoDataModule):
         self.chesapeake = dc | de | md | ny | pa | va | wv
         self.dataset = self.naip & self.chesapeake
 
-        roi = self.dataset.bounds
-        midx = roi.minx + (roi.maxx - roi.minx) / 2
-        midy = roi.miny + (roi.maxy - roi.miny) / 2
+        x, y, t = self.dataset.bounds
+        midx = x.start + (x.stop - x.start) / 2
+        midy = y.start + (y.stop - y.start) / 2
 
         if stage in ['fit']:
-            train_roi = BoundingBox(
-                roi.minx, midx, roi.miny, roi.maxy, roi.mint, roi.maxt
-            )
+            train_roi = BoundingBox(x.start, midx, y.start, y.stop, t.start, t.stop)
             self.train_batch_sampler = RandomBatchGeoSampler(
                 self.dataset, self.patch_size, self.batch_size, self.length, train_roi
             )
         if stage in ['fit', 'validate']:
-            val_roi = BoundingBox(midx, roi.maxx, roi.miny, midy, roi.mint, roi.maxt)
+            val_roi = BoundingBox(midx, x.stop, y.start, midy, t.start, t.stop)
             self.val_sampler = GridGeoSampler(
                 self.dataset, self.patch_size, self.patch_size, val_roi
             )
         if stage in ['test']:
-            test_roi = BoundingBox(midx, roi.maxx, midy, roi.maxy, roi.mint, roi.maxt)
+            test_roi = BoundingBox(midx, x.stop, midy, y.stop, t.start, t.stop)
             self.test_sampler = GridGeoSampler(
                 self.dataset, self.patch_size, self.patch_size, test_roi
             )

--- a/torchgeo/datasets/agrifieldnet.py
+++ b/torchgeo/datasets/agrifieldnet.py
@@ -186,13 +186,11 @@ class AgriFieldNet(RasterDataset):
         """
         assert isinstance(self.paths, str | os.PathLike)
 
-        xmin, xmax, xres, ymin, ymax, yres, tmin, tmax, tres = self._disambiguate_slice(
-            query
-        )
-        interval = pd.Interval(tmin, tmax)
+        x, y, t = self._disambiguate_slice(query)
+        interval = pd.Interval(t.start, t.stop)
         index = self.index.iloc[self.index.index.overlaps(interval)]
-        index = index.iloc[::tres]
-        index = index.cx[xmin:xmax, ymin:ymax]  # type: ignore[misc]
+        index = index.iloc[:: t.step]
+        index = index.cx[x.start : x.stop, y.start : y.stop]  # type: ignore[misc]
 
         if index.empty:
             raise IndexError(

--- a/torchgeo/datasets/agrifieldnet.py
+++ b/torchgeo/datasets/agrifieldnet.py
@@ -190,7 +190,7 @@ class AgriFieldNet(RasterDataset):
         interval = pd.Interval(t.start, t.stop)
         index = self.index.iloc[self.index.index.overlaps(interval)]
         index = index.iloc[:: t.step]
-        index = index.cx[x.start : x.stop, y.start : y.stop]  # type: ignore[misc]
+        index = index.cx[x.start : x.stop, y.start : y.stop]
 
         if index.empty:
             raise IndexError(

--- a/torchgeo/datasets/cdl.py
+++ b/torchgeo/datasets/cdl.py
@@ -14,7 +14,7 @@ from pyproj import CRS
 
 from .errors import DatasetNotFoundError
 from .geo import RasterDataset
-from .utils import BoundingBox, Path, download_url, extract_archive
+from .utils import GeoSlice, Path, download_url, extract_archive
 
 
 class CDL(RasterDataset):
@@ -271,17 +271,17 @@ class CDL(RasterDataset):
             self.ordinal_map[k] = v
             self.ordinal_cmap[v] = torch.tensor(self.cmap[k])
 
-    def __getitem__(self, query: BoundingBox) -> dict[str, Any]:
-        """Retrieve mask and metadata indexed by query.
+    def __getitem__(self, query: GeoSlice) -> dict[str, Any]:
+        """Retrieve input, target, and/or metadata indexed by spatiotemporal slice.
 
         Args:
-            query: (minx, maxx, miny, maxy, mint, maxt) coordinates to index
+            query: [xmin:xmax:xres, ymin:ymax:yres, tmin:tmax:tres] coordinates to index.
 
         Returns:
-            sample of mask and metadata at that index
+            Sample of input, target, and/or metadata at that index.
 
         Raises:
-            IndexError: if query is not found in the index
+            IndexError: If *query* is not found in the index.
         """
         sample = super().__getitem__(query)
         sample['mask'] = self.ordinal_map[sample['mask']]

--- a/torchgeo/datasets/chesapeake.py
+++ b/torchgeo/datasets/chesapeake.py
@@ -530,7 +530,7 @@ class ChesapeakeCVPR(GeoDataset):
         interval = pd.Interval(t.start, t.stop)
         index = self.index.iloc[self.index.index.overlaps(interval)]
         index = index.iloc[:: t.step]
-        index = index.cx[x.start : x.stop, y.start : y.stop]  # type: ignore[misc]
+        index = index.cx[x.start : x.stop, y.start : y.stop]
 
         sample: dict[str, Any] = {
             'image': [],

--- a/torchgeo/datasets/eddmaps.py
+++ b/torchgeo/datasets/eddmaps.py
@@ -17,7 +17,7 @@ from matplotlib.ticker import FuncFormatter
 
 from .errors import DatasetNotFoundError
 from .geo import GeoDataset
-from .utils import BoundingBox, Path, disambiguate_timestamp
+from .utils import GeoSlice, Path, disambiguate_timestamp
 
 
 class EDDMapS(GeoDataset):
@@ -73,21 +73,23 @@ class EDDMapS(GeoDataset):
         geometry = gpd.points_from_xy(df.Longitude, df.Latitude)
         self.index = GeoDataFrame(index=index, geometry=geometry, crs='EPSG:4326')
 
-    def __getitem__(self, query: BoundingBox) -> dict[str, Any]:
-        """Retrieve metadata indexed by query.
+    def __getitem__(self, query: GeoSlice) -> dict[str, Any]:
+        """Retrieve input, target, and/or metadata indexed by spatiotemporal slice.
 
         Args:
-            query: (minx, maxx, miny, maxy, mint, maxt) coordinates to index
+            query: [xmin:xmax:xres, ymin:ymax:yres, tmin:tmax:tres] coordinates to index.
 
         Returns:
-            sample of metadata at that index
+            Sample of input, target, and/or metadata at that index.
 
         Raises:
-            IndexError: if query is not found in the index
+            IndexError: If *query* is not found in the index.
         """
-        interval = pd.Interval(query.mint, query.maxt)
+        x, y, t = self._disambiguate_slice(query)
+        interval = pd.Interval(t.start, t.stop)
         index = self.index.iloc[self.index.index.overlaps(interval)]
-        index = index.cx[query.minx : query.maxx, query.miny : query.maxy]  # type: ignore[misc]
+        index = index.iloc[:: t.step]
+        index = index.cx[x.start : x.stop, y.start : y.stop]  # type: ignore[misc]
 
         if index.empty:
             raise IndexError(

--- a/torchgeo/datasets/eddmaps.py
+++ b/torchgeo/datasets/eddmaps.py
@@ -89,7 +89,7 @@ class EDDMapS(GeoDataset):
         interval = pd.Interval(t.start, t.stop)
         index = self.index.iloc[self.index.index.overlaps(interval)]
         index = index.iloc[:: t.step]
-        index = index.cx[x.start : x.stop, y.start : y.stop]  # type: ignore[misc]
+        index = index.cx[x.start : x.stop, y.start : y.stop]
 
         if index.empty:
             raise IndexError(

--- a/torchgeo/datasets/enviroatlas.py
+++ b/torchgeo/datasets/enviroatlas.py
@@ -351,7 +351,7 @@ class EnviroAtlas(GeoDataset):
         interval = pd.Interval(t.start, t.stop)
         index = self.index.iloc[self.index.index.overlaps(interval)]
         index = index.iloc[:: t.step]
-        index = index.cx[x.start : x.stop, y.start : y.stop]  # type: ignore[misc]
+        index = index.cx[x.start : x.stop, y.start : y.stop]
 
         sample: dict[str, Any] = {
             'image': [],

--- a/torchgeo/datasets/enviroatlas.py
+++ b/torchgeo/datasets/enviroatlas.py
@@ -368,7 +368,6 @@ class EnviroAtlas(GeoDataset):
             filenames = index.iloc[0]
             query_geom_transformed = None  # is set by the first layer
 
-            minx, maxx, miny, maxy, mint, maxt = query
             query_box = shapely.geometry.box(x.start, y.start, x.stop, y.stop)
 
             for layer in self.layers:

--- a/torchgeo/datasets/enviroatlas.py
+++ b/torchgeo/datasets/enviroatlas.py
@@ -24,7 +24,7 @@ from pyproj import CRS
 
 from .errors import DatasetNotFoundError
 from .geo import GeoDataset
-from .utils import BoundingBox, Path, download_url, extract_archive
+from .utils import GeoSlice, Path, download_url, extract_archive
 
 
 class EnviroAtlas(GeoDataset):
@@ -335,21 +335,23 @@ class EnviroAtlas(GeoDataset):
         crs = CRS.from_epsg(3857)
         self.index = GeoDataFrame(data, index=index, geometry=geometries, crs=crs)
 
-    def __getitem__(self, query: BoundingBox) -> dict[str, Any]:
-        """Retrieve image/mask and metadata indexed by query.
+    def __getitem__(self, query: GeoSlice) -> dict[str, Any]:
+        """Retrieve input, target, and/or metadata indexed by spatiotemporal slice.
 
         Args:
-            query: (minx, maxx, miny, maxy, mint, maxt) coordinates to index
+            query: [xmin:xmax:xres, ymin:ymax:yres, tmin:tmax:tres] coordinates to index.
 
         Returns:
-            sample of image/mask and metadata at that index
+            Sample of input, target, and/or metadata at that index.
 
         Raises:
-            IndexError: if query is not found in the index
+            IndexError: If *query* is not found in the index.
         """
-        interval = pd.Interval(query.mint, query.maxt)
+        x, y, t = self._disambiguate_slice(query)
+        interval = pd.Interval(t.start, t.stop)
         index = self.index.iloc[self.index.index.overlaps(interval)]
-        index = index.cx[query.minx : query.maxx, query.miny : query.maxy]  # type: ignore[misc]
+        index = index.iloc[:: t.step]
+        index = index.cx[x.start : x.stop, y.start : y.stop]  # type: ignore[misc]
 
         sample: dict[str, Any] = {
             'image': [],
@@ -367,7 +369,7 @@ class EnviroAtlas(GeoDataset):
             query_geom_transformed = None  # is set by the first layer
 
             minx, maxx, miny, maxy, mint, maxt = query
-            query_box = shapely.geometry.box(minx, miny, maxx, maxy)
+            query_box = shapely.geometry.box(x.start, y.start, x.stop, y.stop)
 
             for layer in self.layers:
                 fn = filenames[layer]

--- a/torchgeo/datasets/gbif.py
+++ b/torchgeo/datasets/gbif.py
@@ -92,7 +92,7 @@ class GBIF(GeoDataset):
         interval = pd.Interval(t.start, t.stop)
         index = self.index.iloc[self.index.index.overlaps(interval)]
         index = index.iloc[:: t.step]
-        index = index.cx[x.start : x.stop, y.start : y.stop]  # type: ignore[misc]
+        index = index.cx[x.start : x.stop, y.start : y.stop]
 
         if index.empty:
             raise IndexError(

--- a/torchgeo/datasets/gbif.py
+++ b/torchgeo/datasets/gbif.py
@@ -18,7 +18,7 @@ from matplotlib.ticker import FuncFormatter
 
 from .errors import DatasetNotFoundError
 from .geo import GeoDataset
-from .utils import BoundingBox, Path, disambiguate_timestamp
+from .utils import GeoSlice, Path, disambiguate_timestamp
 
 
 class GBIF(GeoDataset):
@@ -76,21 +76,23 @@ class GBIF(GeoDataset):
         geometry = gpd.points_from_xy(df.decimalLongitude, df.decimalLatitude)
         self.index = GeoDataFrame(index=index, geometry=geometry, crs='EPSG:4326')
 
-    def __getitem__(self, query: BoundingBox) -> dict[str, Any]:
-        """Retrieve metadata indexed by query.
+    def __getitem__(self, query: GeoSlice) -> dict[str, Any]:
+        """Retrieve input, target, and/or metadata indexed by spatiotemporal slice.
 
         Args:
-            query: (minx, maxx, miny, maxy, mint, maxt) coordinates to index
+            query: [xmin:xmax:xres, ymin:ymax:yres, tmin:tmax:tres] coordinates to index.
 
         Returns:
-            sample of metadata at that index
+            Sample of input, target, and/or metadata at that index.
 
         Raises:
-            IndexError: if query is not found in the index
+            IndexError: If *query* is not found in the index.
         """
-        interval = pd.Interval(query.mint, query.maxt)
+        x, y, t = self._disambiguate_slice(query)
+        interval = pd.Interval(t.start, t.stop)
         index = self.index.iloc[self.index.index.overlaps(interval)]
-        index = index.cx[query.minx : query.maxx, query.miny : query.maxy]  # type: ignore[misc]
+        index = index.iloc[:: t.step]
+        index = index.cx[x.start : x.stop, y.start : y.stop]  # type: ignore[misc]
 
         if index.empty:
             raise IndexError(

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -585,8 +585,9 @@ class RasterDataset(GeoDataset):
             key
         )
         bounds = (xmin, ymin, xmax, ymax)
+        res = (xres, yres)
         dest, _ = rasterio.merge.merge(
-            vrt_fhs, bounds, self.res, indexes=band_indexes, resampling=self.resampling
+            vrt_fhs, bounds, res, indexes=band_indexes, resampling=self.resampling
         )
         # Use array_to_tensor since merge may return uint16/uint32 arrays.
         tensor = array_to_tensor(dest)
@@ -774,8 +775,8 @@ class VectorDataset(GeoDataset):
                     shapes.append((shape, label))
 
         # Rasterize geometries
-        width = (xmax - xmin) / self.res[0]
-        height = (ymax - ymin) / self.res[1]
+        width = (xmax - xmin) / xres
+        height = (ymax - ymin) / yres
         transform = rasterio.transform.from_bounds(
             xmin, ymin, xmax, ymax, width, height
         )

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -545,7 +545,7 @@ class RasterDataset(GeoDataset):
         else:
             data = self._merge_files(index.filepath, query, self.band_indexes)
 
-        sample = {'crs': self.crs, 'bounds': query}
+        sample: dict[str, Any] = {'crs': self.crs, 'bounds': query}
 
         data = data.to(self.dtype)
         if self.is_image:

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -519,6 +519,7 @@ class RasterDataset(GeoDataset):
         )
         interval = pd.Interval(tmin, tmax)
         index = self.index.iloc[self.index.index.overlaps(interval)]
+        index = index.iloc[::tres]
         index = index.cx[xmin:xmax, ymin:ymax]  # type: ignore[misc]
 
         if index.empty:
@@ -750,6 +751,7 @@ class VectorDataset(GeoDataset):
         )
         interval = pd.Interval(tmin, tmax)
         index = self.index.iloc[self.index.index.overlaps(interval)]
+        index = index.iloc[::tres]
         index = index.cx[xmin:xmax, ymin:ymax]  # type: ignore[misc]
 
         if index.empty:

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -543,7 +543,7 @@ class RasterDataset(GeoDataset):
         else:
             data = self._merge_files(index.filepath, query, self.band_indexes)
 
-        sample = {'crs': self.crs}
+        sample = {'crs': self.crs, 'bounds': query}
 
         data = data.to(self.dtype)
         if self.is_image:
@@ -786,7 +786,7 @@ class VectorDataset(GeoDataset):
         masks = array_to_tensor(masks)
 
         masks = masks.to(self.dtype)
-        sample = {'mask': masks, 'crs': self.crs}
+        sample = {'mask': masks, 'crs': self.crs, 'bounds': query}
 
         if self.transforms is not None:
             sample = self.transforms(sample)
@@ -1028,6 +1028,7 @@ class IntersectionDataset(GeoDataset):
         Raises:
             IndexError: If *query* is not found in the index.
         """
+        # All datasets are guaranteed to have a valid query
         samples = [ds[query] for ds in self.datasets]
 
         sample = self.collate_fn(samples)

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -132,7 +132,9 @@ class GeoDataset(Dataset[dict[str, Any]], abc.ABC):
         if isinstance(key, slice):
             key = (key,)
 
+        # For each slice (x, y, t)...
         for i in range(len(key)):
+            # For each component (start, stop, step)...
             if key[i].start is not None:
                 out[i * 3 + 0] = key[i].start
             if key[i].stop is not None:

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -1177,6 +1177,11 @@ class UnionDataset(GeoDataset):
             except IndexError:
                 pass
 
+        if not samples:
+            raise IndexError(
+                f'key: {key} not found in index with bounds: {self.bounds}'
+            )
+
         sample = self.collate_fn(samples)
 
         if self.transforms is not None:

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -135,7 +135,9 @@ class GeoDataset(Dataset[dict[str, Any]], abc.ABC):
             if query[i].step is not None:
                 out[i] = slice(out[i].start, out[i].stop, query[i].step)
 
-        return tuple(out)
+        geoslice = tuple(out)
+        assert len(geoslice) == 3
+        return geoslice
 
     @abc.abstractmethod
     def __getitem__(self, query: GeoSlice) -> dict[str, Any]:
@@ -515,7 +517,7 @@ class RasterDataset(GeoDataset):
         interval = pd.Interval(t.start, t.stop)
         index = self.index.iloc[self.index.index.overlaps(interval)]
         index = index.iloc[:: t.step]
-        index = index.cx[x.start : x.stop, y.start : y.stop]  # type: ignore[misc]
+        index = index.cx[x.start : x.stop, y.start : y.stop]
 
         if index.empty:
             raise IndexError(
@@ -743,7 +745,7 @@ class VectorDataset(GeoDataset):
         interval = pd.Interval(t.start, t.stop)
         index = self.index.iloc[self.index.index.overlaps(interval)]
         index = index.iloc[:: t.step]
-        index = index.cx[x.start : x.stop, y.start : y.stop]  # type: ignore[misc]
+        index = index.cx[x.start : x.stop, y.start : y.stop]
 
         if index.empty:
             raise IndexError(

--- a/torchgeo/datasets/globbiomass.py
+++ b/torchgeo/datasets/globbiomass.py
@@ -199,7 +199,7 @@ class GlobBiomass(RasterDataset):
         interval = pd.Interval(t.start, t.stop)
         index = self.index.iloc[self.index.index.overlaps(interval)]
         index = index.iloc[:: t.step]
-        index = index.cx[x.start : x.stop, y.start : y.stop]  # type: ignore[misc]
+        index = index.cx[x.start : x.stop, y.start : y.stop]
 
         if index.empty:
             raise IndexError(

--- a/torchgeo/datasets/globbiomass.py
+++ b/torchgeo/datasets/globbiomass.py
@@ -18,7 +18,7 @@ from pyproj import CRS
 from .errors import DatasetNotFoundError
 from .geo import RasterDataset
 from .utils import (
-    BoundingBox,
+    GeoSlice,
     Path,
     check_integrity,
     disambiguate_timestamp,
@@ -183,22 +183,23 @@ class GlobBiomass(RasterDataset):
 
         super().__init__(paths, crs, res, transforms=transforms, cache=cache)
 
-    def __getitem__(self, query: BoundingBox) -> dict[str, Any]:
-        """Retrieve image/mask and metadata indexed by query.
+    def __getitem__(self, query: GeoSlice) -> dict[str, Any]:
+        """Retrieve input, target, and/or metadata indexed by spatiotemporal slice.
 
         Args:
-            query: (minx, maxx, miny, maxy, mint, maxt) coordinates to index
+            query: [xmin:xmax:xres, ymin:ymax:yres, tmin:tmax:tres] coordinates to index.
 
         Returns:
-            sample at index consisting of measurement mask with 2 channels,
-            where the first is the measurement and the second the error map
+            Sample of input, target, and/or metadata at that index.
 
         Raises:
-            IndexError: if query is not found in the index
+            IndexError: If *query* is not found in the index.
         """
-        interval = pd.Interval(query.mint, query.maxt)
+        x, y, t = self._disambiguate_slice(query)
+        interval = pd.Interval(t.start, t.stop)
         index = self.index.iloc[self.index.index.overlaps(interval)]
-        index = index.cx[query.minx : query.maxx, query.miny : query.maxy]  # type: ignore[misc]
+        index = index.iloc[:: t.step]
+        index = index.cx[x.start : x.stop, y.start : y.stop]  # type: ignore[misc]
 
         if index.empty:
             raise IndexError(

--- a/torchgeo/datasets/inaturalist.py
+++ b/torchgeo/datasets/inaturalist.py
@@ -85,7 +85,7 @@ class INaturalist(GeoDataset):
         interval = pd.Interval(t.start, t.stop)
         index = self.index.iloc[self.index.index.overlaps(interval)]
         index = index.iloc[:: t.step]
-        index = index.cx[x.start : x.stop, y.start : y.stop]  # type: ignore[misc]
+        index = index.cx[x.start : x.stop, y.start : y.stop]
 
         if index.empty:
             raise IndexError(

--- a/torchgeo/datasets/inaturalist.py
+++ b/torchgeo/datasets/inaturalist.py
@@ -18,7 +18,7 @@ from matplotlib.ticker import FuncFormatter
 
 from .errors import DatasetNotFoundError
 from .geo import GeoDataset
-from .utils import BoundingBox, Path, disambiguate_timestamp
+from .utils import GeoSlice, Path, disambiguate_timestamp
 
 
 class INaturalist(GeoDataset):
@@ -69,21 +69,23 @@ class INaturalist(GeoDataset):
         geometry = gpd.points_from_xy(df.longitude, df.latitude)
         self.index = GeoDataFrame(index=index, geometry=geometry, crs='EPSG:4326')
 
-    def __getitem__(self, query: BoundingBox) -> dict[str, Any]:
-        """Retrieve metadata indexed by query.
+    def __getitem__(self, query: GeoSlice) -> dict[str, Any]:
+        """Retrieve input, target, and/or metadata indexed by spatiotemporal slice.
 
         Args:
-            query: (minx, maxx, miny, maxy, mint, maxt) coordinates to index
+            query: [xmin:xmax:xres, ymin:ymax:yres, tmin:tmax:tres] coordinates to index.
 
         Returns:
-            sample of metadata at that index
+            Sample of input, target, and/or metadata at that index.
 
         Raises:
-            IndexError: if query is not found in the index
+            IndexError: If *query* is not found in the index.
         """
-        interval = pd.Interval(query.mint, query.maxt)
+        x, y, t = self._disambiguate_slice(query)
+        interval = pd.Interval(t.start, t.stop)
         index = self.index.iloc[self.index.index.overlaps(interval)]
-        index = index.cx[query.minx : query.maxx, query.miny : query.maxy]  # type: ignore[misc]
+        index = index.iloc[:: t.step]
+        index = index.cx[x.start : x.stop, y.start : y.stop]  # type: ignore[misc]
 
         if index.empty:
             raise IndexError(

--- a/torchgeo/datasets/l7irish.py
+++ b/torchgeo/datasets/l7irish.py
@@ -16,7 +16,7 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError, RGBBandsMissingError
 from .geo import IntersectionDataset, RasterDataset
-from .utils import BoundingBox, Path, download_url, extract_archive
+from .utils import GeoSlice, Path, download_url, extract_archive
 
 
 class L7IrishImage(RasterDataset):
@@ -57,17 +57,17 @@ class L7IrishMask(RasterDataset):
     ordinal_map[192] = 3
     ordinal_map[255] = 4
 
-    def __getitem__(self, query: BoundingBox) -> dict[str, Any]:
-        """Retrieve image/mask and metadata indexed by query.
+    def __getitem__(self, query: GeoSlice) -> dict[str, Any]:
+        """Retrieve input, target, and/or metadata indexed by spatiotemporal slice.
 
         Args:
-            query: (minx, maxx, miny, maxy, mint, maxt) coordinates to index
+            query: [xmin:xmax:xres, ymin:ymax:yres, tmin:tmax:tres] coordinates to index.
 
         Returns:
-            sample of image, mask and metadata at that index
+            Sample of input, target, and/or metadata at that index.
 
         Raises:
-            IndexError: if query is not found in the index
+            IndexError: If *query* is not found in the index.
         """
         sample = super().__getitem__(query)
         sample['mask'] = self.ordinal_map[sample['mask']]

--- a/torchgeo/datasets/l8biome.py
+++ b/torchgeo/datasets/l8biome.py
@@ -16,7 +16,7 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError, RGBBandsMissingError
 from .geo import IntersectionDataset, RasterDataset
-from .utils import BoundingBox, Path, download_url, extract_archive
+from .utils import GeoSlice, Path, download_url, extract_archive
 
 
 class L8BiomeImage(RasterDataset):
@@ -63,15 +63,17 @@ class L8BiomeMask(RasterDataset):
     ordinal_map[192] = 3
     ordinal_map[255] = 4
 
-    def __getitem__(self, query: BoundingBox) -> dict[str, Any]:
-        """Retrieve image/mask and metadata indexed by query.
+    def __getitem__(self, query: GeoSlice) -> dict[str, Any]:
+        """Retrieve input, target, and/or metadata indexed by spatiotemporal slice.
 
         Args:
-            query: (minx, maxx, miny, maxy, mint, maxt) coordinates to index
+            query: [xmin:xmax:xres, ymin:ymax:yres, tmin:tmax:tres] coordinates to index.
+
         Returns:
-            sample of image, mask and metadata at that index
+            Sample of input, target, and/or metadata at that index.
+
         Raises:
-            IndexError: if query is not found in the index
+            IndexError: If *query* is not found in the index.
         """
         sample = super().__getitem__(query)
         sample['mask'] = self.ordinal_map[sample['mask']]

--- a/torchgeo/datasets/landcoverai.py
+++ b/torchgeo/datasets/landcoverai.py
@@ -24,7 +24,7 @@ from torch.utils.data import Dataset
 
 from .errors import DatasetNotFoundError
 from .geo import NonGeoDataset, RasterDataset
-from .utils import BoundingBox, Path, download_url, extract_archive, working_dir
+from .utils import GeoSlice, Path, download_url, extract_archive, working_dir
 
 
 class LandCoverAIBase(Dataset[dict[str, Any]], abc.ABC):
@@ -242,21 +242,24 @@ class LandCoverAIGeo(LandCoverAIBase, RasterDataset):
         masks = glob.glob(mask_query)
         return len(images) > 0 and len(images) == len(masks)
 
-    def __getitem__(self, query: BoundingBox) -> dict[str, Any]:
-        """Retrieve image/mask and metadata indexed by query.
+    def __getitem__(self, query: GeoSlice) -> dict[str, Any]:
+        """Retrieve input, target, and/or metadata indexed by spatiotemporal slice.
 
         Args:
-            query: (minx, maxx, miny, maxy, mint, maxt) coordinates to index
+            query: [xmin:xmax:xres, ymin:ymax:yres, tmin:tmax:tres] coordinates to index.
 
         Returns:
-            sample of image, mask and metadata at that index
+            Sample of input, target, and/or metadata at that index.
 
         Raises:
-            IndexError: if query is not found in the index
+            IndexError: If *query* is not found in the index.
         """
-        interval = pd.Interval(query.mint, query.maxt)
+        x, y, t = self._disambiguate_slice(query)
+        interval = pd.Interval(t.start, t.stop)
         index = self.index.iloc[self.index.index.overlaps(interval)]
-        index = index.cx[query.minx : query.maxx, query.miny : query.maxy]  # type: ignore[misc]
+        index = index.iloc[:: t.step]
+        index = index.cx[x.start : x.stop, y.start : y.stop]  # type: ignore[misc]
+
         img_filepaths = index.filepath
         mask_filepaths = img_filepaths.apply(lambda x: x.replace('images', 'masks'))
 

--- a/torchgeo/datasets/landcoverai.py
+++ b/torchgeo/datasets/landcoverai.py
@@ -258,7 +258,7 @@ class LandCoverAIGeo(LandCoverAIBase, RasterDataset):
         interval = pd.Interval(t.start, t.stop)
         index = self.index.iloc[self.index.index.overlaps(interval)]
         index = index.iloc[:: t.step]
-        index = index.cx[x.start : x.stop, y.start : y.stop]  # type: ignore[misc]
+        index = index.cx[x.start : x.stop, y.start : y.stop]
 
         img_filepaths = index.filepath
         mask_filepaths = img_filepaths.apply(lambda x: x.replace('images', 'masks'))

--- a/torchgeo/datasets/mmflood.py
+++ b/torchgeo/datasets/mmflood.py
@@ -19,7 +19,7 @@ from torch import Tensor
 
 from .errors import DatasetNotFoundError
 from .geo import IntersectionDataset, RasterDataset
-from .utils import BoundingBox, Path, download_url, extract_archive
+from .utils import GeoSlice, Path, download_url, extract_archive
 
 
 class MMFloodComponent(RasterDataset):
@@ -207,17 +207,17 @@ class MMFlood(IntersectionDataset):
                 with open(part_path, 'rb') as part_fp:
                     dst_fp.write(part_fp.read())
 
-    def __getitem__(self, query: BoundingBox) -> dict[str, Tensor]:
-        """Retrieve image/mask and metadata indexed by query.
+    def __getitem__(self, query: GeoSlice) -> dict[str, Tensor]:
+        """Retrieve input, target, and/or metadata indexed by spatiotemporal slice.
 
         Args:
-            query: (minx, maxx, miny, maxy, mint, maxt) coordinates to index
+            query: [xmin:xmax:xres, ymin:ymax:yres, tmin:tmax:tres] coordinates to index.
 
         Returns:
-            sample of image, mask and metadata at that index
+            Sample of input, target, and/or metadata at that index.
 
         Raises:
-            IndexError: if query is not found in the index
+            IndexError: If *query* is not found in the index.
         """
         data = super().__getitem__(query)
         missing_data = data['image'].isnan().any(dim=0)

--- a/torchgeo/datasets/nccm.py
+++ b/torchgeo/datasets/nccm.py
@@ -13,7 +13,7 @@ from pyproj import CRS
 
 from .errors import DatasetNotFoundError
 from .geo import RasterDataset
-from .utils import BoundingBox, Path, download_url
+from .utils import GeoSlice, Path, download_url
 
 
 class NCCM(RasterDataset):
@@ -129,17 +129,17 @@ class NCCM(RasterDataset):
             self.ordinal_map[k] = i
             self.ordinal_cmap[i] = torch.tensor(v)
 
-    def __getitem__(self, query: BoundingBox) -> dict[str, Any]:
-        """Retrieve mask and metadata indexed by query.
+    def __getitem__(self, query: GeoSlice) -> dict[str, Any]:
+        """Retrieve input, target, and/or metadata indexed by spatiotemporal slice.
 
         Args:
-            query: (minx, maxx, miny, maxy, mint, maxt) coordinates to index
+            query: [xmin:xmax:xres, ymin:ymax:yres, tmin:tmax:tres] coordinates to index.
 
         Returns:
-            sample of mask and metadata at that index
+            Sample of input, target, and/or metadata at that index.
 
         Raises:
-            IndexError: if query is not found in the index
+            IndexError: If *query* is not found in the index.
         """
         sample = super().__getitem__(query)
         sample['mask'] = self.ordinal_map[sample['mask']]

--- a/torchgeo/datasets/nlcd.py
+++ b/torchgeo/datasets/nlcd.py
@@ -14,7 +14,7 @@ from pyproj import CRS
 
 from .errors import DatasetNotFoundError
 from .geo import RasterDataset
-from .utils import BoundingBox, Path, download_url
+from .utils import GeoSlice, Path, download_url
 
 
 class NLCD(RasterDataset):
@@ -190,17 +190,17 @@ class NLCD(RasterDataset):
             self.ordinal_map[k] = v
             self.ordinal_cmap[v] = torch.tensor(self.cmap[k])
 
-    def __getitem__(self, query: BoundingBox) -> dict[str, Any]:
-        """Retrieve mask and metadata indexed by query.
+    def __getitem__(self, query: GeoSlice) -> dict[str, Any]:
+        """Retrieve input, target, and/or metadata indexed by spatiotemporal slice.
 
         Args:
-            query: (minx, maxx, miny, maxy, mint, maxt) coordinates to index
+            query: [xmin:xmax:xres, ymin:ymax:yres, tmin:tmax:tres] coordinates to index.
 
         Returns:
-            sample of mask and metadata at that index
+            Sample of input, target, and/or metadata at that index.
 
         Raises:
-            IndexError: if query is not found in the index
+            IndexError: If *query* is not found in the index.
         """
         sample = super().__getitem__(query)
         sample['mask'] = self.ordinal_map[sample['mask']]

--- a/torchgeo/datasets/openbuildings.py
+++ b/torchgeo/datasets/openbuildings.py
@@ -311,7 +311,7 @@ class OpenBuildings(VectorDataset):
         interval = pd.Interval(t.start, t.stop)
         index = self.index.iloc[self.index.index.overlaps(interval)]
         index = index.iloc[:: t.step]
-        index = index.cx[x.start : x.stop, y.start : y.stop]  # type: ignore[misc]
+        index = index.cx[x.start : x.stop, y.start : y.stop]
 
         if index.empty:
             raise IndexError(

--- a/torchgeo/datasets/openbuildings.py
+++ b/torchgeo/datasets/openbuildings.py
@@ -347,7 +347,7 @@ class OpenBuildings(VectorDataset):
         """Filters a df read from the polygon csv file based on query and conf thresh.
 
         Args:
-            query: (minx, maxx, miny, maxy, mint, maxt) coordinates to index
+            query: [xmin:xmax:xres, ymin:ymax:yres, tmin:tmax:tres] coordinates to index.
             filepaths: filepaths to files that were hits from rmtree index
 
         Returns:

--- a/torchgeo/datasets/openbuildings.py
+++ b/torchgeo/datasets/openbuildings.py
@@ -23,7 +23,7 @@ from pyproj import CRS
 
 from .errors import DatasetNotFoundError
 from .geo import VectorDataset
-from .utils import BoundingBox, Path, check_integrity
+from .utils import GeoSlice, Path, check_integrity
 
 
 class OpenBuildings(VectorDataset):
@@ -295,22 +295,23 @@ class OpenBuildings(VectorDataset):
 
         self._source_crs = source_crs
 
-    def __getitem__(self, query: BoundingBox) -> dict[str, Any]:
-        """Retrieve image/mask and metadata indexed by query.
+    def __getitem__(self, query: GeoSlice) -> dict[str, Any]:
+        """Retrieve input, target, and/or metadata indexed by spatiotemporal slice.
 
         Args:
-            query: (minx, maxx, miny, maxy, mint, maxt) coordinates to index
+            query: [xmin:xmax:xres, ymin:ymax:yres, tmin:tmax:tres] coordinates to index.
 
         Returns:
-            sample of image/mask and metadata for the given query. If there are
-            not matching shapes found within the query, an empty raster is returned
+            Sample of input, target, and/or metadata at that index.
 
         Raises:
-            IndexError: if query is not found in the index
+            IndexError: If *query* is not found in the index.
         """
-        interval = pd.Interval(query.mint, query.maxt)
+        x, y, t = self._disambiguate_slice(query)
+        interval = pd.Interval(t.start, t.stop)
         index = self.index.iloc[self.index.index.overlaps(interval)]
-        index = index.cx[query.minx : query.maxx, query.miny : query.maxy]  # type: ignore[misc]
+        index = index.iloc[:: t.step]
+        index = index.cx[x.start : x.stop, y.start : y.stop]  # type: ignore[misc]
 
         if index.empty:
             raise IndexError(
@@ -320,10 +321,10 @@ class OpenBuildings(VectorDataset):
         shapes = self._filter_geometries(query, index.filepath)
 
         # Rasterize geometries
-        width = (query.maxx - query.minx) / self.res[0]
-        height = (query.maxy - query.miny) / self.res[1]
+        width = (x.stop - x.start) / x.step
+        height = (y.stop - y.start) / y.step
         transform = rasterio.transform.from_bounds(
-            query.minx, query.miny, query.maxx, query.maxy, width, height
+            x.start, y.start, x.stop, y.stop, width, height
         )
         if shapes:
             masks = rasterio.features.rasterize(
@@ -341,7 +342,7 @@ class OpenBuildings(VectorDataset):
         return sample
 
     def _filter_geometries(
-        self, query: BoundingBox, filepaths: list[str]
+        self, query: GeoSlice, filepaths: list[str]
     ) -> list[dict[str, Any]]:
         """Filters a df read from the polygon csv file based on query and conf thresh.
 
@@ -353,12 +354,14 @@ class OpenBuildings(VectorDataset):
             List with all polygons from all hit filepaths
 
         """
+        x, y, t = self._disambiguate_slice(query)
+
         # We need to know the bounding box of the query in the source CRS
         (minx, maxx), (miny, maxy) = fiona.transform.transform(
             self.crs.to_wkt(),
             self._source_crs.to_wkt(),
-            [query.minx, query.maxx],
-            [query.miny, query.maxy],
+            [x.start, x.stop],
+            [y.start, y.stop],
         )
         df_query = (
             f'longitude >= {minx} & longitude <= {maxx} & '

--- a/torchgeo/datasets/south_africa_crop_type.py
+++ b/torchgeo/datasets/south_africa_crop_type.py
@@ -168,7 +168,7 @@ class SouthAfricaCropType(RasterDataset):
         interval = pd.Interval(t.start, t.stop)
         index = self.index.iloc[self.index.index.overlaps(interval)]
         index = index.iloc[:: t.step]
-        index = index.cx[x.start : x.stop, y.start : y.stop]  # type: ignore[misc]
+        index = index.cx[x.start : x.stop, y.start : y.stop]
 
         if index.empty:
             raise IndexError(

--- a/torchgeo/datasets/splits.py
+++ b/torchgeo/datasets/splits.py
@@ -294,9 +294,9 @@ def time_series_split(
 
     .. versionadded:: 0.5
     """
-    minx, maxx, miny, maxy, mint, maxt = dataset.bounds
+    x, y, t = dataset.bounds
 
-    totalt = maxt - mint
+    totalt = t.stop - t.start
 
     if all(isinstance(x, int | float) for x in lengths):
         if any(n <= 0 for n in lengths):
@@ -311,7 +311,7 @@ def time_series_split(
 
     if all(isinstance(x, pd.Timedelta) for x in lengths):
         lengths = [
-            pd.Interval(mint + offset - length, mint + offset, closed='neither')
+            pd.Interval(t.start + offset - length, t.start + offset, closed='neither')
             for offset, length in zip(accumulate(lengths), lengths)
         ]
 
@@ -328,7 +328,7 @@ def time_series_split(
             pd.Timedelta(0) if i == len(lengths) - 1 else pd.Timedelta(1, unit='us')
         )
 
-        if start < mint or end > maxt:
+        if start < t.start or end > t.stop:
             raise ValueError(
                 "Pairs of timestamps in lengths can't be out of dataset's time bounds."
             )

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -41,6 +41,8 @@ __all__ = (
 )
 
 
+GeoSlice: TypeAlias = slice | tuple[slice, slice] | tuple[slice, slice, slice]
+
 Path: TypeAlias = str | os.PathLike[str]
 
 

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -41,8 +41,9 @@ __all__ = (
 )
 
 
-GeoSlice: TypeAlias = slice | tuple[slice, slice] | tuple[slice, slice, slice]
-
+GeoSlice: TypeAlias = (
+    slice | tuple[slice] | tuple[slice, slice] | tuple[slice, slice, slice]
+)
 Path: TypeAlias = str | os.PathLike[str]
 
 

--- a/torchgeo/samplers/batch.py
+++ b/torchgeo/samplers/batch.py
@@ -6,17 +6,19 @@
 import abc
 from collections.abc import Iterator
 
+import pandas as pd
 import shapely
 import torch
 from torch import Generator
 from torch.utils.data import Sampler
 
 from ..datasets import BoundingBox, GeoDataset
+from ..datasets.utils import GeoSlice
 from .constants import Units
 from .utils import _to_tuple, get_random_bounding_box, tile_to_chips
 
 
-class BatchGeoSampler(Sampler[list[BoundingBox]], abc.ABC):
+class BatchGeoSampler(Sampler[list[GeoSlice]], abc.ABC):
     """Abstract base class for sampling from :class:`~torchgeo.datasets.GeoDataset`.
 
     Unlike PyTorch's :class:`~torch.utils.data.BatchSampler`, :class:`BatchGeoSampler`
@@ -42,11 +44,11 @@ class BatchGeoSampler(Sampler[list[BoundingBox]], abc.ABC):
             self.index = self.index.clip(mask)
 
     @abc.abstractmethod
-    def __iter__(self) -> Iterator[list[BoundingBox]]:
+    def __iter__(self) -> Iterator[list[GeoSlice]]:
         """Return a batch of indices of a dataset.
 
         Yields:
-            batch of (minx, maxx, miny, maxy, mint, maxt) coordinates to index a dataset
+            Batch of [xmin:xmax, ymin:ymax, tmin:tmax] coordinates to index a dataset.
         """
 
 
@@ -108,23 +110,22 @@ class RandomBatchGeoSampler(BatchGeoSampler):
 
         self.batch_size = batch_size
         self.length = 0
-        self.hits = []
+        self.bounds = []
+        self.intervals = []
         areas = []
         for hit in range(len(self.index)):
-            minx, miny, maxx, maxy = self.index.geometry.iloc[hit].bounds
-            mint, maxt = self.index.index[hit].left, self.index.index[hit].right
-            bounds = BoundingBox(minx, maxx, miny, maxy, mint, maxt)
-            if (
-                bounds.maxx - bounds.minx >= self.size[1]
-                and bounds.maxy - bounds.miny >= self.size[0]
-            ):
-                if bounds.area > 0:
+            bounds = self.index.geometry.iloc[hit].bounds
+            xmin, ymin, xmax, ymax = bounds
+            tmin, tmax = self.index.index[hit].left, self.index.index[hit].right
+            if xmax - xmin >= self.size[1] and ymax - ymin >= self.size[0]:
+                if xmax > xmin and ymax > ymin:
                     rows, cols = tile_to_chips(bounds, self.size)
                     self.length += rows * cols
                 else:
                     self.length += 1
-                self.hits.append(bounds)
-                areas.append(bounds.area)
+                self.bounds.append(bounds)
+                self.intervals.append(pd.Interval(tmin, tmax))
+                areas.append((xmax - xmin) * (ymax - ymin))
         if length is not None:
             self.length = length
 
@@ -133,16 +134,17 @@ class RandomBatchGeoSampler(BatchGeoSampler):
         if torch.sum(self.areas) == 0:
             self.areas += 1
 
-    def __iter__(self) -> Iterator[list[BoundingBox]]:
+    def __iter__(self) -> Iterator[list[GeoSlice]]:
         """Return the indices of a dataset.
 
         Yields:
-            batch of (minx, maxx, miny, maxy, mint, maxt) coordinates to index a dataset
+            Batch of [xmin:xmax, ymin:ymax, tmin:tmax] coordinates to index a dataset.
         """
         for _ in range(len(self)):
             # Choose a random tile, weighted by area
             idx = torch.multinomial(self.areas, 1)
-            bounds = self.hits[idx]
+            bounds = self.bounds[idx]
+            interval = self.intervals[idx]
 
             # Choose random indices within that tile
             batch = []
@@ -150,7 +152,7 @@ class RandomBatchGeoSampler(BatchGeoSampler):
                 bounding_box = get_random_bounding_box(
                     bounds, self.size, self.res, self.generator
                 )
-                batch.append(bounding_box)
+                batch.append((*bounding_box, slice(interval.left, interval.right)))
 
             yield batch
 

--- a/torchgeo/samplers/batch.py
+++ b/torchgeo/samplers/batch.py
@@ -134,7 +134,7 @@ class RandomBatchGeoSampler(BatchGeoSampler):
         if torch.sum(self.areas) == 0:
             self.areas += 1
 
-    def __iter__(self) -> Iterator[list[GeoSlice]]:
+    def __iter__(self) -> Iterator[list[tuple[slice, slice, slice]]]:  # type: ignore[override]
         """Return the indices of a dataset.
 
         Yields:

--- a/torchgeo/samplers/single.py
+++ b/torchgeo/samplers/single.py
@@ -13,11 +13,12 @@ from torch import Generator
 from torch.utils.data import Sampler
 
 from ..datasets import BoundingBox, GeoDataset
+from ..datasets.utils import GeoSlice
 from .constants import Units
 from .utils import _to_tuple, get_random_bounding_box, tile_to_chips
 
 
-class GeoSampler(Sampler[BoundingBox], abc.ABC):
+class GeoSampler(Sampler[GeoSlice], abc.ABC):
     """Abstract base class for sampling from :class:`~torchgeo.datasets.GeoDataset`.
 
     Unlike PyTorch's :class:`~torch.utils.data.Sampler`, :class:`GeoSampler`
@@ -43,11 +44,11 @@ class GeoSampler(Sampler[BoundingBox], abc.ABC):
             self.index = self.index.clip(mask)
 
     @abc.abstractmethod
-    def __iter__(self) -> Iterator[BoundingBox]:
+    def __iter__(self) -> Iterator[GeoSlice]:
         """Return the index of a dataset.
 
         Yields:
-            (minx, maxx, miny, maxy, mint, maxt) coordinates to index a dataset
+            [xmin:xmax, ymin:ymax, tmin:tmax] coordinates to index a dataset.
         """
 
 
@@ -135,11 +136,11 @@ class RandomGeoSampler(GeoSampler):
         if torch.sum(self.areas) == 0:
             self.areas += 1
 
-    def __iter__(self) -> Iterator[BoundingBox]:
+    def __iter__(self) -> Iterator[GeoSlice]:
         """Return the index of a dataset.
 
         Yields:
-            (minx, maxx, miny, maxy, mint, maxt) coordinates to index a dataset
+            [xmin:xmax, ymin:ymax, tmin:tmax] coordinates to index a dataset.
         """
         for _ in range(len(self)):
             # Choose a random tile, weighted by area
@@ -218,42 +219,39 @@ class GridGeoSampler(GeoSampler):
 
         self.length = 0
         for i in range(len(self.index)):
-            minx, miny, maxx, maxy = self.index.geometry.iloc[i].bounds
-            if maxx - minx < self.size[1] or maxy - miny < self.size[0]:
+            bounds = self.index.geometry.iloc[i].bounds
+            xmin, ymin, xmax, ymax = bounds
+            if xmax - xmin < self.size[1] or ymin - ymax < self.size[0]:
                 continue
-            mint, maxt = self.index.index[i].left, self.index.index[i].right
-            bounds = BoundingBox(minx, maxx, miny, maxy, mint, maxt)
             rows, cols = tile_to_chips(bounds, self.size, self.stride)
             self.length += rows * cols
 
-    def __iter__(self) -> Iterator[BoundingBox]:
+    def __iter__(self) -> Iterator[GeoSlice]:
         """Return the index of a dataset.
 
         Yields:
-            (minx, maxx, miny, maxy, mint, maxt) coordinates to index a dataset
+            [xmin:xmax, ymin:ymax, tmin:tmax] coordinates to index a dataset.
         """
         # For each tile...
         for i in range(len(self.index)):
-            minx, miny, maxx, maxy = self.index.geometry.iloc[i].bounds
-            if maxx - minx < self.size[1] or maxy - miny < self.size[0]:
+            bounds = self.index.geometry.iloc[i].bounds
+            xmin, ymin, xmax, ymax = bounds
+            if xmax - xmin < self.size[1] or ymin - ymax < self.size[0]:
                 continue
-            mint, maxt = self.index.index[i].left, self.index.index[i].right
-            bounds = BoundingBox(minx, maxx, miny, maxy, mint, maxt)
+            tmin, tmax = self.index.index[i].left, self.index.index[i].right
             rows, cols = tile_to_chips(bounds, self.size, self.stride)
-            mint = bounds.mint
-            maxt = bounds.maxt
 
             # For each row...
             for i in range(rows):
-                miny = bounds.miny + i * self.stride[0]
-                maxy = miny + self.size[0]
+                ymin = bounds[1] + i * self.stride[0]
+                ymax = ymin + self.size[0]
 
                 # For each column...
                 for j in range(cols):
-                    minx = bounds.minx + j * self.stride[1]
-                    maxx = minx + self.size[1]
+                    xmin = bounds[0] + j * self.stride[1]
+                    xmax = xmin + self.size[1]
 
-                    yield BoundingBox(minx, maxx, miny, maxy, mint, maxt)
+                    yield slice(xmin, xmax), slice(ymin, ymax), slice(tmin, tmax)
 
     def __len__(self) -> int:
         """Return the number of samples over the ROI.
@@ -304,11 +302,11 @@ class PreChippedGeoSampler(GeoSampler):
         self.shuffle = shuffle
         self.generator = generator
 
-    def __iter__(self) -> Iterator[BoundingBox]:
+    def __iter__(self) -> Iterator[GeoSlice]:
         """Return the index of a dataset.
 
         Yields:
-            (minx, maxx, miny, maxy, mint, maxt) coordinates to index a dataset
+            [xmin:xmax, ymin:ymax, tmin:tmax] coordinates to index a dataset.
         """
         generator: Callable[[int], Iterable[int]] = range
         if self.shuffle:
@@ -316,9 +314,9 @@ class PreChippedGeoSampler(GeoSampler):
 
         for idx in generator(len(self)):
             i = int(idx)
-            minx, miny, maxx, maxy = self.index.geometry.iloc[i].bounds
-            mint, maxt = self.index.index[i].left, self.index.index[i].right
-            yield BoundingBox(minx, maxx, miny, maxy, mint, maxt)
+            xmin, ymin, xmax, ymax = self.index.geometry.iloc[i].bounds
+            tmin, tmax = self.index.index[i].left, self.index.index[i].right
+            yield slice(xmin, xmax), slice(ymin, ymax), slice(tmin, tmax)
 
     def __len__(self) -> int:
         """Return the number of samples over the ROI.

--- a/torchgeo/samplers/single.py
+++ b/torchgeo/samplers/single.py
@@ -138,7 +138,7 @@ class RandomGeoSampler(GeoSampler):
         if torch.sum(self.areas) == 0:
             self.areas += 1
 
-    def __iter__(self) -> Iterator[GeoSlice]:
+    def __iter__(self) -> Iterator[tuple[slice, slice, slice]]:
         """Return the index of a dataset.
 
         Yields:
@@ -229,7 +229,7 @@ class GridGeoSampler(GeoSampler):
             rows, cols = tile_to_chips(bounds, self.size, self.stride)
             self.length += rows * cols
 
-    def __iter__(self) -> Iterator[GeoSlice]:
+    def __iter__(self) -> Iterator[tuple[slice, slice, slice]]:
         """Return the index of a dataset.
 
         Yields:
@@ -305,7 +305,7 @@ class PreChippedGeoSampler(GeoSampler):
         self.shuffle = shuffle
         self.generator = generator
 
-    def __iter__(self) -> Iterator[GeoSlice]:
+    def __iter__(self) -> Iterator[tuple[slice, slice, slice]]:
         """Return the index of a dataset.
 
         Yields:

--- a/torchgeo/samplers/utils.py
+++ b/torchgeo/samplers/utils.py
@@ -87,7 +87,7 @@ def get_random_bounding_box(
 
 
 def tile_to_chips(
-    bounds: BoundingBox,
+    bounds: tuple[float, float, float, float],
     size: tuple[float, float],
     stride: tuple[float, float] | None = None,
 ) -> tuple[int, int]:
@@ -122,7 +122,9 @@ def tile_to_chips(
     assert stride[0] > 0
     assert stride[1] > 0
 
-    rows = math.ceil((bounds.maxy - bounds.miny - size[0]) / stride[0]) + 1
-    cols = math.ceil((bounds.maxx - bounds.minx - size[1]) / stride[1]) + 1
+    xmin, ymin, xmax, ymax = bounds
+
+    rows = math.ceil((ymax - ymin - size[0]) / stride[0]) + 1
+    cols = math.ceil((xmax - xmin - size[1]) / stride[1]) + 1
 
     return rows, cols

--- a/torchgeo/samplers/utils.py
+++ b/torchgeo/samplers/utils.py
@@ -9,8 +9,6 @@ from typing import overload
 import torch
 from torch import Generator
 
-from ..datasets import BoundingBox
-
 
 @overload
 def _to_tuple(value: tuple[int, int] | int) -> tuple[int, int]: ...
@@ -36,11 +34,11 @@ def _to_tuple(value: tuple[float, float] | float) -> tuple[float, float]:
 
 
 def get_random_bounding_box(
-    bounds: BoundingBox,
+    bounds: tuple[float, float, float, float],
     size: tuple[float, float] | float,
     res: tuple[float, float] | float,
     generator: Generator | None = None,
-) -> BoundingBox:
+) -> tuple[slice, slice]:
     """Returns a random bounding box within a given bounding box.
 
     The ``size`` argument can either be:
@@ -62,28 +60,22 @@ def get_random_bounding_box(
     Returns:
         randomly sampled bounding box from the extent of the input
     """
+    xmin, ymin, xmax, ymax = bounds
     t_size = _to_tuple(size)
     t_res = _to_tuple(res)
 
     # May be negative if bounding box is smaller than patch size
-    width = (bounds.maxx - bounds.minx - t_size[1]) / t_res[0]
-    height = (bounds.maxy - bounds.miny - t_size[0]) / t_res[1]
-
-    minx = bounds.minx
-    miny = bounds.miny
+    width = (xmax - xmin - t_size[1]) / t_res[0]
+    height = (ymax - ymin - t_size[0]) / t_res[1]
 
     # Use an integer multiple of res to avoid resampling
-    minx += int(torch.rand(1, generator=generator).item() * width) * t_res[0]
-    miny += int(torch.rand(1, generator=generator).item() * height) * t_res[1]
+    xmin += int(torch.rand(1, generator=generator).item() * width) * t_res[0]
+    ymin += int(torch.rand(1, generator=generator).item() * height) * t_res[1]
 
-    maxx = minx + t_size[1]
-    maxy = miny + t_size[0]
+    xmax = xmin + t_size[1]
+    ymax = ymin + t_size[0]
 
-    mint = bounds.mint
-    maxt = bounds.maxt
-
-    query = BoundingBox(minx, maxx, miny, maxy, mint, maxt)
-    return query
+    return slice(xmin, xmax), slice(ymin, ymax)
 
 
 def tile_to_chips(


### PR DESCRIPTION
This PR adds support for GeoDataset slicing, and is part of ongoing work to add time series support to TorchGeo: #2382.

### Before

```python
ds[BoundingBox(xmin, xmax, ymin, ymax, tmin, tmax)]
```

### After

```python
ds[xmin:xmax, ymin:ymax]
ds[:, :, tmin:tmax]
ds[xmin:xmax:xres, ymin:ymax:yres, tmin:tmax:tres]
```

### Progress

- [x] Dataset Base Classes
  - [x] GeoDataset
  - [x] RasterDataset
  - [x] VectorDataset
  - [x] IntersectionDataset
  - [x] UnionDataset
- [x] Custom Datasets
  - [x] AgriFieldNet
  - [x] Chesapeake CVPR
  - [x] EDDMapS
  - [x] EnviroAtlas
  - [x] GBIF
  - [x] GlobBiomass
  - [x] iNaturalist
  - [x] LandCover.ai
  - [x] Open Buildings
  - [x] South Africa Crop Type
- [x] Samplers
  - [x] GeoSampler
  - [x] RandomGeoSampler
  - [x] GridGeoSampler
  - [x] PreChippedGeoSampler
  - [x] BatchGeoSampler
  - [x] RandomBatchGeoSampler
- [x] Documentation
- [x] Testing

### Backwards-Incompatible Changes

* GeoDatasets are now indexed by GeoSlice, not BoundingBox
* GeoDataset.bounds now returns a GeoSlice, not BoundingBox
* Returned sample bounds are now a GeoSlice, not BoundingBox
* get_random_bounding_box now takes a tuple as input and returns a tuple
* tile_to_chips now takes a tuple as input