### PR TITLE
FarSeg: do not require internet access during tests

### DIFF
--- a/tests/models/test_changestar.py
+++ b/tests/models/test_changestar.py
@@ -17,9 +17,7 @@ SF = [4, 8, 1]
 class TestChangeStar:
     @torch.no_grad()
     def test_changestar_farseg_classes(self) -> None:
-        model = ChangeStarFarSeg(
-            classes=4, backbone='resnet50', backbone_pretrained=False
-        )
+        model = ChangeStarFarSeg(classes=4, backbone='resnet50')
         x = torch.randn(2, 2, 3, 128, 128)
         y = model(x)
 
@@ -27,9 +25,7 @@ class TestChangeStar:
 
     @torch.no_grad()
     def test_changestar_farseg_output_size(self) -> None:
-        model = ChangeStarFarSeg(
-            classes=4, backbone='resnet50', backbone_pretrained=False
-        )
+        model = ChangeStarFarSeg(classes=4, backbone='resnet50')
         model.eval()
         x = torch.randn(2, 2, 3, 128, 128)
         y = model(x)
@@ -46,12 +42,12 @@ class TestChangeStar:
 
     @pytest.mark.parametrize('backbone', BACKBONE)
     def test_valid_changestar_farseg_backbone(self, backbone: str) -> None:
-        ChangeStarFarSeg(classes=4, backbone=backbone, backbone_pretrained=False)
+        ChangeStarFarSeg(classes=4, backbone=backbone)
 
     def test_invalid_changestar_farseg_backbone(self) -> None:
         match = 'unknown backbone: anynet.'
         with pytest.raises(ValueError, match=match):
-            ChangeStarFarSeg(classes=4, backbone='anynet', backbone_pretrained=False)
+            ChangeStarFarSeg(classes=4, backbone='anynet')
 
     @torch.no_grad()
     @pytest.mark.parametrize('inc', IN_CHANNELS)

--- a/tests/models/test_farseg.py
+++ b/tests/models/test_farseg.py
@@ -11,16 +11,10 @@ from torchgeo.models import FarSeg
 class TestFarSeg:
     @torch.no_grad()
     @pytest.mark.parametrize(
-        'backbone,pretrained',
-        [
-            ('resnet18', True),
-            ('resnet34', False),
-            ('resnet50', True),
-            ('resnet101', False),
-        ],
+        'backbone', ['resnet18', 'resnet34', 'resnet50', 'resnet101']
     )
-    def test_valid_backbone(self, backbone: str, pretrained: bool) -> None:
-        model = FarSeg(classes=4, backbone=backbone, backbone_pretrained=pretrained)
+    def test_valid_backbone(self, backbone: str) -> None:
+        model = FarSeg(classes=4, backbone=backbone)
         x = torch.randn(2, 3, 128, 128)
         y = model(x)
 
@@ -29,4 +23,4 @@ class TestFarSeg:
     def test_invalid_backbone(self) -> None:
         match = 'unknown backbone: anynet.'
         with pytest.raises(ValueError, match=match):
-            FarSeg(classes=4, backbone='anynet', backbone_pretrained=False)
+            FarSeg(classes=4, backbone='anynet')

--- a/torchgeo/models/changestar.py
+++ b/torchgeo/models/changestar.py
@@ -8,6 +8,7 @@ import torch.nn as nn
 from einops import rearrange
 from torch import Tensor
 from torch.nn.modules import Module
+from torchvision.models._api import WeightsEnum
 
 from .farseg import FarSeg
 
@@ -188,17 +189,20 @@ class ChangeStarFarSeg(ChangeStar):
         self,
         backbone: str = 'resnet50',
         classes: int = 1,
-        backbone_pretrained: bool = True,
+        backbone_weights: WeightsEnum | None = None,
     ) -> None:
         """Initializes a new ChangeStarFarSeg model.
 
         Args:
             backbone: name of ResNet backbone
             classes: number of output segmentation classes
-            backbone_pretrained: whether to use pretrained weight for backbone
+            backbone_weights: Pre-trained model weights to use.
+
+        .. versionadded:: 0.9
+           The *backbone_weights* parameter.
         """
         model = FarSeg(
-            backbone=backbone, classes=classes, backbone_pretrained=backbone_pretrained
+            backbone=backbone, classes=classes, backbone_weights=backbone_weights
         )
         seg_classifier: Module = model.decoder.classifier
         model.decoder.classifier = nn.modules.Identity()  # type: ignore[assignment]


### PR DESCRIPTION
Alternative to #3342 that keeps the ability to easily use pre-trained backbones but brings FarSeg and ChangeStar more inline with our other models. The user can now specify any weights they want, including models pre-trained on Sentinel imagery.

Closes #3342