### PR TITLE
ty: ignore state_dict type hint issues

### DIFF
--- a/torchgeo/models/panopticon.py
+++ b/torchgeo/models/panopticon.py
@@ -513,7 +513,7 @@ def panopticon_vitb14(
         state_dict.pop('mask_token')
 
         # interpolate positional embeddings (timm==0.9.2) does not support this yet
-        state_dict['pos_embed'] = resize_abs_pos_embed(
+        state_dict['pos_embed'] = resize_abs_pos_embed(  # type: ignore[invalid-assignment]
             state_dict['pos_embed'], img_size // patch_size, 518 // patch_size
         )
 

--- a/torchgeo/models/scale_mae.py
+++ b/torchgeo/models/scale_mae.py
@@ -240,7 +240,7 @@ def scalemae_large_patch16(
         state_dict = weights.get_state_dict(progress=True)
 
         if 'img_size' in kwargs and weights.meta['img_size'] != kwargs['img_size']:
-            state_dict = interpolate_pos_embed(model, state_dict)
+            state_dict = interpolate_pos_embed(model, state_dict)  # type: ignore[invalid-argument-type]
 
         model.load_state_dict(state_dict, strict=False)
 

--- a/torchgeo/models/unet.py
+++ b/torchgeo/models/unet.py
@@ -221,8 +221,8 @@ def unet(
             )
         # Random initialize segmentation head for new task
         else:
-            del state_dict['segmentation_head.0.weight']
-            del state_dict['segmentation_head.0.bias']
+            del state_dict['segmentation_head.0.weight']  # type: ignore[not-subscriptable]
+            del state_dict['segmentation_head.0.bias']  # type: ignore[not-subscriptable]
             missing_keys, unexpected_keys = model.load_state_dict(
                 state_dict, strict=False
             )

--- a/torchgeo/trainers/byol.py
+++ b/torchgeo/trainers/byol.py
@@ -344,7 +344,7 @@ class BYOLTask(BaseTask):
                 _, state_dict = utils.extract_backbone(weights)
             else:
                 state_dict = get_weight(weights).get_state_dict(progress=True)
-            utils.load_state_dict(backbone, state_dict)
+            utils.load_state_dict(backbone, state_dict)  # type: ignore[invalid-argument-type]
 
         self.model = BYOL(backbone, in_channels=in_channels, image_size=(224, 224))
 

--- a/torchgeo/trainers/classification.py
+++ b/torchgeo/trainers/classification.py
@@ -100,7 +100,7 @@ class ClassificationTask(BaseTask):
                 _, state_dict = utils.extract_backbone(weights)
             else:
                 state_dict = get_weight(weights).get_state_dict(progress=True)
-            utils.load_state_dict(self.model, state_dict)
+            utils.load_state_dict(self.model, state_dict)  # type: ignore[invalid-argument-type]
 
         # Freeze backbone and unfreeze classifier head
         if self.hparams['freeze_backbone']:

--- a/torchgeo/trainers/moco.py
+++ b/torchgeo/trainers/moco.py
@@ -250,7 +250,7 @@ class MoCoTask(BaseTask):
                 _, state_dict = utils.extract_backbone(weights)
             else:
                 state_dict = get_weight(weights).get_state_dict(progress=True)
-            utils.load_state_dict(self.backbone, state_dict)
+            utils.load_state_dict(self.backbone, state_dict)  # type: ignore[invalid-argument-type]
 
         # Create projection (and prediction) head
         batch_norm = version == 3

--- a/torchgeo/trainers/regression.py
+++ b/torchgeo/trainers/regression.py
@@ -100,7 +100,7 @@ class RegressionTask(BaseTask):
                 _, state_dict = utils.extract_backbone(weights)
             else:
                 state_dict = get_weight(weights).get_state_dict(progress=True)
-            utils.load_state_dict(self.model, state_dict)
+            utils.load_state_dict(self.model, state_dict)  # type: ignore[invalid-argument-type]
 
         # Freeze backbone and unfreeze classifier head
         if self.hparams['freeze_backbone']:

--- a/torchgeo/trainers/simclr.py
+++ b/torchgeo/trainers/simclr.py
@@ -168,7 +168,7 @@ class SimCLRTask(BaseTask):
                 _, state_dict = utils.extract_backbone(weights)
             else:
                 state_dict = get_weight(weights).get_state_dict(progress=True)
-            utils.load_state_dict(self.backbone, state_dict)
+            utils.load_state_dict(self.backbone, state_dict)  # type: ignore[invalid-argument-type]
 
         # Create projection head
         input_dim = cast(int, self.backbone.num_features)


### PR DESCRIPTION
Ignores issues like:
```
torchgeo/models/panopticon.py:516:9: error[invalid-assignment] Cannot assign to a subscript on an object of type `Mapping[str, Any]`
torchgeo/models/scale_mae.py:243:55: error[invalid-argument-type] Argument to function `interpolate_pos_embed` is incorrect: Expected `dict[str, Tensor]`, found `Mapping[str, Any]`
torchgeo/models/unet.py:224:17: error[not-subscriptable] Cannot delete subscript on object of type `Mapping[str, Any]` with no `__delitem__` method
torchgeo/models/unet.py:225:17: error[not-subscriptable] Cannot delete subscript on object of type `Mapping[str, Any]` with no `__delitem__` method
torchgeo/trainers/byol.py:347:45: error[invalid-argument-type] Argument to function `load_state_dict` is incorrect: Expected `dict[str, Tensor]`, found `Mapping[str, Any] | dict[str, Tensor]`
torchgeo/trainers/classification.py:103:47: error[invalid-argument-type] Argument to function `load_state_dict` is incorrect: Expected `dict[str, Tensor]`, found `Mapping[str, Any] | dict[str, Tensor]`
torchgeo/trainers/moco.py:253:50: error[invalid-argument-type] Argument to function `load_state_dict` is incorrect: Expected `dict[str, Tensor]`, found `Mapping[str, Any] | dict[str, Tensor]`
torchgeo/trainers/regression.py:103:47: error[invalid-argument-type] Argument to function `load_state_dict` is incorrect: Expected `dict[str, Tensor]`, found `Mapping[str, Any] | dict[str, Tensor]`
torchgeo/trainers/simclr.py:171:50: error[invalid-argument-type] Argument to function `load_state_dict` is incorrect: Expected `dict[str, Tensor]`, found `Mapping[str, Any] | dict[str, Tensor]`
```
This is already fixed in https://github.com/pytorch/vision/pull/9286, we can remove these comments after the next torchvision release.