### PR TITLE
VectorDataset: increase test coverage

### DIFF
--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -956,12 +956,9 @@ class VectorDataset(GeoDataset):
             src.to_crs(self.crs, inplace=True)
 
             # Get label values to use for rendering each geometry
-            if self.label_name:
-                labels = np.array(
-                    [self.get_label(row) for _, row in src.iterrows()]
-                ).astype(np.int32)
-            else:
-                labels = np.ones(len(src), dtype=np.int32)
+            labels = np.array(
+                [self.get_label(row) for _, row in src.iterrows()]
+            ).astype(np.int32)
 
             shapes.extend(list(zip(src.geometry, labels)))
 


### PR DESCRIPTION
We added the `if self.label_name:` guard in #2962, but `get_label` also has the same guard. The result is that we no longer hit the fallback in `get_label` during testing.

This PR removes the check in `__getitem__`. We could alternatively remove the check in `get_label`, which would be less backwards-compatible but also maybe faster?