### PR TITLE
Embeddings tutorial: rename section header

### DIFF
--- a/docs/tutorials/basic_usage.rst
+++ b/docs/tutorials/basic_usage.rst
@@ -6,7 +6,7 @@ The following tutorials introduce the basic concepts and components of TorchGeo:
 * `Transforms <transforms.ipynb>`_: Preprocessing and data augmentation transforms for geospatial data
 * `Spectral Indices <indices.ipynb>`_: Visualizing and appending spectral indices
 * `Pretrained Weights <pretrained_weights.ipynb>`_: Models and pretrained weights
-* `Embeddings <pretrained_embeddings.ipynb>`_: Using pretrained models to extract fixed-length embeddings
+* `Embeddings <embeddings.ipynb>`_: Using pretrained models to extract fixed-length embeddings
 * `Lightning Trainers <trainers.ipynb>`_: PyTorch Lightning data modules and trainers
 * `Command-Line Interface <cli.ipynb>`_: TorchGeo's command-line interface
 
@@ -17,6 +17,6 @@ The following tutorials introduce the basic concepts and components of TorchGeo:
    transforms
    indices
    pretrained_weights
-   pretrained_embeddings
+   embeddings
    trainers
    cli

--- a/docs/tutorials/embeddings.ipynb
+++ b/docs/tutorials/embeddings.ipynb
@@ -18,7 +18,7 @@
     "id": "XRSkMFqyrMOE"
    },
    "source": [
-    "# Pretrained Weights\n",
+    "# Embeddings\n",
     "\n",
     "_Written by: Caleb Robinson_\n",
     "\n",


### PR DESCRIPTION
Section header was still copied from our Pretrained Weights tutorial.

I think it's more correct to refer to it as Embeddings than Pretrained Embeddings since only the model is pretrained.