### PR TITLE
torchgeo.trainers: better type checking of loggers

### DIFF
--- a/torchgeo/trainers/change.py
+++ b/torchgeo/trainers/change.py
@@ -15,7 +15,6 @@ import torch.nn as nn
 from einops import rearrange
 from matplotlib.figure import Figure
 from torch import Tensor
-from torch.utils.tensorboard.writer import SummaryWriter
 from torchmetrics import Accuracy, F1Score, JaccardIndex, MetricCollection
 from torchvision.models._api import WeightsEnum
 
@@ -314,7 +313,7 @@ class ChangeDetectionTask(BaseTask):
                 and isinstance(self.trainer.datamodule, BaseDataModule)
                 and self.logger
                 and hasattr(self.logger, 'experiment')
-                and isinstance(self.logger.experiment, SummaryWriter)
+                and hasattr(self.logger.experiment, 'add_figure')
             ):
                 datamodule = self.trainer.datamodule
                 aug = K.AugmentationSequential(
@@ -343,7 +342,7 @@ class ChangeDetectionTask(BaseTask):
                     summary_writer = self.logger.experiment
                     summary_writer.add_figure(
                         f'image/{batch_idx}', fig, global_step=self.global_step
-                    )
+                    )  # type: ignore[call-non-callable]
                     plt.close()
 
         return loss

--- a/torchgeo/trainers/classification.py
+++ b/torchgeo/trainers/classification.py
@@ -15,7 +15,6 @@ import torch.nn as nn
 from matplotlib.figure import Figure
 from segmentation_models_pytorch.losses import FocalLoss, JaccardLoss
 from torch import Tensor
-from torch.utils.tensorboard.writer import SummaryWriter
 from torchmetrics import MetricCollection
 from torchmetrics.classification import Accuracy, FBetaScore, JaccardIndex
 from torchvision.models._api import WeightsEnum
@@ -220,7 +219,7 @@ class ClassificationTask(BaseTask):
             and isinstance(self.trainer.datamodule, BaseDataModule)
             and self.logger
             and hasattr(self.logger, 'experiment')
-            and isinstance(self.logger.experiment, SummaryWriter)
+            and hasattr(self.logger.experiment, 'add_figure')
         ):
             datamodule = self.trainer.datamodule
             aug = K.AugmentationSequential(
@@ -249,7 +248,7 @@ class ClassificationTask(BaseTask):
                 summary_writer = self.logger.experiment
                 summary_writer.add_figure(
                     f'image/{batch_idx}', fig, global_step=self.global_step
-                )
+                )  # type: ignore[call-non-callable]
                 plt.close()
 
     def test_step(self, batch: Any, batch_idx: int, dataloader_idx: int = 0) -> None:

--- a/torchgeo/trainers/detection.py
+++ b/torchgeo/trainers/detection.py
@@ -14,7 +14,6 @@ from matplotlib.figure import Figure
 from timm.models import adapt_input_conv
 from torch import Tensor
 from torch.nn.parameter import Parameter
-from torch.utils.tensorboard.writer import SummaryWriter
 from torchmetrics import MetricCollection
 from torchmetrics.detection.mean_ap import MeanAveragePrecision
 from torchvision.models import resnet as R
@@ -296,7 +295,7 @@ class ObjectDetectionTask(BaseTask):
             and isinstance(self.trainer.datamodule, BaseDataModule)
             and self.logger
             and hasattr(self.logger, 'experiment')
-            and isinstance(self.logger.experiment, SummaryWriter)
+            and hasattr(self.logger.experiment, 'add_figure')
         ):
             datamodule = self.trainer.datamodule
             aug = K.AugmentationSequential(
@@ -325,7 +324,7 @@ class ObjectDetectionTask(BaseTask):
                 summary_writer = self.logger.experiment
                 summary_writer.add_figure(
                     f'image/{batch_idx}', fig, global_step=self.global_step
-                )
+                )  # type: ignore[call-non-callable]
                 plt.close()
 
     def test_step(self, batch: Any, batch_idx: int, dataloader_idx: int = 0) -> None:

--- a/torchgeo/trainers/instance_segmentation.py
+++ b/torchgeo/trainers/instance_segmentation.py
@@ -12,7 +12,6 @@ from matplotlib.figure import Figure
 from timm.models import adapt_input_conv
 from torch import Tensor
 from torch.nn.parameter import Parameter
-from torch.utils.tensorboard.writer import SummaryWriter
 from torchmetrics import MetricCollection
 from torchmetrics.detection.mean_ap import MeanAveragePrecision
 from torchvision.models import ResNet50_Weights
