### PR TITLE
Datasets: fix plot docstring reference to getitem

### DIFF
--- a/torchgeo/datasets/caffe.py
+++ b/torchgeo/datasets/caffe.py
@@ -242,7 +242,7 @@ class CaFFe(NonGeoDataset):
         """Plot a sample from the dataset.
 
         Args:
-            sample: a sample returned by :meth:`CaFFe.__getitem__`
+            sample: a sample returned by :meth:`__getitem__`
             show_titles: flag indicating whether to show titles above each panel
             suptitle: optional string to use as a suptitle
 

--- a/torchgeo/datasets/cdl.py
+++ b/torchgeo/datasets/cdl.py
@@ -341,7 +341,7 @@ class CDL(RasterDataset):
         """Plot a sample from the dataset.
 
         Args:
-            sample: a sample returned by :meth:`RasterDataset.__getitem__`
+            sample: a sample returned by :meth:`__getitem__`
             show_titles: flag indicating whether to show titles above each panel
             suptitle: optional string to use as a suptitle
 

--- a/torchgeo/datasets/dl4gam.py
+++ b/torchgeo/datasets/dl4gam.py
@@ -340,7 +340,7 @@ class DL4GAMAlps(NonGeoDataset):
         """Plot a sample from the dataset.
 
         Args:
-            sample: a sample returned by :meth:`DL4GAMAlps.__getitem__`
+            sample: a sample returned by :meth:`__getitem__`
             show_titles: flag indicating whether to show titles above each panel
             suptitle: optional string to use as a suptitle
             clip_extrema: flag indicating whether to clip the lowest/highest 2.5% of the

--- a/torchgeo/datasets/eurosat.py
+++ b/torchgeo/datasets/eurosat.py
@@ -234,7 +234,7 @@ class EuroSAT(NonGeoClassificationDataset):
         """Plot a sample from the dataset.
 
         Args:
-            sample: a sample returned by :meth:`NonGeoClassificationDataset.__getitem__`
+            sample: a sample returned by :meth:`__getitem__`
             show_titles: flag indicating whether to show titles above each panel
             suptitle: optional string to use as a suptitle
 

--- a/torchgeo/datasets/nccm.py
+++ b/torchgeo/datasets/nccm.py
@@ -174,7 +174,7 @@ class NCCM(RasterDataset):
         """Plot a sample from the dataset.
 
         Args:
-            sample: a sample returned by :meth:`NCCM.__getitem__`
+            sample: a sample returned by :meth:`__getitem__`
             show_titles: flag indicating whether to show titles above each panel
             suptitle: optional string to use as a suptitle
 

--- a/torchgeo/datasets/nlcd.py
+++ b/torchgeo/datasets/nlcd.py
@@ -261,7 +261,7 @@ class NLCD(RasterDataset):
         """Plot a sample from the dataset.
 
         Args:
-            sample: a sample returned by :meth:`RasterDataset.__getitem__`
+            sample: a sample returned by :meth:`__getitem__`
             show_titles: flag indicating whether to show titles above each panel
             suptitle: optional string to use as a suptitle
 

--- a/torchgeo/datasets/skyscript.py
+++ b/torchgeo/datasets/skyscript.py
@@ -164,7 +164,7 @@ class SkyScript(NonGeoDataset):
         """Plot a sample from the dataset.
 
         Args:
-            sample: a sample returned by :meth:`RasterDataset.__getitem__`
+            sample: a sample returned by :meth:`__getitem__`
             show_titles: flag indicating whether to show titles above each panel
             suptitle: optional string to use as a suptitle
 


### PR DESCRIPTION
Many of our `plot` method docstring references to `__getitem__` are either overly constrained or incorrect due to copy-n-paste errors.