### PR TITLE
Tutorials: use modern GDAL CLI syntax

### DIFF
--- a/docs/tutorials/custom_raster_dataset.ipynb
+++ b/docs/tutorials/custom_raster_dataset.ipynb
@@ -38,7 +38,7 @@
     "* `GeoDataset`: for uncurated raw data with geospatial metadata\n",
     "* `NonGeoDataset`: for curated benchmark datasets that lack geospatial metadata\n",
     "\n",
-    "If you're not sure which type of dataset you need, a good rule of thumb is to run `gdal info` on one of the files. If `gdal info` returns information like the bounding box, resolution, and CRS of the file, then you should probably use `GeoDataset`."
+    "If you're not sure which type of dataset you need, a good rule of thumb is to run `gdalinfo` on one of the files. If `gdalinfo` returns information like the bounding box, resolution, and CRS of the file, then you should probably use `GeoDataset`."
    ]
   },
   {

--- a/docs/tutorials/geospatial.ipynb
+++ b/docs/tutorials/geospatial.ipynb
@@ -253,7 +253,8 @@
     "We can use a command like:\n",
     "\n",
     "```\n",
-    "$ gdal raster reproject --src-crs EPSG:5070 --dst-crs EPSG:4326 src.tif dst.tif\n",
+    "$ gdal raster reproject --src-crs EPSG:5070 --dst-crs EPSG:4326 src.tif dst.tif  # GDAL 3.11+\n",
+    "$ gdalwarp -s_srs EPSG:5070 -t_srs EPSG:4326 src.tif dst.tif\n",
     "```\n",
     "\n",
     "to reproject a file from one CRS to another."
@@ -269,7 +270,8 @@
     "As previously mentioned, each dataset may have its own unique spatial resolution, and even separate bands (channels) in a single image may have different resolutions. All data (including input images and target masks for semantic segmentation) must be resampled to the same resolution. This can be done using GDAL like so:\n",
     "\n",
     "```\n",
-    "$ gdal raster reproject --resolution 30,30 src.tif dst.tif\n",
+    "$ gdal raster reproject --resolution 30,30 src.tif dst.tif  # GDAL 3.11+\n",
+    "$ gdalwarp -tr 30 30 src.tif dst.tif\n",
     "```"
    ]
   },
@@ -281,7 +283,8 @@
     "Just because two files have the same resolution does not mean that they have *target-aligned pixels* (TAP). Our goal is that every input pixel is perfectly aligned with every expected output pixel, but differences in geolocation can result in masks that are offset by half a pixel from the input image. We can ensure TAP by adding the `-tap` flag:\n",
     "\n",
     "```\n",
-    "$ gdal raster reproject --resolution 30,30 --target-aligned-pixels src.tif dst.tif\n",
+    "$ gdal raster reproject --resolution 30,30 --target-aligned-pixels src.tif dst.tif  # GDAL 3.11+\n",
+    "$ gdalwarp -tr 30 30 -tap src.tif dst.tif\n",
     "```"
    ]
   },
@@ -301,7 +304,8 @@
     "Of course, semantic segmentation requires these polygon masks to be converted to raster masks. This process is called rasterization, and can be performed like so:\n",
     "\n",
     "```\n",
-    "$ gdal vector rasterize --resolution 30,30 -a BUILDING_HEIGHT -l buildings buildings.shp buildings.tif\n",
+    "$ gdal vector rasterize --resolution 30,30 -a BUILDING_HEIGHT -l buildings buildings.shp buildings.tif  # GDAL 3.11+\n",
+    "$ gdal_rasterize -tr 30 30 -a BUILDING_HEIGHT -l buildings buildings.shp buildings.tif\n",
     "```\n",
     "\n",
     "Above, we set the resolution to 30 m/pixel and use the `BUILDING_HEIGHT` attribute of the `buildings` layer as the burn-in value.\n"


### PR DESCRIPTION
Closes #2852

Note that this syntax was first introduced in GDAL 3.11 (as of May) and does not work with older GDAL. The syntax is also not really final, so those may be good reasons to hold off on this PR. But I'll let other reviewers decide.