### PR TITLE
Add support for bounding boxes and instance masks to VectorDataset

### DIFF
--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -553,10 +553,7 @@ class TestVectorDataset:
         assert isinstance(x['crs'], CRS)
         assert isinstance(x['bbox_xyxy'], torch.Tensor)
         assert isinstance(x['label'], torch.Tensor)
-        assert torch.equal(
-            x['label'],  # type: ignore[no-untyped-call]
-            torch.tensor([1, 2, 3], dtype=torch.uint8),
-        )
+        assert torch.equal(x['label'], torch.tensor([1, 2, 3], dtype=torch.uint8))
         assert x['bbox_xyxy'].shape[-1] == 4
 
         multilabel.task = 'instance_segmentation'
@@ -565,10 +562,7 @@ class TestVectorDataset:
         assert isinstance(x['crs'], CRS)
         assert isinstance(x['bbox_xyxy'], torch.Tensor)
         assert isinstance(x['label'], torch.Tensor)
-        assert torch.equal(
-            x['label'],  # type: ignore[no-untyped-call]
-            torch.tensor([1, 2, 3], dtype=torch.uint8),
-        )
+        assert torch.equal(x['label'], torch.tensor([1, 2, 3], dtype=torch.uint8))
         assert isinstance(x['mask'], torch.Tensor)
         assert torch.equal(
             x['mask'].unique(),  # type: ignore[no-untyped-call]

--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -501,7 +501,7 @@ class TestVectorDataset:
 
     def test_invalid_task(self, dataset: CustomVectorDataset) -> None:
         with pytest.raises(ValueError, match='Invalid task:'):
-            CustomVectorDataset(dataset.paths, task='invalid-task')
+            CustomVectorDataset(dataset.paths, task='invalid-task')  # type: ignore[arg-type]
 
     def test_getitem(self, dataset: CustomVectorDataset) -> None:
         dataset.task = 'semantic_segmentation'

--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -499,6 +499,10 @@ class TestVectorDataset:
             root, res=(0.1, 0.1), transforms=transforms, label_name='label_id'
         )
 
+    def test_invalid_task(self, dataset: CustomVectorDataset) -> None:
+        with pytest.raises(ValueError, match='Invalid task:'):
+            CustomVectorDataset(dataset.paths, task='invalid-task')
+
     def test_getitem(self, dataset: CustomVectorDataset) -> None:
         dataset.task = 'semantic_segmentation'
         x = dataset[dataset.bounds]

--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -553,7 +553,7 @@ class TestVectorDataset:
         assert isinstance(x['crs'], CRS)
         assert isinstance(x['bbox_xyxy'], torch.Tensor)
         assert isinstance(x['label'], torch.Tensor)
-        assert torch.equal(x['label'], torch.tensor([1, 2, 3], dtype=torch.uint8))
+        assert torch.equal(x['label'], torch.tensor([1, 2, 3], dtype=torch.int32))
         assert x['bbox_xyxy'].shape[-1] == 4
 
         multilabel.task = 'instance_segmentation'
@@ -562,7 +562,7 @@ class TestVectorDataset:
         assert isinstance(x['crs'], CRS)
         assert isinstance(x['bbox_xyxy'], torch.Tensor)
         assert isinstance(x['label'], torch.Tensor)
