### PR TITLE
time_series_split: fix type hints

### DIFF
--- a/tests/datasets/test_splits.py
+++ b/tests/datasets/test_splits.py
@@ -261,7 +261,8 @@ def test_roi_split() -> None:
     ],
 )
 def test_time_series_split(
-    lengths: Sequence[tuple[int, int] | int | float], expected_lengths: Sequence[int]
+    lengths: Sequence[float] | Sequence[pd.Interval] | Sequence[pd.Timedelta],
+    expected_lengths: Sequence[int],
 ) -> None:
     geometry = [
         shapely.box(0, 0, 1, 1),


### PR DESCRIPTION
No idea how this one got so messed up, probably during the time series index rewrite.