### PR TITLE
Dataset plots: portrait -> landscape

### DIFF
--- a/torchgeo/datasets/cabuar.py
+++ b/torchgeo/datasets/cabuar.py
@@ -277,7 +277,7 @@ class CaBuAr(NonGeoDataset):
             prediction = sample['prediction'][0]
             ncols += 1
 
-        fig, axs = plt.subplots(nrows=1, ncols=ncols, figsize=(10, ncols * 5))
+        fig, axs = plt.subplots(nrows=1, ncols=ncols, figsize=(ncols * 5, 10))
 
         axs[0].imshow(einops.rearrange(image_pre, 'c h w -> h w c'))
         axs[0].axis('off')

--- a/torchgeo/datasets/chabud.py
+++ b/torchgeo/datasets/chabud.py
@@ -262,7 +262,7 @@ class ChaBuD(NonGeoDataset):
             prediction = sample['prediction'][0]
             ncols += 1
 
-        fig, axs = plt.subplots(nrows=1, ncols=ncols, figsize=(10, ncols * 5))
+        fig, axs = plt.subplots(nrows=1, ncols=ncols, figsize=(ncols * 5, 10))
 
         axs[0].imshow(einops.rearrange(image_pre, 'c h w -> h w c'))
         axs[0].axis('off')

--- a/torchgeo/datasets/cloud_cover.py
+++ b/torchgeo/datasets/cloud_cover.py
@@ -202,13 +202,13 @@ class CloudCoverDetection(NonGeoDataset):
 
         if 'prediction' in sample:
             prediction = sample['prediction']
-            n_cols = 3
+            ncols = 3
         else:
-            n_cols = 2
+            ncols = 2
 
         image, mask = sample['image'] / 3000, sample['mask']
 
-        fig, axs = plt.subplots(nrows=1, ncols=n_cols, figsize=(10, n_cols * 5))
+        fig, axs = plt.subplots(nrows=1, ncols=ncols, figsize=(ncols * 5, 10))
 
         axs[0].imshow(image.permute(1, 2, 0))
         axs[0].axis('off')

--- a/torchgeo/datasets/cv4a_kenya_crop_type.py
+++ b/torchgeo/datasets/cv4a_kenya_crop_type.py
@@ -314,15 +314,15 @@ class CV4AKenyaCropType(NonGeoDataset):
 
         if 'prediction' in sample:
             prediction = sample['prediction']
-            n_cols = 3
+            ncols = 3
         else:
-            n_cols = 2
+            ncols = 2
 
         image, mask = sample['image'], sample['mask']
 
         image = image[time_step, rgb_indices]
 
-        fig, axs = plt.subplots(nrows=1, ncols=n_cols, figsize=(10, n_cols * 5))
+        fig, axs = plt.subplots(nrows=1, ncols=ncols, figsize=(ncols * 5, 10))
 
         axs[0].imshow(image.permute(1, 2, 0))
         axs[0].axis('off')

--- a/torchgeo/datasets/dfc2022.py
+++ b/torchgeo/datasets/dfc2022.py
@@ -324,7 +324,7 @@ class DFC2022(NonGeoDataset):
             pred = sample['prediction'].numpy()
             ncols += 1
 
-        fig, axs = plt.subplots(nrows=1, ncols=ncols, figsize=(10, ncols * 10))
+        fig, axs = plt.subplots(nrows=1, ncols=ncols, figsize=(ncols * 10, 10))
 
         axs[0].imshow(image_arr)
         axs[0].axis('off')

--- a/torchgeo/datasets/gid15.py
+++ b/torchgeo/datasets/gid15.py
@@ -258,7 +258,7 @@ class GID15(NonGeoDataset):
             ncols += 1
             pred = sample['prediction']
 
-        fig, axs = plt.subplots(nrows=1, ncols=ncols, figsize=(10, ncols * 10))
+        fig, axs = plt.subplots(nrows=1, ncols=ncols, figsize=(ncols * 10, 10))
 
         if self.split != 'test':
             axs[0].imshow(image.permute(1, 2, 0))

--- a/torchgeo/datasets/levircd.py
+++ b/torchgeo/datasets/levircd.py
@@ -158,7 +158,7 @@ class LEVIRCDBase(NonGeoDataset, abc.ABC):
         if 'prediction' in sample:
             ncols += 1
 
-        fig, axs = plt.subplots(nrows=1, ncols=ncols, figsize=(10, ncols * 5))
+        fig, axs = plt.subplots(nrows=1, ncols=ncols, figsize=(ncols * 5, 10))
 
         axs[0].imshow(image1)
         axs[0].axis('off')

--- a/torchgeo/datasets/loveda.py
+++ b/torchgeo/datasets/loveda.py
@@ -273,7 +273,7 @@ class LoveDA(NonGeoDataset):
             image = sample['image']
             ncols = 1
 
-        fig, axs = plt.subplots(nrows=1, ncols=ncols, figsize=(10, ncols * 10))
+        fig, axs = plt.subplots(nrows=1, ncols=ncols, figsize=(ncols * 10, 10))
 
         if self.split != 'test':
             axs[0].imshow(image.permute(1, 2, 0))

--- a/torchgeo/datasets/sen12ms.py
+++ b/torchgeo/datasets/sen12ms.py
@@ -347,7 +347,7 @@ class SEN12MS(NonGeoDataset):
             prediction = sample['prediction']
             ncols += 1
 
-        fig, axs = plt.subplots(nrows=1, ncols=ncols, figsize=(10, ncols * 5))
+        fig, axs = plt.subplots(nrows=1, ncols=ncols, figsize=(ncols * 5, 10))
 
         axs[0].imshow(np.transpose(image, (1, 2, 0)))
         axs[0].axis('off')

--- a/torchgeo/datasets/zuericrop.py
+++ b/torchgeo/datasets/zuericrop.py
@@ -288,7 +288,7 @@ class ZueriCrop(NonGeoDataset):
             ncols += 1
             preds = torch.argmax(sample['prediction'], dim=0)
 
-        fig, axs = plt.subplots(ncols=ncols, figsize=(10, 10 * ncols))
+        fig, axs = plt.subplots(ncols=ncols, figsize=(10 * ncols, 10))
 
         axs[0].imshow(image.permute(1, 2, 0))
         axs[0].axis('off')


### PR DESCRIPTION
`figsize` is in (width, height) format, but many of our datasets mixed these up, resulting in tall thin plots with many columns. This PR fixes all occurrences that I found. This is likely a result of too much copy-n-paste.