### PR TITLE
Tests: don't verify checksum of fake files

### DIFF
--- a/tests/datasets/test_advance.py
+++ b/tests/datasets/test_advance.py
@@ -23,12 +23,10 @@ class TestADVANCE:
             os.path.join(data_dir, 'ADVANCE_vision.zip'),
             os.path.join(data_dir, 'ADVANCE_sound.zip'),
         ]
-        md5s = ['43acacecebecd17a82bc2c1e719fd7e4', '039b7baa47879a8a4e32b9dd8287f6ad']
         monkeypatch.setattr(ADVANCE, 'urls', urls)
-        monkeypatch.setattr(ADVANCE, 'md5s', md5s)
         root = tmp_path
         transforms = nn.Identity()
-        return ADVANCE(root, transforms, download=True, checksum=True)
+        return ADVANCE(root, transforms, download=True)
 
     def test_getitem(self, dataset: ADVANCE) -> None:
         x = dataset[0]

--- a/tests/datasets/test_bigearthnet.py
+++ b/tests/datasets/test_bigearthnet.py
@@ -28,13 +28,13 @@ class TestBigEarthNet:
         metadata = {
             's1': {
                 'url': os.path.join(data_dir, 'BigEarthNet-S1-v1.0.tar.gz'),
-                'md5': '5a64e9ce38deb036a435a7b59494924c',
+                'md5': '',
                 'filename': 'BigEarthNet-S1-v1.0.tar.gz',
                 'directory': 'BigEarthNet-S1-v1.0',
             },
             's2': {
                 'url': os.path.join(data_dir, 'BigEarthNet-S2-v1.0.tar.gz'),
-                'md5': 'ef5f41129b8308ca178b04d7538dbacf',
+                'md5': '',
                 'filename': 'BigEarthNet-S2-v1.0.tar.gz',
                 'directory': 'BigEarthNet-v1.0',
             },
@@ -43,17 +43,17 @@ class TestBigEarthNet:
             'train': {
                 'url': os.path.join(data_dir, 'bigearthnet-train.csv'),
                 'filename': 'bigearthnet-train.csv',
-                'md5': '167ac4d5de8dde7b5aeaa812f42031e7',
+                'md5': '',
             },
             'val': {
                 'url': os.path.join(data_dir, 'bigearthnet-val.csv'),
                 'filename': 'bigearthnet-val.csv',
-                'md5': 'aff594ba256a52e839a3b5fefeb9ef42',
+                'md5': '',
             },
             'test': {
                 'url': os.path.join(data_dir, 'bigearthnet-test.csv'),
                 'filename': 'bigearthnet-test.csv',
-                'md5': '851a6bdda484d47f60e121352dcb1bf5',
+                'md5': '',
             },
         }
         monkeypatch.setattr(BigEarthNet, 'metadata', metadata)
@@ -61,9 +61,7 @@ class TestBigEarthNet:
         bands, num_classes, split = request.param
         root = tmp_path
         transforms = nn.Identity()
-        return BigEarthNet(
-            root, split, bands, num_classes, transforms, download=True, checksum=True
-        )
+        return BigEarthNet(root, split, bands, num_classes, transforms, download=True)
 
     def test_getitem(self, dataset: BigEarthNet) -> None:
         x = dataset[0]
@@ -153,23 +151,13 @@ class TestBigEarthNetV2:
         monkeypatch.setattr(BigEarthNetV2, 'url', url)
         metadata = {
             's1': {
-                'files': {
-                    'BigEarthNet-S1.tar.gzaa': '8101e604552c010178af0bf3645cf391',
-                    'BigEarthNet-S1.tar.gzab': 'e77d4408fc4594407b7b50ec0d43053c',
-                }
+                'files': {'BigEarthNet-S1.tar.gzaa': '', 'BigEarthNet-S1.tar.gzab': ''}
             },
             's2': {
-                'files': {
-                    'BigEarthNet-S2.tar.gzaa': '9c611dc8598b20830d2d79f5a73df294',
-                    'BigEarthNet-S2.tar.gzab': '4e6904c7f60504cceaf90a35401e4262',
-                }
+                'files': {'BigEarthNet-S2.tar.gzaa': '', 'BigEarthNet-S2.tar.gzab': ''}
             },
-            'maps': {
-                'files': {'Reference_Maps.tar.gzaa': 'dd129c68c4902bfae48d7caada03fdc0'}
-            },
-            'metadata': {
-                'files': {'metadata.parquet': 'ad100d6b020f2e693673f77ebbe57891'}
-            },
+            'maps': {'files': {'Reference_Maps.tar.gzaa': ''}},
+            'metadata': {'files': {'metadata.parquet': ''}},
         }
         monkeypatch.setattr(BigEarthNetV2, 'metadata_locs', metadata)
 
@@ -177,9 +165,7 @@ class TestBigEarthNetV2:
 
         root = tmp_path
         transforms = nn.Identity()
-        return BigEarthNetV2(
-            root, split, bands, transforms, download=True, checksum=True
-        )
+        return BigEarthNetV2(root, split, bands, transforms, download=True)
 
     def test_getitem(self, dataset: BigEarthNetV2) -> None:
         """Test loading data."""

--- a/tests/datasets/test_cabuar.py
+++ b/tests/datasets/test_cabuar.py
@@ -34,12 +34,7 @@ class TestCaBuAr:
         root = tmp_path
         transforms = nn.Identity()
         return CaBuAr(
-            root=root,
-            split=split,
-            bands=bands,
-            transforms=transforms,
-            download=True,
-            checksum=True,
+            root=root, split=split, bands=bands, transforms=transforms, download=True
         )
 
     def test_getitem(self, dataset: CaBuAr) -> None:

--- a/tests/datasets/test_caffe.py
+++ b/tests/datasets/test_caffe.py
@@ -20,14 +20,12 @@ class TestCaFFe:
     def dataset(
         self, monkeypatch: MonkeyPatch, tmp_path: Path, request: SubRequest
     ) -> CaFFe:
-        md5 = '73c0aba603c356b2cce9ebf952fb7be0'
-        monkeypatch.setattr(CaFFe, 'md5', md5)
         url = os.path.join('tests', 'data', 'caffe', 'caffe.zip')
         monkeypatch.setattr(CaFFe, 'url', url)
         root = tmp_path
         split = request.param
         transforms = nn.Identity()
-        return CaFFe(root, split, transforms, download=True, checksum=True)
+        return CaFFe(root, split, transforms, download=True)
 
     def test_getitem(self, dataset: CaFFe) -> None:
         x = dataset[0]

--- a/tests/datasets/test_cbf.py
+++ b/tests/datasets/test_cbf.py
@@ -27,16 +27,13 @@ class TestCanadianBuildingFootprints:
         monkeypatch.setattr(
             CanadianBuildingFootprints, 'provinces_territories', ['Alberta']
         )
-        monkeypatch.setattr(
-            CanadianBuildingFootprints, 'md5s', ['25091d1f051baa30d8f2026545cfb696']
-        )
         url = os.path.join('tests', 'data', 'cbf') + os.sep
         monkeypatch.setattr(CanadianBuildingFootprints, 'url', url)
         monkeypatch.setattr(plt, 'show', lambda *args: None)
         root = tmp_path
         transforms = nn.Identity()
         return CanadianBuildingFootprints(
-            root, res=(0.1, 0.1), transforms=transforms, download=True, checksum=True
+            root, res=(0.1, 0.1), transforms=transforms, download=True
         )
 
     def test_getitem(self, dataset: CanadianBuildingFootprints) -> None:

--- a/tests/datasets/test_cdl.py
+++ b/tests/datasets/test_cdl.py
@@ -24,23 +24,12 @@ from torchgeo.datasets import (
 class TestCDL:
     @pytest.fixture
     def dataset(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> CDL:
-        md5s = {
-            2023: '3fbd3eecf92b8ce1ae35060ada463c6d',
-            2022: '826c6fd639d9cdd94a44302fbc5b76c3',
-        }
-        monkeypatch.setattr(CDL, 'md5s', md5s)
         url = os.path.join('tests', 'data', 'cdl', '{}_30m_cdls.zip')
         monkeypatch.setattr(CDL, 'url', url)
         monkeypatch.setattr(plt, 'show', lambda *args: None)
         root = tmp_path
         transforms = nn.Identity()
-        return CDL(
-            root,
-            transforms=transforms,
-            download=True,
-            checksum=True,
-            years=[2023, 2022],
-        )
+        return CDL(root, transforms=transforms, download=True, years=[2023, 2022])
 
     def test_getitem(self, dataset: CDL) -> None:
         x = dataset[dataset.bounds]

--- a/tests/datasets/test_chabud.py
+++ b/tests/datasets/test_chabud.py
@@ -23,19 +23,12 @@ class TestChaBuD:
     ) -> ChaBuD:
         data_dir = os.path.join('tests', 'data', 'chabud')
         url = os.path.join(data_dir, 'train_eval.hdf5')
-        md5 = '1bec048beeb87a865c53f40ab418aa75'
         monkeypatch.setattr(ChaBuD, 'url', url)
-        monkeypatch.setattr(ChaBuD, 'md5', md5)
         bands, split = request.param
         root = tmp_path
         transforms = nn.Identity()
         return ChaBuD(
-            root=root,
-            split=split,
-            bands=bands,
-            transforms=transforms,
-            download=True,
-            checksum=True,
+            root=root, split=split, bands=bands, transforms=transforms, download=True
         )
 
     def test_getitem(self, dataset: ChaBuD) -> None:

--- a/tests/datasets/test_chesapeake.py
+++ b/tests/datasets/test_chesapeake.py
@@ -33,13 +33,11 @@ class TestChesapeakeDC:
             '{state}_lulc_{year}_2022-Edition.zip',
         )
         monkeypatch.setattr(ChesapeakeDC, 'url', url)
-        md5s = {2018: '35c644f13ccdb1baf62adf85cb8c7e48'}
+        md5s = {2018: ''}
         monkeypatch.setattr(ChesapeakeDC, 'md5s', md5s)
         monkeypatch.setattr(plt, 'show', lambda *args: None)
         transforms = nn.Identity()
-        return ChesapeakeDC(
-            tmp_path, transforms=transforms, download=True, checksum=True
-        )
+        return ChesapeakeDC(tmp_path, transforms=transforms, download=True)
 
     def test_getitem(self, dataset: ChesapeakeDC) -> None:
         x = dataset[dataset.bounds]
