### PR TITLE
IntersectionDataset: support spatial-only intersection

### DIFF
--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -821,6 +821,20 @@ class TestIntersectionDataset:
         assert shapely.box(1, 1, 3, 3) in ds.index.geometry
         assert shapely.box(2, 2, 3, 3) in ds.index.geometry
 
+        bounds1 = [(0, 2, 0, 2, pd.Timestamp(2025, 4, 1), pd.Timestamp(2025, 4, 2))]
+        bounds2 = [(1, 3, 1, 3, pd.Timestamp(2025, 4, 3), pd.Timestamp(2025, 4, 4))]
+        ds1 = CustomGeoDataset(bounds1)
+        ds2 = CustomGeoDataset(bounds2)
+        ds = IntersectionDataset(ds1, ds2, spatial_only=True)
+        assert len(ds) == 1
+        assert shapely.box(1, 1, 2, 2) in ds.index.geometry
+
+        ds1 = CustomGeoDataset([(0, 1, 0, 1, MINT, MAXT)])
+        ds2 = CustomGeoDataset([(2, 3, 2, 3, MINT, MAXT)])
+        msg = 'Datasets have no spatial intersection'
+        with pytest.raises(RuntimeError, match=msg):
+            IntersectionDataset(ds1, ds2)
+
     def test_temporal_intersection(self) -> None:
         bounds1 = [
             (0, 1, 0, 1, pd.Timestamp(2025, 4, 1), pd.Timestamp(2025, 4, 3)),
@@ -839,6 +853,14 @@ class TestIntersectionDataset:
         assert ds.index.index[0].right == pd.Timestamp(2025, 4, 3)
         assert ds.index.index[1].left == pd.Timestamp(2025, 4, 4)
         assert ds.index.index[1].right == pd.Timestamp(2025, 4, 5)
+
+        bounds1 = [(0, 1, 0, 1, pd.Timestamp(2025, 4, 1), pd.Timestamp(2025, 4, 2))]
+        bounds2 = [(0, 1, 0, 1, pd.Timestamp(2025, 4, 3), pd.Timestamp(2025, 4, 4))]
+        ds1 = CustomGeoDataset(bounds1)
+        ds2 = CustomGeoDataset(bounds2)
+        msg = 'Datasets have no temporal intersection'
+        with pytest.raises(RuntimeError, match=msg):
+            IntersectionDataset(ds1, ds2)
 
     def test_spatiotemporal_intersection(self) -> None:
         bounds1 = [
@@ -866,21 +888,21 @@ class TestIntersectionDataset:
     def test_point_dataset(self) -> None:
         ds1 = CustomGeoDataset([(0, 2, 2, 4, MINT, MAXT)])
         ds2 = CustomGeoDataset([(1, 1, 3, 3, MINT, MINT)])
-        msg = 'Datasets have no spatiotemporal intersection'
+        msg = 'Datasets have no spatial intersection'
         with pytest.raises(RuntimeError, match=msg):
             IntersectionDataset(ds1, ds2)
 
     def test_no_overlap(self) -> None:
         ds1 = CustomGeoDataset([(0, 1, 2, 3, MINT, MINT)])
         ds2 = CustomGeoDataset([(6, 7, 8, 9, MAXT, MAXT)])
-        msg = 'Datasets have no spatiotemporal intersection'
+        msg = 'Datasets have no spatial intersection'
         with pytest.raises(RuntimeError, match=msg):
             IntersectionDataset(ds1, ds2)
 
     def test_grid_overlap(self) -> None:
         ds1 = CustomGeoDataset([(0, 1, 2, 3, MINT, MAXT)])
         ds2 = CustomGeoDataset([(1, 2, 3, 4, MAXT, MAXT)])
-        msg = 'Datasets have no spatiotemporal intersection'
+        msg = 'Datasets have no spatial intersection'
         with pytest.raises(RuntimeError, match=msg):
             IntersectionDataset(ds1, ds2)
 

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -983,8 +983,11 @@ class IntersectionDataset(GeoDataset):
             RuntimeError: if datasets have no spatiotemporal intersection
             ValueError: if either dataset is not a :class:`GeoDataset`
 
+        .. versionadded:: 0.8
+           The *spatial_only* parameter.
+
         .. versionadded:: 0.4
-            The *transforms* parameter.
+           The *transforms* parameter.
         """
         self.datasets = [dataset1, dataset2]
         self.collate_fn = collate_fn

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -958,6 +958,7 @@ class IntersectionDataset(GeoDataset):
         self,
         dataset1: GeoDataset,
         dataset2: GeoDataset,
+        spatial_only: bool = False,
         collate_fn: Callable[
             [Sequence[dict[str, Any]]], dict[str, Any]
         ] = concat_samples,
@@ -973,6 +974,7 @@ class IntersectionDataset(GeoDataset):
         Args:
             dataset1: the first dataset
             dataset2: the second dataset
+            spatial_only: if True, ignore temporal dimension when computing intersection
             collate_fn: function used to collate samples
             transforms: a function/transform that takes input sample and its target as
                 entry and returns a transformed version
@@ -1002,21 +1004,27 @@ class IntersectionDataset(GeoDataset):
             index1, index2, how='intersection', keep_geom_type=True
         )
 
-        # Temporal intersection
-        datetime_1 = pd.IntervalIndex(self.index.pop('datetime_1'))
-        datetime_2 = pd.IntervalIndex(self.index.pop('datetime_2'))
-        mint = np.maximum(datetime_1.left, datetime_2.left)
-        maxt = np.minimum(datetime_1.right, datetime_2.right)
-        valid = maxt >= mint
-        mint = mint[valid]
-        maxt = maxt[valid]
-        self.index = self.index[valid]
-        self.index.index = pd.IntervalIndex.from_arrays(
-            mint, maxt, closed='both', name='datetime'
-        )
-
         if self.index.empty:
-            raise RuntimeError('Datasets have no spatiotemporal intersection')
+            raise RuntimeError('Datasets have no spatial intersection')
+
+        # Temporal intersection
+        if not spatial_only:
+            datetime_1 = pd.IntervalIndex(self.index.pop('datetime_1'))
+            datetime_2 = pd.IntervalIndex(self.index.pop('datetime_2'))
+            mint = np.maximum(datetime_1.left, datetime_2.left)
+            maxt = np.minimum(datetime_1.right, datetime_2.right)
+            valid = maxt >= mint
+            mint = mint[valid]
+            maxt = maxt[valid]
+            self.index = self.index[valid]
+            self.index.index = pd.IntervalIndex.from_arrays(
+                mint, maxt, closed='both', name='datetime'
+            )
+
+            if self.index.empty:
+                msg = 'Datasets have no temporal intersection. Use `spatial_only=True`'
+                msg += ' if you want to ignore temporal intersection'
+                raise RuntimeError(msg)
 
     def __getitem__(self, query: GeoSlice) -> dict[str, Any]:
         """Retrieve input, target, and/or metadata indexed by spatiotemporal slice.


### PR DESCRIPTION
Part of #2382 

Needed for applications like MultiMiner where we have a collection of satellite/drone imagery inputs at different times covering the same year. @MUYang99

Closes #2571