### PR TITLE
fix: Update model/dataset huggingface urls

### DIFF
--- a/torchgeo/datasets/bright.py
+++ b/torchgeo/datasets/bright.py
@@ -65,7 +65,7 @@ class BRIGHTDFC2025(NonGeoDataset):
 
     md5 = '45fd96716e7f5673869b166859a6cb3c'
 
-    url = 'https://huggingface.co/datasets/torchgeo/bright/resolve/d19972f5e682ad684dcde35529a6afad4c719f1b/dfc25_track2_trainval_with_split.zip'
+    url = 'https://hf.co/datasets/isaaccorley/bright/resolve/d19972f5e682ad684dcde35529a6afad4c719f1b/dfc25_track2_trainval_with_split.zip'
 
     data_dir = 'dfc25_track2_trainval'
 

--- a/torchgeo/datasets/dota.py
+++ b/torchgeo/datasets/dota.py
@@ -77,7 +77,7 @@ class DOTA(NonGeoDataset):
     .. versionadded:: 0.7
     """
 
-    url = 'https://huggingface.co/datasets/torchgeo/dota/resolve/672e63236622f7da6ee37fca44c50ac368b77cab/{}'
+    url = 'https://hf.co/datasets/isaaccorley/dota/resolve/672e63236622f7da6ee37fca44c50ac368b77cab/{}'
 
     file_info: ClassVar[dict[str, dict[str, dict[str, dict[str, str]]]]] = {
         'train': {

--- a/torchgeo/datasets/fire_risk.py
+++ b/torchgeo/datasets/fire_risk.py
@@ -51,7 +51,7 @@ class FireRisk(NonGeoClassificationDataset):
     .. versionadded:: 0.5
     """
 
-    url = 'https://hf.co/datasets/torchgeo/fire_risk/resolve/e6046a04350c6f1ab4ad791fb3a40bf8940be269/FireRisk.zip'
+    url = 'https://hf.co/datasets/isaaccorley/fire_risk/resolve/e6046a04350c6f1ab4ad791fb3a40bf8940be269/FireRisk.zip'
     md5 = 'a77b9a100d51167992ae8c51d26198a6'
     filename = 'FireRisk.zip'
     directory = 'FireRisk'

--- a/torchgeo/datasets/landcoverai.py
+++ b/torchgeo/datasets/landcoverai.py
@@ -425,6 +425,6 @@ class LandCoverAI100(LandCoverAI):
     .. versionadded:: 0.7
     """
 
-    url = 'https://huggingface.co/datasets/torchgeo/landcoverai/resolve/5cdf9299bd6c1232506cf79373df01f6e6596b50/landcoverai100.zip'
+    url = 'https://hf.co/datasets/isaaccorley/landcoverai/resolve/5cdf9299bd6c1232506cf79373df01f6e6596b50/landcoverai100.zip'
     filename = 'landcoverai100.zip'
     md5 = '66eb33b5a0cabb631836ce0a4eafb7cd'

--- a/torchgeo/datasets/resisc45.py
+++ b/torchgeo/datasets/resisc45.py
@@ -93,16 +93,16 @@ class RESISC45(NonGeoClassificationDataset):
     * https://doi.org/10.1109/jproc.2017.2675998
     """
 
