### PR TITLE
roi_split: support arbitrary Polygon for roi

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -121,6 +121,7 @@ intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
     'rasterio': ('https://rasterio.readthedocs.io/en/stable/', None),
     'segmentation_models_pytorch': ('https://smp.readthedocs.io/en/stable/', None),
+    'shapely': ('https://shapely.readthedocs.io/en/stable/', None),
     'sklearn': ('https://scikit-learn.org/stable/', None),
     'timm': ('https://huggingface.co/docs/timm/main/en/', None),
     'torch': ('https://docs.pytorch.org/docs/stable/', None),

--- a/tests/datasets/test_splits.py
+++ b/tests/datasets/test_splits.py
@@ -207,9 +207,9 @@ def test_roi_split() -> None:
     train_ds, val_ds, test_ds = roi_split(
         ds,
         rois=[
-            BoundingBox(0, 2, 0, 1, MINT, MAXT),
-            BoundingBox(2, 3.5, 0, 1, MINT, MAXT),
-            BoundingBox(3.5, 4, 0, 1, MINT, MAXT),
+            shapely.box(0, 0, 2, 1),
+            shapely.box(2, 0, 3.5, 1),
+            shapely.box(3.5, 0, 4, 1),
         ],
     )
 
@@ -233,13 +233,7 @@ def test_roi_split() -> None:
 
     # Test invalid input rois
     with pytest.raises(ValueError, match="ROIs in input rois can't overlap."):
-        roi_split(
-            ds,
-            rois=[
-                BoundingBox(0, 2, 0, 1, MINT, MAXT),
-                BoundingBox(1, 3, 0, 1, MINT, MAXT),
-            ],
-        )
+        roi_split(ds, rois=[shapely.box(0, 0, 2, 1), shapely.box(1, 0, 3, 1)])
 
 
 @pytest.mark.parametrize(

--- a/torchgeo/datasets/splits.py
+++ b/torchgeo/datasets/splits.py
@@ -14,11 +14,10 @@ import geopandas
 import pandas as pd
 import shapely
 from geopandas import GeoDataFrame
-from shapely import LineString
+from shapely import LineString, Polygon
 from torch import Generator, default_generator, randint, randperm
 
 from ..datasets import GeoDataset
-from .utils import BoundingBox
 
 
 def _fractions_to_lengths(fractions: Sequence[float], total: int) -> Sequence[int]:
@@ -49,9 +48,9 @@ def random_bbox_assignment(
     lengths: Sequence[float],
     generator: Generator | None = default_generator,
 ) -> list[GeoDataset]:
-    """Split a GeoDataset randomly assigning its index's BoundingBoxes.
+    """Split a GeoDataset randomly assigning its index's objects.
 
-    This function will go through each BoundingBox in the GeoDataset's index and
+    This function will go through each object in the GeoDataset's index and
     randomly assign it to new GeoDatasets.
 
     Args:
@@ -92,10 +91,10 @@ def random_bbox_splitting(
     fractions: Sequence[float],
     generator: Generator | None = default_generator,
 ) -> list[GeoDataset]:
-    """Split a GeoDataset randomly splitting its index's BoundingBoxes.
+    """Split a GeoDataset randomly splitting its index's objects.
 
-    This function will go through each BoundingBox in the GeoDataset's index,
-    split it in a random direction and assign the resulting BoundingBoxes to
+    This function will go through each object in the GeoDataset's index,
+    split it in a random direction and assign the resulting objects to
     new GeoDatasets.
 
     Args:
@@ -182,7 +181,7 @@ def random_grid_cell_assignment(
 ) -> list[GeoDataset]:
     """Overlays a grid over a GeoDataset and randomly assigns cells to new GeoDatasets.
 
-    This function will go through each BoundingBox in the GeoDataset's index, overlay
+    This function will go through each object in the GeoDataset's index, overlay
     a grid over it, and randomly assign each cell to new GeoDatasets.
 
     Args:
@@ -254,7 +253,7 @@ def random_grid_cell_assignment(
     return new_datasets
 
 
-def roi_split(dataset: GeoDataset, rois: Sequence[BoundingBox]) -> list[GeoDataset]:
+def roi_split(dataset: GeoDataset, rois: Sequence[Polygon]) -> list[GeoDataset]:
     """Split a GeoDataset intersecting it with a ROI for each desired new GeoDataset.
 
     Args:
@@ -268,12 +267,14 @@ def roi_split(dataset: GeoDataset, rois: Sequence[BoundingBox]) -> list[GeoDatas
     """
     new_datasets = []
     for i, roi in enumerate(rois):
-        if any(roi.intersects(x) and (roi & x).area > 0 for x in rois[i + 1 :]):
+        if any(
+            shapely.intersects(roi, x) and not shapely.touches(roi, x)
+            for x in rois[i + 1 :]
+        ):
             raise ValueError("ROIs in input rois can't overlap.")
 
         ds = deepcopy(dataset)
-        mask = shapely.box(roi.minx, roi.miny, roi.maxx, roi.maxy)
-        ds.index = geopandas.clip(dataset.index, mask)
+        ds.index = geopandas.clip(dataset.index, roi)
         new_datasets.append(ds)
 
     return new_datasets
@@ -323,7 +324,7 @@ def time_series_split(
         start = interval.left
         end = interval.right
 
-        # Remove one microsecond from each BoundingBox's maxt to avoid overlapping
+        # Remove one microsecond from each object's maxt to avoid overlapping
         offset = (
             pd.Timedelta(0) if i == len(lengths) - 1 else pd.Timedelta(1, unit='us')
         )


### PR DESCRIPTION
Now that we are using geopandas, we can easily support any arbitrary shapely Polygon: #2382

### Backwards-incompatible changes

* roi_sampler no longer supports BoundingBox roi, use shapely Polygon instead

Loosely related to #1170 and #1190