### PR TITLE
VectorDataset: fix bug in instance segmentation

### DIFF
--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -563,7 +563,7 @@ class TestVectorDataset:
         with pytest.raises(ValueError, match='Invalid task:'):
             CustomVectorDataset(dataset.paths, task='invalid-task')  # type: ignore[arg-type]
 
-    def test_getitem(self, dataset: CustomVectorDataset) -> None:
+    def test_getitem_sem_seg(self, dataset: CustomVectorDataset) -> None:
         dataset.task = 'semantic_segmentation'
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
@@ -574,6 +574,7 @@ class TestVectorDataset:
             torch.tensor([0, 1], dtype=torch.uint8),
         )
 
+    def test_getitem_obj_det(self, dataset: CustomVectorDataset) -> None:
         dataset.task = 'object_detection'
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
@@ -582,6 +583,7 @@ class TestVectorDataset:
         assert isinstance(x['label'], torch.Tensor)
         assert x['bbox_xyxy'].shape[-1] == 4
 
+    def test_getitem_ins_seg(self, dataset: CustomVectorDataset) -> None:
         dataset.task = 'instance_segmentation'
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
@@ -596,7 +598,9 @@ class TestVectorDataset:
         assert x['bbox_xyxy'].shape[-1] == 4
         assert len(x['label']) == x['mask'].shape[0]
 
-    def test_getitem_parquet(self, dataset_parquet: CustomVectorParquetDataset) -> None:
+    def test_getitem_parquet_sem_seg(
+        self, dataset_parquet: CustomVectorParquetDataset
+    ) -> None:
         dataset_parquet.task = 'semantic_segmentation'
         x = dataset_parquet[dataset_parquet.bounds]
         assert isinstance(x, dict)
@@ -607,6 +611,9 @@ class TestVectorDataset:
             torch.tensor([0, 1], dtype=torch.uint8),
         )
 
+    def test_getitem_parquet_obj_det(
+        self, dataset_parquet: CustomVectorParquetDataset
+    ) -> None:
         dataset_parquet.task = 'object_detection'
         x = dataset_parquet[dataset_parquet.bounds]
         assert isinstance(x, dict)
@@ -615,6 +622,9 @@ class TestVectorDataset:
         assert isinstance(x['label'], torch.Tensor)
         assert x['bbox_xyxy'].shape[-1] == 4
 
+    def test_getitem_parquet_ins_seg(
+        self, dataset_parquet: CustomVectorParquetDataset
+    ) -> None:
         dataset_parquet.task = 'instance_segmentation'
         x = dataset_parquet[dataset_parquet.bounds]
         assert isinstance(x, dict)
@@ -633,7 +643,7 @@ class TestVectorDataset:
         assert dataset.bounds[2].start > pd.Timestamp.min
         assert dataset.bounds[2].stop < pd.Timestamp.max
 
-    def test_getitem_multilabel(self, multilabel: CustomVectorDataset) -> None:
+    def test_getitem_multilabel_sem_seg(self, multilabel: CustomVectorDataset) -> None:
         multilabel.task = 'semantic_segmentation'
         x = multilabel[multilabel.bounds]
         assert isinstance(x, dict)
@@ -644,6 +654,7 @@ class TestVectorDataset:
             torch.tensor([0, 1, 2, 3], dtype=torch.uint8),
         )
 
+    def test_getitem_multilabel_obj_det(self, multilabel: CustomVectorDataset) -> None:
         multilabel.task = 'object_detection'
         x = multilabel[multilabel.bounds]
         assert isinstance(x, dict)
@@ -653,6 +664,7 @@ class TestVectorDataset:
         assert torch.equal(x['label'], torch.tensor([1, 2, 3], dtype=torch.int32))
         assert x['bbox_xyxy'].shape[-1] == 4
 
+    def test_getitem_multilabel_ins_seg(self, multilabel: CustomVectorDataset) -> None:
         multilabel.task = 'instance_segmentation'
         x = multilabel[multilabel.bounds]
         assert isinstance(x, dict)

--- a/torchgeo/datasets/geo.py
+++ b/torchgeo/datasets/geo.py
@@ -1032,7 +1032,7 @@ class VectorDataset(GeoDataset):
                         box_list.append(p.bounds)
 
                         mask = rasterio.features.rasterize(
-                            (s[0], i + 1),
+                            [(s[0], i + 1)],
                             out_shape=(round(height), round(width)),
                             transform=transform,
                         )


### PR DESCRIPTION
Fixes the following warnings in CI:
```
tests/datasets/test_geo.py::TestVectorDataset::test_getitem
tests/datasets/test_geo.py::TestVectorDataset::test_getitem_parquet
tests/datasets/test_geo.py::TestVectorDataset::test_getitem_multilabel
  /opt/hostedtoolcache/Python/3.13.9/x64/lib/python3.13/site-packages/rasterio/features.py:336: ShapeSkipWarning: Invalid or empty shape 1 at index 1 will not be rasterized.
    warnings.warn(

tests/datasets/test_geo.py::TestVectorDataset::test_getitem
tests/datasets/test_geo.py::TestVectorDataset::test_getitem_parquet
tests/datasets/test_geo.py::TestVectorDataset::test_getitem_multilabel
  /opt/hostedtoolcache/Python/3.13.9/x64/lib/python3.13/site-packages/rasterio/features.py:336: ShapeSkipWarning: Invalid or empty shape 2 at index 1 will not be rasterized.
    warnings.warn(

tests/datasets/test_geo.py::TestVectorDataset::test_getitem
tests/datasets/test_geo.py::TestVectorDataset::test_getitem_parquet
tests/datasets/test_geo.py::TestVectorDataset::test_getitem_multilabel
  /opt/hostedtoolcache/Python/3.13.9/x64/lib/python3.13/site-packages/rasterio/features.py:336: ShapeSkipWarning: Invalid or empty shape 3 at index 1 will not be rasterized.
    warnings.warn(
```
This bug was introduced by yours truly in #3154. Luckily we didn't make a release without fixing this first.

Also split up some of the longer tests to help isolate the problem, it only occurs with instance segmentation.