### PR TITLE
New SMP Decoders

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,8 +69,8 @@ dependencies = [
     "segmentation-models-pytorch>=0.5",
     # shapely 2+ required for shapely.Geometry
     "shapely>=2",
-    # timm 0.8+ required for timm.models.adapt_input_conv, 0.9.2 required by SMP
-    "timm>=0.9.2",
+    # timm 1.0.3+ required for forward_intermediates support for ViT
+    "timm>=1.0.3",
     # torch 2+ required for Python 3.11 wheels
     "torch>=2",
     # torchmetrics 1.2+ required for average argument in mAP metric

--- a/requirements/min-reqs.old
+++ b/requirements/min-reqs.old
@@ -16,7 +16,7 @@ pyproj==3.4.0
 rasterio==1.3.11
 segmentation-models-pytorch==0.5.0
 shapely==2.0.0
-timm==0.9.2
+timm==1.0.3
 torch==2.0.0
 torchmetrics==1.2.0
 torchvision==0.15.1

--- a/tests/conf/inria_dpt.yaml
+++ b/tests/conf/inria_dpt.yaml
@@ -1,0 +1,14 @@
+model:
+  class_path: PixelwiseRegressionTask
+  init_args:
+    model: 'dpt'
+    backbone: 'vit_base_patch16_224'
+    in_channels: 3
+    loss: 'mae'
+data:
+  class_path: InriaAerialImageLabelingDataModule
+  init_args:
+    batch_size: 1
+    patch_size: 2
+  dict_kwargs:
+    root: 'tests/data/inria'

--- a/tests/conf/inria_segformer.yaml
+++ b/tests/conf/inria_segformer.yaml
@@ -1,0 +1,14 @@
+model:
+  class_path: PixelwiseRegressionTask
+  init_args:
+    model: 'segformer'
+    backbone: 'resnet18'
+    in_channels: 3
+    loss: 'mae'
+data:
+  class_path: InriaAerialImageLabelingDataModule
+  init_args:
+    batch_size: 1
+    patch_size: 2
+  dict_kwargs:
+    root: 'tests/data/inria'

--- a/tests/conf/inria_upernet.yaml
+++ b/tests/conf/inria_upernet.yaml
@@ -1,0 +1,14 @@
+model:
+  class_path: PixelwiseRegressionTask
+  init_args:
+    model: 'upernet'
+    backbone: 'resnet18'
+    in_channels: 3
+    loss: 'mae'
+data:
+  class_path: InriaAerialImageLabelingDataModule
+  init_args:
+    batch_size: 1
+    patch_size: 2
+  dict_kwargs:
+    root: 'tests/data/inria'

--- a/tests/trainers/test_change.py
+++ b/tests/trainers/test_change.py
@@ -179,7 +179,7 @@ class TestChangeDetectionTask:
         ],
         backbone: str,
     ) -> None:
-        if not (backbone == 'tu-vit_base_patch16_224' and model_name == 'dpt'):
+        if model_name == 'dpt' and not backbone.startswith('tu-vit'):
             pytest.skip('dpt model only supports vit backbones')
 
         model = ChangeDetectionTask(

--- a/tests/trainers/test_change.py
+++ b/tests/trainers/test_change.py
@@ -167,8 +167,21 @@ class TestChangeDetectionTask:
         'backbone', ['resnet18', 'mobilenet_v2', 'efficientnet-b0']
     )
     def test_freeze_backbone(
-        self, model_name: Literal['unet', 'fcsiamdiff', 'fcsiamconc'], backbone: str
+        self,
+        model_name: Literal[
+            'unet',
+            'deeplabv3+',
+            'segformer',
+            'upernet',
+            'dpt',
+            'fcsiamdiff',
+            'fcsiamconc',
+        ],
+        backbone: str,
     ) -> None:
+        if not (backbone == 'tu-vit_base_patch16_224' and model_name == 'dpt'):
+            pytest.skip('dpt model only supports vit backbones')
+
         model = ChangeDetectionTask(
             model=model_name, backbone=backbone, freeze_backbone=True
         )
@@ -183,11 +196,34 @@ class TestChangeDetectionTask:
             ]
         )
 
