### PR TITLE
Remove deepcopy workaround

### DIFF
--- a/torchgeo/models/dofa.py
+++ b/torchgeo/models/dofa.py
@@ -389,11 +389,6 @@ class DOFA(nn.Module):
 # Normalization is sensor-dependent and is therefore left out
 _dofa_transforms = K.AugmentationSequential(K.CenterCrop((224, 224)), data_keys=None)
 
-# https://github.com/pytorch/vision/pull/6883
-# https://github.com/pytorch/vision/pull/7107
-# Can be removed once torchvision>=0.15 is required
-Weights.__deepcopy__ = lambda *args, **kwargs: args[0]
-
 
 class DOFABase16_Weights(WeightsEnum):  # type: ignore[misc]
     """Dynamic One-For-All (DOFA) base patch size 16 weights.

--- a/torchgeo/models/resnet.py
+++ b/torchgeo/models/resnet.py
@@ -184,11 +184,6 @@ _ssl4eo_l_transforms = K.AugmentationSequential(
     data_keys=None,
 )
 
-# https://github.com/pytorch/vision/pull/6883
-# https://github.com/pytorch/vision/pull/7107
-# Can be removed once torchvision>=0.15 is required
-Weights.__deepcopy__ = lambda *args, **kwargs: args[0]
-
 
 class ResNet18_Weights(WeightsEnum):  # type: ignore[misc]
     """ResNet-18 weights.

--- a/torchgeo/models/scale_mae.py
+++ b/torchgeo/models/scale_mae.py
@@ -185,12 +185,6 @@ def interpolate_pos_embed(
     return state_dict
 
 
-# https://github.com/pytorch/vision/pull/6883
-# https://github.com/pytorch/vision/pull/7107
-# Can be removed once torchvision>=0.15 is required
-Weights.__deepcopy__ = lambda *args, **kwargs: args[0]
-
-
 class ScaleMAELarge16_Weights(WeightsEnum):  # type: ignore[misc]
     """Scale-MAE Large patch size 16 weights.
 

--- a/torchgeo/models/swin.py
+++ b/torchgeo/models/swin.py
@@ -43,11 +43,6 @@ _satlas_landsat_transforms = K.AugmentationSequential(
     data_keys=None,
 )
 
-# https://github.com/pytorch/vision/pull/6883
-# https://github.com/pytorch/vision/pull/7107
-# Can be removed once torchvision>=0.15 is required
-Weights.__deepcopy__ = lambda *args, **kwargs: args[0]
-
 
 class Swin_V2_T_Weights(WeightsEnum):  # type: ignore[misc]
     """Swin Transformer v2 Tiny weights.

--- a/torchgeo/models/unet.py
+++ b/torchgeo/models/unet.py
@@ -24,10 +24,6 @@ _ftw_transforms = K.AugmentationSequential(
 # No normalization used see: https://github.com/Restor-Foundation/tcd/blob/main/src/tcd_pipeline/data/datamodule.py#L145
 _tcd_bands = ['R', 'G', 'B']
 _tcd_transforms = K.AugmentationSequential(K.Resize(size=(1024, 1024)), data_keys=None)
-# https://github.com/pytorch/vision/pull/6883
-# https://github.com/pytorch/vision/pull/7107
-# Can be removed once torchvision>=0.15 is required
-Weights.__deepcopy__ = lambda *args, **kwargs: args[0]
 
 
 class Unet_Weights(WeightsEnum):  # type: ignore[misc]

--- a/torchgeo/models/vit.py
+++ b/torchgeo/models/vit.py
@@ -40,10 +40,6 @@ _ssl4eo_l_transforms = K.AugmentationSequential(
     data_keys=None,
 )
 
-# https://github.com/pytorch/vision/pull/6883
-# https://github.com/pytorch/vision/pull/7107
-# Can be removed once torchvision>=0.15 is required
-Weights.__deepcopy__ = lambda *args, **kwargs: args[0]
 
 KEYS = {'norm.weight', 'norm.bias', 'head.weight', 'head.bias'}
 


### PR DESCRIPTION
Since we bumped min supported torchvision version to `0.15.1` (in #2559), these patches can be removed