### PR TITLE
CI: default to Python 3.13

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 {
   "name": "Torchgeo DevContainer",
   // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-  "image": "mcr.microsoft.com/devcontainers/python:3.14",
+  "image": "mcr.microsoft.com/devcontainers/python:3.13",
 
   // Features to add to the dev container. More info: https://containers.dev/features.
   "features": {

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v6.1.0
         with:
-          python-version: '3.14'
+          python-version: '3.13'
       - name: Install pip dependencies
         run: pip install build
       - name: List pip dependencies

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
         id: setup-python
         uses: actions/setup-python@v6.1.0
         with:
-          python-version: '3.14'
+          python-version: '3.13'
       - name: Cache dependencies
         uses: actions/cache@v5.0.1
         id: cache
@@ -50,7 +50,7 @@ jobs:
         id: setup-python
         uses: actions/setup-python@v6.1.0
         with:
-          python-version: '3.14'
+          python-version: '3.13'
       - name: Cache dependencies
         uses: actions/cache@v5.0.1
         id: cache

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -22,7 +22,7 @@ jobs:
         id: setup-python
         uses: actions/setup-python@v6.1.0
         with:
-          python-version: '3.14'
+          python-version: '3.13'
       - name: Cache dependencies
         uses: actions/cache@v5.0.1
         id: cache
@@ -48,7 +48,7 @@ jobs:
         id: setup-python
         uses: actions/setup-python@v6.1.0
         with:
-          python-version: '3.14'
+          python-version: '3.13'
       - name: Cache dependencies
         uses: actions/cache@v5.0.1
         id: cache

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -92,7 +92,7 @@ jobs:
         id: setup-python
         uses: actions/setup-python@v6.1.0
         with:
-          python-version: '3.14'
+          python-version: '3.13'
       - name: Cache dependencies
         uses: actions/cache@v5.0.1
         id: cache

--- a/.github/workflows/tutorials.yaml
+++ b/.github/workflows/tutorials.yaml
@@ -24,7 +24,7 @@ jobs:
         id: setup-python
         uses: actions/setup-python@v6.1.0
         with:
-          python-version: '3.14'
+          python-version: '3.13'
       - name: Cache dependencies
         uses: actions/cache@v5.0.1
         id: cache


### PR DESCRIPTION
We are seeing consistent segfaults (or something of the sort) with Python 3.14. This PR switches all of CI to test with 3.13 by default. We still keep our 3.14 tests, but make them optional for merge.