### PR TITLE
Fix type hint in dataset tests

### DIFF
--- a/tests/datasets/test_geo.py
+++ b/tests/datasets/test_geo.py
@@ -495,8 +495,8 @@ class TestRasterDataset:
     def test_malformed_res(self, x: int, y: int) -> None:
         root = os.path.join('tests', 'data', 'raster', f'res_{x}-{y}_epsg_4087')
         ds = RasterDataset(root)
-        x = ds[ds.bounds]
-        assert torch.all(x['image'] == 1)
+        sample = ds[ds.bounds]
+        assert torch.all(sample['image'] == 1)
 
 
 class TestXarrayDataset:


### PR DESCRIPTION
`x` can't be an int _and_ a sample dict.