### PR TITLE
PRUE FTW CC-BY Models

### DIFF
--- a/docs/api/weights/sentinel2.csv
+++ b/docs/api/weights/sentinel2.csv
@@ -50,4 +50,7 @@ Unet_Weights.SENTINEL2_3CLASS_NC_FTW,8,`link <https://github.com/fieldsoftheworl
 Unet_Weights.SENTINEL2_FTW_PRUE_EFNETB3,8,`link <https://github.com/fieldsoftheworld/ftw-baselines>`__,,"non-commercial",,,
 Unet_Weights.SENTINEL2_FTW_PRUE_EFNETB5,8,`link <https://github.com/fieldsoftheworld/ftw-baselines>`__,,"non-commercial",,,
 Unet_Weights.SENTINEL2_FTW_PRUE_EFNETB7,8,`link <https://github.com/fieldsoftheworld/ftw-baselines>`__,,"non-commercial",,,
+Unet_Weights.SENTINEL2_FTW_PRUE_CCBY_EFNETB3,8,`link <https://github.com/fieldsoftheworld/ftw-baselines>`__,,"CC-BY-4.0",,,
+Unet_Weights.SENTINEL2_FTW_PRUE_CCBY_EFNETB5,8,`link <https://github.com/fieldsoftheworld/ftw-baselines>`__,,"CC-BY-4.0",,,
+Unet_Weights.SENTINEL2_FTW_PRUE_CCBY_EFNETB7,8,`link <https://github.com/fieldsoftheworld/ftw-baselines>`__,,"CC-BY-4.0",,,
 EarthLoc_Weights.SENTINEL2_RESNET50,3,`link <https://github.com/gmberton/EarthLoc>`__,`link <https://arxiv.org/abs/2403.06758>`__,"MIT",,,

--- a/torchgeo/models/unet.py
+++ b/torchgeo/models/unet.py
@@ -137,6 +137,51 @@ class Unet_Weights(WeightsEnum):  # type: ignore[misc]
             'license': 'non-commercial',
         },
     )
+    SENTINEL2_FTW_PRUE_CCBY_EFNETB3 = Weights(
+        url='https://hf.co/isaaccorley/ftw-prue-ccby/resolve/ce7ffffbceb1b55b3b6db77ecbc82313b7afa163/prue_efnetb3_ccby-aa82bfe9.pth',
+        transforms=_ftw_transforms,
+        meta={
+            'dataset': 'FTW',
+            'in_chans': 8,
+            'num_classes': 3,
+            'model': 'U-Net',
+            'encoder': 'efficientnet-b3',
+            'publication': None,
+            'repo': 'https://github.com/fieldsoftheworld/ftw-baselines',
+            'bands': _ftw_sentinel2_bands,
+            'license': 'CC-BY-4.0',
+        },
+    )
+    SENTINEL2_FTW_PRUE_CCBY_EFNETB5 = Weights(
+        url='https://hf.co/isaaccorley/ftw-prue-ccby/resolve/ce7ffffbceb1b55b3b6db77ecbc82313b7afa163/prue_efnetb5_ccby-a3aaa8b6.pth',
+        transforms=_ftw_transforms,
+        meta={
+            'dataset': 'FTW',
+            'in_chans': 8,
+            'num_classes': 3,
+            'model': 'U-Net',
+            'encoder': 'efficientnet-b5',
+            'publication': None,
+            'repo': 'https://github.com/fieldsoftheworld/ftw-baselines',
+            'bands': _ftw_sentinel2_bands,
+            'license': 'CC-BY-4.0',
+        },
+    )
+    SENTINEL2_FTW_PRUE_CCBY_EFNETB7 = Weights(
+        url='https://hf.co/isaaccorley/ftw-prue-ccby/resolve/ce7ffffbceb1b55b3b6db77ecbc82313b7afa163/prue_efnetb7_ccby-da5ad55e.pth',
+        transforms=_ftw_transforms,
+        meta={
+            'dataset': 'FTW',
+            'in_chans': 8,
+            'num_classes': 3,
+            'model': 'U-Net',
+            'encoder': 'efficientnet-b7',
+            'publication': None,
+            'repo': 'https://github.com/fieldsoftheworld/ftw-baselines',
+            'bands': _ftw_sentinel2_bands,
+            'license': 'CC-BY-4.0',
+        },
+    )
     OAM_RGB_RESNET50_TCD = Weights(
         url='https://hf.co/isaaccorley/unet_resnet50_oam_rgb_tcd/resolve/5df2fe5a0e80fd6e12939686b7370c53f73bf389/unet_resnet50_oam_rgb_tcd-72b9b753.pth',
         transforms=_tcd_transforms,


### PR DESCRIPTION
Follow up to https://github.com/torchgeo/torchgeo/pull/3112. Adding the PRUE U-Net models trained on the FTW CC-BY subset of countries.

Tested that the model works 

PRUE EFFNet-B3
<img width="1489" height="398" alt="image" src="https://github.com/user-attachments/assets/008c61c1-2667-4b0a-801d-0dbefbc54d4e" />

PRUE EFFNet-B5
<img width="1489" height="398" alt="image" src="https://github.com/user-attachments/assets/c37af5b4-7b14-4ff5-bace-63244927eef9" />

PRUE EFFNet-B7
<img width="1489" height="398" alt="image" src="https://github.com/user-attachments/assets/5f92abfd-ea4d-4d63-bb01-b0de81b21b56" />
