### PR TITLE
Collate fn: use Sample type hints

### DIFF
--- a/torchgeo/datasets/utils.py
+++ b/torchgeo/datasets/utils.py
@@ -530,7 +530,7 @@ def _list_dict_to_dict_list(samples: Iterable[Sample]) -> dict[str, list[Any]]:
     return collated
 
 
-def _dict_list_to_list_dict(sample: Mapping[str, Sequence[Tensor]]) -> list[Sample]:
+def _dict_list_to_list_dict(sample: Mapping[str, Sequence[Any]]) -> list[Sample]:
     """Convert a dictionary of lists to a list of dictionaries.
 
     Args:


### PR DESCRIPTION
This PR restricts our collation functions to only support TorchGeo Samples.

### Alternative

If we want to make these more general, we should really be using Generics everywhere instead of Any.