### PR TITLE
Custom Raster Datasets: add examples of dtype/resampling overrides

### DIFF
--- a/docs/tutorials/custom_raster_dataset.ipynb
+++ b/docs/tutorials/custom_raster_dataset.ipynb
@@ -276,6 +276,7 @@
     "    filename_regex = r'^.{6}_(?P<date>\\d{8}T\\d{6})_(?P<band>B0[\\d])'\n",
     "    date_format = '%Y%m%dT%H%M%S'\n",
     "    is_image = True\n",
+    "    dtype = torch.float64\n",
     "    resampling = Resampling.cubic\n",
     "    separate_files = True\n",
     "    all_bands = ('B02', 'B03', 'B04', 'B08')\n",


### PR DESCRIPTION
Following the suggestion of @adamjstewart in https://github.com/torchgeo/torchgeo/pull/2015 I added the example to override the resampling.
