### PR TITLE
Add SSL4Eco SeCo-Eco Weights

### DIFF
--- a/docs/api/weights/sentinel2.csv
+++ b/docs/api/weights/sentinel2.csv
@@ -6,7 +6,8 @@ ResNet50_Weights.SENTINEL2_ALL_DECUR,13,`link <https://github.com/zhu-xlab/DeCUR
 ResNet50_Weights.SENTINEL2_ALL_DINO,13,`link <https://github.com/zhu-xlab/SSL4EO-S12>`__,`link <https://arxiv.org/abs/2211.07044>`__,"CC-BY-4.0",90.7,99.1,63.6,
 ResNet50_Weights.SENTINEL2_ALL_MOCO,13,`link <https://github.com/zhu-xlab/SSL4EO-S12>`__,`link <https://arxiv.org/abs/2211.07044>`__,"CC-BY-4.0",91.8,99.1,60.9,
 ResNet50_Weights.SENTINEL2_ALL_SOFTCON, 13,`link <https://github.com/zhu-xlab/softcon>`__,`link <https://arxiv.org/abs/2405.20462>`__,"CC-BY-4.0"
-ResNet50_Weights.SENTINEL2_ALL_SECO_ECO, 9,`link <https://github.com/PlekhanovaElena/ssl4eco>`__,`link <https://arxiv.org/abs/2504.18256>`__,"MIT"
+ResNet50_Weights.SENTINEL2_ALL_SECO_ECO, 12,`link <https://github.com/PlekhanovaElena/ssl4eco>`__,`link <https://arxiv.org/abs/2504.18256>`__,"MIT"
+ResNet50_Weights.SENTINEL2_ALL_NDVI_SECO_ECO, 9,`link <https://github.com/PlekhanovaElena/ssl4eco>`__,`link <https://arxiv.org/abs/2504.18256>`__,"MIT"
 ResNet50_Weights.SENTINEL2_MI_MS_SATLAS,9,`link <https://github.com/allenai/satlaspretrain_models>`__,`link <https://arxiv.org/abs/2211.15660>`__,ODC-BY,,,,
 ResNet50_Weights.SENTINEL2_MI_RGB_SATLAS,3,`link <https://github.com/allenai/satlaspretrain_models>`__,`link <https://arxiv.org/abs/2211.15660>`__,ODC-BY,,,,
 ResNet50_Weights.SENTINEL2_SI_MS_SATLAS,9,`link <https://github.com/allenai/satlaspretrain_models>`__,`link <https://arxiv.org/abs/2211.15660>`__,ODC-BY,,,,

--- a/docs/api/weights/sentinel2.csv
+++ b/docs/api/weights/sentinel2.csv
@@ -6,6 +6,7 @@ ResNet50_Weights.SENTINEL2_ALL_DECUR,13,`link <https://github.com/zhu-xlab/DeCUR
 ResNet50_Weights.SENTINEL2_ALL_DINO,13,`link <https://github.com/zhu-xlab/SSL4EO-S12>`__,`link <https://arxiv.org/abs/2211.07044>`__,"CC-BY-4.0",90.7,99.1,63.6,
 ResNet50_Weights.SENTINEL2_ALL_MOCO,13,`link <https://github.com/zhu-xlab/SSL4EO-S12>`__,`link <https://arxiv.org/abs/2211.07044>`__,"CC-BY-4.0",91.8,99.1,60.9,
 ResNet50_Weights.SENTINEL2_ALL_SOFTCON, 13,`link <https://github.com/zhu-xlab/softcon>`__,`link <https://arxiv.org/abs/2405.20462>`__,"CC-BY-4.0"
+ResNet50_Weights.SENTINEL2_ALL_SECO_ECO, 9,`link <https://github.com/PlekhanovaElena/ssl4eco>`__,`link <https://arxiv.org/abs/2504.18256>`__,"MIT"
 ResNet50_Weights.SENTINEL2_MI_MS_SATLAS,9,`link <https://github.com/allenai/satlaspretrain_models>`__,`link <https://arxiv.org/abs/2211.15660>`__,ODC-BY,,,,
 ResNet50_Weights.SENTINEL2_MI_RGB_SATLAS,3,`link <https://github.com/allenai/satlaspretrain_models>`__,`link <https://arxiv.org/abs/2211.15660>`__,ODC-BY,,,,
 ResNet50_Weights.SENTINEL2_SI_MS_SATLAS,9,`link <https://github.com/allenai/satlaspretrain_models>`__,`link <https://arxiv.org/abs/2211.15660>`__,ODC-BY,,,,

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -155,6 +155,18 @@ _seco_transforms = K.AugmentationSequential(
     data_keys=None,
 )
 
+
+# Normalization only available for RGB dataset, defined here:
+# https://github.com/PlekhanovaElena/ssl4eco/blob/7445e048035f7ae31c0eb45e1ed8426c9989fe56/pretraining/pretrain_seco_3heads.py#L140
+# https://github.com/PlekhanovaElena/ssl4eco/blob/7445e048035f7ae31c0eb45e1ed8426c9989fe56/downstream_tasks/test_modules/secoeco_test_module.py#L28
+_seco_eco_bands = ['B2', 'B3', 'B4', 'B5', 'B6', 'B7', 'B8', 'B8A', 'NDVI']
+_seco_eco_transforms = K.AugmentationSequential(
+    K.Resize((224, 224)),
+    K.Normalize(mean=torch.tensor(0.0), std=torch.tensor(10000.0)),
+    data_keys=None,
+)
+
+
 # Normalization only available for RGB dataset, defined here:
 # https://github.com/sustainlab-group/geography-aware-ssl/blob/main/moco_fmow/main_moco_geo%2Btp.py#L287
 _mean = torch.tensor([0.485, 0.456, 0.406])
