### PR TITLE
Change Detection: Add multiclass/multilabel support

### DIFF
--- a/tests/trainers/test_change.py
+++ b/tests/trainers/test_change.py
@@ -50,7 +50,6 @@ class MockMulticlassChangeDataModule:
         self.num_classes = 3  # no change, building change, vegetation change
 
     def train_dataloader(self) -> MockDataLoader:
-        # Return a simple iterator that yields one batch
         class DataLoader:
             def __init__(self, batch_fn: Callable[[], dict[str, torch.Tensor]]) -> None:
                 self.batch_fn = batch_fn
@@ -61,7 +60,6 @@ class MockMulticlassChangeDataModule:
         return DataLoader(self._mock_batch)
 
     def val_dataloader(self) -> MockDataLoader:
-        # Return a simple iterator that yields one batch
         class DataLoader:
             def __init__(self, batch_fn: Callable[[], dict[str, torch.Tensor]]) -> None:
                 self.batch_fn = batch_fn
@@ -91,7 +89,6 @@ class MockMultilabelChangeDataModule:
         self.num_labels = 3  # building, vegetation, water changes
 
     def train_dataloader(self) -> MockDataLoader:
-        # Return a simple iterator that yields one batch
         class DataLoader:
             def __init__(self, batch_fn: Callable[[], dict[str, torch.Tensor]]) -> None:
                 self.batch_fn = batch_fn
@@ -102,7 +99,6 @@ class MockMultilabelChangeDataModule:
         return DataLoader(self._mock_batch)
 
     def val_dataloader(self) -> MockDataLoader:
-        # Return a simple iterator that yields one batch
         class DataLoader:
             def __init__(self, batch_fn: Callable[[], dict[str, torch.Tensor]]) -> None:
                 self.batch_fn = batch_fn
@@ -352,7 +348,7 @@ class TestChangeDetectionTask:
         trainer.validate(model=model, datamodule=datamodule)
 
 
-class TestNewChangeDetectionTasks:
+class TestMulticlassMultilabelChangeDetectionTasks:
     """Tests for multiclass and multilabel change detection functionality."""
 
     def test_multiclass_change_detection(self, fast_dev_run: bool) -> None:

--- a/tests/trainers/test_change.py
+++ b/tests/trainers/test_change.py
@@ -2,8 +2,9 @@
 # Licensed under the MIT License.
 
 import os
+from collections.abc import Callable, Generator
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, Protocol
 
 import pytest
 import segmentation_models_pytorch as smp
@@ -32,6 +33,96 @@ class ChangeDetectionTestModel(Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         x = self.conv1(x)
         return x
+
+
+class MockDataLoader(Protocol):
+    """Protocol for mock data loaders."""
+
+    def __iter__(self) -> Generator[dict[str, torch.Tensor], None, None]: ...
+
+
+class MockMulticlassChangeDataModule:
+    """Mock datamodule for multiclass change detection."""
+
+    def __init__(self, batch_size: int = 2, patch_size: int = 32) -> None:
+        self.batch_size = batch_size
+        self.patch_size = patch_size
+        self.num_classes = 3  # no change, building change, vegetation change
+
+    def train_dataloader(self) -> MockDataLoader:
+        # Return a simple iterator that yields one batch
+        class DataLoader:
+            def __init__(self, batch_fn: Callable[[], dict[str, torch.Tensor]]) -> None:
+                self.batch_fn = batch_fn
+
+            def __iter__(self) -> Generator[dict[str, torch.Tensor], None, None]:
+                yield self.batch_fn()
+
+        return DataLoader(self._mock_batch)
+
+    def val_dataloader(self) -> MockDataLoader:
+        # Return a simple iterator that yields one batch
+        class DataLoader:
+            def __init__(self, batch_fn: Callable[[], dict[str, torch.Tensor]]) -> None:
+                self.batch_fn = batch_fn
+
+            def __iter__(self) -> Generator[dict[str, torch.Tensor], None, None]:
+                yield self.batch_fn()
+
+        return DataLoader(self._mock_batch)
+
+    def _mock_batch(self) -> dict[str, torch.Tensor]:
+        return {
+            'image': torch.randn(
+                self.batch_size, 2, 3, self.patch_size, self.patch_size
+            ),
+            'mask': torch.randint(
+                0, self.num_classes, (self.batch_size, self.patch_size, self.patch_size)
+            ),
+        }
+
+
+class MockMultilabelChangeDataModule:
+    """Mock datamodule for multilabel change detection."""
+
+    def __init__(self, batch_size: int = 2, patch_size: int = 32) -> None:
+        self.batch_size = batch_size
+        self.patch_size = patch_size
+        self.num_labels = 3  # building, vegetation, water changes
+
+    def train_dataloader(self) -> MockDataLoader:
+        # Return a simple iterator that yields one batch
+        class DataLoader:
+            def __init__(self, batch_fn: Callable[[], dict[str, torch.Tensor]]) -> None:
+                self.batch_fn = batch_fn
+
+            def __iter__(self) -> Generator[dict[str, torch.Tensor], None, None]:
+                yield self.batch_fn()
+
+        return DataLoader(self._mock_batch)
+
+    def val_dataloader(self) -> MockDataLoader:
+        # Return a simple iterator that yields one batch
+        class DataLoader:
+            def __init__(self, batch_fn: Callable[[], dict[str, torch.Tensor]]) -> None:
+                self.batch_fn = batch_fn
+
+            def __iter__(self) -> Generator[dict[str, torch.Tensor], None, None]:
+                yield self.batch_fn()
+
+        return DataLoader(self._mock_batch)
+
+    def _mock_batch(self) -> dict[str, torch.Tensor]:
+        return {
+            'image': torch.randn(
+                self.batch_size, 2, 3, self.patch_size, self.patch_size
+            ),
+            'mask': torch.randint(
+                0,
+                2,
+                (self.batch_size, self.num_labels, self.patch_size, self.patch_size),
+            ).float(),
+        }
 
 
 def create_model(**kwargs: Any) -> Module:
@@ -259,3 +350,99 @@ class TestChangeDetectionTask:
             max_epochs=1,
         )
         trainer.validate(model=model, datamodule=datamodule)
