### PR TITLE
GeoDataset: remove 'bounds', 'crs'

### DIFF
--- a/tests/datamodules/test_geo.py
+++ b/tests/datamodules/test_geo.py
@@ -40,7 +40,7 @@ class CustomGeoDataset(GeoDataset):
 
     def __getitem__(self, query: GeoSlice) -> dict[str, Any]:
         image = torch.arange(3 * 2 * 2, dtype=torch.float).view(3, 2, 2)
-        return {'image': image, 'crs': self.index.crs, 'bounds': query}
+        return {'image': image}
 
     def plot(self, *args: Any, **kwargs: Any) -> Figure:
         return plt.figure()

--- a/tests/datasets/test_agb_live_woody_density.py
+++ b/tests/datasets/test_agb_live_woody_density.py
@@ -8,7 +8,6 @@ import matplotlib.pyplot as plt
 import pytest
 import torch
 import torch.nn as nn
-from pyproj import CRS
 from pytest import MonkeyPatch
 
 from torchgeo.datasets import (
@@ -41,7 +40,6 @@ class TestAbovegroundLiveWoodyBiomassDensity:
     def test_getitem(self, dataset: AbovegroundLiveWoodyBiomassDensity) -> None:
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
-        assert isinstance(x['crs'], CRS)
         assert isinstance(x['mask'], torch.Tensor)
 
     def test_len(self, dataset: AbovegroundLiveWoodyBiomassDensity) -> None:

--- a/tests/datasets/test_agrifieldnet.py
+++ b/tests/datasets/test_agrifieldnet.py
@@ -9,7 +9,6 @@ import pandas as pd
 import pytest
 import torch
 import torch.nn as nn
-from pyproj import CRS
 from pytest import MonkeyPatch
 
 from torchgeo.datasets import (
@@ -35,7 +34,6 @@ class TestAgriFieldNet:
     def test_getitem(self, dataset: AgriFieldNet) -> None:
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
-        assert isinstance(x['crs'], CRS)
         assert isinstance(x['image'], torch.Tensor)
         assert isinstance(x['mask'], torch.Tensor)
 

--- a/tests/datasets/test_airphen.py
+++ b/tests/datasets/test_airphen.py
@@ -9,7 +9,6 @@ import pandas as pd
 import pytest
 import torch
 import torch.nn as nn
-from pyproj import CRS
 
 from torchgeo.datasets import (
     Airphen,
@@ -34,7 +33,6 @@ class TestAirphen:
     def test_getitem(self, dataset: Airphen) -> None:
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
-        assert isinstance(x['crs'], CRS)
         assert isinstance(x['image'], torch.Tensor)
 
     def test_and(self, dataset: Airphen) -> None:

--- a/tests/datasets/test_astergdem.py
+++ b/tests/datasets/test_astergdem.py
@@ -10,7 +10,6 @@ import pandas as pd
 import pytest
 import torch
 import torch.nn as nn
-from pyproj import CRS
 
 from torchgeo.datasets import (
     AsterGDEM,
@@ -38,7 +37,6 @@ class TestAsterGDEM:
     def test_getitem(self, dataset: AsterGDEM) -> None:
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
-        assert isinstance(x['crs'], CRS)
         assert isinstance(x['mask'], torch.Tensor)
 
     def test_len(self, dataset: AsterGDEM) -> None:

--- a/tests/datasets/test_cbf.py
+++ b/tests/datasets/test_cbf.py
@@ -9,7 +9,6 @@ import pandas as pd
 import pytest
 import torch
 import torch.nn as nn
-from pyproj import CRS
 from pytest import MonkeyPatch
 
 from torchgeo.datasets import (
@@ -43,7 +42,6 @@ class TestCanadianBuildingFootprints:
     def test_getitem(self, dataset: CanadianBuildingFootprints) -> None:
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
-        assert isinstance(x['crs'], CRS)
         assert isinstance(x['mask'], torch.Tensor)
 
     def test_len(self, dataset: CanadianBuildingFootprints) -> None:

--- a/tests/datasets/test_cdl.py
+++ b/tests/datasets/test_cdl.py
@@ -11,7 +11,6 @@ import pandas as pd
 import pytest
 import torch
 import torch.nn as nn
-from pyproj import CRS
 from pytest import MonkeyPatch
 
 from torchgeo.datasets import (
@@ -46,7 +45,6 @@ class TestCDL:
     def test_getitem(self, dataset: CDL) -> None:
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
-        assert isinstance(x['crs'], CRS)
         assert isinstance(x['mask'], torch.Tensor)
 
     def test_len(self, dataset: CDL) -> None:

--- a/tests/datasets/test_chesapeake.py
+++ b/tests/datasets/test_chesapeake.py
@@ -11,7 +11,6 @@ import pytest
 import torch
 import torch.nn as nn
 from _pytest.fixtures import SubRequest
-from pyproj import CRS
 from pytest import MonkeyPatch
 
 from torchgeo.datasets import (
@@ -45,7 +44,6 @@ class TestChesapeakeDC:
     def test_getitem(self, dataset: ChesapeakeDC) -> None:
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
-        assert isinstance(x['crs'], CRS)
         assert isinstance(x['mask'], torch.Tensor)
 
     def test_len(self, dataset: ChesapeakeDC) -> None:
@@ -148,7 +146,6 @@ class TestChesapeakeCVPR:
     def test_getitem(self, dataset: ChesapeakeCVPR) -> None:
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
-        assert isinstance(x['crs'], CRS)
         assert isinstance(x['mask'], torch.Tensor)
 
     def test_len(self, dataset: ChesapeakeCVPR) -> None:

--- a/tests/datasets/test_cms_mangrove_canopy.py
+++ b/tests/datasets/test_cms_mangrove_canopy.py
@@ -9,7 +9,6 @@ import matplotlib.pyplot as plt
 import pytest
 import torch
 import torch.nn as nn
-from pyproj import CRS
 from pytest import MonkeyPatch
 
 from torchgeo.datasets import (
@@ -42,7 +41,6 @@ class TestCMSGlobalMangroveCanopy:
     def test_getitem(self, dataset: CMSGlobalMangroveCanopy) -> None:
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
-        assert isinstance(x['crs'], CRS)
         assert isinstance(x['mask'], torch.Tensor)
 
     def test_len(self, dataset: CMSGlobalMangroveCanopy) -> None:

--- a/tests/datasets/test_enmap.py
+++ b/tests/datasets/test_enmap.py
@@ -9,7 +9,6 @@ import pandas as pd
 import pytest
 import torch
 import torch.nn as nn
-from pyproj import CRS
 
 from torchgeo.datasets import (
     DatasetNotFoundError,
@@ -30,7 +29,6 @@ class TestEnMAP:
     def test_getitem(self, dataset: EnMAP) -> None:
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
-        assert isinstance(x['crs'], CRS)
         assert isinstance(x['image'], torch.Tensor)
 
     def test_len(self, dataset: EnMAP) -> None:

--- a/tests/datasets/test_enviroatlas.py
+++ b/tests/datasets/test_enviroatlas.py
@@ -11,7 +11,6 @@ import pytest
 import torch
 import torch.nn as nn
 from _pytest.fixtures import SubRequest
-from pyproj import CRS
 from pytest import MonkeyPatch
 
 from torchgeo.datasets import (
@@ -58,7 +57,6 @@ class TestEnviroAtlas:
     def test_getitem(self, dataset: EnviroAtlas) -> None:
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
-        assert isinstance(x['crs'], CRS)
         assert isinstance(x['mask'], torch.Tensor)
 
     def test_len(self, dataset: EnviroAtlas) -> None:

--- a/tests/datasets/test_esri2020.py
+++ b/tests/datasets/test_esri2020.py
@@ -10,7 +10,6 @@ import pandas as pd
 import pytest
 import torch
 import torch.nn as nn
-from pyproj import CRS
 from pytest import MonkeyPatch
 
 from torchgeo.datasets import (
@@ -43,7 +42,6 @@ class TestEsri2020:
     def test_getitem(self, dataset: Esri2020) -> None:
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
-        assert isinstance(x['crs'], CRS)
         assert isinstance(x['mask'], torch.Tensor)
 
     def test_len(self, dataset: Esri2020) -> None:

--- a/tests/datasets/test_eudem.py
+++ b/tests/datasets/test_eudem.py
@@ -10,7 +10,6 @@ import pandas as pd
 import pytest
 import torch
 import torch.nn as nn
-from pyproj import CRS
 from pytest import MonkeyPatch
 
 from torchgeo.datasets import (
@@ -35,7 +34,6 @@ class TestEUDEM:
     def test_getitem(self, dataset: EUDEM) -> None:
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
-        assert isinstance(x['crs'], CRS)
         assert isinstance(x['mask'], torch.Tensor)
 
     def test_len(self, dataset: EUDEM) -> None:

--- a/tests/datasets/test_eurocrops.py
+++ b/tests/datasets/test_eurocrops.py
@@ -10,7 +10,6 @@ import pytest
 import torch
 import torch.nn as nn
 from _pytest.fixtures import SubRequest
-from pyproj import CRS
 from pytest import MonkeyPatch
 
 from torchgeo.datasets import (
@@ -43,7 +42,6 @@ class TestEuroCrops:
     def test_getitem(self, dataset: EuroCrops) -> None:
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
-        assert isinstance(x['crs'], CRS)
         assert isinstance(x['mask'], torch.Tensor)
 
     def test_len(self, dataset: EuroCrops) -> None:

--- a/tests/datasets/test_gbm.py
+++ b/tests/datasets/test_gbm.py
@@ -8,7 +8,6 @@ import matplotlib.pyplot as plt
 import pandas as pd
 import pytest
 import torch
-from pyproj import CRS
 
 from torchgeo.datasets import (
     DatasetNotFoundError,
@@ -27,7 +26,6 @@ class TestGlobalBuildingMap:
     def test_getitem(self, dataset: GlobalBuildingMap) -> None:
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
-        assert isinstance(x['crs'], CRS)
         assert isinstance(x['mask'], torch.Tensor)
 
     def test_len(self, dataset: GlobalBuildingMap) -> None:

--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -409,14 +409,12 @@ class TestRasterDataset:
     def test_getitem_single_file(self, naip: NAIP) -> None:
         x = naip[naip.bounds]
         assert isinstance(x, dict)
-        assert isinstance(x['crs'], CRS)
         assert isinstance(x['image'], torch.Tensor)
         assert len(naip.bands) == x['image'].shape[0]
 
     def test_getitem_separate_files(self, sentinel: Sentinel2) -> None:
         x = sentinel[sentinel.bounds]
         assert isinstance(x, dict)
-        assert isinstance(x['crs'], CRS)
         assert isinstance(x['image'], torch.Tensor)
         assert len(sentinel.bands) == x['image'].shape[0]
 
@@ -553,7 +551,6 @@ class TestVectorDataset:
         dataset.task = 'semantic_segmentation'
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
-        assert isinstance(x['crs'], CRS)
         assert isinstance(x['mask'], torch.Tensor)
         assert torch.equal(
             x['mask'].unique(),  # type: ignore[no-untyped-call]
@@ -563,7 +560,6 @@ class TestVectorDataset:
         dataset.task = 'object_detection'
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
-        assert isinstance(x['crs'], CRS)
         assert isinstance(x['bbox_xyxy'], torch.Tensor)
         assert isinstance(x['label'], torch.Tensor)
         assert x['bbox_xyxy'].shape[-1] == 4
@@ -571,7 +567,6 @@ class TestVectorDataset:
         dataset.task = 'instance_segmentation'
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
-        assert isinstance(x['crs'], CRS)
         assert isinstance(x['bbox_xyxy'], torch.Tensor)
         assert isinstance(x['label'], torch.Tensor)
         assert isinstance(x['mask'], torch.Tensor)
@@ -590,7 +585,6 @@ class TestVectorDataset:
         multilabel.task = 'semantic_segmentation'
         x = multilabel[multilabel.bounds]
         assert isinstance(x, dict)
-        assert isinstance(x['crs'], CRS)
         assert isinstance(x['mask'], torch.Tensor)
         assert torch.equal(
             x['mask'].unique(),  # type: ignore[no-untyped-call]
@@ -600,7 +594,6 @@ class TestVectorDataset:
         multilabel.task = 'object_detection'
         x = multilabel[multilabel.bounds]
         assert isinstance(x, dict)
-        assert isinstance(x['crs'], CRS)
         assert isinstance(x['bbox_xyxy'], torch.Tensor)
         assert isinstance(x['label'], torch.Tensor)
         assert torch.equal(x['label'], torch.tensor([1, 2, 3], dtype=torch.int32))
@@ -609,7 +602,6 @@ class TestVectorDataset:
         multilabel.task = 'instance_segmentation'
         x = multilabel[multilabel.bounds]
         assert isinstance(x, dict)
-        assert isinstance(x['crs'], CRS)
         assert isinstance(x['bbox_xyxy'], torch.Tensor)
         assert isinstance(x['label'], torch.Tensor)
         assert torch.equal(x['label'], torch.tensor([1, 2, 3], dtype=torch.int32))

--- a/tests/datasets/test_globbiomass.py
+++ b/tests/datasets/test_globbiomass.py
@@ -10,7 +10,6 @@ import pandas as pd
 import pytest
 import torch
 import torch.nn as nn
-from pyproj import CRS
 from pytest import MonkeyPatch
 
 from torchgeo.datasets import (
@@ -44,7 +43,6 @@ class TestGlobBiomass:
     def test_getitem(self, dataset: GlobBiomass) -> None:
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
-        assert isinstance(x['crs'], CRS)
         assert isinstance(x['mask'], torch.Tensor)
 
     def test_len(self, dataset: GlobBiomass) -> None:

--- a/tests/datasets/test_iobench.py
+++ b/tests/datasets/test_iobench.py
@@ -11,7 +11,6 @@ import pandas as pd
 import pytest
 import torch
 import torch.nn as nn
-from pyproj import CRS
 from pytest import MonkeyPatch
 
 from torchgeo.datasets import (
@@ -37,7 +36,6 @@ class TestIOBench:
     def test_getitem(self, dataset: IOBench) -> None:
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
-        assert isinstance(x['crs'], CRS)
         assert isinstance(x['image'], torch.Tensor)
         assert isinstance(x['mask'], torch.Tensor)
 

--- a/tests/datasets/test_l7irish.py
+++ b/tests/datasets/test_l7irish.py
@@ -12,7 +12,6 @@ import pandas as pd
 import pytest
 import torch
 import torch.nn as nn
-from pyproj import CRS
 from pytest import MonkeyPatch
 
 from torchgeo.datasets import (
@@ -42,7 +41,6 @@ class TestL7Irish:
     def test_getitem(self, dataset: L7Irish) -> None:
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
-        assert isinstance(x['crs'], CRS)
         assert isinstance(x['image'], torch.Tensor)
         assert isinstance(x['mask'], torch.Tensor)
 

--- a/tests/datasets/test_l8biome.py
+++ b/tests/datasets/test_l8biome.py
@@ -12,7 +12,6 @@ import pandas as pd
 import pytest
 import torch
 import torch.nn as nn
-from pyproj import CRS
 from pytest import MonkeyPatch
 
 from torchgeo.datasets import (
@@ -42,7 +41,6 @@ class TestL8Biome:
     def test_getitem(self, dataset: L8Biome) -> None:
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
-        assert isinstance(x['crs'], CRS)
         assert isinstance(x['image'], torch.Tensor)
         assert isinstance(x['mask'], torch.Tensor)
 

--- a/tests/datasets/test_landsat.py
+++ b/tests/datasets/test_landsat.py
@@ -10,7 +10,6 @@ import pytest
 import torch
 import torch.nn as nn
 from _pytest.fixtures import SubRequest
-from pyproj import CRS
 
 from torchgeo.datasets import (
     DatasetNotFoundError,
@@ -37,7 +36,6 @@ class TestLandsat8:
     def test_getitem(self, dataset: Landsat8) -> None:
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
-        assert isinstance(x['crs'], CRS)
         assert isinstance(x['image'], torch.Tensor)
 
     def test_len(self, dataset: Landsat8) -> None:

--- a/tests/datasets/test_mmflood.py
+++ b/tests/datasets/test_mmflood.py
@@ -11,7 +11,6 @@ import pytest
 import torch
 import torch.nn as nn
 from _pytest.fixtures import SubRequest
-from pyproj import CRS
 from pytest import MonkeyPatch
 
 from torchgeo.datasets import (
@@ -49,7 +48,6 @@ class TestMMFlood:
     def test_getitem(self, dataset: MMFlood) -> None:
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
-        assert isinstance(x['crs'], CRS)
         assert isinstance(x['image'], torch.Tensor)
         assert isinstance(x['mask'], torch.Tensor)
         nchannels = 2

--- a/tests/datasets/test_naip.py
+++ b/tests/datasets/test_naip.py
@@ -9,7 +9,6 @@ import pandas as pd
 import pytest
 import torch
 import torch.nn as nn
-from pyproj import CRS
 
 from torchgeo.datasets import (
     NAIP,
@@ -29,7 +28,6 @@ class TestNAIP:
     def test_getitem(self, dataset: NAIP) -> None:
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
-        assert isinstance(x['crs'], CRS)
         assert isinstance(x['image'], torch.Tensor)
 
     def test_len(self, dataset: NAIP) -> None:

--- a/tests/datasets/test_nccm.py
+++ b/tests/datasets/test_nccm.py
@@ -9,7 +9,6 @@ import pandas as pd
 import pytest
 import torch
 import torch.nn as nn
-from pyproj import CRS
 from pytest import MonkeyPatch
 
 from torchgeo.datasets import (
@@ -42,7 +41,6 @@ class TestNCCM:
     def test_getitem(self, dataset: NCCM) -> None:
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
-        assert isinstance(x['crs'], CRS)
         assert isinstance(x['mask'], torch.Tensor)
 
     def test_len(self, dataset: NCCM) -> None:

--- a/tests/datasets/test_nlcd.py
+++ b/tests/datasets/test_nlcd.py
@@ -10,7 +10,6 @@ import pandas as pd
 import pytest
 import torch
 import torch.nn as nn
-from pyproj import CRS
 from pytest import MonkeyPatch
 
 from torchgeo.datasets import (
@@ -46,7 +45,6 @@ class TestNLCD:
     def test_getitem(self, dataset: NLCD) -> None:
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
-        assert isinstance(x['crs'], CRS)
         assert isinstance(x['mask'], torch.Tensor)
 
     def test_len(self, dataset: NLCD) -> None:

--- a/tests/datasets/test_openbuildings.py
+++ b/tests/datasets/test_openbuildings.py
@@ -49,7 +49,6 @@ class TestOpenBuildings:
         df.to_csv(path, compression='gzip')
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
-        assert isinstance(x['crs'], CRS)
         assert isinstance(x['mask'], torch.Tensor)
 
     def test_not_download(self, tmp_path: Path) -> None:
@@ -77,7 +76,6 @@ class TestOpenBuildings:
     def test_getitem(self, dataset: OpenBuildings) -> None:
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
-        assert isinstance(x['crs'], CRS)
         assert isinstance(x['mask'], torch.Tensor)
 
     def test_len(self, dataset: OpenBuildings) -> None:

--- a/tests/datasets/test_prisma.py
+++ b/tests/datasets/test_prisma.py
@@ -9,7 +9,6 @@ import pandas as pd
 import pytest
 import torch
 import torch.nn as nn
-from pyproj import CRS
 
 from torchgeo.datasets import (
     PRISMA,
@@ -32,7 +31,6 @@ class TestPRISMA:
     def test_getitem(self, dataset: PRISMA) -> None:
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
-        assert isinstance(x['crs'], CRS)
         assert isinstance(x['image'], torch.Tensor)
 
     def test_and(self, dataset: PRISMA) -> None:

--- a/tests/datasets/test_sentinel.py
+++ b/tests/datasets/test_sentinel.py
@@ -10,7 +10,6 @@ import pytest
 import torch
 import torch.nn as nn
 from _pytest.fixtures import SubRequest
-from pyproj import CRS
 
 from torchgeo.datasets import (
     DatasetNotFoundError,
@@ -46,7 +45,6 @@ class TestSentinel1:
     def test_getitem(self, dataset: Sentinel1) -> None:
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
-        assert isinstance(x['crs'], CRS)
         assert isinstance(x['image'], torch.Tensor)
 
     def test_len(self, dataset: Sentinel1) -> None:
@@ -122,7 +120,6 @@ class TestSentinel2:
     def test_getitem(self, dataset: Sentinel2) -> None:
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
-        assert isinstance(x['crs'], CRS)
         assert isinstance(x['image'], torch.Tensor)
 
     def test_len(self, dataset: Sentinel2) -> None:

--- a/tests/datasets/test_south_africa_crop_type.py
+++ b/tests/datasets/test_south_africa_crop_type.py
@@ -10,7 +10,6 @@ import pytest
 import torch
 import torch.nn as nn
 from _pytest.fixtures import SubRequest
-from pyproj import CRS
 from pytest import MonkeyPatch
 
 from torchgeo.datasets import (
@@ -43,7 +42,6 @@ class TestSouthAfricaCropType:
     def test_getitem(self, dataset: SouthAfricaCropType) -> None:
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
-        assert isinstance(x['crs'], CRS)
         assert isinstance(x['image'], torch.Tensor)
         assert isinstance(x['mask'], torch.Tensor)
 

--- a/tests/datasets/test_south_america_soybean.py
+++ b/tests/datasets/test_south_america_soybean.py
@@ -9,7 +9,6 @@ import pandas as pd
 import pytest
 import torch
 import torch.nn as nn
-from pyproj import CRS
 from pytest import MonkeyPatch
 
 from torchgeo.datasets import (
@@ -41,7 +40,6 @@ class TestSouthAmericaSoybean:
     def test_getitem(self, dataset: SouthAmericaSoybean) -> None:
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
-        assert isinstance(x['crs'], CRS)
         assert isinstance(x['mask'], torch.Tensor)
 
     def test_len(self, dataset: SouthAmericaSoybean) -> None:

--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -12,7 +12,6 @@ import numpy as np
 import pandas as pd
 import pytest
 import torch
-from pyproj import CRS
 
 from torchgeo.datasets import BoundingBox, DependencyNotFoundError
 from torchgeo.datasets.utils import (
@@ -405,42 +404,32 @@ def test_disambiguate_timestamp(
 class TestCollateFunctionsMatchingKeys:
     @pytest.fixture(scope='class')
     def samples(self) -> list[dict[str, Any]]:
-        return [
-            {'image': torch.tensor([1, 2, 0]), 'crs': CRS.from_epsg(2000)},
-            {'image': torch.tensor([0, 0, 3]), 'crs': CRS.from_epsg(2001)},
-        ]
+        return [{'image': torch.tensor([1, 2, 0])}, {'image': torch.tensor([0, 0, 3])}]
 
     def test_stack_unbind_samples(self, samples: list[dict[str, Any]]) -> None:
         sample = stack_samples(samples)
         assert sample['image'].size() == torch.Size([2, 3])
         assert torch.allclose(sample['image'], torch.tensor([[1, 2, 0], [0, 0, 3]]))
-        assert sample['crs'] == [CRS.from_epsg(2000), CRS.from_epsg(2001)]
 
         new_samples = unbind_samples(sample)
         for i in range(2):
             assert torch.allclose(samples[i]['image'], new_samples[i]['image'])
-            assert samples[i]['crs'] == new_samples[i]['crs']
 
     def test_concat_samples(self, samples: list[dict[str, Any]]) -> None:
         sample = concat_samples(samples)
         assert sample['image'].size() == torch.Size([6])
         assert torch.allclose(sample['image'], torch.tensor([1, 2, 0, 0, 0, 3]))
-        assert sample['crs'] == CRS.from_epsg(2000)
 
     def test_merge_samples(self, samples: list[dict[str, Any]]) -> None:
         sample = merge_samples(samples)
         assert sample['image'].size() == torch.Size([3])
         assert torch.allclose(sample['image'], torch.tensor([1, 2, 3]))
-        assert sample['crs'] == CRS.from_epsg(2001)
 
 
 class TestCollateFunctionsDifferingKeys:
     @pytest.fixture(scope='class')
     def samples(self) -> list[dict[str, Any]]:
-        return [
-            {'image': torch.tensor([1, 2, 0]), 'crs1': CRS.from_epsg(2000)},
-            {'mask': torch.tensor([0, 0, 3]), 'crs2': CRS.from_epsg(2001)},
-        ]
+        return [{'image': torch.tensor([1, 2, 0])}, {'mask': torch.tensor([0, 0, 3])}]
 
     def test_stack_unbind_samples(self, samples: list[dict[str, Any]]) -> None:
         sample = stack_samples(samples)
@@ -448,14 +437,10 @@ class TestCollateFunctionsDifferingKeys:
         assert sample['mask'].size() == torch.Size([1, 3])
         assert torch.allclose(sample['image'], torch.tensor([[1, 2, 0]]))
         assert torch.allclose(sample['mask'], torch.tensor([[0, 0, 3]]))
-        assert sample['crs1'] == [CRS.from_epsg(2000)]
-        assert sample['crs2'] == [CRS.from_epsg(2001)]
 
         new_samples = unbind_samples(sample)
         assert torch.allclose(samples[0]['image'], new_samples[0]['image'])
-        assert samples[0]['crs1'] == new_samples[0]['crs1']
         assert torch.allclose(samples[1]['mask'], new_samples[0]['mask'])
-        assert samples[1]['crs2'] == new_samples[0]['crs2']
 
     def test_concat_samples(self, samples: list[dict[str, Any]]) -> None:
         sample = concat_samples(samples)
@@ -463,8 +448,6 @@ class TestCollateFunctionsDifferingKeys:
         assert sample['mask'].size() == torch.Size([3])
         assert torch.allclose(sample['image'], torch.tensor([1, 2, 0]))
         assert torch.allclose(sample['mask'], torch.tensor([0, 0, 3]))
-        assert sample['crs1'] == CRS.from_epsg(2000)
-        assert sample['crs2'] == CRS.from_epsg(2001)
 
     def test_merge_samples(self, samples: list[dict[str, Any]]) -> None:
         sample = merge_samples(samples)
@@ -472,8 +455,6 @@ class TestCollateFunctionsDifferingKeys:
         assert sample['mask'].size() == torch.Size([3])
         assert torch.allclose(sample['image'], torch.tensor([1, 2, 0]))
         assert torch.allclose(sample['mask'], torch.tensor([0, 0, 3]))
-        assert sample['crs1'] == CRS.from_epsg(2000)
-        assert sample['crs2'] == CRS.from_epsg(2001)
 
 
 def test_existing_directory(tmp_path: Path) -> None:

--- a/torchgeo/datamodules/geo.py
+++ b/torchgeo/datamodules/geo.py
@@ -339,28 +339,6 @@ class GeoDataModule(BaseDataModule):
         """
         return self._dataloader_factory('predict')
 
-    def transfer_batch_to_device(
-        self, batch: dict[str, Tensor], device: torch.device, dataloader_idx: int
-    ) -> dict[str, Tensor]:
-        """Transfer batch to device.
-
-        Defines how custom data types are moved to the target device.
-
-        Args:
-            batch: A batch of data that needs to be transferred to a new device.
-            device: The target device as defined in PyTorch.
-            dataloader_idx: The index of the dataloader to which the batch belongs.
-
-        Returns:
-            A reference to the data on the new device.
-        """
-        # Non-Tensor values cannot be moved to a device
-        del batch['crs']
-        del batch['bounds']
-
-        batch = super().transfer_batch_to_device(batch, device, dataloader_idx)
-        return batch
-
 
 class NonGeoDataModule(BaseDataModule):
     """Base class for data modules lacking geospatial information.

--- a/torchgeo/datasets/agrifieldnet.py
+++ b/torchgeo/datasets/agrifieldnet.py
@@ -228,8 +228,6 @@ class AgriFieldNet(RasterDataset):
 
         transform = rasterio.transform.from_origin(x.start, y.stop, x.step, y.step)
         sample = {
-            'crs': self.crs,
-            'bounds': query,
             'image': image.float(),
             'mask': mask.long(),
             'transform': torch.tensor(transform),

--- a/torchgeo/datasets/benin_cashews.py
+++ b/torchgeo/datasets/benin_cashews.py
@@ -15,7 +15,6 @@ import rasterio
 import rasterio.features
 import torch
 from matplotlib.figure import Figure
-from pyproj import CRS
 from torch import Tensor
 
 from .errors import DatasetNotFoundError, RGBBandsMissingError
@@ -217,11 +216,11 @@ class BeninSmallHolderCashews(NonGeoDataset):
             index: index to return
 
         Returns:
-            a dict containing image, mask, transform, crs, and metadata at index.
+            a dict containing image, mask, transform, and metadata at index.
         """
         y, x = self.chips_metadata[index]
 
-        img, transform, crs = self._load_all_imagery()
+        img, transform = self._load_all_imagery()
         labels = self._load_mask(transform)
 
         img = img[:, :, y : y + self.chip_size, x : x + self.chip_size]
@@ -233,7 +232,6 @@ class BeninSmallHolderCashews(NonGeoDataset):
             'x': torch.tensor(x),
             'y': torch.tensor(y),
             'transform': torch.tensor(transform),
-            'crs': crs,
         }
 
         if self.transforms is not None:
@@ -250,14 +248,13 @@ class BeninSmallHolderCashews(NonGeoDataset):
         return len(self.chips_metadata)
 
     @lru_cache(maxsize=128)
-    def _load_all_imagery(self) -> tuple[Tensor, rasterio.Affine, CRS]:
+    def _load_all_imagery(self) -> tuple[Tensor, rasterio.Affine]:
         """Load all the imagery (across time) for the dataset.
 
         Returns:
             imagery of shape (70, number of bands, 1186, 1122) where 70 is the number
-            of points in time, 1186 is the tile height, and 1122 is the tile width
+            of points in time, 1186 is the tile height, and 1122 is the tile width;
             rasterio affine transform, mapping pixel coordinates to geo coordinates
-            coordinate reference system of transform
         """
         img = torch.zeros(
             len(self.dates),
@@ -268,13 +265,13 @@ class BeninSmallHolderCashews(NonGeoDataset):
         )
 
         for date_index, date in enumerate(self.dates):
-            single_scene, transform, crs = self._load_single_scene(date)
+            single_scene, transform = self._load_single_scene(date)
             img[date_index] = single_scene
 
-        return img, transform, crs
+        return img, transform
 
     @lru_cache(maxsize=128)
-    def _load_single_scene(self, date: str) -> tuple[Tensor, rasterio.Affine, CRS]:
+    def _load_single_scene(self, date: str) -> tuple[Tensor, rasterio.Affine]:
         """Load the imagery for a single date.
 
         Args:
@@ -282,8 +279,7 @@ class BeninSmallHolderCashews(NonGeoDataset):
 
         Returns:
             Tensor containing a single image tile, rasterio affine transform,
-            mapping pixel coordinates to geo coordinates, and coordinate
-            reference system of transform.
+            mapping pixel coordinates to geo coordinates
         """
         img = torch.zeros(
             len(self.bands), self.tile_height, self.tile_width, dtype=torch.float32
@@ -298,11 +294,10 @@ class BeninSmallHolderCashews(NonGeoDataset):
             )
             with rasterio.open(filepath) as src:
                 transform = src.transform  # same transform for every band
-                crs = src.crs
                 array = src.read().astype(np.float32)
                 img[band_index] = torch.from_numpy(array)
 
-        return img, transform, crs
+        return img, transform
 
     @lru_cache
     def _load_mask(self, transform: rasterio.Affine) -> Tensor:

--- a/torchgeo/datasets/chesapeake.py
+++ b/torchgeo/datasets/chesapeake.py
@@ -519,8 +519,6 @@ class ChesapeakeCVPR(GeoDataset):
         sample: dict[str, Any] = {
             'image': [],
             'mask': [],
-            'crs': self.crs,
-            'bounds': query,
             'transform': torch.tensor(transform),
         }
 

--- a/torchgeo/datasets/eddmaps.py
+++ b/torchgeo/datasets/eddmaps.py
@@ -98,12 +98,7 @@ class EDDMapS(GeoDataset):
 
         keypoints = torch.tensor(index.get_coordinates().values, dtype=torch.float32)
         transform = rasterio.transform.from_origin(x.start, y.stop, x.step, y.step)
-        sample = {
-            'crs': self.crs,
-            'bounds': index,
-            'keypoints': keypoints,
-            'transform': torch.tensor(transform),
-        }
+        sample = {'keypoints': keypoints, 'transform': torch.tensor(transform)}
 
         return sample
 

--- a/torchgeo/datasets/enviroatlas.py
+++ b/torchgeo/datasets/enviroatlas.py
@@ -334,8 +334,6 @@ class EnviroAtlas(GeoDataset):
         sample: dict[str, Any] = {
             'image': [],
             'mask': [],
-            'crs': self.crs,
-            'bounds': query,
             'transform': torch.tensor(transform),
         }
 

--- a/torchgeo/datasets/gbif.py
+++ b/torchgeo/datasets/gbif.py
@@ -101,12 +101,7 @@ class GBIF(GeoDataset):
 
         keypoints = torch.tensor(index.get_coordinates().values, dtype=torch.float32)
         transform = rasterio.transform.from_origin(x.start, y.stop, x.step, y.step)
-        sample = {
-            'crs': self.crs,
-            'bounds': index,
-            'keypoints': keypoints,
-            'transform': torch.tensor(transform),
-        }
+        sample = {'keypoints': keypoints, 'transform': torch.tensor(transform)}
 
         return sample
 

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -538,11 +538,7 @@ class RasterDataset(GeoDataset):
             data = self._merge_files(index.filepath, query, self.band_indexes)
 
         transform = rasterio.transform.from_origin(x.start, y.stop, x.step, y.step)
-        sample: dict[str, Any] = {
-            'crs': self.crs,
-            'bounds': query,
-            'transform': torch.tensor(transform),
-        }
+        sample: dict[str, Any] = {'transform': torch.tensor(transform)}
 
         data = data.to(self.dtype)
         if self.is_image:
@@ -748,12 +744,7 @@ class XarrayDataset(GeoDataset):
 
         image = self._merge_files(index.filepath, query)
         transform = rasterio.transform.from_origin(x.start, y.stop, x.step, y.step)
-        sample: dict[str, Any] = {
-            'crs': self.crs,
-            'bounds': query,
-            'image': image,
-            'transform': torch.tensor(transform),
-        }
+        sample: dict[str, Any] = {'image': image, 'transform': torch.tensor(transform)}
 
         if self.transforms is not None:
             sample = self.transforms(sample)
@@ -1059,11 +1050,7 @@ class VectorDataset(GeoDataset):
             labels = np.empty((0,), dtype=np.int32)
 
         transform = rasterio.transform.from_origin(x.start, y.stop, x.step, y.step)
-        sample: dict[str, Any] = {
-            'crs': self.crs,
-            'bounds': query,
-            'transform': torch.tensor(transform),
-        }
+        sample: dict[str, Any] = {'transform': torch.tensor(transform)}
 
         # Use array_to_tensor since rasterize may return uint16/uint32 arrays.
         match self.task:

--- a/torchgeo/datasets/globbiomass.py
+++ b/torchgeo/datasets/globbiomass.py
@@ -215,12 +215,7 @@ class GlobBiomass(RasterDataset):
         mask = torch.cat((mask, std_err_mask), dim=0)
 
         transform = rasterio.transform.from_origin(x.start, y.stop, x.step, y.step)
-        sample = {
-            'mask': mask,
-            'crs': self.crs,
-            'bounds': query,
-            'transform': torch.tensor(transform),
-        }
+        sample = {'mask': mask, 'transform': torch.tensor(transform)}
 
         if self.transforms is not None:
             sample = self.transforms(sample)

--- a/torchgeo/datasets/inaturalist.py
+++ b/torchgeo/datasets/inaturalist.py
@@ -94,12 +94,7 @@ class INaturalist(GeoDataset):
 
         keypoints = torch.tensor(index.get_coordinates().values, dtype=torch.float32)
         transform = rasterio.transform.from_origin(x.start, y.stop, x.step, y.step)
-        sample = {
-            'crs': self.crs,
-            'bounds': index,
-            'keypoints': keypoints,
-            'transform': torch.tensor(transform),
-        }
+        sample = {'keypoints': keypoints, 'transform': torch.tensor(transform)}
 
         return sample
 

--- a/torchgeo/datasets/landcoverai.py
+++ b/torchgeo/datasets/landcoverai.py
@@ -273,8 +273,6 @@ class LandCoverAIGeo(LandCoverAIBase, RasterDataset):
         mask = self._merge_files(mask_filepaths, query, self.band_indexes)
         transform = rasterio.transform.from_origin(x.start, y.stop, x.step, y.step)
         sample = {
-            'crs': self.crs,
-            'bounds': query,
             'image': img.float(),
             'mask': mask.long(),
             'transform': torch.tensor(transform),

--- a/torchgeo/datasets/mmearth.py
+++ b/torchgeo/datasets/mmearth.py
@@ -460,7 +460,6 @@ class MMEarth(NonGeoDataset):
             sample['lat'] = tile_info['lat']
             sample['lon'] = tile_info['lon']
             sample['date'] = tile_info['S2_DATE']
-            sample['crs'] = tile_info['CRS']
             sample['tile_id'] = name
 
         return sample

--- a/torchgeo/datasets/openbuildings.py
+++ b/torchgeo/datasets/openbuildings.py
@@ -310,12 +310,7 @@ class OpenBuildings(VectorDataset):
             masks = torch.zeros(size=(1, round(height), round(width)))
 
         transform = rasterio.transform.from_origin(x.start, y.stop, x.step, y.step)
-        sample = {
-            'mask': masks,
-            'crs': self.crs,
-            'bounds': query,
-            'transform': torch.tensor(transform),
-        }
+        sample = {'mask': masks, 'transform': torch.tensor(transform)}
 
         if self.transforms is not None:
             sample = self.transforms(sample)

--- a/torchgeo/datasets/south_africa_crop_type.py
+++ b/torchgeo/datasets/south_africa_crop_type.py
@@ -233,8 +233,6 @@ class SouthAfricaCropType(RasterDataset):
 
         transform = rasterio.transform.from_origin(x.start, y.stop, x.step, y.step)
         sample = {
-            'crs': self.crs,
-            'bounds': query,
             'image': image.float(),
             'mask': mask.long(),
             'transform': torch.tensor(transform),


### PR DESCRIPTION
My goal is to ensure that samples returned by datasets are (mostly) of the form `dict[str, Tensor]`. This PR removes 'bounds' and 'crs', which are 90% of the instances of non-Tensor outputs. We may still have a few lists for bboxes remaining.

### Pros

* Compatibility with PyTorch's `default_collate function`
* Compatibility with Lightning's `transfer_batch_to_device`
* Fewer instances of dynamic type hints (`typing.Any`)

### Cons

* Backwards-incompatible changes (removing CRS, bounds)

Alternative to #3138
Closes #3138
Closes #3135