### PR TITLE
Allow newer lightning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,10 +24,6 @@ updates:
           - 'torch'
           - 'torchvision'
     ignore:
-      # lightning 2.5.5 contains known bugs related to checkpoint loading
-      # https://github.com/torchgeo/torchgeo/issues/2995
-      - dependency-name: 'lightning'
-        versions: '>=2.5.5'
       # sphinx 6 is incompatible with pytorch-sphinx-theme
       # https://github.com/pytorch/pytorch_sphinx_theme/issues/175
       - dependency-name: 'sphinx'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
     # https://github.com/Lightning-AI/pytorch-lightning/issues/20511
     # lightning 2.5.5 contains known bugs related to checkpoint loading
     # https://github.com/torchgeo/torchgeo/issues/2995
-    "lightning>=2,!=2.3.*,!=2.5.0,<2.5.5",
+    "lightning>=2,!=2.3.*,!=2.5.0,!=2.5.5",
     # matplotlib 3.6+ required for Python 3.11 wheels
     "matplotlib>=3.6",
     # numpy 1.24+ required by rasterio


### PR DESCRIPTION
The bug introduced in https://github.com/Lightning-AI/pytorch-lightning/pull/21116 was fixed in https://github.com/Lightning-AI/pytorch-lightning/pull/21246. It appears the next release will be 2.6.0 and will include this bug fix. Let's remove the upper bound before the next release.

Closes #2995