### PR TITLE
SeasoNet: fix type hints

### DIFF
--- a/torchgeo/datasets/seasonet.py
+++ b/torchgeo/datasets/seasonet.py
@@ -86,7 +86,7 @@ class SeasoNet(NonGeoDataset):
     .. versionadded:: 0.5
     """
 
-    metadata = (
+    metadata: tuple[dict[str, str], ...] = (
         {
             'name': 'spring',
             'ext': '.zip',


### PR DESCRIPTION
Fixes warnings like:
```
error[invalid-argument-type]: Argument to bound method `setitem` is incorrect
  --> tests/datasets/test_seasonet.py:34:13
   |
32 |     ) -> SeasoNet:
33 |         monkeypatch.setitem(
34 |             SeasoNet.metadata[0],
   |             ^^^^^^^^^^^^^^^^^^^^ Expected `Mapping[Literal["url"], LiteralString]`, found `Unknown | dict[Unknown | str, Unknown | str]`
35 |             'url',
36 |             os.path.join('tests', 'data', 'seasonet', 'spring.zip'),
   |
info: Element `dict[Unknown | str, Unknown | str]` of this union is not assignable to `Mapping[Literal["url"], LiteralString]`
info: Method defined here
   --> /Users/Adam/spack/var/spack/environments/default/.spack-env/._view/gd2vtbwe4fojggua4emapinyxnqhryg4/lib/python3.14/site-packages/_pytest/monkeypatch.py:293:9
    |
291 |             delattr(target, name)
292 |
293 |     def setitem(self, dic: Mapping[K, V], name: K, value: V) -> None:
    |         ^^^^^^^       ------------------ Parameter declared here
294 |         """Set dictionary entry ``name`` to value."""
295 |         self._setitem.append((dic, name, dic.get(name, notset)))
    |
info: rule `invalid-argument-type` is enabled by default
```
I resisted the urge to whip out a TypedDict, which would actually be more appropriate.