-    @pytest.mark.parametrize('model_name', ['unet', 'fcsiamdiff', 'fcsiamconc'])
+    @pytest.mark.parametrize(
+        'model_name',
+        [
+            'unet',
+            'deeplabv3+',
+            'segformer',
+            'upernet',
+            'dpt',
+            'fcsiamdiff',
+            'fcsiamconc',
+        ],
+    )
     def test_freeze_decoder(
-        self, model_name: Literal['unet', 'fcsiamdiff', 'fcsiamconc']
+        self,
+        model_name: Literal[
+            'unet',
+            'deeplabv3+',
+            'segformer',
+            'upernet',
+            'dpt',
+            'fcsiamdiff',
+            'fcsiamconc',
+        ],
     ) -> None:
-        model = ChangeDetectionTask(model=model_name, freeze_decoder=True)
+        backbone = 'resnet18' if model_name != 'dpt' else 'tu-vit_base_patch16_224'
+        model = ChangeDetectionTask(
+            model=model_name, backbone=backbone, freeze_decoder=True
+        )
         assert all(
             [param.requires_grad is False for param in model.model.decoder.parameters()]
         )

--- a/tests/trainers/test_change.py
+++ b/tests/trainers/test_change.py
@@ -169,19 +169,10 @@ class TestChangeDetectionTask:
     def test_freeze_backbone(
         self,
         model_name: Literal[
-            'unet',
-            'deeplabv3+',
-            'segformer',
-            'upernet',
-            'dpt',
-            'fcsiamdiff',
-            'fcsiamconc',
+            'unet', 'deeplabv3+', 'segformer', 'upernet', 'fcsiamdiff', 'fcsiamconc'
         ],
         backbone: str,
     ) -> None:
-        if model_name == 'dpt' and not backbone.startswith('tu-vit'):
-            pytest.skip('dpt model only supports vit backbones')
-
         model = ChangeDetectionTask(
             model=model_name, backbone=backbone, freeze_backbone=True
         )
@@ -198,31 +189,16 @@ class TestChangeDetectionTask:
 
     @pytest.mark.parametrize(
         'model_name',
-        [
-            'unet',
-            'deeplabv3+',
-            'segformer',
-            'upernet',
-            'dpt',
-            'fcsiamdiff',
-            'fcsiamconc',
-        ],
+        ['unet', 'deeplabv3+', 'segformer', 'upernet', 'fcsiamdiff', 'fcsiamconc'],
     )
     def test_freeze_decoder(
         self,
         model_name: Literal[
-            'unet',
-            'deeplabv3+',
-            'segformer',
-            'upernet',
-            'dpt',
-            'fcsiamdiff',
-            'fcsiamconc',
+            'unet', 'deeplabv3+', 'segformer', 'upernet', 'fcsiamdiff', 'fcsiamconc'
         ],
     ) -> None:
-        backbone = 'resnet18' if model_name != 'dpt' else 'tu-vit_base_patch16_224'
         model = ChangeDetectionTask(
-            model=model_name, backbone=backbone, freeze_decoder=True
+            model=model_name, backbone='resnet18', freeze_decoder=True
         )
         assert all(
             [param.requires_grad is False for param in model.model.decoder.parameters()]
@@ -234,6 +210,9 @@ class TestChangeDetectionTask:
                 for param in model.model.segmentation_head.parameters()
             ]
         )
+
+    def test_vit_backbone(self) -> None:
+        ChangeDetectionTask(model='dpt', backbone='tu-vit_base_patch16_224')
 
     @pytest.mark.parametrize('loss_fn', ['bce', 'jaccard', 'focal'])
     def test_losses(self, loss_fn: Literal['bce', 'jaccard', 'focal']) -> None:

--- a/tests/trainers/test_change.py
+++ b/tests/trainers/test_change.py
@@ -214,6 +214,10 @@ class TestChangeDetectionTask:
     def test_vit_backbone(self) -> None:
         ChangeDetectionTask(model='dpt', backbone='tu-vit_base_patch16_224')
 
