### PR TITLE
Type hints: ignore pandas IntervalIndex

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -366,6 +366,7 @@ include = ["torchgeo*"]
 
 [tool.ty.rules]
 deprecated = "ignore"
+possibly-missing-attribute = "ignore"
 unresolved-attribute = "ignore"
 unresolved-import = "ignore"
 unresolved-reference = "ignore"


### PR DESCRIPTION
`pd.DataFrame` is not yet generic, so we can't do something like `gpd.GeoDataFrame[pd.IntervalIndex]`. Instead, `pd.DataFrame.index` is assumed to be `pd.Index[Any]`, which does not have attributes like `left`, `right`, or `overlaps`. Ty (and mypy if we merge #3170) complain about this. For now, ignore all instances of this. Hopefully pandas will make dataframes generic soon.

Alternative is to explicitly ignore or cast each line where this occurs.