@@ -69,7 +67,7 @@ class TestChesapeakeDC:
 
     def test_not_downloaded(self, tmp_path: Path) -> None:
         with pytest.raises(DatasetNotFoundError, match='Dataset not found'):
-            ChesapeakeDC(tmp_path, checksum=True)
+            ChesapeakeDC(tmp_path)
 
     def test_plot(self, dataset: ChesapeakeDC) -> None:
         index = dataset.bounds
@@ -99,14 +97,6 @@ class TestChesapeakeCVPR:
     def dataset(
         self, request: SubRequest, monkeypatch: MonkeyPatch, tmp_path: Path
     ) -> ChesapeakeCVPR:
-        monkeypatch.setattr(
-            ChesapeakeCVPR,
-            'md5s',
-            {
-                'base': '882d18b1f15ea4498bf54e674aecd5d4',
-                'prior_extension': '677446c486f3145787938b14ee3da13f',
-            },
-        )
         monkeypatch.setattr(
             ChesapeakeCVPR,
             'urls',
@@ -140,7 +130,6 @@ class TestChesapeakeCVPR:
             layers=request.param,
             transforms=transforms,
             download=True,
-            checksum=True,
         )
 
     def test_getitem(self, dataset: ChesapeakeCVPR) -> None:
@@ -184,7 +173,7 @@ class TestChesapeakeCVPR:
 
     def test_not_downloaded(self, tmp_path: Path) -> None:
         with pytest.raises(DatasetNotFoundError, match='Dataset not found'):
-            ChesapeakeCVPR(tmp_path, checksum=True)
+            ChesapeakeCVPR(tmp_path)
 
     def test_out_of_bounds_index(self, dataset: ChesapeakeCVPR) -> None:
         with pytest.raises(

--- a/tests/datasets/test_cms_mangrove_canopy.py
+++ b/tests/datasets/test_cms_mangrove_canopy.py
@@ -26,17 +26,10 @@ class TestCMSGlobalMangroveCanopy:
     ) -> CMSGlobalMangroveCanopy:
         zipfile = 'CMS_Global_Map_Mangrove_Canopy_1665.zip'
         monkeypatch.setattr(CMSGlobalMangroveCanopy, 'zipfile', zipfile)
-
-        md5 = 'd6894fa6293cc9c0f3f95a810e842de5'
-        monkeypatch.setattr(CMSGlobalMangroveCanopy, 'md5', md5)
-
         root = os.path.join('tests', 'data', 'cms_mangrove_canopy')
         transforms = nn.Identity()
         country = 'Angola'
-
-        return CMSGlobalMangroveCanopy(
-            root, country=country, transforms=transforms, checksum=True
-        )
+        return CMSGlobalMangroveCanopy(root, country=country, transforms=transforms)
 
     def test_getitem(self, dataset: CMSGlobalMangroveCanopy) -> None:
         x = dataset[dataset.bounds]

--- a/tests/datasets/test_cowc.py
+++ b/tests/datasets/test_cowc.py
@@ -28,21 +28,10 @@ class TestCOWCCounting:
     ) -> COWC:
         base_url = os.path.join('tests', 'data', 'cowc_counting') + os.sep
         monkeypatch.setattr(COWCCounting, 'base_url', base_url)
-        md5s = [
-            '7d0c6d1fb548d3ea3a182a56ce231f97',
-            '2e9a806b19b21f9d796c7393ad8f51ee',
-            '39453c0627effd908e773c5c1f8aecc9',
-            '67190b3e0ca8aa1fc93250aa5383a8f3',
-            '575aead6a0c92aba37d613895194da7c',
-            'e7c2279040d3ce31b9c925c45d0c61e2',
-            'f159e23d52bd0b5656fe296f427b98e1',
-            '0a4daed8c5f6c4e20faa6e38636e4346',
-        ]
-        monkeypatch.setattr(COWCCounting, 'md5s', md5s)
         root = tmp_path
         split = request.param
         transforms = nn.Identity()
-        return COWCCounting(root, split, transforms, download=True, checksum=True)
+        return COWCCounting(root, split, transforms, download=True)
 
     def test_getitem(self, dataset: COWC) -> None:
         x = dataset[0]
@@ -91,21 +80,10 @@ class TestCOWCDetection:
     ) -> COWC:
         base_url = os.path.join('tests', 'data', 'cowc_detection') + os.sep
         monkeypatch.setattr(COWCDetection, 'base_url', base_url)
-        md5s = [
-            '6bbbdb36ee4922e879f66ed9234cb8ab',
-            '09e4af08c6e6553afe5098b328ce9749',
-            '12a2708ab7644766e43f5aae34aa7f2a',
-            'a896433398a0c58263c0d266cfc93bc4',
-            '911ed42c104db60f7a7d03a5b36bc1ab',
-            '4cdb4fefab6a2951591e7840c11a229d',
-            'dd315cfb48dfa7ddb8230c942682bc37',
-            'dccc2257e9c4a9dde2b4f84769804046',
-        ]
-        monkeypatch.setattr(COWCDetection, 'md5s', md5s)
         root = tmp_path
         split = request.param
         transforms = nn.Identity()
-        return COWCDetection(root, split, transforms, download=True, checksum=True)
+        return COWCDetection(root, split, transforms, download=True)
 
     def test_getitem(self, dataset: COWC) -> None:
         x = dataset[0]

--- a/tests/datasets/test_cropharvest.py
+++ b/tests/datasets/test_cropharvest.py
@@ -20,12 +20,6 @@ class TestCropHarvest:
     @pytest.fixture
     def dataset(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> CropHarvest:
         monkeypatch.setitem(
-            CropHarvest.file_dict['features'], 'md5', 'ef6f4f00c0b3b50ed8380b0044928572'
-        )
-        monkeypatch.setitem(
-            CropHarvest.file_dict['labels'], 'md5', '1d93b6bfcec7b6797b75acbd9d284b92'
-        )
-        monkeypatch.setitem(
             CropHarvest.file_dict['features'],
             'url',
             os.path.join('tests', 'data', 'cropharvest', 'features.tar.gz'),
@@ -39,7 +33,7 @@ class TestCropHarvest:
         root = tmp_path
         transforms = nn.Identity()
 
-        dataset = CropHarvest(root, transforms, download=True, checksum=True)
+        dataset = CropHarvest(root, transforms, download=True)
         return dataset
 
     def test_getitem(self, dataset: CropHarvest) -> None:

--- a/tests/datasets/test_deepglobelandcover.py
+++ b/tests/datasets/test_deepglobelandcover.py
@@ -10,22 +10,17 @@ import pytest
 import torch
 import torch.nn as nn
 from _pytest.fixtures import SubRequest
-from pytest import MonkeyPatch
 
 from torchgeo.datasets import DatasetNotFoundError, DeepGlobeLandCover
 
 
 class TestDeepGlobeLandCover:
     @pytest.fixture(params=['train', 'test'])
-    def dataset(
-        self, monkeypatch: MonkeyPatch, request: SubRequest
-    ) -> DeepGlobeLandCover:
-        md5 = '2cbd68d36b1485f09f32d874dde7c5c5'
-        monkeypatch.setattr(DeepGlobeLandCover, 'md5', md5)
+    def dataset(self, request: SubRequest) -> DeepGlobeLandCover:
         root = os.path.join('tests', 'data', 'deepglobelandcover')
         split = request.param
         transforms = nn.Identity()
-        return DeepGlobeLandCover(root, split, transforms, checksum=True)
+        return DeepGlobeLandCover(root, split, transforms)
 
     def test_getitem(self, dataset: DeepGlobeLandCover) -> None:
         x = dataset[0]

--- a/tests/datasets/test_dfc2022.py
+++ b/tests/datasets/test_dfc2022.py
@@ -10,29 +10,17 @@ import pytest
 import torch
 import torch.nn as nn
 from _pytest.fixtures import SubRequest
-from pytest import MonkeyPatch
 
 from torchgeo.datasets import DFC2022, DatasetNotFoundError
 
 
 class TestDFC2022:
     @pytest.fixture(params=['train', 'train-unlabeled', 'val'])
-    def dataset(self, monkeypatch: MonkeyPatch, request: SubRequest) -> DFC2022:
-        monkeypatch.setitem(
-            DFC2022.metadata['train'], 'md5', '6e380c4fa659d05ca93be71b50cacd90'
-        )
-        monkeypatch.setitem(
-            DFC2022.metadata['train-unlabeled'],
-            'md5',
-            'b2bf3839323d4eae636f198921442945',
-        )
-        monkeypatch.setitem(
-            DFC2022.metadata['val'], 'md5', 'e018dc6865bd3086738038fff27b818a'
-        )
+    def dataset(self, request: SubRequest) -> DFC2022:
         root = os.path.join('tests', 'data', 'dfc2022')
         split = request.param
         transforms = nn.Identity()
-        return DFC2022(root, split, transforms, checksum=True)
+        return DFC2022(root, split, transforms)
 
     def test_getitem(self, dataset: DFC2022) -> None:
         x = dataset[0]

--- a/tests/datasets/test_digital_typhoon.py
+++ b/tests/datasets/test_digital_typhoon.py
@@ -32,11 +32,6 @@ class TestDigitalTyphoon:
         url = os.path.join('tests', 'data', 'digital_typhoon', 'WP.tar.gz{0}')
         monkeypatch.setattr(DigitalTyphoon, 'url', url)
 
-        md5sums = {
-            'aa': '692ea3796c9bc9ef1e0ab6f2b8bc51ad',
-            'ab': '692ea3796c9bc9ef1e0ab6f2b8bc51ad',
-        }
-        monkeypatch.setattr(DigitalTyphoon, 'md5sums', md5sums)
         root = tmp_path
 
         transforms = nn.Identity()
@@ -47,7 +42,6 @@ class TestDigitalTyphoon:
             max_feature_value=max_features,
             transforms=transforms,
             download=True,
-            checksum=True,
         )
 
     def test_len(self, dataset: DigitalTyphoon) -> None:

--- a/tests/datasets/test_dior.py
+++ b/tests/datasets/test_dior.py
@@ -25,29 +25,16 @@ class TestDIOR:
 
         files = {
             'trainval': {
-                'images': {
-                    'filename': 'Images_trainval.zip',
-                    'md5': '585e21ddd28fdf1166e463db43cfe68d',
-                },
-                'labels': {
-                    'filename': 'Annotations_trainval.zip',
-                    'md5': 'dcc93fa421804515029a5a574f34fafc',
-                },
+                'images': {'filename': 'Images_trainval.zip', 'md5': ''},
+                'labels': {'filename': 'Annotations_trainval.zip', 'md5': ''},
             },
-            'test': {
-                'images': {
-                    'filename': 'Images_test.zip',
-                    'md5': '0273920291def20cec60849b35eca713',
-                }
-            },
+            'test': {'images': {'filename': 'Images_test.zip', 'md5': ''}},
         }
         monkeypatch.setattr(DIOR, 'files', files)
         root = tmp_path
         split = request.param
         transforms = nn.Identity()
-        return DIOR(
-            root=root, split=split, transforms=transforms, download=True, checksum=True
-        )
+        return DIOR(root=root, split=split, transforms=transforms, download=True)
 
     def test_already_downloaded(self, dataset: DIOR) -> None:
         DIOR(root=dataset.root, download=True)

--- a/tests/datasets/test_dl4gam.py
+++ b/tests/datasets/test_dl4gam.py
@@ -32,18 +32,9 @@ class TestDL4GAMAlps:
     ) -> DL4GAMAlps:
         url = Path('tests', 'data', 'dl4gam_alps')
         download_metadata = {
-            'dataset_small': {
-                'url': str(url / 'dataset_small.tar.gz'),
-                'checksum': '35f85360b943caa8661d9fb573b0f0b5',
-            },
-            'dataset_large': {
-                'url': str(url / 'dataset_large.tar.gz'),
-                'checksum': '636be5be35b8bd1e7771e9010503e4bc',
-            },
-            'splits_csv': {
-                'url': str(url / 'splits.csv'),
-                'checksum': '973367465c8ab322d0cf544a345b02f5',
-            },
+            'dataset_small': {'url': str(url / 'dataset_small.tar.gz'), 'checksum': ''},
+            'dataset_large': {'url': str(url / 'dataset_large.tar.gz'), 'checksum': ''},
+            'splits_csv': {'url': str(url / 'splits.csv'), 'checksum': ''},
         }
 
         monkeypatch.setattr(DL4GAMAlps, 'download_metadata', download_metadata)
