### PR TITLE
ty: ignore incorrect Path type suggestions

### DIFF
--- a/torchgeo/datasets/bigearthnet.py
+++ b/torchgeo/datasets/bigearthnet.py
@@ -358,7 +358,7 @@ class BigEarthNet(NonGeoDataset):
         ]
         return folders
 
-    def _load_paths(self, index: int) -> list[Path] | list[str]:
+    def _load_paths(self, index: int) -> list[str]:
         """Load paths to band files.
 
         Args:
@@ -384,7 +384,7 @@ class BigEarthNet(NonGeoDataset):
             paths = glob.glob(os.path.join(folder, '*.tif'))
             paths = sorted(paths, key=sort_sentinel2_bands)
 
-        return paths
+        return paths  # type: ignore[invalid-return-type]
 
     def _load_image(self, index: int) -> Tensor:
         """Load a single image.

--- a/torchgeo/datasets/oscd.py
+++ b/torchgeo/datasets/oscd.py
@@ -185,8 +185,8 @@ class OSCD(NonGeoDataset):
             region = folder.split(os.sep)[-2]
             mask = os.path.join(labels_root, region, 'cm', 'cm.png')
 
-            def get_image_paths(ind: int) -> list[Path]:
-                return sorted(
+            def get_image_paths(ind: int) -> list[str]:
+                return sorted(  # type: ignore[invalid-return-type]
                     glob.glob(
                         os.path.join(images_root, region, f'imgs_{ind}_rect', '*.tif')
                     ),


### PR DESCRIPTION
We're getting into random type hint bug fix territory. I'm not convinced that pathlib.Path is even possible here, but I don't have the energy to fight ty on this one.