### PR TITLE
Fix minimum tests

### DIFF
--- a/requirements/min-reqs.old
+++ b/requirements/min-reqs.old
@@ -44,3 +44,4 @@ packaging==21.0
 pytest==7.3.2
 pytest-cov==4.0.0
 pytest-socket==0.3.4
+setuptools==81.0.0  # remove once nbmake 1.4.4+ required


### PR DESCRIPTION
Today's release of setuptools 82 broke at least nbmake 1.3.3, possibly other min versions, due to the removal of pkg_resources.

Alternative is to bump all affected deps, but we typically pin things in testing if we can.