### PR TITLE
torchgeo.models.Unet: type is nn.Module

### DIFF
--- a/torchgeo/models/unet.py
+++ b/torchgeo/models/unet.py
@@ -209,7 +209,7 @@ def unet(
     else:
         kwargs['classes'] = 1 if classes is None else classes
 
-    model = smp.create_model(*args, **kwargs)
+    model: nn.Module = smp.create_model(*args, **kwargs)
 
     if weights:
         state_dict = weights.get_state_dict(progress=True)


### PR DESCRIPTION
Flagged by `ty check`.

`smp.create_model` returns `nn.Module`, not `Unet`.

Not sure how I feel about this one, as `smp.create_model` technically returns `Any` (it is dynamic), although this any is always a subclass of `nn.Module`. Unclear if this is a bug in torchgeo or in SMP.