### PR TITLE
Silence shapely warnings on macOS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -298,6 +298,9 @@ filterwarnings = [
     # Unexpected warnings, worth investigating
     # https://github.com/pytest-dev/pytest/issues/11461
     "ignore::pytest.PytestUnraisableExceptionWarning",
+    # https://github.com/shapely/shapely/issues/2215
+    "ignore:divide by zero encountered in oriented_envelope:RuntimeWarning:shapely",
+    "ignore:invalid value encountered in oriented_envelope:RuntimeWarning:shapely",
 ]
 markers = [
     "slow: marks tests as slow",


### PR DESCRIPTION
These warnings only appear on macOS and appear to be harmless. Possibly an upstream Apple Silicon bug in GEOS.
```
tests/datasets/test_soda.py::TestSODAA::test_getitem[dataset1]
tests/datasets/test_soda.py::TestSODAA::test_getitem[dataset3]
tests/datasets/test_soda.py::TestSODAA::test_getitem[dataset5]
tests/datasets/test_soda.py::TestSODAA::test_plot[dataset1]
tests/datasets/test_soda.py::TestSODAA::test_plot[dataset3]
tests/datasets/test_soda.py::TestSODAA::test_plot[dataset5]
  /Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/shapely/constructive.py:1353: RuntimeWarning: divide by zero encountered in oriented_envelope
    return lib.oriented_envelope(geometry, **kwargs)

tests/datasets/test_soda.py::TestSODAA::test_getitem[dataset1]
tests/datasets/test_soda.py::TestSODAA::test_getitem[dataset3]
tests/datasets/test_soda.py::TestSODAA::test_getitem[dataset5]
tests/datasets/test_soda.py::TestSODAA::test_plot[dataset1]
tests/datasets/test_soda.py::TestSODAA::test_plot[dataset3]
tests/datasets/test_soda.py::TestSODAA::test_plot[dataset5]
  /Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/shapely/constructive.py:1353: RuntimeWarning: invalid value encountered in oriented_envelope
    return lib.oriented_envelope(geometry, **kwargs)
```