### PR TITLE
fix: torch.Tensor -> torch.tensor usage throughout repo

### DIFF
--- a/torchgeo/datamodules/caffe.py
+++ b/torchgeo/datamodules/caffe.py
@@ -20,8 +20,8 @@ class CaFFeDataModule(NonGeoDataModule):
     .. versionadded:: 0.7
     """
 
-    mean = torch.Tensor([0.5517])
-    std = torch.Tensor([11.8478])
+    mean = torch.tensor([0.5517])
+    std = torch.tensor([11.8478])
 
     def __init__(
         self, batch_size: int = 64, num_workers: int = 0, size: int = 512, **kwargs: Any

--- a/torchgeo/datasets/digital_typhoon.py
+++ b/torchgeo/datasets/digital_typhoon.py
@@ -275,7 +275,9 @@ class DigitalTyphoon(NonGeoDataset):
         )
 
         # torchgeo expects a single label
-        sample['label'] = torch.Tensor([sample[target] for target in self.targets])
+        sample['label'] = torch.tensor(
+            [sample[target] for target in self.targets], dtype=torch.float32
+        )
 
         if self.transforms is not None:
             sample = self.transforms(sample)

--- a/torchgeo/datasets/everwatch.py
+++ b/torchgeo/datasets/everwatch.py
@@ -189,9 +189,10 @@ class EverWatch(NonGeoDataset):
         boxes = torch.from_numpy(
             sample_df[['xmin', 'ymin', 'xmax', 'ymax']].values
         ).float()
-        labels = torch.Tensor(
-            [self.class2idx[label] for label in sample_df['label'].tolist()]
-        ).long()
+        labels = torch.tensor(
+            [self.class2idx[label] for label in sample_df['label'].tolist()],
+            dtype=torch.long,
+        )
         return boxes, labels
 
     def _verify(self) -> None:

--- a/torchgeo/datasets/reforestree.py
+++ b/torchgeo/datasets/reforestree.py
@@ -177,11 +177,15 @@ class ReforesTree(NonGeoDataset):
         """
         tile_df = self.annot_df[self.annot_df['img_path'] == os.path.basename(filepath)]
 
-        boxes = torch.Tensor(tile_df[['xmin', 'ymin', 'xmax', 'ymax']].values.tolist())
-        labels = torch.Tensor(
-            [self.class2idx[label] for label in tile_df['group'].tolist()]
-        ).long()
-        agb = torch.Tensor(tile_df['AGB'].tolist())
+        boxes = torch.tensor(
+            tile_df[['xmin', 'ymin', 'xmax', 'ymax']].values.tolist(),
+            dtype=torch.float32,
+        )
+        labels = torch.tensor(
+            [self.class2idx[label] for label in tile_df['group'].tolist()],
+            dtype=torch.long,
+        )
+        agb = torch.tensor(tile_df['AGB'].tolist(), dtype=torch.float32)
 
         return boxes, labels, agb
 

--- a/torchgeo/models/croma.py
+++ b/torchgeo/models/croma.py
@@ -173,7 +173,7 @@ def get_2dalibi(num_heads: int, num_patches: int) -> Tensor:
         ratio = start
         return [start * ratio**i for i in range(n)]
 
-    slopes = torch.Tensor(get_slopes(num_heads)).unsqueeze(1)
+    slopes = torch.tensor(get_slopes(num_heads), dtype=torch.float32).unsqueeze(1)
     idxs = []
     for p1 in points:
         for p2 in points:


### PR DESCRIPTION
Replace `torch.Tensor` with `torch.tensor`. `torch.Tensor` automatically casts everything to float. It's recommended to use torch.tensor which infers the dtype.

## Files changed
- `torchgeo/models/croma.py`
- `torchgeo/datasets/reforestree.py`
- `torchgeo/datasets/everwatch.py`
- `torchgeo/datasets/digital_typhoon.py`
- `torchgeo/datamodules/caffe.py`