### PR TITLE
Fix minimum tests, avoid broken safetensors

### DIFF
--- a/requirements/min-reqs.old
+++ b/requirements/min-reqs.old
@@ -14,6 +14,8 @@ pandas==1.5.0
 pillow==9.2.0
 pyproj==3.4.0
 rasterio==1.3.11
+# https://github.com/huggingface/safetensors/issues/641
+safetensors<0.6  # Remove when safetensors 0.6.2 is released
 segmentation-models-pytorch==0.5.0
 shapely==2.0.0
 timm==1.0.3


### PR DESCRIPTION
Failing minimum tests due to huggingface/safetensors#641, for now we can pin to older safetensors.