### PR TITLE
Add project instructions for Claude Code

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,3 @@
+# TorchGeo Claude Code Instructions
+
+@.github/copilot-instructions.md


### PR DESCRIPTION
As Claude Code is very popular right now, I believe this is a worthwile addtion following up with #3306. 

This PR enables Claude Code to read the same instructions as Copliot. This way we only need to maintain one instructions file for LLMs. 