### PR TITLE
Lightning 2.5.6 contains a checkpoint loading bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,9 +54,9 @@ dependencies = [
     # https://github.com/Lightning-AI/pytorch-lightning/issues/19977
     # lightning 2.5.0 contains backwards-incompatible import changes
     # https://github.com/Lightning-AI/pytorch-lightning/issues/20511
-    # lightning 2.5.5 contains known bugs related to checkpoint loading
+    # lightning 2.5.5-2.5.6 contain known bugs related to checkpoint loading
     # https://github.com/torchgeo/torchgeo/issues/2995
-    "lightning>=2,!=2.3.*,!=2.5.0,!=2.5.5",
+    "lightning>=2,!=2.3.*,!=2.5.0,!=2.5.5,!=2.5.6",
     # matplotlib 3.6+ required for Python 3.11 wheels
     "matplotlib>=3.6",
     # numpy 1.24+ required by rasterio


### PR DESCRIPTION
Unfortunately 2.5.6 didn't get the bug fix I was hoping for: https://github.com/Lightning-AI/pytorch-lightning/pull/21246