### PR TITLE
InstanceSegmentationTask: do not require internet access during tests

### DIFF
--- a/tests/trainers/test_instance_segmentation.py
+++ b/tests/trainers/test_instance_segmentation.py
@@ -71,10 +71,6 @@ class TestInstanceSegmentationTask:
         with pytest.raises(ValueError, match=match):
             InstanceSegmentationTask(backbone='invalid_backbone')
 
-    def test_weights(self) -> None:
-        InstanceSegmentationTask(weights=True, num_classes=3)
-        InstanceSegmentationTask(weights=True, num_classes=91)
-
     def test_no_plot_method(self, monkeypatch: MonkeyPatch, fast_dev_run: bool) -> None:
         monkeypatch.setattr(VHR10DataModule, 'plot', plot)
         datamodule = VHR10DataModule(


### PR DESCRIPTION
Working towards #1088 and #3343. This puts our InstanceSegmentationTask more inline with other tasks, with support for arbitrary WeightsEnum inputs. We probably should also support bool and str like our other tasks, but I was too tired to add tests for this and my goal of avoiding downloads is all I care about right now. Perhaps in a follow-up PR?

If this looks good, I'll do the same thing for ObjectDetectionTask.