### PR TITLE
Trainers: Forward weights to ChangeViT and BTC for CLI pretrained support

### DIFF
--- a/torchgeo/trainers/change.py
+++ b/torchgeo/trainers/change.py
@@ -236,10 +236,17 @@ class ChangeDetectionTask(BaseTask):
                 )
             case 'changevit':
                 self.model = ChangeViT(
-                    backbone=backbone, in_channels=in_channels, num_classes=num_classes
+                    backbone=backbone,
+                    in_channels=in_channels,
+                    num_classes=num_classes,
+                    pretrained=weights is True,
                 )
             case 'btc':
-                self.model = BTC(backbone=backbone, classes=num_classes)
+                self.model = BTC(
+                    backbone=backbone,
+                    classes=num_classes,
+                    backbone_pretrained=weights is True,
+                )
 
         if weights and weights is not True:
             if isinstance(weights, WeightsEnum):


### PR DESCRIPTION
The weights parameter was not being passed to ChangeViT and BTC models in ChangeDetectionTask, making it impossible to use pretrained weights via the CLI. This fix forwards the weights parameter to both models:
- ChangeViT: pretrained=weights is True
- BTC: backbone_pretrained=weights is True

Default behavior unchanged (no weights downloaded unless explicitly set).