### PR TITLE
mypy: only check torchgeo and tests directories

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: List pip dependencies
         run: pip list
       - name: Run mypy checks
-        run: mypy .
+        run: mypy
   ruff:
     name: ruff
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,8 +134,8 @@ models = [
     "microsoft-aurora>=1.6",
 ]
 style = [
-    # mypy 0.900+ required for pyproject.toml support
-    "mypy>=0.900",
+    # mypy 1.16+ required for exclude_gitignore configuration
+    "mypy>=1.16",
     # ruff 0.9+ required for 2025 style guide
     "ruff>=0.9",
 ]
@@ -174,9 +174,11 @@ show_missing = true
 # https://mypy.readthedocs.io/en/stable/config_file.html
 [tool.mypy]
 # Import discovery
+packages = ["torchgeo", "tests"]
+exclude = ["^tests/data"]
+exclude_gitignore = true
 ignore_missing_imports = true
 disable_error_code = "import-untyped"
-exclude = "(build|data|dist|docs/.*|images|logo|.*logs|output|requirements)/"
 
 # Disallow dynamic typing (TODO: work in progress)
 disallow_any_unimported = false


### PR DESCRIPTION
I'm sick of erroneous type hint warnings in `experiments` and `docs`. I propose we only officially type `torchgeo` and `tests` (and maybe our tutorials once we switch to ty, mypy doesn't support jupyter notebooks).

Related to #3070.