### PR TITLE
Add time dimension to TreeSatAI dataset

### DIFF
--- a/torchgeo/datasets/treesatai.py
+++ b/torchgeo/datasets/treesatai.py
@@ -192,7 +192,9 @@ class TreeSatAI(NonGeoDataset):
         sample = {'label': label}
         for directory in self.sensors:
             with rio.open(os.path.join(self.root, directory, '60m', file)) as f:
-                sample[f'image_{directory}'] = torch.tensor(f.read().astype('float32')).unsqueeze(0)
+                sample[f'image_{directory}'] = torch.tensor(
+                    f.read().astype('float32')
+                ).unsqueeze(0)
 
         if self.transforms is not None:
             sample = self.transforms(sample)


### PR DESCRIPTION
The dataset doesn't directly have time-series images. It has one timestamp per location. 

Current shape: C x H x W
New shape: 1 x C x H x W