@@ -59,7 +50,6 @@ class TestDL4GAMAlps:
             extra_features,
             transforms,
             download=True,
-            checksum=True,
         )
 
     def test_getitem(self, dataset: DL4GAMAlps) -> None:

--- a/tests/datasets/test_dota.py
+++ b/tests/datasets/test_dota.py
@@ -31,62 +31,26 @@ class TestDOTA:
         file_info = {
             'train': {
                 'images': {
-                    '1.0': {
-                        'filename': 'dotav1.0_images_train.tar.gz',
-                        'md5': '126d42cc8b2c093e7914528ac01ea8fc',
-                    },
-                    '1.5': {
-                        'filename': 'dotav1.0_images_train.tar.gz',
-                        'md5': 'fd187ea8acc3d429f0ba9e5ef96def75',
-                    },
-                    '2.0': {
-                        'filename': 'dotav2.0_images_train.tar.gz',
-                        'md5': '613d192b70dc53fe7e10f95eed0e1a9d',
-                    },
+                    '1.0': {'filename': 'dotav1.0_images_train.tar.gz', 'md5': ''},
+                    '1.5': {'filename': 'dotav1.0_images_train.tar.gz', 'md5': ''},
+                    '2.0': {'filename': 'dotav2.0_images_train.tar.gz', 'md5': ''},
                 },
                 'annotations': {
-                    '1.0': {
-                        'filename': 'dotav1.0_annotations_train.tar.gz',
-                        'md5': '1fbdb35e2d55cab2632a8c20ed54a6de',
-                    },
-                    '1.5': {
-                        'filename': 'dotav1.5_annotations_train.tar.gz',
-                        'md5': '7a7ed5a309acb45dd1885f088fa24783',
-                    },
-                    '2.0': {
-                        'filename': 'dotav2.0_annotations_train.tar.gz',
-                        'md5': 'f8cd1bf53362bd372ddc2fba97cff2b6',
-                    },
+                    '1.0': {'filename': 'dotav1.0_annotations_train.tar.gz', 'md5': ''},
+                    '1.5': {'filename': 'dotav1.5_annotations_train.tar.gz', 'md5': ''},
+                    '2.0': {'filename': 'dotav2.0_annotations_train.tar.gz', 'md5': ''},
                 },
             },
             'val': {
                 'images': {
-                    '1.0': {
-                        'filename': 'dotav1.0_images_val.tar.gz',
-                        'md5': 'f73dbdc8aa4e580dda4ef6cb54cfbd68',
-                    },
-                    '1.5': {
-                        'filename': 'dotav1.0_images_val.tar.gz',
-                        'md5': 'b1c618180e0ca3e4426ecf53b82c8d74',
-                    },
-                    '2.0': {
-                        'filename': 'dotav2.0_images_val.tar.gz',
-                        'md5': '0950df7a4c700934572f3a9a85133520',
-                    },
+                    '1.0': {'filename': 'dotav1.0_images_val.tar.gz', 'md5': ''},
+                    '1.5': {'filename': 'dotav1.0_images_val.tar.gz', 'md5': ''},
+                    '2.0': {'filename': 'dotav2.0_images_val.tar.gz', 'md5': ''},
                 },
                 'annotations': {
-                    '1.0': {
-                        'filename': 'dotav1.0_annotations_val.tar.gz',
-                        'md5': '700fd2e7cba8dd543ca5bcbe411c9db4',
-                    },
-                    '1.5': {
-                        'filename': 'dotav1.5_annotations_val.tar.gz',
-                        'md5': 'f0a32911fa3614a8de67f5fd8d04dd9e',
-                    },
-                    '2.0': {
-                        'filename': 'dotav2.0_annotations_val.tar.gz',
-                        'md5': '4823cdc2c35d5f74254ffab0d99ea876',
-                    },
+                    '1.0': {'filename': 'dotav1.0_annotations_val.tar.gz', 'md5': ''},
+                    '1.5': {'filename': 'dotav1.5_annotations_val.tar.gz', 'md5': ''},
+                    '2.0': {'filename': 'dotav2.0_annotations_val.tar.gz', 'md5': ''},
                 },
             },
         }

--- a/tests/datasets/test_enviroatlas.py
+++ b/tests/datasets/test_enviroatlas.py
@@ -32,7 +32,6 @@ class TestEnviroAtlas:
     def dataset(
         self, request: SubRequest, monkeypatch: MonkeyPatch, tmp_path: Path
     ) -> EnviroAtlas:
-        monkeypatch.setattr(EnviroAtlas, 'md5', '071ec65c611e1d4915a5247bffb5ad87')
         monkeypatch.setattr(
             EnviroAtlas,
             'url',
@@ -51,7 +50,6 @@ class TestEnviroAtlas:
             transforms=transforms,
             prior_as_input=request.param[1],
             download=True,
-            checksum=True,
         )
 
     def test_getitem(self, dataset: EnviroAtlas) -> None:
@@ -82,7 +80,7 @@ class TestEnviroAtlas:
 
     def test_not_downloaded(self, tmp_path: Path) -> None:
         with pytest.raises(DatasetNotFoundError, match='Dataset not found'):