@@ -635,7 +647,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
 
     SENTINEL2_ALL_SECO_ECO = Weights(
         url='https://hf.co/torchgeo/seco-eco/resolve/a3f7fea6619d000cf5dadbb8aab8f089234e480b/resnet50_sentinel2_all_seco_eco-62d9d740.pth',
-        transforms=_seco_transforms,
+        transforms=_seco_eco_transforms,
         meta={
             'dataset': 'SSL4Eco Dataset',
             'in_chans': 9,
@@ -643,7 +655,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2504.18256',
             'repo': 'https://github.com/PlekhanovaElena/ssl4eco',
             'ssl_method': 'seco-eco',
-            'bands': ['B2', 'B3', 'B4', 'B5', 'B6', 'B7', 'B8', 'B8A', 'NDVI'],
+            'bands': _seco_eco_bands,
         },
     )
 

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -633,6 +633,20 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
         },
     )
 
+    SENTINEL2_ALL_SECO_ECO = Weights(
+        url='https://hf.co/torchgeo/seco-eco/resolve/a3f7fea6619d000cf5dadbb8aab8f089234e480b/resnet50_sentinel2_all_seco_eco-62d9d740.pth',
+        transforms=_seco_transforms,
+        meta={
+            'dataset': 'SSL4Eco Dataset',
+            'in_chans': 9,
+            'model': 'resnet50',
+            'publication': 'https://arxiv.org/abs/2504.18256',
+            'repo': 'https://github.com/PlekhanovaElena/ssl4eco',
+            'ssl_method': 'seco-eco',
+            'bands': ['B2', 'B3', 'B4', 'B5', 'B6', 'B7', 'B8', 'B8A', 'NDVI'],
+        },
+    )
+
     SENTINEL2_MI_MS_SATLAS = Weights(
         url='https://hf.co/torchgeo/satlas/resolve/081d6607431bf36bdb59c223777cbb267131b8f2/sentinel2_resnet50_mi_ms-da5413d2.pth',
         transforms=_satlas_sentinel2_transforms,

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -159,7 +159,6 @@ _seco_transforms = K.AugmentationSequential(
 # Normalization only available for RGB dataset, defined here:
 # https://github.com/PlekhanovaElena/ssl4eco/blob/7445e048035f7ae31c0eb45e1ed8426c9989fe56/pretraining/pretrain_seco_3heads.py#L140
 # https://github.com/PlekhanovaElena/ssl4eco/blob/7445e048035f7ae31c0eb45e1ed8426c9989fe56/downstream_tasks/test_modules/secoeco_test_module.py#L28
-_seco_eco_bands = ['B2', 'B3', 'B4', 'B5', 'B6', 'B7', 'B8', 'B8A', 'NDVI']
 _seco_eco_transforms = K.AugmentationSequential(
     K.Resize((224, 224)),
     K.Normalize(mean=torch.tensor(0.0), std=torch.tensor(10000.0)),
@@ -646,7 +645,34 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
     )
 
     SENTINEL2_ALL_SECO_ECO = Weights(
-        url='https://hf.co/torchgeo/seco-eco/resolve/a3f7fea6619d000cf5dadbb8aab8f089234e480b/resnet50_sentinel2_all_seco_eco-62d9d740.pth',
+        url='https://hf.co/torchgeo/seco-eco/resolve/aea279ea46572cfca5876ac1f9d8d8595fcdeb3b/resnet50_sentinel2_all_seco_eco-90ec322f.pth',
+        transforms=_seco_eco_transforms,
+        meta={
+            'dataset': 'SSL4Eco Dataset',
+            'in_chans': 12,
+            'model': 'resnet50',
+            'publication': 'https://arxiv.org/abs/2504.18256',
+            'repo': 'https://github.com/PlekhanovaElena/ssl4eco',
+            'ssl_method': 'seco-eco',
+            'bands': [
+                'B1',
+                'B2',
+                'B3',
+                'B4',
+                'B5',
+                'B6',
+                'B7',
+                'B8',
+                'B8A',
+                'B9',
+                'B11',
+                'B12',
+            ],
+        },
+    )
+
+    SENTINEL2_ALL_NDVI_SECO_ECO = Weights(
+        url='https://hf.co/torchgeo/seco-eco-ndvi/resolve/44fae184c63b73e15a32be816e023957dc4c56c1/resnet50_sentinel2_all_ndvi_seco_eco-65292b83.pth',
         transforms=_seco_eco_transforms,
         meta={
             'dataset': 'SSL4Eco Dataset',
@@ -655,7 +681,7 @@ class ResNet50_Weights(WeightsEnum):  # type: ignore[misc]
             'publication': 'https://arxiv.org/abs/2504.18256',
             'repo': 'https://github.com/PlekhanovaElena/ssl4eco',
             'ssl_method': 'seco-eco',
-            'bands': _seco_eco_bands,
+            'bands': ['B2', 'B3', 'B4', 'B5', 'B6', 'B7', 'B8', 'B8A', 'NDVI'],
         },
     )
 


### PR DESCRIPTION
Adds the RN50 weights pretrained on the new SSL4Eco dataset using the SeCo-Eco method modified from the original SeCo method. This is from the CVPR Earthvision paper ["SSL4Eco: A Global Seasonal Dataset for Geospatial Foundation Models in Ecology", Plekhanova et al. (2025)](https://arxiv.org/abs/2504.18256).

Weights were extracted from the checkpoint and tweaked to be loadable with timm and torchvision resnet50 and rehosted to huggingface [here](https://huggingface.co/torchgeo/seco-eco).

cc: @PlekhanovaElena @drprojects @jdollinger-bit