### PR TITLE
Investigate slow tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -43,7 +43,7 @@ jobs:
         run: pip list
       - name: Run pytest checks
         run: |
-          pytest --cov=torchgeo --cov-report=xml
+          pytest --cov=torchgeo --cov-report=xml --durations=10
           python3 -m torchgeo --help
       - name: Report coverage
         uses: codecov/codecov-action@v5.5.1
@@ -75,7 +75,7 @@ jobs:
         run: pip list
       - name: Run pytest checks
         run: |
-          pytest --cov=torchgeo --cov-report=xml
+          pytest --cov=torchgeo --cov-report=xml --durations=10
           python3 -m torchgeo --help
       - name: Report coverage
         uses: codecov/codecov-action@v5.5.1
@@ -107,7 +107,7 @@ jobs:
         run: pip list
       - name: Run pytest checks
         run: |
-          pytest --cov=torchgeo --cov-report=xml
+          pytest --cov=torchgeo --cov-report=xml --durations=10
           python3 -m torchgeo --help
       - name: Report coverage
         uses: codecov/codecov-action@v5.5.1


### PR DESCRIPTION
macOS tests are 3x slower than Linux, and some trainer tests seem to be duplicated. Let's see if we can speed things up.