### PR TITLE
download_and_extract_archive: fix test type hints

### DIFF
--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -381,7 +381,7 @@ def test_download_url(tmp_path: Path) -> None:
 
 
 def test_download_and_extract_archive(tmp_path: Path) -> None:
-    url = Path('tests/data/vhr10/NWPU VHR-10 dataset.zip')
+    url = str(Path('tests/data/vhr10/NWPU VHR-10 dataset.zip'))
     md5 = '497cb7e19a12c7d5abbefe8eac71d22d'
     sha256 = '2cd7abf9ec04bd10356208a634a9b0ea82c96405bd98882878883a9b6f3d7b46'
 


### PR DESCRIPTION
We previously used Path to make a file:// URI, but then removed that because it didn't work with our monkey patching. The result is that we're now incorrectly using a Path for a URL.