### PR TITLE
Geospatial Tutorial: fix hyperspectral image link

### DIFF
--- a/docs/tutorials/geospatial.ipynb
+++ b/docs/tutorials/geospatial.ipynb
@@ -98,6 +98,7 @@
     "\n",
     "<center>\n",
     "<img src=\"https://www.esa.int/var/esa/storage/images/esa_multimedia/images/2014/04/hyperspectral_image_data_cube/14371194-1-eng-GB/Hyperspectral_image_data_cube_pillars.jpg\" width=\"500\">\n",
+    "\n",
     "Photo: ©ESA\n",
     "</center>"
    ]


### PR DESCRIPTION
Previous image link is dead.