@@ -187,7 +186,7 @@ class InstanceSegmentationTask(BaseTask):
             and isinstance(self.trainer.datamodule, BaseDataModule)
             and self.logger
             and hasattr(self.logger, 'experiment')
-            and isinstance(self.logger.experiment, SummaryWriter)
+            and hasattr(self.logger.experiment, 'add_figure')
         ):
             datamodule = self.trainer.datamodule
             aug = K.AugmentationSequential(
@@ -215,7 +214,7 @@ class InstanceSegmentationTask(BaseTask):
                 summary_writer = self.logger.experiment
                 summary_writer.add_figure(
                     f'image/{batch_idx}', fig, global_step=self.global_step
-                )
+                )  # type: ignore[call-non-callable]
                 plt.close()
 
     def test_step(self, batch: Any, batch_idx: int, dataloader_idx: int = 0) -> None:

--- a/torchgeo/trainers/regression.py
+++ b/torchgeo/trainers/regression.py
@@ -14,7 +14,6 @@ import torch
 import torch.nn as nn
 from matplotlib.figure import Figure
 from torch import Tensor
-from torch.utils.tensorboard.writer import SummaryWriter
 from torchmetrics import MeanAbsoluteError, MeanSquaredError, MetricCollection
 from torchvision.models._api import WeightsEnum
 
@@ -203,7 +202,7 @@ class RegressionTask(BaseTask):
             and isinstance(self.trainer.datamodule, BaseDataModule)
             and self.logger
             and hasattr(self.logger, 'experiment')
-            and isinstance(self.logger.experiment, SummaryWriter)
+            and hasattr(self.logger.experiment, 'add_figure')
         ):
             datamodule = self.trainer.datamodule
             aug = K.AugmentationSequential(
@@ -230,7 +229,7 @@ class RegressionTask(BaseTask):
                 summary_writer = self.logger.experiment
                 summary_writer.add_figure(
                     f'image/{batch_idx}', fig, global_step=self.global_step
-                )
+                )  # type: ignore[call-non-callable]
                 plt.close()
 
     def test_step(self, batch: Any, batch_idx: int, dataloader_idx: int = 0) -> None:

--- a/torchgeo/trainers/segmentation.py
+++ b/torchgeo/trainers/segmentation.py
@@ -15,7 +15,6 @@ import torch.nn as nn
 from einops import rearrange
 from matplotlib.figure import Figure
 from torch import Tensor
-from torch.utils.tensorboard.writer import SummaryWriter
 from torchmetrics import Accuracy, JaccardIndex, MetricCollection
 from torchvision.models._api import WeightsEnum
 
@@ -313,7 +312,7 @@ class SemanticSegmentationTask(BaseTask):
             and isinstance(self.trainer.datamodule, BaseDataModule)
             and self.logger
             and hasattr(self.logger, 'experiment')
-            and isinstance(self.logger.experiment, SummaryWriter)
+            and hasattr(self.logger.experiment, 'add_figure')
         ):
             datamodule = self.trainer.datamodule
             if batch['image'].ndim == 5:
@@ -356,7 +355,7 @@ class SemanticSegmentationTask(BaseTask):
                 summary_writer = self.logger.experiment
                 summary_writer.add_figure(
                     f'image/{batch_idx}', fig, global_step=self.global_step
-                )
+                )  # type: ignore[call-non-callable]
                 plt.close()
 
     def test_step(self, batch: Any, batch_idx: int, dataloader_idx: int = 0) -> None:


### PR DESCRIPTION
Resolves ty errors like:
```
> ty check torchgeo/trainers/change.py
error[call-non-callable]: Object of type `object` is not callable
   --> torchgeo/trainers/change.py:336:27
    |
334 |                 fig: Figure | None = None
335 |                 try:
336 |                     fig = datamodule.plot(sample)
    |                           ^^^^^^^^^^^^^^^^^^^^^^^
337 |                 except RGBBandsMissingError:
338 |                     pass
    |
info: rule `call-non-callable` is enabled by default

error[call-non-callable]: Object of type `object` is not callable
   --> torchgeo/trainers/change.py:342:21
    |
340 |                   if fig:
341 |                       summary_writer = self.logger.experiment
342 | /                     summary_writer.add_figure(
343 | |                         f'image/{batch_idx}', fig, global_step=self.global_step
344 | |                     )
    | |_____________________^
345 |                       plt.close()
    |
info: rule `call-non-callable` is enabled by default

Found 2 diagnostics
```
Pretty sure mypy just ignores these as Any, whereas ty doesn't like not knowing the type.