### PR TITLE
Update features.csv with the correct numbers of weights for TerraTorch

### DIFF
--- a/docs/user/metrics/features.csv
+++ b/docs/user/metrics/features.csv
@@ -1,7 +1,7 @@
 Library,ML Backend,I/O Backend,Spatial Backend,Transform Backend,Datasets,Weights,CLI,GUI,Reprojection,STAC,Time Series
 `TorchGeo`_,PyTorch,"GDAL, h5py, laspy, NetCDF4, OpenCV, pandas, pillow, scipy, xarray","geopandas, R-tree*",Kornia,127,120,✅,❌,✅,❌,🚧
 `OTB`_,"LibSVM, OpenCV, Shark",GDAL,-,-,0,0,✅,✅,✅,❌,❌
-`TerraTorch`_,PyTorch,"GDAL, h5py, pandas, xarray",-,Albumentations,0 (127 from TorchGeo),1374,✅,❌,✅,❌,🚧
+`TerraTorch`_,PyTorch,"GDAL, h5py, pandas, xarray",-,Albumentations,27,13,✅,❌,✅,❌,🚧
 `Raster Vision`_,"PyTorch, TensorFlow*","GDAL, OpenCV, pandas, pillow, scipy, xarray",STAC,Albumentations,0,6,✅,❌,✅,✅,🚧
 `DeepForest`_,"PyTorch, TensorFlow*","GDAL, OpenCV, pandas, pillow, scipy",R-tree,Albumentations,0,4,❌,❌,❌,❌,❌
 `samgeo`_,PyTorch,"GDAL, OpenCV, pandas, xarray",geopandas,numpy,0,0,❌,✅,✅,❌,❌


### PR DESCRIPTION
I have updated the number of datasets and weights in TerraTorch.  We don’t have the concept of datasets in TerraTorch, we rely on TorchGeo for that, so I changed the count of datasets to 0 put in parentheses the same number as TorchGeo.  As for weights, we currently have integrated 1374 models into TerraTorch (1282 are TIMM models). The count can be obtained by running: len(BACKBONE_REGISTRY) in TerraTorch.