### PR TITLE
UNet: do not require internet access during tests

### DIFF
--- a/torchgeo/models/unet.py
+++ b/torchgeo/models/unet.py
@@ -200,9 +200,9 @@ def unet(
         A U-Net model.
     """
     kwargs['arch'] = 'Unet'
+    kwargs['encoder_weights'] = None
 
     if weights:
-        kwargs['encoder_weights'] = None
         kwargs['in_channels'] = weights.meta['in_chans']
         kwargs['encoder_name'] = weights.meta['encoder']
         kwargs['classes'] = weights.meta['num_classes'] if classes is None else classes


### PR DESCRIPTION
Part of #1088 

A bit confusing because technically our API only supports custom weights or None, it doesn't support True/False/etc. But technically None meant that imagenet weights were loaded, which is no longer the case. So technically backwards-incompatible. Not sure if there's a better way to handle this such that imagenet weights are still supported.