### PR TITLE
Lightning 2.5.5 contains a checkpoint loading bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ we can see the script in action:
 # Train and validate a model
 torchgeo fit --config config.yaml
 # Validate-only
-torchgeo validate --config config.yaml
+torchgeo validate --config config.yaml --ckpt_path=...
 # Calculate and report test accuracy
 torchgeo test --config config.yaml --ckpt_path=...
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,11 @@ dependencies = [
     # lightning 2+ required for LightningCLI args + sys.argv support
     # lightning 2.3 contains known bugs related to YAML parsing
     # https://github.com/Lightning-AI/pytorch-lightning/issues/19977
-    "lightning[pytorch-extra]>=2,!=2.3.*,!=2.5.0",
+    # lightning 2.5.0 contains backwards-incompatible import changes
+    # https://github.com/Lightning-AI/pytorch-lightning/issues/20511
+    # lightning 2.5.5 contains known bugs related to checkpoint loading
+    # https://github.com/torchgeo/torchgeo/issues/2995
+    "lightning[pytorch-extra]>=2,!=2.3.*,!=2.5.0,<2.5.5",
     # matplotlib 3.6+ required for Python 3.11 wheels
     "matplotlib>=3.6",
     # numpy 1.24+ required by rasterio


### PR DESCRIPTION
Temporarily limit supported lightning versions until #2995 is fixed.