### PR TITLE
Disable Python 3.14 in CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.12', '3.13', '3.14']
+        python-version: ['3.12', '3.13']
     steps:
       - name: Clone repo
         uses: actions/checkout@v6.0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Scientific/Engineering :: GIS",
 ]


### PR DESCRIPTION
Tests pass most of the time, but result in OOM errors like https://github.com/torchgeo/torchgeo/pull/3084#issuecomment-3723541955 more often than I would like. Let's not promise 3.14 until the next PyTorch release, which will hopefully fix this?