-        assert torch.equal(x['label'], torch.tensor([1, 2, 3], dtype=torch.uint8))
+        assert torch.equal(x['label'], torch.tensor([1, 2, 3], dtype=torch.int32))
         assert isinstance(x['mask'], torch.Tensor)
         assert torch.equal(
             x['mask'].unique(),  # type: ignore[no-untyped-call]
@@ -578,11 +578,11 @@ class TestVectorDataset:
 
         dataset.task = 'object_detection'
         x = dataset[1.1:1.9, 1.1:1.9, pd.Timestamp.min : pd.Timestamp.max]  # type: ignore[misc]
-        assert torch.equal(x['bbox_xyxy'], torch.empty(0, dtype=dataset.dtype))
+        assert torch.equal(x['bbox_xyxy'], torch.empty(0, 4, dtype=torch.float32))
 
         dataset.task = 'instance_segmentation'
         x = dataset[1.1:1.9, 1.1:1.9, pd.Timestamp.min : pd.Timestamp.max]  # type: ignore[misc]
-        assert torch.equal(x['bbox_xyxy'], torch.empty(0, dtype=dataset.dtype))
+        assert torch.equal(x['bbox_xyxy'], torch.empty(0, 4, dtype=torch.float32))
         assert torch.equal(x['mask'], torch.zeros(8, 8, dtype=torch.uint8))
 
     def test_invalid_query(self, dataset: CustomVectorDataset) -> None:

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -674,7 +674,7 @@ class VectorDataset(GeoDataset):
                 entry and returns a transformed version
             label_name: name of the dataset property that has the label to be
                 rasterized into the mask
-            task: what is the tas the dataset is used for. Supported output types
+            task: computer vision task the dataset is used for. Supported output types
                `object_detection`, `semantic_segmentation`, `instance_segmentation`
             layer: if the input is a multilayer vector dataset, such as a geopackage,
                 specify which layer to use. Can be int to specify the index of the layer,

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -876,7 +876,7 @@ class VectorDataset(GeoDataset):
             labels = np.empty((0,), dtype=np.int32)
 
         # Use array_to_tensor since rasterize may return uint16/uint32 arrays.
-        sample: dict[str, Tensor | CRS | GeoSlice] = {'crs': self.crs, 'bounds': query}
+        sample: dict[str, Any] = {'crs': self.crs, 'bounds': query}
 
         match self.task:
             case 'semantic_segmentation':

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -739,7 +739,9 @@ def convert_poly_coords(
         inverse: If true, convert geocoordinates to pixel coordinates
 
     Returns:
-        shapely.geometry.shape: input shape converted to pixel coordinates
+        input shape converted to pixel coordinates
+
+    .. versionadded:: 0.8
     """
     if inverse:
         affine_obj = ~affine_obj

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -17,12 +17,12 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any, TypeAlias, cast, overload
 
-import affine
 import numpy as np
 import pandas as pd
 import rasterio
 import shapely
 import torch
+from rasterio import Affine
 from torch import Tensor
 from torchvision.datasets.utils import (
     check_integrity,
@@ -729,13 +729,13 @@ def which(name: Path) -> Executable:
 
 
 def convert_poly_coords(
-    geom: shapely.geometry.shape, affine_obj: affine.Affine, inverse: bool = False
+    geom: shapely.geometry.shape, affine_obj: Affine, inverse: bool = False
 ) -> shapely.geometry.shape:
     """Convert geocoordinates to pixel coordinates and vice versa, based on `affine_obj`.
 
     Args:
         geom: shapely.geometry.shape to convert
-        affine_obj: affine.Affine object to use for geoconversion
+        affine_obj: rasterio.Affine object to use for geoconversion
         inverse: If true, convert geocoordinates to pixel coordinates
 
     Returns:

--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -17,9 +17,11 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any, TypeAlias, cast, overload
 
+import affine
 import numpy as np
 import pandas as pd
 import rasterio
+import shapely
 import torch
 from torch import Tensor
 from torchvision.datasets.utils import (
@@ -724,3 +726,33 @@ def which(name: Path) -> Executable:
     else:
         msg = f'{name} is not installed and is required to use this dataset.'
         raise DependencyNotFoundError(msg) from None
+
+
+def convert_poly_coords(
+    geom: shapely.geometry.shape, affine_obj: affine.Affine, inverse: bool = False
+) -> shapely.geometry.shape:
+    """Convert geocoordinates to pixel coordinates and vice versa, based on `affine_obj`.
+
+    Args:
+        geom: shapely.geometry.shape to convert
+        affine_obj: affine.Affine object to use for geoconversion
+        inverse: If true, convert geocoordinates to pixel coordinates
+
+    Returns:
+        shapely.geometry.shape: input shape converted to pixel coordinates
+    """
+    if inverse:
+        affine_obj = ~affine_obj
+
+    xformed_shape = shapely.affinity.affine_transform(
+        geom,
+        [
+            affine_obj.a,
+            affine_obj.b,
+            affine_obj.d,
+            affine_obj.e,
+            affine_obj.xoff,
+            affine_obj.yoff,
+        ],
+    )
+    return xformed_shape


### PR DESCRIPTION
Closes #2505 , a proposal to add `bbox_xyxy`, `segmentation` and `label` as the return values for `VectorDataset.__getitem__`. After this, `VectorDataset.__getitem__` returns

```python
        sample = {
            'mask': masks, # As before
            'bbox_xyxy': boxes_xyxy, # N, 4 tensor containing the bounding boxes in xmin, ymin, xmax, ymax
            'segmentation': segmentations, # A list of N tensors containing the COCO format segmentations
            'crs': self.crs,
            'label': labels, # N tensor containing the int labels for each object
            'bounds': query,
        }
```

Major downside: as the object detection related things are returned by default, `VectorDataset` can't be used with most of the common `collate_fn`s, such as `stack_samples` if the batch size is larger than 1. 

Example gist: https://gist.github.com/mayrajeo/1de0497dd82d2c9a2b6381ef482face8 

