### PR TITLE
Swap Sentinel-2 TOA and SR number of channels in SSL4EO-S12

### DIFF
--- a/torchgeo/datasets/ssl4eo.py
+++ b/torchgeo/datasets/ssl4eo.py
@@ -406,12 +406,12 @@ class SSL4EOS12(SSL4EO):
        * - s2c
          - Sentinel-2
          - TOA
-         - 12
+         - 13
          - `GEE <https://developers.google.com/earth-engine/datasets/catalog/COPERNICUS_S2_HARMONIZED>`__
        * - s2a
          - Sentinel-2
          - SR
-         - 13
+         - 12
          - `GEE <https://developers.google.com/earth-engine/datasets/catalog/COPERNICUS_S2_SR_HARMONIZED>`__
 
     Each patch has the following properties:


### PR DESCRIPTION
I spotted this error in the documentation of SSL4EO-S12. 

I think SR should be 12 bands and TOA 13 bands. The band lists seems correctly assigned instead.