### PR TITLE
BigEarthNetV2: Correctly pass filename and md5 arguments to download_url()

### DIFF
--- a/torchgeo/datasets/bigearthnet.py
+++ b/torchgeo/datasets/bigearthnet.py
@@ -894,7 +894,12 @@ class BigEarthNetV2(NonGeoDataset):
             for fname, md5 in meta['files'].items():
                 target_path = os.path.join(self.root, fname)
                 if not os.path.exists(target_path):
-                    download_url(self.url.format(fname), self.root, md5)
+                    download_url(
+                        self.url.format(fname),
+                        self.root,
+                        filename=fname,
+                        md5=md5 if self.checksum else None,
+                    )
 
     def _extract(self) -> None:
         """Extract the tarball parts.


### PR DESCRIPTION
Hi,

For BigEarthNetv2, md5 was passed as the filename argument to download_url. This caused the downloaded files to be named after the md5 hash values. BigEarthNetV2._extract method is failing as it expects the right filenames. This silently passed the tests as torchgeo/tests/data/bigearthnet/v2/ contains the right filenames.