### PR TITLE
Trainers: ignore PyTorch attribute hints

### DIFF
--- a/torchgeo/trainers/classification.py
+++ b/torchgeo/trainers/classification.py
@@ -113,7 +113,7 @@ class ClassificationTask(ClassificationMixin, BaseTask):
         if self.hparams['freeze_backbone']:
             for param in self.model.parameters():
                 param.requires_grad = False
-            for param in self.model.get_classifier().parameters():
+            for param in self.model.get_classifier().parameters():  # type: ignore[call-non-callable]
                 param.requires_grad = True
 
     def training_step(

--- a/torchgeo/trainers/detection.py
+++ b/torchgeo/trainers/detection.py
@@ -198,9 +198,9 @@ class ObjectDetectionTask(BaseTask):
         else:
             raise ValueError(f"Model type '{model}' is not valid.")
 
-        weight = adapt_input_conv(in_channels, self.model.backbone.body.conv1.weight)
-        self.model.backbone.body.conv1.weight = Parameter(weight)
-        self.model.backbone.body.conv1.in_channels = in_channels
+        weight = adapt_input_conv(in_channels, self.model.backbone.body.conv1.weight)  # type: ignore[invalid-assignment]
+        self.model.backbone.body.conv1.weight = Parameter(weight)  # type: ignore[invalid-assignment]
+        self.model.backbone.body.conv1.in_channels = in_channels  # type: ignore[invalid-assignment]
 
     def configure_metrics(self) -> None:
         """Initialize the performance metrics.

--- a/torchgeo/trainers/regression.py
+++ b/torchgeo/trainers/regression.py
@@ -106,7 +106,7 @@ class RegressionTask(BaseTask):
         if self.hparams['freeze_backbone']:
             for param in self.model.parameters():
                 param.requires_grad = False
-            for param in self.model.get_classifier().parameters():
+            for param in self.model.get_classifier().parameters():  # type: ignore[call-non-callable]
                 param.requires_grad = True
 
     def configure_losses(self) -> None:


### PR DESCRIPTION
I believe this is due to `nn.Module.__getattr__` being hard-coded to return a Tensor. This is a long-standing issue with PyTorch's type hints. We should really report this upstream and fix it someday.