### PR TITLE
docs: copilot-instructions -> AGENTS.mds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# TorchGeo Instructions
+# TorchGeo LLM Instructions
 
 Datasets, samplers, transforms, and pre-trained models for geospatial data.
 


### PR DESCRIPTION
Copilot Reviewer now is able to reference custom instructions from `AGENTS.md`. [AGENTS.md](https://agents.md) is currently the standard instructions location for all coding agent providers (not github copilot specific). This should fix the issue in this PR where Claude Code isn't automatically aware of the `~/.github/copilot-instructions.md` https://github.com/torchgeo/torchgeo/pull/3312.

https://docs.github.com/en/copilot/how-tos/configure-custom-instructions/add-repository-instructions#creating-custom-instructions