### PR TITLE
Tests: no unconditional skips

### DIFF
--- a/tests/datasets/test_copernicus.py
+++ b/tests/datasets/test_copernicus.py
@@ -114,7 +114,8 @@ class TestCopernicusBench:
         if dataset.name.endswith('s1'):
             all_bands = ['VV']
         elif dataset.name.endswith('s5p'):
-            pytest.skip('single-band dataset')
+            # single-band dataset
+            return
 
         dataset = CopernicusBench(dataset.name, dataset.root, bands=all_bands)
         match = 'Dataset does not contain some of the RGB bands'


### PR DESCRIPTION
Please tell me if I'm being crazy...

99% of our `pytest.mark.skip` instances are for missing dependencies. When I see "skip", I just assume I'm missing some dependency or condition required to test this specific function. Indeed, [pytest's documentation](https://docs.pytest.org/en/stable/how-to/skipping.html) describes skip as:

> A **skip** means that you expect your test to pass only if some conditions are met, otherwise pytest should skip running the test altogether. Common examples are skipping windows-only tests on non-windows platforms, or skipping tests that depend on an external resource which is not available at the moment (for example a database).

That is, skips should be _conditional_. Note that the same docs later include an example of an _unconditional_ skip, so my reasoning isn't completely well founded:
```python
def test_function():
    if not valid_config():
        pytest.skip("unsupported configuration")
```
With this change, there are no longer any skipped tests assuming all optional dependencies are installed.