### PR TITLE
aws.bat and azcopy.bat python command

### DIFF
--- a/tests/datasets/aws.bat
+++ b/tests/datasets/aws.bat
@@ -3,7 +3,4 @@ REM Licensed under the MIT License.
 
 @ECHO OFF
 
-python3 tests\datasets\aws.py %*
-IF %ERRORLEVEL% NEQ 0 (
-    python tests\datasets\aws.py %*
-)
+python tests\datasets\aws.py %*

--- a/tests/datasets/azcopy.bat
+++ b/tests/datasets/azcopy.bat
@@ -3,7 +3,4 @@ REM Licensed under the MIT License.
 
 @ECHO OFF
 
-python3 tests\datasets\azcopy.py %*
-IF %ERRORLEVEL% NEQ 0 (
-    python tests\datasets\azcopy.py %*
-)
+python tests\datasets\azcopy.py %*


### PR DESCRIPTION
By default, the aws.bat and azcopy.bat in the test folder only run the `python3` command. On my Windows system with conda environment, the `python3` command is not available by default. I have added a simple line which tries both the `python3` and `python` command.