### PR TITLE
CI: fix minimum tests

### DIFF
--- a/requirements/min-reqs.old
+++ b/requirements/min-reqs.old
@@ -6,6 +6,7 @@ jsonargparse[signatures]==4.35.0
 kornia==0.8.2
 lightly==1.4.5
 lightning==2.0.0
+lightning-cloud<0.6
 matplotlib==3.7.3
 numpy==1.26.0
 pandas[parquet]==2.1.1


### PR DESCRIPTION
Fixes failing tests like https://github.com/torchgeo/torchgeo/actions/runs/20762005476/job/59619106920?pr=3249

New release of lightning-cloud came out today and is not compatible with ancient versions of lightning: https://pypi.org/project/lightning-cloud/