+    def test_fcn_model(self) -> None:
+        """FCN has no backbone/decoder. Need separate test for full test coverage."""
+        ChangeDetectionTask(model='fcn')
+
     @pytest.mark.parametrize('loss_fn', ['bce', 'jaccard', 'focal'])
     def test_losses(self, loss_fn: Literal['bce', 'jaccard', 'focal']) -> None:
         ChangeDetectionTask(loss=loss_fn)

--- a/tests/trainers/test_regression.py
+++ b/tests/trainers/test_regression.py
@@ -3,7 +3,7 @@
 
 import os
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 import pytest
 import segmentation_models_pytorch as smp
@@ -340,13 +340,13 @@ class TestPixelwiseRegressionTask:
         'backbone',
         ['resnet18', 'mobilenet_v2', 'efficientnet-b0', 'tu-vit_base_patch16_224'],
     )
-    def test_freeze_backbone(self, model_name: str, backbone: str) -> None:
-        if backbone == 'tu-vit_base_patch16_224':
-            if model_name != 'dpt':
-                return
-        else:
-            if model_name == 'dpt':
-                return
+    def test_freeze_backbone(
+        self,
+        model_name: Literal['unet', 'deeplabv3+', 'segformer', 'upernet', 'dpt'],
+        backbone: str,
+    ) -> None:
+        if not (backbone == 'tu-vit_base_patch16_224' and model_name == 'dpt'):
+            pytest.skip('dpt model only supports vit backbones')
 
         model = PixelwiseRegressionTask(
             model=model_name, backbone=backbone, freeze_backbone=True
@@ -365,7 +365,9 @@ class TestPixelwiseRegressionTask:
     @pytest.mark.parametrize(
         'model_name', ['unet', 'deeplabv3+', 'segformer', 'upernet', 'dpt']
     )
-    def test_freeze_decoder(self, model_name: str) -> None:
+    def test_freeze_decoder(
+        self, model_name: Literal['unet', 'deeplabv3+', 'segformer', 'upernet', 'dpt']
+    ) -> None:
         backbone = 'resnet18' if model_name != 'dpt' else 'tu-vit_base_patch16_224'
         model = PixelwiseRegressionTask(
             model=model_name, backbone=backbone, freeze_decoder=True

--- a/tests/trainers/test_regression.py
+++ b/tests/trainers/test_regression.py
@@ -345,7 +345,7 @@ class TestPixelwiseRegressionTask:
         model_name: Literal['unet', 'deeplabv3+', 'segformer', 'upernet', 'dpt'],
         backbone: str,
     ) -> None:
-        if not (backbone == 'tu-vit_base_patch16_224' and model_name == 'dpt'):
+        if model_name == 'dpt' and not backbone.startswith('tu-vit'):
             pytest.skip('dpt model only supports vit backbones')
 
         model = PixelwiseRegressionTask(

--- a/tests/trainers/test_regression.py
+++ b/tests/trainers/test_regression.py
@@ -3,7 +3,7 @@
 
 import os
 from pathlib import Path
-from typing import Any, Literal, cast
+from typing import Any, cast
 
 import pytest
 import segmentation_models_pytorch as smp
@@ -268,11 +268,6 @@ class TestPixelwiseRegressionTask:
         except MisconfigurationException:
             pass
 
-    def test_invalid_model(self) -> None:
-        match = "Model type 'invalid_model' is not valid."
-        with pytest.raises(ValueError, match=match):
-            PixelwiseRegressionTask(model='invalid_model')
-
     @pytest.fixture
     def weights(self) -> WeightsEnum:
         return ResNet18_Weights.SENTINEL2_ALL_MOCO
@@ -340,11 +335,7 @@ class TestPixelwiseRegressionTask:
         'backbone',
         ['resnet18', 'mobilenet_v2', 'efficientnet-b0', 'tu-vit_base_patch16_224'],
     )
-    def test_freeze_backbone(
-        self,
-        model_name: Literal['unet', 'deeplabv3+', 'segformer', 'upernet', 'dpt'],
-        backbone: str,
-    ) -> None:
+    def test_freeze_backbone(self, model_name: str, backbone: str) -> None:
         if model_name == 'dpt' and not backbone.startswith('tu-vit'):
             pytest.skip('dpt model only supports vit backbones')
 
@@ -365,9 +356,7 @@ class TestPixelwiseRegressionTask:
     @pytest.mark.parametrize(
         'model_name', ['unet', 'deeplabv3+', 'segformer', 'upernet', 'dpt']
     )
-    def test_freeze_decoder(
-        self, model_name: Literal['unet', 'deeplabv3+', 'segformer', 'upernet', 'dpt']
-    ) -> None:
+    def test_freeze_decoder(self, model_name: str) -> None:
         backbone = 'resnet18' if model_name != 'dpt' else 'tu-vit_base_patch16_224'
         model = PixelwiseRegressionTask(
             model=model_name, backbone=backbone, freeze_decoder=True

--- a/tests/trainers/test_regression.py
+++ b/tests/trainers/test_regression.py
@@ -329,16 +329,12 @@ class TestPixelwiseRegressionTask:
         )
 
     @pytest.mark.parametrize(
-        'model_name', ['unet', 'deeplabv3+', 'segformer', 'upernet', 'dpt']
+        'model_name', ['unet', 'deeplabv3+', 'segformer', 'upernet']
     )
     @pytest.mark.parametrize(
-        'backbone',
-        ['resnet18', 'mobilenet_v2', 'efficientnet-b0', 'tu-vit_base_patch16_224'],
+        'backbone', ['resnet18', 'mobilenet_v2', 'efficientnet-b0']
     )
     def test_freeze_backbone(self, model_name: str, backbone: str) -> None:
-        if model_name == 'dpt' and not backbone.startswith('tu-vit'):
-            pytest.skip('dpt model only supports vit backbones')
-
         model = PixelwiseRegressionTask(
             model=model_name, backbone=backbone, freeze_backbone=True
         )
@@ -354,12 +350,11 @@ class TestPixelwiseRegressionTask:
         )
 
     @pytest.mark.parametrize(
-        'model_name', ['unet', 'deeplabv3+', 'segformer', 'upernet', 'dpt']
+        'model_name', ['unet', 'deeplabv3+', 'segformer', 'upernet']
     )
     def test_freeze_decoder(self, model_name: str) -> None:
