### PR TITLE
Deprecation policy: NEP 29 -> SPEC 0

### DIFF
--- a/requirements/README.md
+++ b/requirements/README.md
@@ -6,4 +6,4 @@ All files with a `.txt` extension are managed by dependabot and should not be ma
 
 ### Not managed by dependabot
 
-All files with a `.old` extension are not managed by dependabot. They document the minimum version of our dependencies that we support, or older versions required for versions of Python that the numpy ecosystem no longer supports. See [NEP-29](https://numpy.org/neps/nep-0029-deprecation_policy.html) for more information on the numpy deprecation timeline. See https://github.com/dependabot/dependabot-core/issues/5299 and https://github.com/dependabot/dependabot-core/issues/5300 for why these dependencies have to be in separate files with a different file extension.
+All files with a `.old` extension are not managed by dependabot. They document the minimum version of our dependencies that we support. See [SPEC 0](https://scientific-python.org/specs/spec-0000/) for more information on the Scientific Python ecosystem deprecation timeline. See https://github.com/dependabot/dependabot-core/issues/5299 and https://github.com/dependabot/dependabot-core/issues/5300 for why these dependencies have to be in separate files with a different file extension.


### PR DESCRIPTION
We've been following SPEC 0 since it came out, but forgot to update this reference.