### PR TITLE
NAIPChesapeakeDataModule: fix overlap between train and test

### DIFF
--- a/torchgeo/datamodules/naip.py
+++ b/torchgeo/datamodules/naip.py
@@ -100,7 +100,7 @@ class NAIPChesapeakeDataModule(GeoDataModule):
             )
         if stage in ['test']:
             test_roi = BoundingBox(
-                roi.minx, roi.maxx, midy, roi.maxy, roi.mint, roi.maxt
+                midx, roi.maxx, midy, roi.maxy, roi.mint, roi.maxt
             )
             self.test_sampler = GridGeoSampler(
                 self.dataset, self.patch_size, self.patch_size, test_roi

--- a/torchgeo/datamodules/naip.py
+++ b/torchgeo/datamodules/naip.py
@@ -99,9 +99,7 @@ class NAIPChesapeakeDataModule(GeoDataModule):
                 self.dataset, self.patch_size, self.patch_size, val_roi
             )
         if stage in ['test']:
-            test_roi = BoundingBox(
-                midx, roi.maxx, midy, roi.maxy, roi.mint, roi.maxt
-            )
+            test_roi = BoundingBox(midx, roi.maxx, midy, roi.maxy, roi.mint, roi.maxt)
             self.test_sampler = GridGeoSampler(
                 self.dataset, self.patch_size, self.patch_size, test_roi
             )


### PR DESCRIPTION
It's not every day you find a bug that has existed since TorchGeo 0.1: https://github.com/microsoft/torchgeo/blob/v0.1.0/torchgeo/datasets/naip.py#L154

Discovered while working on #2804.