-        backbone = 'resnet18' if model_name != 'dpt' else 'tu-vit_base_patch16_224'
         model = PixelwiseRegressionTask(
-            model=model_name, backbone=backbone, freeze_decoder=True
+            model=model_name, backbone='resnet18', freeze_decoder=True
         )
         assert all(
             [param.requires_grad is False for param in model.model.decoder.parameters()]
@@ -371,3 +366,6 @@ class TestPixelwiseRegressionTask:
                 for param in model.model.segmentation_head.parameters()
             ]
         )
+
+    def test_vit_backbone(self) -> None:
+        PixelwiseRegressionTask(model='dpt', backbone='tu-vit_base_patch16_224')

--- a/tests/trainers/test_segmentation.py
+++ b/tests/trainers/test_segmentation.py
@@ -251,12 +251,8 @@ class TestSemanticSegmentationTask:
         model_name: Literal['unet', 'deeplabv3+', 'segformer', 'upernet', 'dpt'],
         backbone: str,
     ) -> None:
-        if backbone == 'tu-vit_base_patch16_224':
-            if model_name != 'dpt':
-                return
-        else:
-            if model_name == 'dpt':
-                return
+        if not (backbone == 'tu-vit_base_patch16_224' and model_name == 'dpt'):
+            pytest.skip('dpt model only supports vit backbones')
 
         model = SemanticSegmentationTask(
             model=model_name, backbone=backbone, num_classes=10, freeze_backbone=True

--- a/tests/trainers/test_segmentation.py
+++ b/tests/trainers/test_segmentation.py
@@ -285,4 +285,6 @@ class TestSemanticSegmentationTask:
         )
 
     def test_vit_backbone(self) -> None:
-        SemanticSegmentationTask(model='dpt', backbone='tu-vit_base_patch16_224')
+        SemanticSegmentationTask(
+            model='dpt', backbone='tu-vit_base_patch16_224', num_classes=2
+        )

