### PR TITLE
Trainers: fix type hints for SSL methods

### DIFF
--- a/torchgeo/trainers/moco.py
+++ b/torchgeo/trainers/moco.py
@@ -6,7 +6,7 @@
 import os
 import warnings
 from collections.abc import Sequence
-from typing import Any
+from typing import Any, cast
 
 import kornia.augmentation as K
 import lightning.pytorch.utilities.types
@@ -255,7 +255,7 @@ class MoCoTask(BaseTask):
         # Create projection (and prediction) head
         batch_norm = version == 3
         if version > 1:
-            input_dim = self.backbone.num_features
+            input_dim = cast(int, self.backbone.num_features)
             self.projection_head = MoCoProjectionHead(
                 input_dim, hidden_dim, output_dim, layers, batch_norm=batch_norm
             )
@@ -408,7 +408,8 @@ class MoCoTask(BaseTask):
                 k = self.forward_momentum(x2)
             loss = self.criterion(q, k)
         if self.hparams['version'] == 3:
-            m = cosine_schedule(self.current_epoch, self.trainer.max_epochs, m, 1)
+            max_steps = self.trainer.max_epochs or 200
+            m = cosine_schedule(self.current_epoch, max_steps, m, 1)
             q1, h1 = self.forward(x1)
             q2, _ = self.forward(x2)
             with torch.no_grad():

--- a/torchgeo/trainers/simclr.py
+++ b/torchgeo/trainers/simclr.py
@@ -5,7 +5,7 @@
 
 import os
 import warnings
-from typing import Any
+from typing import Any, cast
 
 import kornia.augmentation as K
 import lightning.pytorch.utilities.types
@@ -171,7 +171,7 @@ class SimCLRTask(BaseTask):
             utils.load_state_dict(self.backbone, state_dict)
 
         # Create projection head
-        input_dim = self.backbone.num_features
+        input_dim = cast(int, self.backbone.num_features)
         if self.hparams['hidden_dim'] is None:
             self.hparams['hidden_dim'] = input_dim
         if self.hparams['output_dim'] is None:


### PR DESCRIPTION
Last remaining problems with `torchgeo.trainers` flagged by `ty check`.