+
+
+class TestNewChangeDetectionTasks:
+    """Tests for multiclass and multilabel change detection functionality."""
+
+    def test_multiclass_change_detection(self, fast_dev_run: bool) -> None:
+        """Test multiclass change detection (3 classes: no change, building, vegetation)."""
+        datamodule = MockMulticlassChangeDataModule(batch_size=2, patch_size=32)
+        model = ChangeDetectionTask(
+            backbone='resnet18',
+            in_channels=3,
+            model='unet',
+            task='multiclass',
+            num_classes=3,
+            loss='ce',
+        )
+        trainer = Trainer(
+            accelerator='cpu',
+            fast_dev_run=fast_dev_run,
+            log_every_n_steps=1,
+            max_epochs=1,
+        )
+        trainer.fit(
+            model=model,
+            train_dataloaders=datamodule.train_dataloader(),
+            val_dataloaders=datamodule.val_dataloader(),
+        )
+
+    def test_multilabel_change_detection(self, fast_dev_run: bool) -> None:
+        """Test multilabel change detection (3 labels: building, vegetation, water)."""
+        datamodule = MockMultilabelChangeDataModule(batch_size=2, patch_size=32)
+        model = ChangeDetectionTask(
+            backbone='resnet18',
+            in_channels=3,
+            model='unet',
+            task='multilabel',
+            num_labels=3,
+            loss='bce',
+        )
+        trainer = Trainer(
+            accelerator='cpu',
+            fast_dev_run=fast_dev_run,
+            log_every_n_steps=1,
+            max_epochs=1,
+        )
+        trainer.fit(
+            model=model,
+            train_dataloaders=datamodule.train_dataloader(),
+            val_dataloaders=datamodule.val_dataloader(),
+        )
+
+    def test_multiclass_with_jaccard_loss(self, fast_dev_run: bool) -> None:
+        """Test multiclass change detection with Jaccard loss."""
+        datamodule = MockMulticlassChangeDataModule(batch_size=2, patch_size=32)
+        model = ChangeDetectionTask(
+            backbone='resnet18',
+            in_channels=3,
+            model='unet',
+            task='multiclass',
+            num_classes=3,
+            loss='jaccard',
+        )
+        trainer = Trainer(
+            accelerator='cpu',
+            fast_dev_run=fast_dev_run,
+            log_every_n_steps=1,
+            max_epochs=1,
+        )
+        trainer.fit(
+            model=model,
+            train_dataloaders=datamodule.train_dataloader(),
+            val_dataloaders=datamodule.val_dataloader(),
+        )
+
+    def test_multilabel_with_focal_loss(self, fast_dev_run: bool) -> None:
+        """Test multilabel change detection with Focal loss."""
+        datamodule = MockMultilabelChangeDataModule(batch_size=2, patch_size=32)
+        model = ChangeDetectionTask(
+            backbone='resnet18',
+            in_channels=3,
+            model='unet',
+            task='multilabel',
+            num_labels=3,
+            loss='focal',
+        )
+        trainer = Trainer(
+            accelerator='cpu',
+            fast_dev_run=fast_dev_run,
+            log_every_n_steps=1,
+            max_epochs=1,
+        )
+        trainer.fit(
+            model=model,
+            train_dataloaders=datamodule.train_dataloader(),
+            val_dataloaders=datamodule.val_dataloader(),
+        )


### PR DESCRIPTION
- Add task parameter (binary/multiclass/multilabel) with binary as default
- Add num_classes and num_labels parameters for multiclass/multilabel tasks
- Add class_weights and ignore_index parameters for loss functions
- Update metrics to use task-specific variants (Accuracy, JaccardIndex)
- Update prediction logic to handle different task types
- Maintain backward compatibility for binary tasks
- Set num_filters based on task type (1 for binary, num_classes for multiclass, num_labels for multilabel)

This change follows the same pattern as SemanticSegmentationTask from PR #2219.as mentioned in https://github.com/microsoft/torchgeo/pull/2422#issuecomment-2897273053

I used mock data for the tests as there is no multiclass/multilabel dataset yet fully implemented in Torchgeo. I guess we can later use the xView2 dataset for that?

**Note**: This is my first contribution to TorchGeo! I followed the existing patterns closely and would appreciate any feedback on the implementation and especially the testing approach.
