### PR TITLE
No null transforms

### DIFF
--- a/torchgeo/models/copernicusfm.py
+++ b/torchgeo/models/copernicusfm.py
@@ -701,7 +701,7 @@ class CopernicusFM_Base_Weights(WeightsEnum):  # type: ignore[misc]
 
     CopernicusFM_ViT = Weights(
         url='https://huggingface.co/torchgeo/copernicus-fm/resolve/f395812cc990ba25a451dbb9c9e6d95c8482947e/CopernicusFM_ViT_base_varlang-085350e4.pth',
-        transforms=None,
+        transforms=nn.Identity(),
         meta={
             'dataset': 'Copernicus-Pretrain',
             'model': 'copernicusfm_base',

--- a/torchgeo/models/croma.py
+++ b/torchgeo/models/croma.py
@@ -504,7 +504,7 @@ class CROMABase_Weights(WeightsEnum):  # type: ignore[misc]
 
     CROMA_VIT = Weights(
         url='https://hf.co/torchgeo/croma/resolve/387883f08af79d777167519c57cd826eda89a16f/CROMA_base-0238d814.pt',
-        transforms=None,
+        transforms=nn.Identity(),
         meta={
             'dataset': 'SSL4EO',
             'model': 'vit',
@@ -523,7 +523,7 @@ class CROMALarge_Weights(WeightsEnum):  # type: ignore[misc]
 
     CROMA_VIT = Weights(
         url='https://huggingface.co/torchgeo/croma/resolve/92cb1a0f4e34c6c01558baf070197c01255382f6/CROMA_large-921e69ad.pt',
-        transforms=None,
+        transforms=nn.Identity(),
         meta={
             'dataset': 'SSL4EO',
             'model': 'vit',

--- a/torchgeo/models/panopticon.py
+++ b/torchgeo/models/panopticon.py
@@ -475,7 +475,7 @@ class Panopticon_Weights(WeightsEnum):  # type: ignore[misc]
 
     VIT_BASE14 = Weights(
         url='https://hf.co/lewaldm/panopticon/resolve/c8c2bb9555819e8b2bcedf5b3b00e3bf531554e7/panopticon_vitb14_teacher.pth',
-        transforms=None,
+        transforms=nn.Identity(),
         meta={
             'model': 'panopticon_vitb14',
             'publication': 'https://arxiv.org/abs/2503.10845',


### PR DESCRIPTION
the `transforms` attr from a torchvision `WeightsEnum` must be a `nn.Module` so that there are no surprises to users when it happens to be a `None` type.