### PR TITLE
SatSure core-dino Model

### DIFF
--- a/docs/api/weights/agnostic.csv
+++ b/docs/api/weights/agnostic.csv
@@ -7,6 +7,6 @@ DOFALarge16_Weights.DOFA_MAE,`link <https://github.com/zhu-xlab/DOFA>`__,`link <
 Panopticon_Weights.VIT_BASE14,`link <https://github.com/Panopticon-FM/panopticon>`__,`link <https://www.arxiv.org/abs/2503.10845>`__,Apache-2.0,implicit,,explicit,-,56.3,96.7,96.4,61.7,96.4,95.2,92.6,79.6,59.3,52.6,78.1
 ResNet50_Weights.FMOW_RGB_GASSL,`link <https://github.com/sustainlab-group/geography-aware-ssl>`__,`link <https://arxiv.org/abs/2011.09980>`__,-,implicit,-,-,,,,,,,,,,,,
 ScaleMAE_ViTLarge16_Weights.FMOW_RGB_SCALEMAE,`link <https://github.com/bair-climate-initiative/scale-mae>`__,`link <https://arxiv.org/abs/2212.14532>`__,CC-BY-NC-4.0,explicit,-,-,,,,,,,,,,,
+YOLO_Weights.CORE_DINO,`link <https://huggingface.co/gajeshladhar/core-dino>`__,,CC-BY-NC-3.0,implicit,-,-,,,,,,,,,,,
 YOLO_Weights.DELINEATE_ANYTHING,`link <https://github.com/Lavreniuk/Delineate-Anything>`__,`link <https://arxiv.org/abs/2409.16252>`__,AGPL-3.0,implicit,-,-,,,,,,,,,,,
 YOLO_Weights.DELINEATE_ANYTHING_SMALL,`link <https://github.com/Lavreniuk/Delineate-Anything>`__,`link <https://arxiv.org/abs/2409.16252>`__,AGPL-3.0,implicit,-,-,,,,,,,,,,,
-YOLO_Weights.CORE_DINO,`link <https://huggingface.co/gajeshladhar/core-dino>`__,,CC-BY-NC-3.0,implicit,-,-,,,,,,,,,,,

--- a/docs/api/weights/agnostic.csv
+++ b/docs/api/weights/agnostic.csv
@@ -9,3 +9,4 @@ ResNet50_Weights.FMOW_RGB_GASSL,`link <https://github.com/sustainlab-group/geogr
 ScaleMAE_ViTLarge16_Weights.FMOW_RGB_SCALEMAE,`link <https://github.com/bair-climate-initiative/scale-mae>`__,`link <https://arxiv.org/abs/2212.14532>`__,CC-BY-NC-4.0,explicit,-,-,,,,,,,,,,,
 YOLO_Weights.DELINEATE_ANYTHING,`link <https://github.com/Lavreniuk/Delineate-Anything>`__,`link <https://arxiv.org/abs/2409.16252>`__,AGPL-3.0,implicit,-,-,,,,,,,,,,,
 YOLO_Weights.DELINEATE_ANYTHING_SMALL,`link <https://github.com/Lavreniuk/Delineate-Anything>`__,`link <https://arxiv.org/abs/2409.16252>`__,AGPL-3.0,implicit,-,-,,,,,,,,,,,
+YOLO_Weights.CORE_DINO,`link <https://huggingface.co/gajeshladhar/core-dino>`__,,CC-BY-NC-3.0,implicit,-,-,,,,,,,,,,,

--- a/tests/models/test_yolo.py
+++ b/tests/models/test_yolo.py
@@ -24,7 +24,7 @@ class TestYOLO:
         import ultralytics
 
         weights = YOLO_Weights.DELINEATE_ANYTHING
-        path = tmp_path / f'{weights}.pth'
+        path = tmp_path / f'{weights}.pt'
         model = ultralytics.YOLO(
             model=f'{weights.meta["model"]}.yaml', task=weights.meta['task']
         )
