### PR TITLE
Tests: bundle all trainer tests together

### DIFF
--- a/tests/trainers/conftest.py
+++ b/tests/trainers/conftest.py
@@ -13,9 +13,7 @@ from torch import Tensor
 from torch.nn.modules import Module
 
 
-@pytest.fixture(
-    scope='package', params=[True, pytest.param(False, marks=pytest.mark.slow)]
-)
+@pytest.fixture(params=[True, pytest.param(False, marks=pytest.mark.slow)])
 def fast_dev_run(request: SubRequest) -> bool:
     flag: bool = request.param
     return flag


### PR DESCRIPTION
Can't say I fully understand this one. This may be a bug or unintended consequence in pytest. Basically, due to some strange interaction between `pytest.fixture`, `pytest.param`, `pytest.mark`, and `scope='package'`, we were first running all trainer tests involving `fast_dev_run`, then running all other tests later. This resulted in a strange order of tests.

This PR doesn't make our tests faster, it just runs all tests in order so the output is more clear. This fixture is basically instantaneous, so it doesn't really matter if we run it once or hundreds of times. Other fixtures don't appear to be affected, only `fast_dev_run`.

### Before

```
# runs all fast_dev_run tests
tests/trainers/test_byol.py .........                                    [ 91%]
tests/trainers/test_change.py ...............                            [ 92%]
tests/trainers/test_classification.py ......................             [ 92%]
tests/trainers/test_detection.py ......                                  [ 93%]
tests/trainers/test_instance_segmentation.py ....                        [ 93%]
tests/trainers/test_iobench.py .                                         [ 93%]
tests/trainers/test_moco.py ........                                     [ 93%]
tests/trainers/test_regression.py ...............                        [ 94%]
tests/trainers/test_segmentation.py .................................... [ 95%]
                                                                         [ 95%]
tests/trainers/test_simclr.py ........                                   [ 95%]
# runs all non-fast_dev_run tests
tests/trainers/test_byol.py ....                                         [ 95%]
tests/trainers/test_change.py ..........................                 [ 96%]
tests/trainers/test_classification.py ........                           [ 96%]
tests/trainers/test_detection.py ............                            [ 96%]
tests/trainers/test_instance_segmentation.py ......                      [ 97%]
tests/trainers/test_moco.py .....                                        [ 97%]
tests/trainers/test_regression.py .............................          [ 98%]
tests/trainers/test_segmentation.py ......................               [ 98%]
tests/trainers/test_simclr.py .....                                      [ 98%]
tests/trainers/test_utils.py ...........                                 [ 99%]
```

### After

```
# runs all tests
tests/trainers/test_byol.py .............                                [ 91%]
tests/trainers/test_change.py .........................................  [ 93%]
tests/trainers/test_classification.py ..............................     [ 94%]
tests/trainers/test_detection.py ..................                      [ 94%]
tests/trainers/test_instance_segmentation.py ..........                  [ 94%]
tests/trainers/test_iobench.py .                                         [ 95%]
tests/trainers/test_moco.py .............                                [ 95%]
tests/trainers/test_regression.py ...................................... [ 96%]
......                                                                   [ 96%]
tests/trainers/test_segmentation.py .................................... [ 97%]
......................                                                   [ 98%]
tests/trainers/test_simclr.py .............                              [ 98%]
tests/trainers/test_utils.py ...........                                 [ 99%]
```