### PR TITLE
Update docs on building docs

### DIFF
--- a/docs/user/contributing.rst
+++ b/docs/user/contributing.rst
@@ -128,13 +128,12 @@ Now, every time you run ``git commit``, pre-commit will run and let you know if 
 Documentation
 -------------
 
-All of our documentation is hosted on `Read the Docs <https://about.readthedocs.com/>`_. If you make non-trivial changes to the documentation, it helps to build the documentation yourself locally. To do this, make sure you are using **Python < 3.13** and that the dependencies are installed:
+All of our documentation is hosted on `Read the Docs <https://about.readthedocs.com/>`_. If you make non-trivial changes to the documentation, it helps to build the documentation yourself locally. To do this, make sure the dependencies are installed:
 
 .. code-block:: console
 
    $ pip install .[docs]
    $ cd docs
-   $ pip install -r requirements.txt
 
 Pandoc must also be installed. You can download it from the `official Pandoc website <https://pandoc.org/installing.html>`_ and ensure it is included in your system PATH.
 


### PR DESCRIPTION
We removed this `requirements.txt` and can now use newer Python.