### PR TITLE
ruff: enable docstring-code-format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -338,6 +338,7 @@ extend-include = ["*.ipynb"]
 fix = true
 
 [tool.ruff.format]
+docstring-code-format = true
 quote-style = "single"
 skip-magic-trailing-comma = true
 

--- a/torchgeo/datasets/copernicus/pretrain.py
+++ b/torchgeo/datasets/copernicus/pretrain.py
@@ -60,10 +60,8 @@ class CopernicusPretrain(IterableDataset[dict[str, Any]]):
        dem = sample['dem.pth']
 
        # Create a DataLoader for distributed training on 2 GPUs
-       dataset = dataset.dataset.batched(10) # batch size
-       dataloader = webdataset.WebLoader(
-           dataset, batch_size=None, num_workers=2
-       )
+       dataset = dataset.dataset.batched(10)  # batch size
+       dataloader = webdataset.WebLoader(dataset, batch_size=None, num_workers=2)
        # Unbatch, shuffle, and rebatch to mix samples from different workers
        dataloader = dataloader.unbatched().shuffle(100).batched(10)
        # A resampled dataset is infinite size, but we can recreate a fixed epoch length

--- a/torchgeo/datasets/openstreetmap.py
+++ b/torchgeo/datasets/openstreetmap.py
@@ -59,9 +59,9 @@ class OpenStreetMap(VectorDataset):
     Example::
 
         classes = [
-            {'name': 'buildings', 'selector': [{'building': '*'}]},        # label=1
-            {'name': 'roads', 'selector': [{'highway': '*'}]},             # label=2
-            {'name': 'commercial', 'selector': [{'landuse': 'commercial'}]} # label=3
+            {'name': 'buildings', 'selector': [{'building': '*'}]},  # label=1
+            {'name': 'roads', 'selector': [{'highway': '*'}]},  # label=2
+            {'name': 'commercial', 'selector': [{'landuse': 'commercial'}]},  # label=3
         ]
 
         # A feature with tags {'building': 'yes', 'landuse': 'commercial'}

--- a/torchgeo/models/copernicusfm.py
+++ b/torchgeo/models/copernicusfm.py
@@ -369,25 +369,49 @@ class CopernicusFM(nn.Module):
         **1. Spectral Mode (Using Wavelength and Bandwidth):**
 
         >>> model = CopernicusFM()
-        >>> x = torch.randn(1, 4, 224, 224) # input image
-        >>> metadata = torch.full((1, 4), float('nan')) # [lon (degree), lat (degree), delta_time (days since 1970/1/1), patch_token_area (km^2)], assume unknown
-        >>> wavelengths = [490, 560, 665, 842] # wavelength (nm): B,G,R,NIR (Sentinel 2)
-        >>> bandwidths = [65, 35, 30, 115] # bandwidth (nm): B,G,R,NIR (Sentinel 2)
-        >>> kernel_size = 16 # expected patch size
+        >>> x = torch.randn(1, 4, 224, 224)  # input image
+        >>> metadata = torch.full(
+        ...     (1, 4), float('nan')
+        ... )  # [lon (degree), lat (degree), delta_time (days since 1970/1/1), patch_token_area (km^2)], assume unknown
+        >>> wavelengths = [
+        ...     490,
+        ...     560,
+        ...     665,
+        ...     842,
+        ... ]  # wavelength (nm): B,G,R,NIR (Sentinel 2)
+        >>> bandwidths = [65, 35, 30, 115]  # bandwidth (nm): B,G,R,NIR (Sentinel 2)
+        >>> kernel_size = 16  # expected patch size
         >>> input_mode = 'spectral'
-        >>> logit = model(x, metadata, wavelengths=wavelengths, bandwidths=bandwidths, input_mode=input_mode, kernel_size=kernel_size)
+        >>> logit = model(
+        ...     x,
+        ...     metadata,
+        ...     wavelengths=wavelengths,
+        ...     bandwidths=bandwidths,
+        ...     input_mode=input_mode,
+        ...     kernel_size=kernel_size,
+        ... )
         >>> print(logit.shape)
 
         **2. Variable Mode (Using language embedding):**
 
         >>> model = CopernicusFM()
-        >>> varname = 'Sentinel 5P Nitrogen Dioxide' # variable name (as input to a LLM for language embed)
-        >>> x = torch.randn(1, 1, 56, 56) # input image
-        >>> metadata = torch.full((1, 4), float('nan')) # [lon (degree), lat (degree), delta_time (days since 1970/1/1), patch_token_area (km^2)], assume unknown
-        >>> language_embed = torch.randn(2048) # language embedding: encode varname with a LLM (e.g. Llama)
-        >>> kernel_size = 4 # expected patch size
+        >>> varname = 'Sentinel 5P Nitrogen Dioxide'  # variable name (as input to a LLM for language embed)
+        >>> x = torch.randn(1, 1, 56, 56)  # input image
+        >>> metadata = torch.full(
+        ...     (1, 4), float('nan')
+        ... )  # [lon (degree), lat (degree), delta_time (days since 1970/1/1), patch_token_area (km^2)], assume unknown
+        >>> language_embed = torch.randn(
+        ...     2048
+        ... )  # language embedding: encode varname with a LLM (e.g. Llama)
+        >>> kernel_size = 4  # expected patch size
         >>> input_mode = 'variable'
-        >>> logit = model(x, metadata, language_embed=language_embed, input_mode=input_mode, kernel_size=kernel_size)
+        >>> logit = model(
+        ...     x,
+        ...     metadata,
+        ...     language_embed=language_embed,
+        ...     input_mode=input_mode,
+        ...     kernel_size=kernel_size,
+        ... )
         >>> print(logit.shape)
 
     """

--- a/torchgeo/models/fcsiam.py
+++ b/torchgeo/models/fcsiam.py
@@ -69,7 +69,7 @@ class FCSiamConc(SegmentationModel):  # type: ignore[misc]
 
                   **Example**:
                   ```python
-                  decoder_use_norm={"type": "layernorm", "eps": 1e-2}
+                  decoder_use_norm = {'type': 'layernorm', 'eps': 1e-2}
                   ```
             decoder_attention_type: Attention module used in decoder of the model.
                 Available options are **None** and **scse**. SCSE paper


### PR DESCRIPTION
Neat feature I wasn't aware of. We don't heavily use code snippets in docstrings, but maybe we should.