### PR TITLE
Increase test coverage

### DIFF
--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -467,7 +467,10 @@ class TestCollateFunctionsMatchingKeys:
 class TestCollateFunctionsDifferingKeys:
     @pytest.fixture(scope='class')
     def samples(self) -> list[Sample]:
-        return [{'image': torch.tensor([1, 2, 0])}, {'mask': torch.tensor([0, 0, 3])}]
+        return [
+            {'image': torch.tensor([1, 2, 0])},
+            {'mask': torch.tensor([0, 0, 3]), 'other': 5},
+        ]
 
     def test_stack_unbind_samples(self, samples: list[Sample]) -> None:
         sample = stack_samples(samples)


### PR DESCRIPTION
#3138 changed our tests to remove crs and convert bounds to a Tensor. As a result, we lost 1 line of coverage for our collation functions that are now only tested with Tensors.

At some point, we will change Sample to only support `dict[str, Tensor]`, at which point we will have to change the collation functions to only check for `dict[str, Tensor]`. Until then, add back a non-Tensor test case.