### PR TITLE
torchgeo.trainers.utils: OrderedDict -> dict

### DIFF
--- a/torchgeo/trainers/utils.py
+++ b/torchgeo/trainers/utils.py
@@ -4,7 +4,6 @@
 """Common trainer utilities."""
 
 import warnings
-from collections import OrderedDict
 from typing import cast
 
 import torch
@@ -31,7 +30,7 @@ class GeneralizedRCNNTransformNoOp(GeneralizedRCNNTransform):  # type: ignore[mi
         return image, target
 
 
-def extract_backbone(path: str) -> tuple[str, 'OrderedDict[str, Tensor]']:
+def extract_backbone(path: str) -> tuple[str, dict[str, Tensor]]:
     """Extracts a backbone from a lightning checkpoint file.
 
     Args:
@@ -51,19 +50,17 @@ def extract_backbone(path: str) -> tuple[str, 'OrderedDict[str, Tensor]']:
     if 'model' in checkpoint['hyper_parameters']:
         name = checkpoint['hyper_parameters']['model']
         state_dict = checkpoint['state_dict']
-        state_dict = OrderedDict({k: v for k, v in state_dict.items() if 'model.' in k})
-        state_dict = OrderedDict(
-            {k.replace('model.', ''): v for k, v in state_dict.items()}
-        )
+        state_dict = {k: v for k, v in state_dict.items() if 'model.' in k}
+        state_dict = {k.replace('model.', ''): v for k, v in state_dict.items()}
     elif 'backbone' in checkpoint['hyper_parameters']:
         name = checkpoint['hyper_parameters']['backbone']
         state_dict = checkpoint['state_dict']
-        state_dict = OrderedDict(
-            {k: v for k, v in state_dict.items() if 'model.backbone.model' in k}
-        )
-        state_dict = OrderedDict(
-            {k.replace('model.backbone.model.', ''): v for k, v in state_dict.items()}
-        )
+        state_dict = {
+            k: v for k, v in state_dict.items() if 'model.backbone.model' in k
+        }
+        state_dict = {
+            k.replace('model.backbone.model.', ''): v for k, v in state_dict.items()
+        }
     else:
         raise ValueError(
             'Unknown checkpoint task. Only backbone or model extraction is supported'
@@ -90,7 +87,7 @@ def _get_input_layer_name_and_module(model: Module) -> tuple[str, Module]:
 
 
 def load_state_dict(
-    model: Module, state_dict: 'OrderedDict[str, Tensor]'
+    model: Module, state_dict: dict[str, Tensor]
 ) -> tuple[list[str], list[str]]:
     """Load pretrained resnet weights to a model.
 


### PR DESCRIPTION
Pretty sure PyTorch used to use OrderedDict but now uses dict. As a result, ty complains with:
```
error[invalid-argument-type]: Argument to function `load_state_dict` is incorrect
   --> torchgeo/trainers/byol.py:347:45
    |
345 |             else:
346 |                 state_dict = get_weight(weights).get_state_dict(progress=True)
347 |             utils.load_state_dict(backbone, state_dict)
    |                                             ^^^^^^^^^^ Expected `OrderedDict[str, Tensor]`, found `dict[str, Any] | OrderedDict[str, Tensor]`
348 |
349 |         self.model = BYOL(backbone, in_channels=in_channels, image_size=(224, 224))
    |
info: Element `dict[str, Any]` of this union is not assignable to `OrderedDict[str, Tensor]`
info: Function defined here
  --> torchgeo/trainers/utils.py:92:5
   |
92 | def load_state_dict(
   |     ^^^^^^^^^^^^^^^
93 |     model: Module, state_dict: 'OrderedDict[str, Tensor]'
   |                    -------------------------------------- Parameter declared here
94 | ) -> tuple[list[str], list[str]]:
95 |     """Load pretrained resnet weights to a model.
   |
info: rule `invalid-argument-type` is enabled by default
```
This PR replaces OrderedDict with dict to make ty happy.