### PR TITLE
Datamodules: fix type hints

### DIFF
--- a/torchgeo/datamodules/geo.py
+++ b/torchgeo/datamodules/geo.py
@@ -159,7 +159,7 @@ class BaseDataModule(LightningDataModule):
             dataset = dataset.dataset
         if dataset is not None:
             if hasattr(dataset, 'plot'):
-                fig = dataset.plot(*args, **kwargs)
+                fig = dataset.plot(*args, **kwargs)  # type: ignore[call-non-callable]
         return fig
 
 


### PR DESCRIPTION
Only type hint problem flagged by `ty check` in `torchgeo.datamodules`. Until we make the `plot` method required in all datasets, we can't do anything about this. I guess we _could_ add a `Protocol`, but that sounds like overkill.