--- a/tests/trainers/test_segmentation.py
+++ b/tests/trainers/test_segmentation.py
@@ -240,20 +240,16 @@ class TestSemanticSegmentationTask:
         trainer.validate(model=model, datamodule=datamodule)
 
     @pytest.mark.parametrize(
-        'model_name', ['unet', 'deeplabv3+', 'segformer', 'upernet', 'dpt']
+        'model_name', ['unet', 'deeplabv3+', 'segformer', 'upernet']
     )
     @pytest.mark.parametrize(
-        'backbone',
-        ['resnet18', 'mobilenet_v2', 'efficientnet-b0', 'tu-vit_base_patch16_224'],
+        'backbone', ['resnet18', 'mobilenet_v2', 'efficientnet-b0']
     )
     def test_freeze_backbone(
         self,
-        model_name: Literal['unet', 'deeplabv3+', 'segformer', 'upernet', 'dpt'],
+        model_name: Literal['unet', 'deeplabv3+', 'segformer', 'upernet'],
         backbone: str,
     ) -> None:
-        if model_name == 'dpt' and not backbone.startswith('tu-vit'):
-            pytest.skip('dpt model only supports vit backbones')
-
         model = SemanticSegmentationTask(
             model=model_name, backbone=backbone, num_classes=10, freeze_backbone=True
         )
@@ -269,14 +265,13 @@ class TestSemanticSegmentationTask:
         )
 
     @pytest.mark.parametrize(
-        'model_name', ['unet', 'deeplabv3+', 'segformer', 'upernet', 'dpt']
+        'model_name', ['unet', 'deeplabv3+', 'segformer', 'upernet']
     )
     def test_freeze_decoder(
-        self, model_name: Literal['unet', 'deeplabv3+', 'segformer', 'upernet', 'dpt']
+        self, model_name: Literal['unet', 'deeplabv3+', 'segformer', 'upernet']
     ) -> None:
-        backbone = 'resnet18' if model_name != 'dpt' else 'tu-vit_base_patch16_224'
         model = SemanticSegmentationTask(
-            model=model_name, backbone=backbone, num_classes=10, freeze_decoder=True
+            model=model_name, backbone='resnet18', num_classes=10, freeze_decoder=True
         )
         assert all(
             [param.requires_grad is False for param in model.model.decoder.parameters()]
@@ -288,3 +283,6 @@ class TestSemanticSegmentationTask:
                 for param in model.model.segmentation_head.parameters()
             ]
         )
+
+    def test_vit_backbone(self) -> None:
+        SemanticSegmentationTask(model='dpt', backbone='tu-vit_base_patch16_224')

--- a/tests/trainers/test_segmentation.py
+++ b/tests/trainers/test_segmentation.py
@@ -251,7 +251,7 @@ class TestSemanticSegmentationTask:
         model_name: Literal['unet', 'deeplabv3+', 'segformer', 'upernet', 'dpt'],
         backbone: str,
     ) -> None:
