### PR TITLE
Trainers: add ClassificationMixin

### DIFF
--- a/torchgeo/trainers/__init__.py
+++ b/torchgeo/trainers/__init__.py
@@ -10,6 +10,7 @@ from .classification import ClassificationTask, MultiLabelClassificationTask
 from .detection import ObjectDetectionTask
 from .instance_segmentation import InstanceSegmentationTask
 from .iobench import IOBenchTask
+from .mixins import ClassificationMixin
 from .moco import MoCoTask
 from .regression import PixelwiseRegressionTask, RegressionTask
 from .segmentation import SemanticSegmentationTask
@@ -19,6 +20,7 @@ __all__ = (
     'BYOLTask',
     'BaseTask',
     'ChangeDetectionTask',
+    'ClassificationMixin',
     'ClassificationTask',
     'IOBenchTask',
     'InstanceSegmentationTask',

--- a/torchgeo/trainers/mixins.py
+++ b/torchgeo/trainers/mixins.py
@@ -1,0 +1,126 @@
+# Copyright (c) TorchGeo Contributors. All rights reserved.
+# Licensed under the MIT License.
+
+"""Mix-ins for trainers."""
+
+import segmentation_models_pytorch as smp
+import torch
+from lightning.pytorch import LightningModule
+from torch import Tensor, nn
+from torchmetrics import Metric, MetricCollection
+from torchmetrics.classification import (
+    Accuracy,
+    F1Score,
+    JaccardIndex,
+    Precision,
+    Recall,
+)
+from torchmetrics.wrappers import ClasswiseWrapper
+
+
+class ClassificationMixin(LightningModule):
+    """Mix-in for classification-based tasks.
+
+    .. versionadded:: 0.9
+    """
+
+    def configure_losses(self) -> None:
+        """Initialize the loss criterion."""
+        ignore_index: int | None = self.hparams['ignore_index']
+        class_weights = self.hparams['class_weights']
+        if class_weights is not None and not isinstance(class_weights, Tensor):
+            class_weights = torch.tensor(class_weights, dtype=torch.float32)
+
+        match self.hparams['loss']:
+            case 'ce':
+                ignore_value = -1000 if ignore_index is None else ignore_index
+                self.criterion: nn.Module = nn.CrossEntropyLoss(
+                    ignore_index=ignore_value, weight=class_weights
+                )
+            case 'bce':
+                self.criterion = nn.BCEWithLogitsLoss(
+                    pos_weight=self.hparams['pos_weight']
+                )
+            case 'jaccard':
+                # JaccardLoss requires a list of classes to use instead of a class
+                # index to ignore.
+                if self.hparams['task'] == 'multiclass' and ignore_index is not None:
+                    classes = [
+                        i
+                        for i in range(self.hparams['num_classes'])
+                        if i != ignore_index
+                    ]
+                    self.criterion = smp.losses.JaccardLoss(
+                        mode=self.hparams['task'], classes=classes
+                    )
+                else:
+                    self.criterion = smp.losses.JaccardLoss(mode=self.hparams['task'])
+            case 'focal':
+                self.criterion = smp.losses.FocalLoss(
+                    mode=self.hparams['task'],
+                    ignore_index=ignore_index,
+                    normalized=True,
+                )
+            case 'dice':
+                self.criterion = smp.losses.DiceLoss(
+                    mode=self.hparams['task'], ignore_index=ignore_index
+                )
+
+    def configure_metrics(self) -> None:
+        r"""Initialize the performance metrics.
+
+        Includes the following metrics:
+
+        * :class:`~torchmetrics.Accuracy`: :math:`\frac{TP + TN}{P + N}`
+        * :class:`~torchmetrics.Precision`: :math:`\frac{TP}{TP + FP}`
+        * :class:`~torchmetrics.Recall`: :math:`\frac{TP}{P}`
+        * :class:`~torchmetrics.F1Score`: :math:`\frac{2 TP}{2 TP + FP + FN}`
+        * :class:`~torchmetrics.JaccardIndex`: :math:`\frac{TP}{TP + FN + FP}`
+
+        See https://en.wikipedia.org/wiki/Evaluation_of_binary_classifiers
+        for more details.
+
+        Higher values are better for all metrics. All metrics report multiple versions:
+
+        * Overall (micro): Sum statistics over all labels
+        * Average (macro): Calculate statistics for each label and average them
+        * Classwise (none): Calculates statistic for each label and applies no reduction
+        """
+        kwargs = {
+            'task': self.hparams['task'],
+            'num_classes': self.hparams['num_classes'],
+            'num_labels': self.hparams['num_labels'],
+            'ignore_index': self.hparams['ignore_index'],
+        }
+        metrics_dict: dict[str, Metric | MetricCollection] = {}
+        for metric in [Accuracy, Precision, Recall, F1Score, JaccardIndex]:
+            metrics_dict |= {
+                f'Overall{metric.__name__}': metric(average='micro', **kwargs),
+                f'Average{metric.__name__}': metric(average='macro', **kwargs),
+            }
+            if self.hparams['task'] != 'binary':
+                metrics_dict[metric.__name__] = ClasswiseWrapper(
+                    metric(average='none', **kwargs),
+                    labels=self.hparams['labels'],
+                    prefix=f'Classwise{metric.__name__}_',
+                )
+
+        metrics = MetricCollection(metrics_dict)
+        self.train_metrics = metrics.clone(prefix='train_')
+        self.val_metrics = metrics.clone(prefix='val_')
+        self.test_metrics = metrics.clone(prefix='test_')
+
+    def on_train_epoch_end(self) -> None:
+        """Log train metrics."""
+        self.log_dict(self.train_metrics.compute())
+        self.train_metrics.reset()
+
+    def on_validation_epoch_end(self) -> None:
+        """Log validation metrics."""
+        self.log_dict(self.val_metrics.compute())
+        self.val_metrics.reset()
+
+    def on_test_epoch_end(self) -> None:
+        """Log test metrics."""
+        self.log_dict(self.test_metrics.compute())
+        self.test_metrics.reset()

--- a/torchgeo/trainers/segmentation.py
+++ b/torchgeo/trainers/segmentation.py
@@ -10,12 +10,9 @@ from typing import Any, Literal
 import kornia.augmentation as K
 import matplotlib.pyplot as plt
 import segmentation_models_pytorch as smp
-import torch
-import torch.nn as nn
 from einops import rearrange
 from matplotlib.figure import Figure
 from torch import Tensor
-from torchmetrics import Accuracy, JaccardIndex, MetricCollection
 from torchvision.models._api import WeightsEnum
 
 from ..datamodules import BaseDataModule
@@ -23,9 +20,10 @@ from ..datasets import RGBBandsMissingError, unbind_samples
 from ..models import FCN, get_weight
 from . import utils
 from .base import BaseTask
+from .mixins import ClassificationMixin
 
 
-class SemanticSegmentationTask(BaseTask):
+class SemanticSegmentationTask(ClassificationMixin, BaseTask):
     """Semantic Segmentation."""
 
     def __init__(
@@ -39,8 +37,10 @@ class SemanticSegmentationTask(BaseTask):
         task: Literal['binary', 'multiclass', 'multilabel'] = 'multiclass',
         num_classes: int | None = None,
         num_labels: int | None = None,
+        labels: list[str] | None = None,
         num_filters: int = 3,
-        loss: Literal['ce', 'bce', 'jaccard', 'focal'] = 'ce',
+        pos_weight: Tensor | None = None,
+        loss: Literal['ce', 'bce', 'jaccard', 'focal', 'dice'] = 'ce',
         class_weights: Tensor | Sequence[float] | None = None,
         ignore_index: int | None = None,
         lr: float = 1e-3,
@@ -64,9 +64,11 @@ class SemanticSegmentationTask(BaseTask):
             task: One of 'binary', 'multiclass', or 'multilabel'.
             num_classes: Number of prediction classes (only for ``task='multiclass'``).
             num_labels: Number of prediction labels (only for ``task='multilabel'``).
+            labels: List of class names.
             num_filters: Number of filters. Only applicable when model='fcn'.
+            pos_weight: A weight of positive examples and used with 'bce' loss.
             loss: Name of the loss function, currently supports
-                'ce', 'bce', 'jaccard', and 'focal' loss.
+                'ce', 'bce', 'jaccard', 'focal', and 'dice' loss.
             class_weights: Optional rescaling weight given to each
                 class and used with 'ce' loss.
             ignore_index: Optional integer class index to ignore in the loss and
@@ -77,6 +79,9 @@ class SemanticSegmentationTask(BaseTask):
                 decoder and segmentation head.
             freeze_decoder: Freeze the decoder network to linear probe
                 the segmentation head.
+
+        .. versionadded:: 0.9
+           The *labels* and *pos_weight* parameters and dice loss support.
 
         .. versionadded:: 0.8
            Time series, DPT, Segformer, and UPerNet support.
@@ -192,69 +197,6 @@ class SemanticSegmentationTask(BaseTask):
             for param in self.model.decoder.parameters():
                 param.requires_grad = False
 
-    def configure_losses(self) -> None:
-        """Initialize the loss criterion."""
-        ignore_index: int | None = self.hparams['ignore_index']
-        class_weights = self.hparams['class_weights']
-        if class_weights is not None and not isinstance(class_weights, Tensor):
-            class_weights = torch.tensor(class_weights, dtype=torch.float32)
-
-        match self.hparams['loss']:
-            case 'ce':
-                ignore_value = -1000 if ignore_index is None else ignore_index
-                self.criterion: nn.Module = nn.CrossEntropyLoss(
-                    ignore_index=ignore_value, weight=class_weights
-                )
-            case 'bce':
-                self.criterion = nn.BCEWithLogitsLoss()
-            case 'jaccard':
-                # JaccardLoss requires a list of classes to use instead of a class
-                # index to ignore.
-                classes = [
-                    i for i in range(self.hparams['num_classes']) if i != ignore_index
-                ]
-
-                self.criterion = smp.losses.JaccardLoss(
-                    mode=self.hparams['task'], classes=classes
-                )
-            case 'focal':
-                self.criterion = smp.losses.FocalLoss(
-                    mode=self.hparams['task'],
-                    ignore_index=ignore_index,
-                    normalized=True,
-                )
-
-    def configure_metrics(self) -> None:
-        """Initialize the performance metrics.
-
-        * :class:`~torchmetrics.Accuracy`: Overall accuracy
-          (OA) using 'micro' averaging. The number of true positives divided by the
-          dataset size. Higher values are better.
-        * :class:`~torchmetrics.JaccardIndex`: Intersection
-          over union (IoU). Uses 'micro' averaging. Higher valuers are better.
-
-        .. note::
-           * 'Micro' averaging suits overall performance evaluation but may not reflect
-             minority class accuracy.
-           * 'Macro' averaging, not used here, gives equal weight to each class, useful
-             for balanced performance assessment across imbalanced classes.
-        """
-        kwargs = {
-            'task': self.hparams['task'],
-            'num_classes': self.hparams['num_classes'],
-            'num_labels': self.hparams['num_labels'],
-            'ignore_index': self.hparams['ignore_index'],
-        }
-        metrics = MetricCollection(
-            [
-                Accuracy(multidim_average='global', average='micro', **kwargs),
-                JaccardIndex(average='micro', **kwargs),
-            ]
-        )
-        self.train_metrics = metrics.clone(prefix='train_')
-        self.val_metrics = metrics.clone(prefix='val_')
-        self.test_metrics = metrics.clone(prefix='test_')
-
     def training_step(
         self, batch: Any, batch_idx: int, dataloader_idx: int = 0
     ) -> Tensor:
@@ -273,7 +215,6 @@ class SemanticSegmentationTask(BaseTask):
         batch_size = x.shape[0]
         y_hat = self(x).squeeze(1)
         self.train_metrics(y_hat, y)
-        self.log_dict(self.train_metrics, batch_size=batch_size)
 
         if self.hparams['loss'] == 'bce':
             y = y.float()
@@ -298,7 +239,6 @@ class SemanticSegmentationTask(BaseTask):
         batch_size = x.shape[0]
         y_hat = self(x).squeeze(1)
         self.val_metrics(y_hat, y)
-        self.log_dict(self.val_metrics, batch_size=batch_size)
 
         if self.hparams['loss'] == 'bce':
             y = y.float()
@@ -371,7 +311,6 @@ class SemanticSegmentationTask(BaseTask):
         batch_size = x.shape[0]
         y_hat = self(x).squeeze(1)
         self.test_metrics(y_hat, y)
-        self.log_dict(self.test_metrics, batch_size=batch_size)
 
         if self.hparams['loss'] == 'bce':
             y = y.float()


### PR DESCRIPTION
This PR introduces a `ClassificationMixin` that can be shared across all trainers involving patch or pixel classification. In general, I think we should start using mixins more often in our samplers and trainers to avoid code duplication and better support time series variants.

### Pros

* Reduced code duplication
* Ensures consistent feature support across trainers

### New Features

- [x] ClassificationTask: add labels, pos_weight, and ignore_index parameters
- [x] ClassificationTask: add dice loss support
- [x] ClassificationTask: add precision and recall metrics
- [x] SemanticSegmentationTask: add labels and pos_weight parameters
- [x] SemanticSegmentationTask: add dice loss support
- [x] SemanticSegmentationTask: add precision, recall, and F1-score metrics
- [x] ChangeDetectionTask: add labels parameter
- [x] ChangeDetectionTask: add precision and recall metrics
- [x] All three: add overall, average, and class-wise metrics

All while reducing the total number of lines of code 😎 

These could be split into separate PRs if needed.

Closes #2800 
Closes #2130
Closes #2121

@robmarkcole @esmat-fahim47