@@ -38,6 +38,9 @@ class TestYOLO:
 
     def test_yolo_weights(self, mocked_weights: WeightsEnum) -> None:
         yolo(weights=mocked_weights)
+
+    def test_different_task(self, mocked_weights: WeightsEnum) -> None:
+        yolo(weights=mocked_weights, task='obb')
 
     def test_bands(self, weights: WeightsEnum) -> None:
         if 'bands' in weights.meta:

--- a/torchgeo/models/yolo.py
+++ b/torchgeo/models/yolo.py
@@ -29,7 +29,7 @@ class YOLO_Weights(WeightsEnum):  # type: ignore[misc]
     """
 
     DELINEATE_ANYTHING = Weights(
-        url='https://huggingface.co/torchgeo/delineate-anything-s/resolve/60bea7b2f81568d16d5c75e4b5b06289e1d7efaf/delineate_anything_rgb_yolo11x-88ede029.pt',
+        url='https://hf.co/torchgeo/delineate-anything-s/resolve/60bea7b2f81568d16d5c75e4b5b06289e1d7efaf/delineate_anything_rgb_yolo11x-88ede029.pt',
         transforms=_delineate_anything_transforms,
         meta={
             'dataset': 'FBIS-22M',
@@ -48,7 +48,7 @@ class YOLO_Weights(WeightsEnum):  # type: ignore[misc]
         },
     )
     DELINEATE_ANYTHING_SMALL = Weights(
-        url='https://huggingface.co/torchgeo/delineate-anything-s/resolve/69cd440b0c5bd450ced145e68294aa9393ddae05/delineate_anything_s_rgb_yolo11n-b879d643.pt',
+        url='https://hf.co/torchgeo/delineate-anything-s/resolve/69cd440b0c5bd450ced145e68294aa9393ddae05/delineate_anything_s_rgb_yolo11n-b879d643.pt',
         transforms=_delineate_anything_transforms,
         meta={
             'dataset': 'FBIS-22M',
@@ -64,6 +64,25 @@ class YOLO_Weights(WeightsEnum):  # type: ignore[misc]
             'repo': 'https://github.com/Lavreniuk/Delineate-Anything',
             'resolution': None,
             'license': 'AGPL-3.0',
+        },
+    )
+    CORE_DINO = Weights(
+        url='https://hf.co/torchgeo/core-dino/resolve/59427e13d114cbbf02f4745e1bea7570be3e2057/core_dino_rgb_yolo11x-80ca836f.pt',
+        transforms=nn.Identity(),  # transform is handled within ultralytics.YOLO model
+        meta={
+            'dataset': 'core-five',
+            'in_chans': 3,
+            'num_classes': None,
+            'classes': None,
+            'model': 'yolo11x',
+            'task': 'bbox',
+            'encoder': None,
+            'input_shape': (3, -1, -1),  # trained for dynamic input shape
+            'bands': ['R', 'G', 'B'],
+            'publication': None,
+            'repo': 'https://huggingface.co/gajeshladhar/core-dino',
+            'resolution': None,
+            'license': 'CC-BY-NC-3.0',
         },
     )
 
@@ -88,7 +107,9 @@ def yolo(weights: YOLO_Weights | None = None, *args: Any, **kwargs: Any) -> nn.M
 
     if weights:
         kwargs['model'] = weights.url
-        kwargs['task'] = weights.meta['task']
+
+        if 'task' not in kwargs:
+            kwargs['task'] = weights.meta['task']
 
     model = ultralytics.YOLO(*args, **kwargs)
     return cast(nn.Module, model)


### PR DESCRIPTION
This PR adds the YOLO pretrained weights for SatSure's [core-dino](https://huggingface.co/gajeshladhar/core-dino) model. This model is a YOLO11x encoder-only pretrained using DINO on the [core-five](https://huggingface.co/datasets/gajeshladhar/core-five) dataset.

Note: I added an option to the `torchgeo.models.yolo` function to allow users to override the task type of a YOLO model. This basically means that if a model is pretrained for object detection (bbox), for example, you can pass `yolo(weights, task="segment")` to use the pretrained model for instance segmentation instead.