### PR TITLE
pyproject.toml: add explicit license-files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ description = "TorchGeo: datasets, samplers, transforms, and pre-trained models 
 readme = "README.md"
 requires-python = ">=3.11"
 license = "MIT"
+license-files = ["LICENSE"]
 authors = [
     {name = "Adam J. Stewart", email = "ajstewart426@gmail.com"},
 ]


### PR DESCRIPTION
Although setuptools has a default value for this, technically there should be no default. If we ever switch to a different build backend, this may be required anyway.

https://peps.python.org/pep-0639/appendix-rejected-ideas/#use-a-default-value-for-license-files-if-not-specified