### PR TITLE
SpaceNet: resolve warning message

### DIFF
--- a/torchgeo/datasets/spacenet/base.py
+++ b/torchgeo/datasets/spacenet/base.py
@@ -192,7 +192,7 @@ class SpaceNet(NonGeoDataset, ABC):
             with open(path) as f:
                 json.load(f)
 
-            gdf = gpd.GeoDataFrame.from_file(path, driver='GeoJSON')
+            gdf = gpd.read_file(path)
 
         except JSONDecodeError:
             # Handle empty files


### PR DESCRIPTION
Fixes the following warning message in CI:
```
tests/datasets/test_spacenet.py::TestSpaceNet::test_getitem[SpaceNet1-1]
tests/datasets/test_spacenet.py::TestSpaceNet::test_getitem[SpaceNet6-1]
tests/trainers/test_segmentation.py::TestSemanticSegmentationTask::test_trainer[True-spacenet1]
tests/trainers/test_segmentation.py::TestSemanticSegmentationTask::test_trainer[True-spacenet1]
tests/trainers/test_segmentation.py::TestSemanticSegmentationTask::test_trainer[True-spacenet6]
  /opt/hostedtoolcache/Python/3.13.9/x64/lib/python3.13/site-packages/pyogrio/raw.py:198: RuntimeWarning: driver GeoJSON does not support open option DRIVER
    return ogr_read(
```