### PR TITLE
CI: silence Python 3.14 warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -286,7 +286,8 @@ filterwarnings = [
     "ignore:__array_wrap__ must accept context and return_scalar arguments:DeprecationWarning",
     # https://github.com/lightly-ai/lightly/issues/1791
     # https://github.com/pydantic/pydantic/issues/12618
-    "ignore:Core Pydantic V1 functionality isn't compatible with Python 3.14 or greater.:UserWarning:pydantic",
+    "ignore:Core Pydantic V1 functionality isn't compatible with Python 3.14 or greater.:UserWarning",
+    "ignore:ForwardRef._evaluate is a private API and is retained for compatibility:DeprecationWarning",
     # https://github.com/pydantic/pydantic/pull/11377
     "ignore:Failing to pass a value to the 'type_params' parameter of 'typing.*' is deprecated:DeprecationWarning:pydantic",
     # https://github.com/Lightning-AI/pytorch-lightning/pull/20802


### PR DESCRIPTION
Reported upstream, nothing else we can do to prepare.