### PR TITLE
Bump pillow

### DIFF
--- a/requirements/required.txt
+++ b/requirements/required.txt
@@ -8,7 +8,7 @@ lightning==2.6.0
 matplotlib==3.10.8
 numpy==2.4.1
 pandas==3.0.0
-pillow==12.1.0
+pillow==12.1.1
 pyproj==3.7.2
 rasterio==1.5.0
 requests==2.32.5


### PR DESCRIPTION
12.1.0 has a security vulnerability, and dependabot is busted, so manually bumping.