### PR TITLE
Contributing: use mypy without directory

### DIFF
--- a/docs/user/contributing.rst
+++ b/docs/user/contributing.rst
@@ -102,7 +102,7 @@ Mypy won't fix your code for you, but will warn you about potential issues with 
 
 .. code-block:: console
 
-   $ mypy .
+   $ mypy
 
 
 If you've never used mypy before or aren't familiar with `Python type hints <https://docs.python.org/3/library/typing.html>`_, this check can be particularly daunting. Don't hesitate to ask for help with resolving any of these warnings on your pull request.


### PR DESCRIPTION
I think this might be the smallest PR I've ever made.

In #3153 we added a list of directories mypy should search. This lets us ignore type hint issues in docs/experiments, which we don't really care about. We forgot to update the docs, and `mypy .` doesn't ignore any of those directories.

We could explicitly add these directories to `ignore` if we want `mypy` to match `mypy .`