### PR TITLE
Fix OSCD100: add dates.txt with consistent format

### DIFF
--- a/torchgeo/datasets/oscd.py
+++ b/torchgeo/datasets/oscd.py
@@ -364,13 +364,13 @@ class OSCD100(OSCD):
     """
 
     urls: ClassVar[dict[str, str]] = {
-        'Onera Satellite Change Detection dataset - Images.zip': 'https://hf.co/datasets/hkristen/oscd100/resolve/ecf6fcf15e6f20219324f9009f7509aa866b51d5/Onera%20Satellite%20Change%20Detection%20dataset%20-%20Images.zip',
-        'Onera Satellite Change Detection dataset - Train Labels.zip': 'https://hf.co/datasets/hkristen/oscd100/resolve/ecf6fcf15e6f20219324f9009f7509aa866b51d5/Onera%20Satellite%20Change%20Detection%20dataset%20-%20Train%20Labels.zip',
-        'Onera Satellite Change Detection dataset - Val Labels.zip': 'https://hf.co/datasets/hkristen/oscd100/resolve/ecf6fcf15e6f20219324f9009f7509aa866b51d5/Onera%20Satellite%20Change%20Detection%20dataset%20-%20Val%20Labels.zip',
-        'Onera Satellite Change Detection dataset - Test Labels.zip': 'https://hf.co/datasets/hkristen/oscd100/resolve/ecf6fcf15e6f20219324f9009f7509aa866b51d5/Onera%20Satellite%20Change%20Detection%20dataset%20-%20Test%20Labels.zip',
+        'Onera Satellite Change Detection dataset - Images.zip': 'https://hf.co/datasets/hkristen/oscd100/resolve/cac594329ee7f1a7f7781b1fe9c3d57befa50044/Onera%20Satellite%20Change%20Detection%20dataset%20-%20Images.zip',
+        'Onera Satellite Change Detection dataset - Train Labels.zip': 'https://hf.co/datasets/hkristen/oscd100/resolve/cac594329ee7f1a7f7781b1fe9c3d57befa50044/Onera%20Satellite%20Change%20Detection%20dataset%20-%20Train%20Labels.zip',
+        'Onera Satellite Change Detection dataset - Val Labels.zip': 'https://hf.co/datasets/hkristen/oscd100/resolve/cac594329ee7f1a7f7781b1fe9c3d57befa50044/Onera%20Satellite%20Change%20Detection%20dataset%20-%20Val%20Labels.zip',
+        'Onera Satellite Change Detection dataset - Test Labels.zip': 'https://hf.co/datasets/hkristen/oscd100/resolve/cac594329ee7f1a7f7781b1fe9c3d57befa50044/Onera%20Satellite%20Change%20Detection%20dataset%20-%20Test%20Labels.zip',
     }
     md5s: ClassVar[dict[str, str]] = {
-        'Onera Satellite Change Detection dataset - Images.zip': '2e8792a3da012f7eb0440b557eef4c11',
+        'Onera Satellite Change Detection dataset - Images.zip': 'e6c3e5d9ca6003c39fcf7991f5d05f14',
         'Onera Satellite Change Detection dataset - Train Labels.zip': '4fdc210a90e2c881a553fa9c72c7d6ce',
         'Onera Satellite Change Detection dataset - Val Labels.zip': '99a38997829cc81a18b04d4afb3493ba',
         'Onera Satellite Change Detection dataset - Test Labels.zip': '5e43ae36cfe0cc83ddcbd4fcb03ace60',


### PR DESCRIPTION
This PR fixes the OSCD100 dataset by adding `dates.txt` files in a format consistent with the original OSCD dataset. Found this when trying to update the change detection notebook in #3222

## Problem
- OSCD100 inherits from OSCD, which requires `dates.txt` in each region directory
- The current HuggingFace dataset was missing `dates.txt` files, causing crashes when loading
- This was missed in PR #3221

## Solution
- Added `dates.txt` to all 100 regions in the OSCD100 HuggingFace dataset
- Used the same format as OSCD: `date_1: YYYYMMDD` and `date_2: YYYYMMDD`
- Updated URLs to point to the new HuggingFace commit with dates.txt
- Updated MD5 hash for the Images.zip file

## Changes
- Updated `torchgeo/datasets/oscd.py`:
  - OSCD100 URLs now point to commit `cac5943` (contains dates.txt)
  - Updated MD5 for Images.zip: `e6c3e5d9ca6003c39fcf7991f5d05f14`

Fixes a bug introduced in #3221.