### PR TITLE
ChesapeakeRSC Road Segmentation U-Net

### DIFF
--- a/docs/api/weights/naip.csv
+++ b/docs/api/weights/naip.csv
@@ -2,3 +2,4 @@ Weight,Channels,Source,Citation,License
 Swin_V2_B_Weights.NAIP_RGB_MI_SATLAS,3,`link <https://github.com/allenai/satlas>`__,`link <https://arxiv.org/abs/2211.15660>`__,ODC-BY
 Swin_V2_B_Weights.NAIP_RGB_SI_SATLAS,3,`link <https://github.com/allenai/satlas>`__,`link <https://arxiv.org/abs/2211.15660>`__,ODC-BY
 TileNet_Weights.NAIP_ALL_TILE2VEC,4,`link <https://github.com/ermongroup/tile2vec>`__,`link <https://arxiv.org/abs/1805.02855>`__,MIT
+Unet_Weights.NAIP_RGBN_RESNET18_CHESAPEAKERSC,4,`link <https://github.com/isaaccorley/ChesapeakeRSC>`__,`link <https://arxiv.org/abs/2401.06762>`__,MIT

--- a/torchgeo/models/unet.py
+++ b/torchgeo/models/unet.py
@@ -173,6 +173,24 @@ class Unet_Weights(WeightsEnum):  # type: ignore[misc]
             'license': 'CC-BY-NC-4.0',
         },
     )
+    NAIP_RGBN_RESNET18_CHESAPEAKERSC = Weights(
+        url='https://hf.co/isaaccorley/chesapeakersc/resolve/fe3dc77a9edfe95fde49b0318fb047c1fc6dd195/unet-resnet18-6c2e3984.pth',
+        transforms=T.Normalize(mean=[0.0], std=[255.0], inplace=True),
+        meta={
+            'dataset': 'ChesapeakeRSC',
+            'in_chans': 4,
+            'num_classes': 2,
+            'model': 'U-Net',
+            'encoder': 'resnet18',
+            'publication': 'https://arxiv.org/abs/2401.06762',
+            'repo': 'https://github.com/isaaccorley/ChesapeakeRSC',
+            'bands': ('R', 'G', 'B', 'N'),
+            'classes': ('background', 'road'),
+            'input_shape': (4, 512, 512),
+            'resolution': 1.0,
+            'license': 'MIT',
+        },
+    )
 
 
 def unet(


### PR DESCRIPTION
From @calebrob6 and my [paper](https://arxiv.org/abs/2401.06762)

Model trained for rural road segmentation to "see" roads even through the tree canopy

Example that it works:

<img width="1479" height="511" alt="image" src="https://github.com/user-attachments/assets/21ccab1e-de77-463b-81a1-13edb857e515" />

Code to reproduce:

```python
import torch
import rasterio
import matplotlib.pyplot as plt
from torchgeo.models import Unet_Weights, unet


weights = Unet_Weights.NAIP_RGBN_RESNET18_CHESAPEAKERSC
transforms = weights.transforms
model = unet(weights=weights).eval()

with rasterio.open("https://github.com/isaaccorley/ChesapeakeRSC/raw/refs/heads/main/assets/8782_image.tif") as src:
    image = src.read()

with rasterio.open("https://github.com/isaaccorley/ChesapeakeRSC/raw/refs/heads/main/assets/8782_mask.tif") as src:
    mask = src.read(1)
    mask = (mask == 9) | (mask == 12)
    mask = mask.astype('uint8')

x = torch.from_numpy(image).unsqueeze(0).to(torch.float)
preds = model(transforms(x)).squeeze(0).argmax(dim=0).numpy()
print(mask.shape)
fig, ax = plt.subplots(1, 3, figsize=(15, 5))
ax[0].imshow(image[:3].transpose(1, 2, 0))
ax[0].set_title('Input Image')
ax[1].imshow(preds, cmap='grey', vmin=0, vmax=2)
ax[1].set_title('Preds')
ax[2].imshow(mask)
ax[2].set_title('Ground Truth Mask')
for a in ax:
    a.axis('off')
plt.tight_layout()
plt.show()
plt.close()
```