-        if not (backbone == 'tu-vit_base_patch16_224' and model_name == 'dpt'):
+        if model_name == 'dpt' and not backbone.startswith('tu-vit'):
             pytest.skip('dpt model only supports vit backbones')
 
         model = SemanticSegmentationTask(

--- a/torchgeo/trainers/regression.py
+++ b/torchgeo/trainers/regression.py
@@ -4,7 +4,7 @@
 """Trainers for regression."""
 
 import os
-from typing import Any, Literal
+from typing import Any
 
 import kornia.augmentation as K
 import matplotlib.pyplot as plt
@@ -30,16 +30,7 @@ class RegressionTask(BaseTask):
 
     def __init__(
         self,
-        model: Literal[
-            'unet',
-            'deeplabv3+',
-            'fcn',
-            'upernet',
-            'segformer',
-            'dpt',
-            'fcsiamdiff',
-            'fcsiamconc',
-        ] = 'unet',
+        model: str = 'resnet50',
         backbone: str = 'resnet50',
         weights: WeightsEnum | str | bool | None = None,
         in_channels: int = 3,

--- a/torchgeo/trainers/regression.py
+++ b/torchgeo/trainers/regression.py
@@ -4,7 +4,7 @@
 """Trainers for regression."""
 
 import os
-from typing import Any
+from typing import Any, Literal
 
 import kornia.augmentation as K
 import matplotlib.pyplot as plt
@@ -30,7 +30,16 @@ class RegressionTask(BaseTask):
 
     def __init__(
         self,
-        model: str = 'resnet50',
+        model: Literal[
+            'unet',
+            'deeplabv3+',
+            'fcn',
+            'upernet',
+            'segformer',
+            'dpt',
+            'fcsiamdiff',
+            'fcsiamconc',
+        ] = 'unet',
         backbone: str = 'resnet50',
         weights: WeightsEnum | str | bool | None = None,
         in_channels: int = 3,
@@ -285,52 +294,48 @@ class PixelwiseRegressionTask(RegressionTask):
         backbone = self.hparams['backbone']
         in_channels = self.hparams['in_channels']
 
-        if model == 'unet':
-            self.model = smp.Unet(
-                encoder_name=backbone,
-                encoder_weights='imagenet' if weights is True else None,
-                in_channels=in_channels,
-                classes=1,
-            )
-        elif model == 'deeplabv3+':
-            self.model = smp.DeepLabV3Plus(
-                encoder_name=backbone,
-                encoder_weights='imagenet' if weights is True else None,
-                in_channels=in_channels,
-                classes=1,
-            )
-        elif model == 'fcn':
-            self.model = FCN(
-                in_channels=in_channels,
-                classes=1,
-                num_filters=self.hparams['num_filters'],
-            )
-        elif model == 'upernet':
-            self.model = smp.UPerNet(
-                encoder_name=backbone,
-                encoder_weights='imagenet' if weights is True else None,
-                in_channels=in_channels,
-                classes=1,
-            )
-        elif model == 'segformer':
-            self.model = smp.Segformer(
-                encoder_name=backbone,
-                encoder_weights='imagenet' if weights is True else None,
-                in_channels=in_channels,
-                classes=1,
-            )
-        elif model == 'dpt':
-            self.model = smp.DPT(
-                encoder_name=backbone,
-                encoder_weights='imagenet' if weights is True else None,
-                in_channels=in_channels,
-                classes=1,
-            )
-        else:
-            raise ValueError(
-                f"Model type '{model}' is not valid. "
-                "Currently, only supports 'unet', 'deeplabv3+', 'fcn', 'upernet', 'segformer', and 'dpt'."
-            )
+        match model:
+            case 'unet':
+                self.model = smp.Unet(
+                    encoder_name=backbone,
+                    encoder_weights='imagenet' if weights is True else None,
+                    in_channels=in_channels,
+                    classes=1,
+                )
+            case 'deeplabv3+':
+                self.model = smp.DeepLabV3Plus(
+                    encoder_name=backbone,
+                    encoder_weights='imagenet' if weights is True else None,
+                    in_channels=in_channels,
+                    classes=1,
+                )
+            case 'fcn':
+                self.model = FCN(
+                    in_channels=in_channels,
+                    classes=1,
+                    num_filters=self.hparams['num_filters'],
+                )
+            case 'upernet':
+                self.model = smp.UPerNet(
+                    encoder_name=backbone,
+                    encoder_weights='imagenet' if weights is True else None,
+                    in_channels=in_channels,
+                    classes=1,
+                )
+            case 'segformer':
+                self.model = smp.Segformer(
+                    encoder_name=backbone,
+                    encoder_weights='imagenet' if weights is True else None,
+                    in_channels=in_channels,
+                    classes=1,
+                )
+            case 'dpt':
+                self.model = smp.DPT(
+                    encoder_name=backbone,
+                    encoder_weights='imagenet' if weights is True else None,
+                    in_channels=in_channels,
+                    classes=1,
+                )
 
         if model != 'fcn':
             if weights and weights is not True:

--- a/torchgeo/trainers/regression.py
+++ b/torchgeo/trainers/regression.py
@@ -281,33 +281,58 @@ class PixelwiseRegressionTask(RegressionTask):
         """Initialize the model."""
         weights = self.weights
 
-        if self.hparams['model'] == 'unet':
+        model = self.hparams['model']
+        backbone = self.hparams['backbone']
+        in_channels = self.hparams['in_channels']
+
+        if model == 'unet':
             self.model = smp.Unet(
-                encoder_name=self.hparams['backbone'],
+                encoder_name=backbone,
                 encoder_weights='imagenet' if weights is True else None,
-                in_channels=self.hparams['in_channels'],
+                in_channels=in_channels,
                 classes=1,
             )
-        elif self.hparams['model'] == 'deeplabv3+':
+        elif model == 'deeplabv3+':
             self.model = smp.DeepLabV3Plus(
-                encoder_name=self.hparams['backbone'],
+                encoder_name=backbone,
                 encoder_weights='imagenet' if weights is True else None,
-                in_channels=self.hparams['in_channels'],
+                in_channels=in_channels,
                 classes=1,
             )
-        elif self.hparams['model'] == 'fcn':
+        elif model == 'fcn':
             self.model = FCN(
-                in_channels=self.hparams['in_channels'],
+                in_channels=in_channels,
                 classes=1,
                 num_filters=self.hparams['num_filters'],
             )
+        elif model == 'upernet':
+            self.model = smp.UPerNet(
+                encoder_name=backbone,
+                encoder_weights='imagenet' if weights is True else None,
+                in_channels=in_channels,
+                classes=1,
+            )
+        elif model == 'segformer':
+            self.model = smp.Segformer(
+                encoder_name=backbone,
+                encoder_weights='imagenet' if weights is True else None,
+                in_channels=in_channels,
+                classes=1,
+            )
+        elif model == 'dpt':
+            self.model = smp.DPT(
+                encoder_name=backbone,
+                encoder_weights='imagenet' if weights is True else None,
+                in_channels=in_channels,
+                classes=1,
+            )
         else:
             raise ValueError(
-                f"Model type '{self.hparams['model']}' is not valid. "
-                "Currently, only supports 'unet', 'deeplabv3+' and 'fcn'."
+                f"Model type '{model}' is not valid. "
+                "Currently, only supports 'unet', 'deeplabv3+', 'fcn', 'upernet', 'segformer', and 'dpt'."
             )
 
-        if self.hparams['model'] != 'fcn':
+        if model != 'fcn':
             if weights and weights is not True:
                 if isinstance(weights, WeightsEnum):
                     state_dict = weights.get_state_dict(progress=True)
@@ -318,17 +343,11 @@ class PixelwiseRegressionTask(RegressionTask):
                 self.model.encoder.load_state_dict(state_dict)
 
         # Freeze backbone
-        if self.hparams.get('freeze_backbone', False) and self.hparams['model'] in [
-            'unet',
-            'deeplabv3+',
-        ]:
+        if self.hparams.get('freeze_backbone', False) and model != 'fcn':
             for param in self.model.encoder.parameters():
                 param.requires_grad = False
 
         # Freeze decoder
-        if self.hparams.get('freeze_decoder', False) and self.hparams['model'] in [
-            'unet',
-            'deeplabv3+',
-        ]:
+        if self.hparams.get('freeze_decoder', False) and model != 'fcn':
             for param in self.model.decoder.parameters():
                 param.requires_grad = False

--- a/torchgeo/trainers/segmentation.py
+++ b/torchgeo/trainers/segmentation.py
@@ -137,21 +137,21 @@ class SemanticSegmentationTask(BaseTask):
                     encoder_name=backbone,
                     encoder_weights='imagenet' if weights is True else None,
                     in_channels=in_channels,
-                    classes=1,
+                    classes=num_classes,
                 )
             case 'segformer':
                 self.model = smp.Segformer(
                     encoder_name=backbone,
                     encoder_weights='imagenet' if weights is True else None,
                     in_channels=in_channels,
-                    classes=1,
+                    classes=num_classes,
                 )
             case 'dpt':
                 self.model = smp.DPT(
                     encoder_name=backbone,
                     encoder_weights='imagenet' if weights is True else None,
                     in_channels=in_channels,
-                    classes=1,
+                    classes=num_classes,
                 )
         if model != 'fcn':
             if weights and weights is not True:


### PR DESCRIPTION
This PR adds the newly supported SMP decoders (UPerNet, Segformer, DPT) for all dense output tasks (semantic seg, pixelwise regression, change detection).

In research papers I've been seeing a trend towards using UPerNet and DPT decoders to evaluate geospatial foundation models (particularly transformer-based ones) so we should enable users to do this within our trainers.