-    url = 'https://hf.co/datasets/torchgeo/resisc45/resolve/a826b44d938a883185f11ebe3d512d38b464312f/NWPU-RESISC45.zip'
+    url = 'https://hf.co/datasets/isaaccorley/resisc45/resolve/883edc0eee77b2c84225472f10f126e3ed83fa6e/NWPU-RESISC45.zip'
     md5 = '75206b2e16446591afa88e2628744886'
     filename = 'NWPU-RESISC45.zip'
     directory = 'NWPU-RESISC45'
 
     splits = ('train', 'val', 'test')
     split_urls: ClassVar[dict[str, str]] = {
-        'train': 'https://hf.co/datasets/torchgeo/resisc45/resolve/a826b44d938a883185f11ebe3d512d38b464312f/resisc45-train.txt',
-        'val': 'https://hf.co/datasets/torchgeo/resisc45/resolve/a826b44d938a883185f11ebe3d512d38b464312f/resisc45-val.txt',
-        'test': 'https://hf.co/datasets/torchgeo/resisc45/resolve/a826b44d938a883185f11ebe3d512d38b464312f/resisc45-test.txt',
+        'train': 'https://hf.co/datasets/isaaccorley/resisc45/resolve/883edc0eee77b2c84225472f10f126e3ed83fa6e/resisc45-train.txt',
+        'val': 'https://hf.co/datasets/isaaccorley/resisc45/resolve/883edc0eee77b2c84225472f10f126e3ed83fa6e/resisc45-val.txt',
+        'test': 'https://hf.co/datasets/isaaccorley/resisc45/resolve/883edc0eee77b2c84225472f10f126e3ed83fa6e/resisc45-test.txt',
     }
     split_md5s: ClassVar[dict[str, str]] = {
         'train': 'b5a4c05a37de15e4ca886696a85c403e',

--- a/torchgeo/datasets/vhr10.py
+++ b/torchgeo/datasets/vhr10.py
@@ -159,12 +159,12 @@ class VHR10(NonGeoDataset):
     """
 
     image_meta: ClassVar[dict[str, str]] = {
-        'url': 'https://hf.co/datasets/torchgeo/vhr10/resolve/7e7968ad265dadc4494e0ca4a079e0b63dc6f3f8/NWPU%20VHR-10%20dataset.zip',
+        'url': 'https://hf.co/datasets/isaaccorley/vhr10/resolve/60ecc4be33609184e2224606858cd00b7daba8df/NWPU%20VHR-10%20dataset.zip',
         'filename': 'NWPU VHR-10 dataset.zip',
         'md5': '6add6751469c12dd8c8d6223064c6c4d',
     }
     target_meta: ClassVar[dict[str, str]] = {
-        'url': 'https://hf.co/datasets/torchgeo/vhr10/resolve/7e7968ad265dadc4494e0ca4a079e0b63dc6f3f8/annotations.json',
+        'url': 'https://hf.co/datasets/isaaccorley/vhr10/resolve/7e7968ad265dadc4494e0ca4a079e0b63dc6f3f8/annotations.json',
         'filename': 'annotations.json',
         'md5': '7c76ec50c17a61bb0514050d20f22c08',
     }

--- a/torchgeo/datasets/zuericrop.py
+++ b/torchgeo/datasets/zuericrop.py
@@ -52,7 +52,7 @@ class ZueriCrop(NonGeoDataset):
        * `h5py <https://pypi.org/project/h5py/>`_ to load the dataset
     """
 
-    url = 'https://hf.co/datasets/torchgeo/zuericrop/resolve/8ac0f416fbaab032d8670cc55f984b9f079e86b2/'
+    url = 'https://hf.co/datasets/isaaccorley/zuericrop/resolve/8ac0f416fbaab032d8670cc55f984b9f079e86b2/'
     md5s = ('1635231df67f3d25f4f1e62c98e221a4', '5118398c7a5bbc246f5f6bb35d8d529b')
     filenames = ('ZueriCrop.hdf5', 'labels.csv')
 

--- a/torchgeo/models/scale_mae.py
+++ b/torchgeo/models/scale_mae.py
@@ -192,7 +192,7 @@ class ScaleMAELarge16_Weights(WeightsEnum):  # type: ignore[misc]
     """
 
     FMOW_RGB = Weights(
-        url='https://hf.co/torchgeo/vit_large_patch16_224_fmow_rgb_scalemae/resolve/9dc7f569424baeb780698352cf6e87638c882123/vit_large_patch16_224_fmow_rgb_scalemae-98ed9821.pth',
+        url='https://hf.co/isaaccorley/vit_large_patch16_224_fmow_rgb_scalemae/resolve/9dc7f569424baeb780698352cf6e87638c882123/vit_large_patch16_224_fmow_rgb_scalemae-98ed9821.pth',
         transforms=_scale_mae_transforms,
         meta={
             'dataset': 'fMoW',

--- a/torchgeo/models/unet.py
+++ b/torchgeo/models/unet.py
@@ -96,7 +96,7 @@ class Unet_Weights(WeightsEnum):  # type: ignore[misc]
         },
     )
     OAM_RGB_RESNET50_TCD = Weights(
-        url='https://hf.co/torchgeo/unet_resnet50_oam_rgb_tcd/resolve/main/unet_resnet50_oam_rgb_tcd-72b9b753.pth',
+        url='https://hf.co/isaaccorley/unet_resnet50_oam_rgb_tcd/resolve/main/unet_resnet50_oam_rgb_tcd-72b9b753.pth',
         transforms=_tcd_transforms,
         meta={
             'dataset': 'OAM-TCD',
@@ -114,7 +114,7 @@ class Unet_Weights(WeightsEnum):  # type: ignore[misc]
         },
     )
     OAM_RGB_RESNET34_TCD = Weights(
-        url='https://hf.co/torchgeo/unet_resnet34_oam_rgb_tcd/resolve/main/unet_resnet34_oam_rgb_tcd-72b9b753.pth',
+        url='https://hf.co/isaaccorley/unet_resnet34_oam_rgb_tcd/resolve/main/unet_resnet34_oam_rgb_tcd-72b9b753.pth',
         transforms=_tcd_transforms,
         meta={
             'dataset': 'OAM-TCD',

--- a/torchgeo/models/yolo.py
+++ b/torchgeo/models/yolo.py
@@ -77,7 +77,7 @@ class YOLO_Weights(WeightsEnum):  # type: ignore[misc]
         },
     )
     CORE_DINO = Weights(
-        url='https://hf.co/torchgeo/core-dino/resolve/59427e13d114cbbf02f4745e1bea7570be3e2057/core_dino_rgb_yolo11x-80ca836f.pt',
+        url='https://hf.co/isaaccorley/core-dino/resolve/59427e13d114cbbf02f4745e1bea7570be3e2057/core_dino_rgb_yolo11x-80ca836f.pt',
         transforms=nn.Identity(),  # transform is handled within ultralytics.YOLO model
         meta={
             'dataset': 'core-five',


### PR DESCRIPTION
Some non-commercial models/datasets have been moved out of the torchgeo huggingface account and into my personal account. This PR updates the urls. Note that huggingface redirects the original urls to the new user account but this is to explicitly update this.

@adamjstewart note that some datasets in the TorchGeo account were not actually being used in the library e.g. `million-aid` and `isaid` datasets.