### PR TITLE
UC Merced: fix type hints

### DIFF
--- a/torchgeo/datasets/ucmerced.py
+++ b/torchgeo/datasets/ucmerced.py
@@ -136,7 +136,7 @@ class UCMerced(NonGeoClassificationDataset):
             the image and class label
         """
         img, label = super()._load_image(index)
-        img = F.resize(img, size=(256, 256), antialias=True)
+        img = F.resize(img, size=[256, 256], antialias=True)
         return img, label
 
     def _check_integrity(self) -> bool:


### PR DESCRIPTION
Type hints only officially support lists. Pretty sure the type hints are wrong, but torchvision doesn't maintain its type hints, so it's easier to turn a blind eye to this one.