### PR TITLE
Revert "Fix minimum tests, avoid broken safetensors"

### DIFF
--- a/requirements/min-reqs.old
+++ b/requirements/min-reqs.old
@@ -14,8 +14,6 @@ pandas==1.5.0
 pillow==9.2.0
 pyproj==3.4.0
 rasterio==1.3.11
-# https://github.com/huggingface/safetensors/issues/641
-safetensors<0.6  # Remove when safetensors 0.6.2 is released
 segmentation-models-pytorch==0.5.0
 shapely==2.0.0
 timm==1.0.3


### PR DESCRIPTION
Reverts microsoft/torchgeo#2923

safetensors 0.6.2 is now out and fixes the bug introduced in 0.6.1