### PR TITLE
PR to update OSCD license

### DIFF
--- a/docs/api/datasets/non_geo_datasets.csv
+++ b/docs/api/datasets/non_geo_datasets.csv
@@ -39,7 +39,7 @@ Dataset,Task,Source,License,# Samples,# Classes,Size (px),Resolution (m),Bands
 `Million-AID`_,C,Google Earth,-,1M,51--73,,0.5--153,RGB
 `MMEarth`_,"C, S","Aster, Sentinel, ERA5","CC-BY-4.0","100K--1M",,"128x128 or 64x64",10,MSI
 `NASA Marine Debris`_,OD,PlanetScope,"Apache-2.0",707,1,256x256,3,RGB
-`OSCD`_,CD,Sentinel-2,"CC-BY-NC-SA",24,2,"241--1,180",60,MSI
+`OSCD`_,CD,Sentinel-2,"CC-BY-NC-SA-4.0",24,2,"241--1,180",60,MSI
 `PASTIS`_,I,Sentinel-1/2,"CC-BY-4.0","2,433",19,128x128xT,10,MSI
 `PatternNet`_,C,Google Earth,"CC-BY-4.0","30,400",38,256x256,0.06--5,RGB
 `Potsdam`_,S,Aerial,-,38,6,"6,000x6,000",0.05,MSI


### PR DESCRIPTION
torchgeo stated OSCD license as CC BY 4.0, but their website says CC BY-NC-SA 