-            EnviroAtlas(tmp_path, checksum=True)
+            EnviroAtlas(tmp_path)
 
     def test_out_of_bounds_index(self, dataset: EnviroAtlas) -> None:
         with pytest.raises(

--- a/tests/datasets/test_esri2020.py
+++ b/tests/datasets/test_esri2020.py
@@ -26,8 +26,6 @@ class TestEsri2020:
         zipfile = 'io-lulc-model-001-v01-composite-v03-supercell-v02-clip-v01.zip'
         monkeypatch.setattr(Esri2020, 'zipfile', zipfile)
 
-        md5 = '34aec55538694171c7b605b0cc0d0138'
-        monkeypatch.setattr(Esri2020, 'md5', md5)
         url = os.path.join(
             'tests',
             'data',
@@ -37,7 +35,7 @@ class TestEsri2020:
         monkeypatch.setattr(Esri2020, 'url', url)
         root = tmp_path
         transforms = nn.Identity()
-        return Esri2020(root, transforms=transforms, download=True, checksum=True)
+        return Esri2020(root, transforms=transforms, download=True)
 
     def test_getitem(self, dataset: Esri2020) -> None:
         x = dataset[dataset.bounds]
@@ -62,7 +60,7 @@ class TestEsri2020:
 
     def test_not_downloaded(self, tmp_path: Path) -> None:
         with pytest.raises(DatasetNotFoundError, match='Dataset not found'):
-            Esri2020(tmp_path, checksum=True)
+            Esri2020(tmp_path)
 
     def test_and(self, dataset: Esri2020) -> None:
         ds = dataset & dataset

--- a/tests/datasets/test_etci2021.py
+++ b/tests/datasets/test_etci2021.py
@@ -23,19 +23,16 @@ class TestETCI2021:
         metadata = {
             'train': {
                 'filename': 'train.zip',
-                'md5': 'bd55f2116e43a35d5b94a765938be2aa',
                 'directory': 'train',
                 'url': os.path.join(data_dir, 'train.zip'),
             },
             'val': {
                 'filename': 'val_with_ref_labels.zip',
-                'md5': '96ed69904043e514c13c14ffd3ec45cd',
                 'directory': 'test',
                 'url': os.path.join(data_dir, 'val_with_ref_labels.zip'),
             },
             'test': {
                 'filename': 'test_without_ref_labels.zip',
-                'md5': '1b66d85e22c8f5b0794b3542c5ea09ef',
                 'directory': 'test_internal',
                 'url': os.path.join(data_dir, 'test_without_ref_labels.zip'),
             },
@@ -44,7 +41,7 @@ class TestETCI2021:
         root = tmp_path
         split = request.param
         transforms = nn.Identity()
-        return ETCI2021(root, split, transforms, download=True, checksum=True)
+        return ETCI2021(root, split, transforms, download=True)
 
     def test_getitem(self, dataset: ETCI2021) -> None:
         x = dataset[0]

--- a/tests/datasets/test_eudem.py
+++ b/tests/datasets/test_eudem.py
@@ -10,7 +10,6 @@ import pandas as pd
 import pytest
 import torch
 import torch.nn as nn
-from pytest import MonkeyPatch
 
 from torchgeo.datasets import (
     EUDEM,
@@ -22,9 +21,7 @@ from torchgeo.datasets import (
 
 class TestEUDEM:
     @pytest.fixture
-    def dataset(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> EUDEM:
-        md5s = {'eu_dem_v11_E30N10.zip': 'ef148466c02197a08be169eaad186591'}
-        monkeypatch.setattr(EUDEM, 'md5s', md5s)
+    def dataset(self, tmp_path: Path) -> EUDEM:
         zipfile = os.path.join('tests', 'data', 'eudem', 'eu_dem_v11_E30N10.zip')
         shutil.copy(zipfile, tmp_path)
         root = tmp_path

--- a/tests/datasets/test_eurocrops.py
+++ b/tests/datasets/test_eurocrops.py
@@ -26,10 +26,8 @@ class TestEuroCrops:
         self, monkeypatch: MonkeyPatch, tmp_path: Path, request: SubRequest
     ) -> EuroCrops:
         classes = request.param
-        monkeypatch.setattr(
-            EuroCrops, 'zenodo_files', [('AA.zip', 'b2ef5cac231294731c1dfea47cba544d')]
-        )
-        monkeypatch.setattr(EuroCrops, 'hcat_md5', '22d61cf3b316c8babfd209ae81419d8f')
+        monkeypatch.setattr(EuroCrops, 'zenodo_files', [('AA.zip', '')])
+        monkeypatch.setattr(EuroCrops, 'hcat_md5', '')
         base_url = os.path.join('tests', 'data', 'eurocrops') + os.sep
         monkeypatch.setattr(EuroCrops, 'base_url', base_url)
         monkeypatch.setattr(plt, 'show', lambda *args: None)

--- a/tests/datasets/test_everwatch.py
+++ b/tests/datasets/test_everwatch.py
@@ -19,12 +19,10 @@ class TestEverWatch:
     def dataset(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> EverWatch:
         data_dir = os.path.join('tests', 'data', 'everwatch')
         url = os.path.join(data_dir, 'everwatch-benchmark.zip')
-        md5 = '6d797a56dc7edea89109b38c47c55e53'
         monkeypatch.setattr(EverWatch, 'url', url)
-        monkeypatch.setattr(EverWatch, 'md5', md5)
         root = tmp_path
         transforms = nn.Identity()
-        return EverWatch(root=root, transforms=transforms, download=True, checksum=True)
+        return EverWatch(root=root, transforms=transforms, download=True)
 
     def test_already_downloaded(self, dataset: EverWatch) -> None:
         EverWatch(root=dataset.root, download=True)

--- a/tests/datasets/test_fair1m.py
+++ b/tests/datasets/test_fair1m.py
@@ -39,29 +39,11 @@ class TestFAIR1M:
                 os.path.join(self.test_root, 'test', 'images2.zip'),
             ),
         }
-        md5s = {
-            'train': (
-                'ffbe9329e51ae83161ce24b5b46dc934',
-                '2db6fbe64be6ebb0a03656da6c6effe7',
-                '401b0f1d75d9d23f2e088bfeaf274cfa',
-                'd62b18eae8c3201f6112c2e9db84d605',
-            ),
-            'val': (
-                '83d2f06574fc7158ded0eb1fb256c8fe',
-                '316490b200503c54cf43835a341b6dbe',
-            ),
-            'test': (
-                '3c02845752667b96a5749c90c7fdc994',
-                '9359107f1d0abac6a5b98725f4064bc0',
-                'd7bc2985c625ffd47d86cdabb2a9d2bc',
-            ),
-        }
         monkeypatch.setattr(FAIR1M, 'urls', urls)
-        monkeypatch.setattr(FAIR1M, 'md5s', md5s)
         root = tmp_path
         split = request.param
         transforms = nn.Identity()
-        return FAIR1M(root, split, transforms, download=True, checksum=True)
+        return FAIR1M(root, split, transforms, download=True)
 
     def test_getitem(self, dataset: FAIR1M) -> None:
         x = dataset[0]
@@ -95,11 +77,9 @@ class TestFAIR1M:
             os.makedirs(os.path.dirname(output), exist_ok=True)
             shutil.copy(url, output)
 
-        FAIR1M(root=tmp_path, split=dataset.split, checksum=True)
+        FAIR1M(root=tmp_path, split=dataset.split)
 
     def test_corrupted(self, tmp_path: Path, dataset: FAIR1M) -> None:
-        md5s = tuple(['randomhash'] * len(FAIR1M.md5s[dataset.split]))
-        FAIR1M.md5s[dataset.split] = md5s
         shutil.rmtree(dataset.root)
         for filepath, url in zip(
             dataset.paths[dataset.split], dataset.urls[dataset.split]

--- a/tests/datasets/test_fire_risk.py
+++ b/tests/datasets/test_fire_risk.py
@@ -21,13 +21,11 @@ class TestFireRisk:
         self, monkeypatch: MonkeyPatch, tmp_path: Path, request: SubRequest
     ) -> FireRisk:
         url = os.path.join('tests', 'data', 'fire_risk', 'FireRisk.zip')
-        md5 = 'db22106d61b10d855234b4a74db921ac'
-        monkeypatch.setattr(FireRisk, 'md5', md5)
         monkeypatch.setattr(FireRisk, 'url', url)
         root = tmp_path
         split = request.param
         transforms = nn.Identity()
-        return FireRisk(root, split, transforms, download=True, checksum=True)
+        return FireRisk(root, split, transforms, download=True)
 
     def test_getitem(self, dataset: FireRisk) -> None:
         x = dataset[0]

--- a/tests/datasets/test_forestdamage.py
+++ b/tests/datasets/test_forestdamage.py
@@ -19,14 +19,10 @@ class TestForestDamage:
     def dataset(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> ForestDamage:
         data_dir = os.path.join('tests', 'data', 'forestdamage')
         url = os.path.join(data_dir, 'Data_Set_Larch_Casebearer.zip')
-        md5 = '52d82ac38899e6e6bb40aacda643ee15'
         monkeypatch.setattr(ForestDamage, 'url', url)
-        monkeypatch.setattr(ForestDamage, 'md5', md5)
         root = tmp_path
         transforms = nn.Identity()
-        return ForestDamage(
-            root=root, transforms=transforms, download=True, checksum=True
-        )
+        return ForestDamage(root=root, transforms=transforms, download=True)
 
     def test_already_downloaded(self, dataset: ForestDamage) -> None:
         ForestDamage(root=dataset.root, download=True)

--- a/tests/datasets/test_ftw.py
+++ b/tests/datasets/test_ftw.py
@@ -29,23 +29,12 @@ class TestFieldsOfTheWorld:
         split, task = request.param
 
         monkeypatch.setattr(FieldsOfTheWorld, 'valid_countries', ['austria'])
-        monkeypatch.setattr(
-            FieldsOfTheWorld,
-            'country_to_md5',
-            {'austria': '1cf9593c9bdceeaba21bbcb24d35816c'},
-        )
         base_url = os.path.join('tests', 'data', 'ftw') + '/'
         monkeypatch.setattr(FieldsOfTheWorld, 'base_url', base_url)
         root = tmp_path
         transforms = nn.Identity()
         return FieldsOfTheWorld(
-            root,
-            split,
-            task,
-            countries='austria',
-            transforms=transforms,
-            download=True,
-            checksum=True,
+            root, split, task, countries='austria', transforms=transforms, download=True
         )
 
     def test_getitem(self, dataset: FieldsOfTheWorld) -> None:

--- a/tests/datasets/test_geonrw.py
+++ b/tests/datasets/test_geonrw.py
@@ -20,8 +20,6 @@ class TestGeoNRW:
     def dataset(
         self, monkeypatch: MonkeyPatch, tmp_path: Path, request: SubRequest
     ) -> GeoNRW:
-        md5 = '6ffc014d4b345bba3076e8d76ab481fa'
-        monkeypatch.setattr(GeoNRW, 'md5', md5)
         url = os.path.join('tests', 'data', 'geonrw', 'nrw_dataset.tar.gz')
         monkeypatch.setattr(GeoNRW, 'url', url)
         monkeypatch.setattr(GeoNRW, 'train_list', ['aachen', 'bergisch', 'bielefeld'])
@@ -29,7 +27,7 @@ class TestGeoNRW:
         root = tmp_path
         split = request.param
         transforms = nn.Identity()
-        return GeoNRW(root, split, transforms, download=True, checksum=True)
+        return GeoNRW(root, split, transforms, download=True)
 
     def test_getitem(self, dataset: GeoNRW) -> None:
         x = dataset[0]

--- a/tests/datasets/test_gid15.py
+++ b/tests/datasets/test_gid15.py
@@ -19,14 +19,12 @@ class TestGID15:
     def dataset(
         self, monkeypatch: MonkeyPatch, tmp_path: Path, request: SubRequest
     ) -> GID15:
-        md5 = '3d5b1373ef9a3084ec493b9b2056fe07'
-        monkeypatch.setattr(GID15, 'md5', md5)
         url = os.path.join('tests', 'data', 'gid15', 'gid-15.zip')
         monkeypatch.setattr(GID15, 'url', url)
         root = tmp_path
         split = request.param
         transforms = nn.Identity()
-        return GID15(root, split, transforms, download=True, checksum=True)
+        return GID15(root, split, transforms, download=True)
 
     def test_getitem(self, dataset: GID15) -> None:
         x = dataset[0]

--- a/tests/datasets/test_globbiomass.py
+++ b/tests/datasets/test_globbiomass.py
@@ -10,7 +10,6 @@ import pandas as pd
 import pytest
 import torch
 import torch.nn as nn
-from pytest import MonkeyPatch
 
 from torchgeo.datasets import (
     DatasetNotFoundError,
@@ -22,23 +21,16 @@ from torchgeo.datasets import (
 
 class TestGlobBiomass:
     @pytest.fixture
-    def dataset(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> GlobBiomass:
+    def dataset(self, tmp_path: Path) -> GlobBiomass:
         shutil.copy(
             os.path.join('tests', 'data', 'globbiomass', 'N00E020_agb.zip'), tmp_path
         )
         shutil.copy(
             os.path.join('tests', 'data', 'globbiomass', 'N00E020_gsv.zip'), tmp_path
         )
-
-        md5s = {
-            'N00E020_agb.zip': '22e11817ede672a2a76b8a5588bc4bf4',
-            'N00E020_gsv.zip': 'e79bf051ac5d659cb21c566c53ce7b98',
-        }
-
-        monkeypatch.setattr(GlobBiomass, 'md5s', md5s)
         root = tmp_path
         transforms = nn.Identity()
-        return GlobBiomass(root, transforms=transforms, checksum=True)
+        return GlobBiomass(root, transforms=transforms)
 
     def test_getitem(self, dataset: GlobBiomass) -> None:
         x = dataset[dataset.bounds]
@@ -53,7 +45,7 @@ class TestGlobBiomass:
 
     def test_not_downloaded(self, tmp_path: Path) -> None:
         with pytest.raises(DatasetNotFoundError, match='Dataset not found'):
-            GlobBiomass(tmp_path, checksum=True)
+            GlobBiomass(tmp_path)
 
     def test_corrupted(self, tmp_path: Path) -> None:
         with open(os.path.join(tmp_path, 'N00E020_agb.zip'), 'w') as f:

--- a/tests/datasets/test_idtrees.py
+++ b/tests/datasets/test_idtrees.py
@@ -27,12 +27,12 @@ class TestIDTReeS:
         metadata = {
             'train': {
                 'url': os.path.join(data_dir, 'IDTREES_competition_train_v2.zip'),
-                'md5': '5ddfa76240b4bb6b4a7861d1d31c299c',
+                'md5': '',
                 'filename': 'IDTREES_competition_train_v2.zip',
             },
             'test': {
                 'url': os.path.join(data_dir, 'IDTREES_competition_test_v2.zip'),
-                'md5': 'b108931c84a70f2a38a8234290131c9b',
+                'md5': '',
                 'filename': 'IDTREES_competition_test_v2.zip',
             },
         }
@@ -40,7 +40,7 @@ class TestIDTReeS:
         monkeypatch.setattr(IDTReeS, 'metadata', metadata)
         root = tmp_path
         transforms = nn.Identity()
-        return IDTReeS(root, split, task, transforms, download=True, checksum=True)
+        return IDTReeS(root, split, task, transforms, download=True)
 
     def test_getitem(self, dataset: IDTReeS) -> None:
         x = dataset[0]

--- a/tests/datasets/test_inria.py
+++ b/tests/datasets/test_inria.py
@@ -20,11 +20,9 @@ class TestInriaAerialImageLabeling:
         self, request: SubRequest, monkeypatch: MonkeyPatch
     ) -> InriaAerialImageLabeling:
         root = os.path.join('tests', 'data', 'inria')
-        test_md5 = '3ecbe95eb84aea064e455c4321546be1'
-        monkeypatch.setattr(InriaAerialImageLabeling, 'md5', test_md5)
         transforms = nn.Identity()
         return InriaAerialImageLabeling(
-            root, split=request.param, transforms=transforms, checksum=True
+            root, split=request.param, transforms=transforms
         )
 
     def test_getitem(self, dataset: InriaAerialImageLabeling) -> None:
@@ -53,7 +51,6 @@ class TestInriaAerialImageLabeling:
             InriaAerialImageLabeling(tmp_path)
 
     def test_dataset_checksum(self, dataset: InriaAerialImageLabeling) -> None:
-        InriaAerialImageLabeling.md5 = 'randommd5hash123'
         shutil.rmtree(os.path.join(dataset.root, dataset.directory))
         with pytest.raises(RuntimeError, match='Dataset corrupted'):
             InriaAerialImageLabeling(root=dataset.root, checksum=True)

--- a/tests/datasets/test_iobench.py
+++ b/tests/datasets/test_iobench.py
@@ -25,13 +25,11 @@ from torchgeo.datasets import (
 class TestIOBench:
     @pytest.fixture
     def dataset(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> IOBench:
-        md5 = 'e82398add7c35896a31c4398c608ef83'
         url = os.path.join('tests', 'data', 'iobench', '{}.tar.gz')
         monkeypatch.setattr(IOBench, 'url', url)
-        monkeypatch.setitem(IOBench.md5s, 'preprocessed', md5)
         root = tmp_path
         transforms = nn.Identity()
-        return IOBench(root, transforms=transforms, download=True, checksum=True)
+        return IOBench(root, transforms=transforms, download=True)
 
     def test_getitem(self, dataset: IOBench) -> None:
         x = dataset[dataset.bounds]

--- a/tests/datasets/test_l7irish.py
+++ b/tests/datasets/test_l7irish.py
@@ -26,17 +26,13 @@ from torchgeo.datasets import (
 class TestL7Irish:
     @pytest.fixture
     def dataset(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> L7Irish:
-        md5s = {
-            'austral': '0485d6045f6b508068ef8daf9e5a5326',
-            'boreal': '5798f32545d7166564c4c4429357b840',
-        }
-
+        md5s = {'austral': '', 'boreal': ''}
         url = os.path.join('tests', 'data', 'l7irish', '{}.tar.gz')
         monkeypatch.setattr(L7Irish, 'url', url)
         monkeypatch.setattr(L7Irish, 'md5s', md5s)
         root = tmp_path
         transforms = nn.Identity()
-        return L7Irish(root, transforms=transforms, download=True, checksum=True)
+        return L7Irish(root, transforms=transforms, download=True)
 
     def test_getitem(self, dataset: L7Irish) -> None:
         x = dataset[dataset.bounds]

--- a/tests/datasets/test_l8biome.py
+++ b/tests/datasets/test_l8biome.py
@@ -26,17 +26,13 @@ from torchgeo.datasets import (
 class TestL8Biome:
     @pytest.fixture
     def dataset(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> L8Biome:
-        md5s = {
-            'barren': '29c9910adbc89677389f210226fb163d',
-            'forest': 'b7dbb82fb2c22cbb03389d8828d73713',
-        }
-
+        md5s = {'barren': '', 'forest': ''}
         url = os.path.join('tests', 'data', 'l8biome', '{}.tar.gz')
         monkeypatch.setattr(L8Biome, 'url', url)
         monkeypatch.setattr(L8Biome, 'md5s', md5s)
         root = tmp_path
         transforms = nn.Identity()
-        return L8Biome(root, transforms=transforms, download=True, checksum=True)
+        return L8Biome(root, transforms=transforms, download=True)
 
     def test_getitem(self, dataset: L8Biome) -> None:
         x = dataset[dataset.bounds]

--- a/tests/datasets/test_landcoverai.py
+++ b/tests/datasets/test_landcoverai.py
@@ -26,13 +26,11 @@ from torchgeo.datasets import (
 class TestLandCoverAIGeo:
     @pytest.fixture
     def dataset(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> LandCoverAIGeo:
-        md5 = '3ac7a20f8bbf2cedb2999b70e153b229'
-        monkeypatch.setattr(LandCoverAIGeo, 'md5', md5)
         url = os.path.join('tests', 'data', 'landcoverai', 'landcover.ai.v1.zip')
         monkeypatch.setattr(LandCoverAIGeo, 'url', url)
         root = tmp_path
         transforms = nn.Identity()
-        return LandCoverAIGeo(root, transforms=transforms, download=True, checksum=True)
+        return LandCoverAIGeo(root, transforms=transforms, download=True)
 
     def test_getitem(self, dataset: LandCoverAIGeo) -> None:
         x = dataset[dataset.bounds]
@@ -79,14 +77,12 @@ class TestLandCoverAI:
     ) -> LandCoverAI:
         base_class: type[LandCoverAI] = request.param[0]
         split: str = request.param[1]
-        md5 = '3ac7a20f8bbf2cedb2999b70e153b229'
-        monkeypatch.setattr(base_class, 'md5', md5)
         url = os.path.join('tests', 'data', 'landcoverai', 'landcover.ai.v1.zip')
         monkeypatch.setattr(base_class, 'url', url)
         monkeypatch.setattr(base_class, 'filename', 'landcover.ai.v1.zip')
         root = tmp_path
         transforms = nn.Identity()
-        return base_class(root, split, transforms, download=True, checksum=True)
+        return base_class(root, split, transforms, download=True)
 
     def test_getitem(self, dataset: LandCoverAI) -> None:
         x = dataset[0]

--- a/tests/datasets/test_loveda.py
+++ b/tests/datasets/test_loveda.py
@@ -19,23 +19,21 @@ class TestLoveDA:
     def dataset(
         self, monkeypatch: MonkeyPatch, tmp_path: Path, request: SubRequest
     ) -> LoveDA:
-        md5 = '3d5b1373ef9a3084ec493b9b2056fe07'
-
         info_dict = {
             'train': {
                 'url': os.path.join('tests', 'data', 'loveda', 'Train.zip'),
                 'filename': 'Train.zip',
-                'md5': md5,
+                'md5': '',
             },
             'val': {
                 'url': os.path.join('tests', 'data', 'loveda', 'Val.zip'),
                 'filename': 'Val.zip',
-                'md5': md5,
+                'md5': '',
             },
             'test': {
                 'url': os.path.join('tests', 'data', 'loveda', 'Test.zip'),
                 'filename': 'Test.zip',
-                'md5': md5,
+                'md5': '',
             },
         }
 
@@ -44,9 +42,7 @@ class TestLoveDA:
         root = tmp_path
         split = request.param
         transforms = nn.Identity()
-        return LoveDA(
-            root=root, split=split, transforms=transforms, download=True, checksum=True
-        )
+        return LoveDA(root=root, split=split, transforms=transforms, download=True)
 
     def test_getitem(self, dataset: LoveDA) -> None:
         x = dataset[0]

--- a/tests/datasets/test_mapinwild.py
+++ b/tests/datasets/test_mapinwild.py
@@ -22,27 +22,6 @@ class TestMapInWild:
     def dataset(
         self, tmp_path: Path, monkeypatch: MonkeyPatch, request: SubRequest
     ) -> MapInWild:
-        md5s = {
-            'ESA_WC.zip': '3a1e696353d238c50996958855da02fc',
-            'VIIRS.zip': 'e8b0e230edb1183c02092357af83bd52',
-            'mask.zip': '15245bb6368d27dbb4bd16310f4604fa',
-            's1_part1.zip': 'e660da4175518af993b63644e44a9d03',
-            's1_part2.zip': '620cf0a7d598a2893bc7642ad7ee6087',
-            's2_autumn_part1.zip': '624b6cf0191c5e0bc0d51f92b568e676',
-            's2_autumn_part2.zip': 'f848c62b8de36f06f12fb6b1b065c7b6',
-            's2_spring_part1.zip': '3296f3a7da7e485708dd16be91deb111',
-            's2_spring_part2.zip': 'd27e94387a59f0558fe142a791682861',
-            's2_summer_part1.zip': '41d783706c3c1e4238556a772d3232fb',
-            's2_summer_part2.zip': '3495c87b67a771cfac5153d1958daa0c',
-            's2_temporal_subset_part1.zip': '06fa463888cb033011a06cf69f82273e',
-            's2_temporal_subset_part2.zip': '93e5383adeeea27f00051ecf110fcef8',
-            's2_winter_part1.zip': '617abe1c6ad8d38725aa27c9dcc38ceb',
-            's2_winter_part2.zip': '4e40d7bb0eec4ddea0b7b00314239a49',
-            'split_IDs.csv': 'ca22c3d30d0b62e001ed0c327c147127',
-        }
-
-        monkeypatch.setattr(MapInWild, 'md5s', md5s)
-
         urls = os.path.join('tests', 'data', 'mapinwild')
         monkeypatch.setattr(MapInWild, 'url', urls)
 
@@ -62,12 +41,7 @@ class TestMapInWild:
             's2_temporal_subset',
         ]
         return MapInWild(
-            root,
-            modality=modality,
-            split=split,
-            transforms=transforms,
-            download=True,
-            checksum=True,
+            root, modality=modality, split=split, transforms=transforms, download=True
         )
 
     def test_getitem(self, dataset: MapInWild) -> None:
@@ -114,7 +88,7 @@ class TestMapInWild:
         with open(os.path.join(tmp_path, 'mask.zip'), 'w') as f:
             f.write('bad')
         with pytest.raises(RuntimeError, match='Dataset found, but corrupted'):
-            MapInWild(root=tmp_path, download=True, checksum=True)
+            MapInWild(root=tmp_path, checksum=True)
 
     def test_already_downloaded(self, dataset: MapInWild, tmp_path: Path) -> None:
         MapInWild(root=tmp_path, modality=dataset.modality, download=True)

--- a/tests/datasets/test_mdas.py
+++ b/tests/datasets/test_mdas.py
@@ -44,8 +44,6 @@ class TestMDAS:
     def dataset(
         self, monkeypatch: MonkeyPatch, tmp_path: Path, request: SubRequest
     ) -> MDAS:
-        md5 = '99e1744ca6f19aa19a3aa23a2bbf7bef'
-        monkeypatch.setattr(MDAS, 'md5', md5)
         url = os.path.join('tests', 'data', 'mdas', 'Augsburg_data_4_publication.zip')
         monkeypatch.setattr(MDAS, 'url', url)
 
@@ -62,7 +60,6 @@ class TestMDAS:
             modalities=modalities,
             transforms=transforms,
             download=True,
-            checksum=True,
         )
 
     def test_getitem(self, dataset: MDAS) -> None:

--- a/tests/datasets/test_millionaid.py
+++ b/tests/datasets/test_millionaid.py
@@ -22,9 +22,7 @@ class TestMillionAID:
         root = os.path.join('tests', 'data', 'millionaid')
         split, task = request.param
         transforms = nn.Identity()
-        return MillionAID(
-            root=root, split=split, task=task, transforms=transforms, checksum=True
-        )
+        return MillionAID(root=root, split=split, task=task, transforms=transforms)
 
     def test_getitem(self, dataset: MillionAID) -> None:
         x = dataset[0]

--- a/tests/datasets/test_mmflood.py
+++ b/tests/datasets/test_mmflood.py
@@ -42,7 +42,6 @@ class TestMMFlood:
             include_hydro=include_hydro,
             transforms=nn.Identity(),
             download=True,
-            checksum=True,
         )
 
     def test_getitem(self, dataset: MMFlood) -> None:

--- a/tests/datasets/test_nccm.py
+++ b/tests/datasets/test_nccm.py
@@ -22,12 +22,6 @@ from torchgeo.datasets import (
 class TestNCCM:
     @pytest.fixture
     def dataset(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> NCCM:
-        md5s = {
-            2017: 'ae5c390d0ffb8970d544b8a09142759f',
-            2018: '0d453bdb8ea5b7318c33e62513760580',
-            2019: 'd4ab7ab00bb57623eafb6b27747e5639',
-        }
-        monkeypatch.setattr(NCCM, 'md5s', md5s)
         urls = {
             2017: os.path.join('tests', 'data', 'nccm', 'CDL2017_clip.tif'),
             2018: os.path.join('tests', 'data', 'nccm', 'CDL2018_clip1.tif'),
@@ -36,7 +30,7 @@ class TestNCCM:
         monkeypatch.setattr(NCCM, 'urls', urls)
         transforms = nn.Identity()
         root = tmp_path
-        return NCCM(root, transforms=transforms, download=True, checksum=True)
+        return NCCM(root, transforms=transforms, download=True)
 
     def test_getitem(self, dataset: NCCM) -> None:
         x = dataset[dataset.bounds]

--- a/tests/datasets/test_nlcd.py
+++ b/tests/datasets/test_nlcd.py
@@ -24,23 +24,12 @@ from torchgeo.datasets import (
 class TestNLCD:
     @pytest.fixture
     def dataset(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> NLCD:
-        md5s = {
-            2011: '531fcba859a0bee6bfeb362a26f6a07f',
-            2019: '19a64a25e3c36d8d51b40ab59bddc1ec',
-        }
-        monkeypatch.setattr(NLCD, 'md5s', md5s)
         url = os.path.join('tests', 'data', 'nlcd', 'Annual_NLCD_LndCov_{}_CU_C1V1.zip')
         monkeypatch.setattr(NLCD, 'url', url)
         monkeypatch.setattr(plt, 'show', lambda *args: None)
         root = tmp_path
         transforms = nn.Identity()
-        return NLCD(
-            root,
-            transforms=transforms,
-            download=True,
-            checksum=True,
-            years=[2011, 2019],
-        )
+        return NLCD(root, transforms=transforms, download=True, years=[2011, 2019])
 
     def test_getitem(self, dataset: NLCD) -> None:
         x = dataset[dataset.bounds]

--- a/tests/datasets/test_openbuildings.py
+++ b/tests/datasets/test_openbuildings.py
@@ -32,9 +32,7 @@ class TestOpenBuildings:
         shutil.copy(
             os.path.join('tests', 'data', 'openbuildings', '000_buildings.csv.gz'), root
         )
-
-        md5s = {'000_buildings.csv.gz': '20aeeec9d45a0ce4d772a26e0bcbc25f'}
-
+        md5s = {'000_buildings.csv.gz': 'fake'}
         monkeypatch.setattr(OpenBuildings, 'md5s', md5s)
         transforms = nn.Identity()
         return OpenBuildings(root, transforms=transforms)

--- a/tests/datasets/test_pastis.py
+++ b/tests/datasets/test_pastis.py
@@ -41,8 +41,6 @@ class TestPASTIS:
         mode = params['mode']
         transforms = nn.Identity()
 
-        md5 = '135a29fb8221241dde14f31579c07f45'
-        monkeypatch.setattr(base_class, 'md5', md5)
         url = os.path.join('tests', 'data', 'pastis', 'PASTIS-R.zip')
         monkeypatch.setattr(base_class, 'url', url)
         return base_class(
@@ -52,7 +50,6 @@ class TestPASTIS:
             mode=mode,
             transforms=transforms,
             download=True,
-            checksum=True,
         )
 
     def test_getitem_semantic(self, dataset: PASTIS) -> None:

--- a/tests/datasets/test_patternnet.py
+++ b/tests/datasets/test_patternnet.py
@@ -17,13 +17,11 @@ from torchgeo.datasets import DatasetNotFoundError, PatternNet
 class TestPatternNet:
     @pytest.fixture(params=['train', 'test'])
     def dataset(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> PatternNet:
-        md5 = '5649754c78219a2c19074ff93666cc61'
-        monkeypatch.setattr(PatternNet, 'md5', md5)
         url = os.path.join('tests', 'data', 'patternnet', 'PatternNet.zip')
         monkeypatch.setattr(PatternNet, 'url', url)
         root = tmp_path
         transforms = nn.Identity()
-        return PatternNet(root, transforms, download=True, checksum=True)
+        return PatternNet(root, transforms, download=True)
 
     def test_getitem(self, dataset: PatternNet) -> None:
         x = dataset[0]

--- a/tests/datasets/test_potsdam.py
+++ b/tests/datasets/test_potsdam.py
@@ -18,17 +18,15 @@ from torchgeo.datasets import DatasetNotFoundError, Potsdam2D
 class TestPotsdam2D:
     @pytest.fixture(params=['train', 'test'])
     def dataset(self, monkeypatch: MonkeyPatch, request: SubRequest) -> Potsdam2D:
-        md5s = ['e47175da529c5844052c7d483b483a30', '0cb795003a01154a72db7efaabbc76ae']
         splits = {
             'train': ['top_potsdam_2_10', 'top_potsdam_2_11'],
             'test': ['top_potsdam_5_15', 'top_potsdam_6_15'],
         }
-        monkeypatch.setattr(Potsdam2D, 'md5s', md5s)
         monkeypatch.setattr(Potsdam2D, 'splits', splits)
         root = os.path.join('tests', 'data', 'potsdam')
         split = request.param
         transforms = nn.Identity()
-        return Potsdam2D(root, split, transforms, checksum=True)
+        return Potsdam2D(root, split, transforms)
 
     def test_getitem(self, dataset: Potsdam2D) -> None:
         x = dataset[0]

--- a/tests/datasets/test_quakeset.py
+++ b/tests/datasets/test_quakeset.py
@@ -22,15 +22,11 @@ class TestQuakeSet:
         self, monkeypatch: MonkeyPatch, tmp_path: Path, request: SubRequest
     ) -> QuakeSet:
         url = os.path.join('tests', 'data', 'quakeset', 'earthquakes.h5')
-        md5 = '127d0d6a1f82d517129535f50053a4c9'
-        monkeypatch.setattr(QuakeSet, 'md5', md5)
         monkeypatch.setattr(QuakeSet, 'url', url)
         root = tmp_path
         split = request.param
         transforms = nn.Identity()
-        return QuakeSet(
-            root, split, transforms=transforms, download=True, checksum=True
-        )
+        return QuakeSet(root, split, transforms=transforms, download=True)
 
     def test_getitem(self, dataset: QuakeSet) -> None:
         x = dataset[0]

--- a/tests/datasets/test_reforestree.py
+++ b/tests/datasets/test_reforestree.py
@@ -19,14 +19,10 @@ class TestReforesTree:
     def dataset(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> ReforesTree:
         data_dir = os.path.join('tests', 'data', 'reforestree')
         url = os.path.join(data_dir, 'reforesTree.zip')
-        md5 = 'bfc8d35df5d61d1ff4020375843018d9'
         monkeypatch.setattr(ReforesTree, 'url', url)
-        monkeypatch.setattr(ReforesTree, 'md5', md5)
         root = tmp_path
         transforms = nn.Identity()
-        return ReforesTree(
-            root=root, transforms=transforms, download=True, checksum=True
-        )
+        return ReforesTree(root=root, transforms=transforms, download=True)
 
     def test_already_downloaded(self, dataset: ReforesTree) -> None:
         ReforesTree(root=dataset.root, download=True)

--- a/tests/datasets/test_resisc45.py
+++ b/tests/datasets/test_resisc45.py
@@ -33,19 +33,10 @@ class TestRESISC45:
                 'test': os.path.join('tests', 'data', 'resisc45', 'resisc45-test.txt'),
             },
         )
-        monkeypatch.setattr(
-            RESISC45,
-            'split_md5s',
-            {
-                'train': '7760b1960c9a3ff46fb985810815e14d',
-                'val': '7760b1960c9a3ff46fb985810815e14d',
-                'test': '7760b1960c9a3ff46fb985810815e14d',
-            },
-        )
         root = tmp_path
         split = request.param
         transforms = nn.Identity()
-        return RESISC45(root, split, transforms, download=True, checksum=True)
+        return RESISC45(root, split, transforms, download=True)
 
     def test_getitem(self, dataset: RESISC45) -> None:
         x = dataset[0]

--- a/tests/datasets/test_seasonet.py
+++ b/tests/datasets/test_seasonet.py
@@ -31,27 +31,6 @@ class TestSeasoNet:
         self, monkeypatch: MonkeyPatch, tmp_path: Path, request: SubRequest
     ) -> SeasoNet:
         monkeypatch.setitem(
-            SeasoNet.metadata[0], 'md5', '836a0896eba0e3005208f3fd180e429d'
-        )
-        monkeypatch.setitem(
-            SeasoNet.metadata[1], 'md5', '405656c8c19d822620bbb9f92e687337'
-        )
-        monkeypatch.setitem(
-            SeasoNet.metadata[2], 'md5', 'dc0dda18de019a9f50a794b8b4060a3b'
-        )
-        monkeypatch.setitem(
-            SeasoNet.metadata[3], 'md5', 'a70abca62e78eb1591555809dc81d91d'
-        )
-        monkeypatch.setitem(
-            SeasoNet.metadata[4], 'md5', '67651cc9095207e07ea4db1a71f0ebc2'
-        )
-        monkeypatch.setitem(
-            SeasoNet.metadata[5], 'md5', '576324ba1c32a7e9ba858f1c2577cf2a'
-        )
-        monkeypatch.setitem(
-            SeasoNet.metadata[6], 'md5', '48ff6e9e01fdd92379e5712e4f336ea8'
-        )
-        monkeypatch.setitem(
             SeasoNet.metadata[0],
             'url',
             os.path.join('tests', 'data', 'seasonet', 'spring.zip'),
@@ -98,7 +77,6 @@ class TestSeasoNet:
             concat_seasons=concat_seasons,
             transforms=transforms,
             download=True,
-            checksum=True,
         )
 
     def test_getitem(self, dataset: SeasoNet) -> None:

--- a/tests/datasets/test_seco.py
+++ b/tests/datasets/test_seco.py
@@ -38,23 +38,15 @@ class TestSeasonalContrastS2:
             os.path.join('tests', 'data', 'seco', 'seco_100k.zip'),
         )
         monkeypatch.setitem(
-            SeasonalContrastS2.metadata['100k'],
-            'md5',
-            '6f527567f066562af2c78093114599f9',
-        )
-        monkeypatch.setitem(
             SeasonalContrastS2.metadata['1m'],
             'url',
             os.path.join('tests', 'data', 'seco', 'seco_1m.zip'),
-        )
-        monkeypatch.setitem(
-            SeasonalContrastS2.metadata['1m'], 'md5', '3bb3fcf90f5de7d5781ce0cb85fd20af'
         )
         root = tmp_path
         version, seasons, bands = request.param
         transforms = nn.Identity()
         return SeasonalContrastS2(
-            root, version, seasons, bands, transforms, download=True, checksum=True
+            root, version, seasons, bands, transforms, download=True
         )
 
     def test_getitem(self, dataset: SeasonalContrastS2) -> None:

--- a/tests/datasets/test_skippd.py
+++ b/tests/datasets/test_skippd.py
@@ -24,23 +24,13 @@ class TestSKIPPD:
         self, monkeypatch: MonkeyPatch, tmp_path: Path, request: SubRequest
     ) -> SKIPPD:
         task, split = request.param
-        md5 = {
-            'nowcast': '6f5e54906927278b189f9281a2f54f39',
-            'forecast': 'f3b5d7d5c28ba238144fa1e726c46969',
-        }
-        monkeypatch.setattr(SKIPPD, 'md5', md5)
         url = os.path.join('tests', 'data', 'skippd', '{}')
         monkeypatch.setattr(SKIPPD, 'url', url)
         monkeypatch.setattr(plt, 'show', lambda *args: None)
         root = tmp_path
         transforms = nn.Identity()
         return SKIPPD(
-            root=root,
-            task=task,
-            split=split,
-            transforms=transforms,
-            download=True,
-            checksum=True,
+            root=root, task=task, split=split, transforms=transforms, download=True
         )
 
     def test_already_extracted(self, dataset: SKIPPD) -> None:

--- a/tests/datasets/test_so2sat.py
+++ b/tests/datasets/test_so2sat.py
@@ -9,7 +9,6 @@ import pytest
 import torch
 import torch.nn as nn
 from _pytest.fixtures import SubRequest
-from pytest import MonkeyPatch
 
 from torchgeo.datasets import DatasetNotFoundError, RGBBandsMissingError, So2Sat
 
@@ -18,20 +17,11 @@ pytest.importorskip('h5py', minversion='3.10')
 
 class TestSo2Sat:
     @pytest.fixture(params=['train', 'validation', 'test'])
-    def dataset(self, monkeypatch: MonkeyPatch, request: SubRequest) -> So2Sat:
-        md5s_by_version = {
-            '2': {
-                'train': '56e6fa0edb25b065124a3113372f76e5',
-                'validation': '940c95a737bd2fcdcc46c9a52b31424d',
-                'test': 'e97a6746aadc731a1854097f32ab1755',
-            }
-        }
-
-        monkeypatch.setattr(So2Sat, 'md5s_by_version', md5s_by_version)
+    def dataset(self, request: SubRequest) -> So2Sat:
         root = os.path.join('tests', 'data', 'so2sat')
         split = request.param
         transforms = nn.Identity()
-        return So2Sat(root=root, split=split, transforms=transforms, checksum=True)
+        return So2Sat(root=root, split=split, transforms=transforms)
 
     def test_getitem(self, dataset: So2Sat) -> None:
         x = dataset[0]

--- a/tests/datasets/test_soda.py
+++ b/tests/datasets/test_soda.py
@@ -26,14 +26,8 @@ class TestSODAA:
         url = os.path.join('tests', 'data', 'soda', '{}')
         monkeypatch.setattr(SODAA, 'url', url)
         files = {
-            'images': {
-                'filename': 'Images.zip',
-                'md5sum': '8a3bb78816643dd1567e9664ac9c1b67',
-            },
-            'labels': {
-                'filename': 'Annotations.zip',
-                'md5sum': '73e84f03b96f94c92aeb46816e43d2c0',
-            },
+            'images': {'filename': 'Images.zip'},
+            'labels': {'filename': 'Annotations.zip'},
         }
         monkeypatch.setattr(SODAA, 'files', files)
         split, bbox_orientation = request.param
@@ -45,7 +39,6 @@ class TestSODAA:
             bbox_orientation=bbox_orientation,
             transforms=transforms,
             download=True,
-            checksum=True,
         )
 
     def test_already_downloaded(self, dataset: SODAA) -> None:

--- a/tests/datasets/test_south_america_soybean.py
+++ b/tests/datasets/test_south_america_soybean.py
@@ -30,11 +30,7 @@ class TestSouthAmericaSoybean:
         monkeypatch.setattr(SouthAmericaSoybean, 'url', url)
         root = tmp_path
         return SouthAmericaSoybean(
-            paths=root,
-            years=[2002, 2021],
-            transforms=transforms,
-            download=True,
-            checksum=True,
+            paths=root, years=[2002, 2021], transforms=transforms, download=True
         )
 
     def test_getitem(self, dataset: SouthAmericaSoybean) -> None:

--- a/tests/datasets/test_ssl4eo.py
+++ b/tests/datasets/test_ssl4eo.py
@@ -26,38 +26,18 @@ class TestSSL4EOL:
         monkeypatch.setattr(SSL4EOL, 'url', url)
 
         checksums = {
-            'tm_toa': {
-                'aa': '010b9d72b476e0e30741c17725f84e5c',
-                'ab': '39171bd7bca8a56a8cb339a0f88da9d3',
-                'ac': '3cfc407ce3f4f4d6e3c5fdb457bb87da',
-            },
-            'etm_toa': {
-                'aa': '87e47278f5a30acd3b696b6daaa4713b',
-                'ab': '59295e1816e08a5acd3a18ae56b6f32e',
-                'ac': 'f3ff76eb6987501000228ce15684e09f',
-            },
-            'etm_sr': {
-                'aa': 'fd61a4154eafaeb350dbb01a2551a818',
-                'ab': '0c3117bc7682ba9ffdc6871e6c364b36',
-                'ac': '93d3385e47de4578878ca5c4fa6a628d',
-            },
-            'oli_tirs_toa': {
-                'aa': 'defb9e91a73b145b2dbe347649bded06',
-                'ab': '97f7edaa4e288fc14ec7581dccea766f',
-                'ac': '7472fad9929a0dc96ccf4dc6c804b92f',
-            },
-            'oli_sr': {
-                'aa': '8fd3aa6b581d024299f44457956faa05',
-                'ab': '7eb4d761ce1afd89cae9c6142ca17882',
-                'ac': 'a3210da9fcc71e3a4efde71c30d78c59',
-            },
+            'tm_toa': {'aa': '', 'ab': '', 'ac': ''},
+            'etm_toa': {'aa': '', 'ab': '', 'ac': ''},
+            'etm_sr': {'aa': '', 'ab': '', 'ac': ''},
+            'oli_tirs_toa': {'aa': '', 'ab': '', 'ac': ''},
+            'oli_sr': {'aa': '', 'ab': '', 'ac': ''},
         }
         monkeypatch.setattr(SSL4EOL, 'checksums', checksums)
 
         root = tmp_path
         split, seasons = request.param
         transforms = nn.Identity()
-        return SSL4EOL(root, split, seasons, transforms, download=True, checksum=True)
+        return SSL4EOL(root, split, seasons, transforms, download=True)
 
     def test_getitem(self, dataset: SSL4EOL) -> None:
         x = dataset[0]
@@ -121,24 +101,14 @@ class TestSSL4EOS12:
 
     def test_download(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
         url = os.path.join('tests', 'data', 'ssl4eo', 's12', '{0}.tar.gz.part{1}')
-        checksums = {
-            's2c': {
-                'aa': 'ddabb8a21c75bc10c047ca480d0f93c9',
-                'ab': '5e634bb5bf4c261ce6f8c46afcccf2d5',
-            }
-        }
+        checksums = {'s2c': {'aa': '', 'ab': ''}}
         monkeypatch.setattr(SSL4EOS12, 'url', url)
         monkeypatch.setattr(SSL4EOS12, 'checksums', checksums)
         SSL4EOS12(tmp_path, download=True)
 
     def test_extract(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
         root = os.path.join('tests', 'data', 'ssl4eo', 's12')
-        checksums = {
-            's2c': {
-                'aa': 'ddabb8a21c75bc10c047ca480d0f93c9',
-                'ab': '5e634bb5bf4c261ce6f8c46afcccf2d5',
-            }
-        }
+        checksums = {'s2c': {'aa': '', 'ab': ''}}
         monkeypatch.setattr(SSL4EOS12, 'checksums', checksums)
         for filename in ['s2_l1c.tar.gz.partaa', 's2_l1c.tar.gz.partab']:
             shutil.copyfile(os.path.join(root, filename), tmp_path / filename)

--- a/tests/datasets/test_ssl4eo_benchmark.py
+++ b/tests/datasets/test_ssl4eo_benchmark.py
@@ -44,31 +44,6 @@ class TestSSL4EOLBenchmark:
             SSL4EOLBenchmark, 'split_percentages', [1 / 3, 1 / 3, 1 / 3]
         )
 
-        img_md5s = {
-            'tm_toa': '81e3c0701057957f5d323483c3b4a871',
-            'etm_sr': 'b38eac2744c36cc2929c11d141e21b2c',
-            'etm_toa': '80172f2621eb4d5633b90f4344ad1d3d',
-            'oli_tirs_toa': '5df398ecae45c86005b489dbe657f4bf',
-            'oli_sr': 'd27ac929c2c1c84925077f35bdbebf5f',
-        }
-        monkeypatch.setattr(SSL4EOLBenchmark, 'img_md5s', img_md5s)
-
-        mask_md5s = {
-            'tm': {
-                'cdl': '4b825e55a48c58f1ae5b3893987dca45',
-                'nlcd': '2df58c68c636f941f938618214a9118c',
-            },
-            'etm': {
-                'cdl': '4e854aadf8309a102d9fbf322f52a122',
-                'nlcd': 'ebeae394bef0dace53ba83ba6ac3943c',
-            },
-            'oli': {
-                'cdl': '33ab6ba3b3dc3ad15b34264392883bbf',
-                'nlcd': 'dd044814e5df845ff8583d9ce0883c0f',
-            },
-        }
-        monkeypatch.setattr(SSL4EOLBenchmark, 'mask_md5s', mask_md5s)
-
         transforms = nn.Identity()
         return SSL4EOLBenchmark(
             root=root,
@@ -77,7 +52,6 @@ class TestSSL4EOLBenchmark:
             split=split,
             transforms=transforms,
             download=True,
-            checksum=True,
         )
 
     def test_getitem(self, dataset: SSL4EOLBenchmark) -> None:

--- a/tests/datasets/test_sustainbench_crop_yield.py
+++ b/tests/datasets/test_sustainbench_crop_yield.py
@@ -20,8 +20,6 @@ class TestSustainBenchCropYield:
     def dataset(
         self, monkeypatch: MonkeyPatch, tmp_path: Path, request: SubRequest
     ) -> SustainBenchCropYield:
-        md5 = '7a5591794e14dd73d2b747cd2244acbc'
-        monkeypatch.setattr(SustainBenchCropYield, 'md5', md5)
         url = os.path.join('tests', 'data', 'sustainbench_crop_yield', 'soybeans.zip')
         monkeypatch.setattr(SustainBenchCropYield, 'url', url)
         monkeypatch.setattr(plt, 'show', lambda *args: None)
@@ -29,9 +27,7 @@ class TestSustainBenchCropYield:
         split = request.param
         countries = ['argentina', 'brazil', 'usa']
         transforms = nn.Identity()
-        return SustainBenchCropYield(
-            root, split, countries, transforms, download=True, checksum=True
-        )
+        return SustainBenchCropYield(root, split, countries, transforms, download=True)
 
     def test_already_extracted(self, dataset: SustainBenchCropYield) -> None:
         SustainBenchCropYield(root=dataset.root, download=True)

--- a/tests/datasets/test_usavars.py
+++ b/tests/datasets/test_usavars.py
@@ -30,9 +30,6 @@ class TestUSAVars:
     def dataset(
         self, monkeypatch: MonkeyPatch, tmp_path: Path, request: SubRequest
     ) -> USAVars:
-        md5 = 'b504580a00bdc27097d5421dec50481b'
-        monkeypatch.setattr(USAVars, 'md5', md5)
-
         data_url = os.path.join('tests', 'data', 'usavars', 'uar.zip')
         monkeypatch.setattr(USAVars, 'data_url', data_url)
 
@@ -51,17 +48,14 @@ class TestUSAVars:
             'train': {
                 'url': os.path.join('tests', 'data', 'usavars', 'train_split.txt'),
                 'filename': 'train_split.txt',
-                'md5': 'b94f3f6f63110b253779b65bc31d91b5',
             },
             'val': {
                 'url': os.path.join('tests', 'data', 'usavars', 'val_split.txt'),
                 'filename': 'val_split.txt',
-                'md5': 'e39aa54b646c4c45921fcc9765d5a708',
             },
             'test': {
                 'url': os.path.join('tests', 'data', 'usavars', 'test_split.txt'),
                 'filename': 'test_split.txt',
-                'md5': '4ab0f5549fee944a5690de1bc95ed245',
             },
         }
         monkeypatch.setattr(USAVars, 'split_metadata', split_metadata)
@@ -70,9 +64,7 @@ class TestUSAVars:
         split, labels = request.param
         transforms = nn.Identity()
 
-        return USAVars(
-            root, split, labels, transforms=transforms, download=True, checksum=True
-        )
+        return USAVars(root, split, labels, transforms=transforms, download=True)
 
     def test_getitem(self, dataset: USAVars) -> None:
         x = dataset[0]

--- a/tests/datasets/test_vaihingen.py
+++ b/tests/datasets/test_vaihingen.py
@@ -18,17 +18,15 @@ from torchgeo.datasets import DatasetNotFoundError, Vaihingen2D
 class TestVaihingen2D:
     @pytest.fixture(params=['train', 'test'])
     def dataset(self, monkeypatch: MonkeyPatch, request: SubRequest) -> Vaihingen2D:
-        md5s = ['c15fbff78d307e51c73f609c0859afc3', 'ec2c0a5149f2371479b38cf8cfbab961']
         splits = {
             'train': ['top_mosaic_09cm_area1.tif', 'top_mosaic_09cm_area11.tif'],
             'test': ['top_mosaic_09cm_area6.tif', 'top_mosaic_09cm_area24.tif'],
         }
-        monkeypatch.setattr(Vaihingen2D, 'md5s', md5s)
         monkeypatch.setattr(Vaihingen2D, 'splits', splits)
         root = os.path.join('tests', 'data', 'vaihingen')
         split = request.param
         transforms = nn.Identity()
-        return Vaihingen2D(root, split, transforms, checksum=True)
+        return Vaihingen2D(root, split, transforms)
 
     def test_getitem(self, dataset: Vaihingen2D) -> None:
         x = dataset[0]

--- a/tests/datasets/test_vhr10.py
+++ b/tests/datasets/test_vhr10.py
@@ -24,16 +24,12 @@ class TestVHR10:
     ) -> VHR10:
         url = os.path.join('tests', 'data', 'vhr10', 'NWPU VHR-10 dataset.zip')
         monkeypatch.setitem(VHR10.image_meta, 'url', url)
-        md5 = '497cb7e19a12c7d5abbefe8eac71d22d'
-        monkeypatch.setitem(VHR10.image_meta, 'md5', md5)
         url = os.path.join('tests', 'data', 'vhr10', 'annotations.json')
         monkeypatch.setitem(VHR10.target_meta, 'url', url)
-        md5 = '567c4cd8c12624864ff04865de504c58'
-        monkeypatch.setitem(VHR10.target_meta, 'md5', md5)
         root = tmp_path
         split = request.param
         transforms = nn.Identity()
-        return VHR10(root, split, transforms, download=True, checksum=True)
+        return VHR10(root, split, transforms, download=True)
 
     def test_getitem(self, dataset: VHR10) -> None:
         for i in range(2):

--- a/tests/datasets/test_xbd.py
+++ b/tests/datasets/test_xbd.py
@@ -24,12 +24,10 @@ class TestxBD:
             {
                 'train': {
                     'filename': 'train_images_labels_targets.tar.gz',
-                    'md5': '373e61d55c1b294aa76b94dbbd81332b',
                     'directory': 'train',
                 },
                 'test': {
                     'filename': 'test_images_labels_targets.tar.gz',
-                    'md5': 'bc6de81c956a3bada38b5b4e246266a1',
                     'directory': 'test',
                 },
             },
@@ -37,7 +35,7 @@ class TestxBD:
         root = os.path.join('tests', 'data', 'xbd')
         split = request.param
         transforms = nn.Identity()
-        return xBD(root, split, transforms, checksum=True)
+        return xBD(root, split, transforms)
 
     def test_getitem(self, dataset: xBD) -> None:
         x = dataset[0]


### PR DESCRIPTION
In the process of converting all md5 -> sha256, we need to either:

1. Convert all md5 -> sha256 for our test data, or
2. Don't verify the checksum of our test data

I opted for the latter, as:

1. We're able to reduce our test code by 470 lines
2. These lines aren't required for coverage
3. This makes it simpler to add new datasets (less testing required)
4. We monkeypatch download_url, so the checksum check is skipped anyway

We can also remove a similar number of SLOCs from `tests/data/*/data.py`, but that's lower priority. Can be done in a separate PR.