### PR TITLE
chore: EarthLoc internet access in tests

### DIFF
--- a/torchgeo/models/earthloc.py
+++ b/torchgeo/models/earthloc.py
@@ -159,7 +159,7 @@ class EarthLoc(nn.Module):
         image_size: int = 320,
         desc_dim: int = 4096,
         backbone: str = 'resnet50',
-        pretrained: bool = True,
+        pretrained: bool = False,
     ) -> None:
         """Initialize the EarthLoc model.
 


### PR DESCRIPTION
We shouldn't download ImageNet pretrained ResNet50 backbone weights and then also download the EarthLoc pretrained weights. Let's default the ImageNet weights downloading to False instead of True