### PR TITLE
Dependabot: don't track setuptools

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,9 +24,6 @@ updates:
           - 'torch'
           - 'torchvision'
     ignore:
-      # setuptools releases new versions almost daily
-      - dependency-name: 'setuptools'
-        update-types: ['version-update:semver-patch']
       # sphinx 6 is incompatible with pytorch-sphinx-theme
       # https://github.com/pytorch/pytorch_sphinx_theme/issues/175
       - dependency-name: 'sphinx'

--- a/requirements/min-reqs.old
+++ b/requirements/min-reqs.old
@@ -1,7 +1,4 @@
-# setup
-setuptools==77.0.1
-
-# install
+# required
 einops==0.3.0
 fiona==1.8.22
 geopandas==0.12.1

--- a/requirements/models.txt
+++ b/requirements/models.txt
@@ -1,2 +1,3 @@
+# models
 microsoft-aurora==1.7.0
 ultralytics==8.3.162

--- a/requirements/required.txt
+++ b/requirements/required.txt
@@ -1,7 +1,4 @@
-# setup
-setuptools==80.9.0
-
-# install
+# required
 einops==0.8.1
 fiona==1.10.1
 geopandas==1.0.1


### PR DESCRIPTION
Pip does not have an easy way to pin the version of setuptools used to build the project. Instead, it installs the latest version of setuptools into a separate build environment, ignoring the version of setuptools already present on the system. Since it doesn't work, let's reduce the number of dependabot PRs by removing this.

See https://discuss.python.org/t/pinning-build-dependencies/8363 for reference