### PR TITLE
ty: ignore fewer rules in config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,8 +133,6 @@ models = [
     "microsoft-aurora>=1.6",
 ]
 style = [
-    # oldest version on PyPI
-    "h5py-stubs>=0.1.0",
     # pandas 2.1.1+ required for Python 3.12 wheels
     "pandas-stubs>=2.1.1",
     # ruff 0.9+ required for 2025 style guide
@@ -333,6 +331,7 @@ include = ["torchgeo*"]
 [tool.ty.rules]
 deprecated = "ignore"
 unresolved-attribute = "ignore"
+unresolved-import = "ignore"
 
 [tool.ty.src]
 include = ["torchgeo", "tests"]

--- a/requirements/style.txt
+++ b/requirements/style.txt
@@ -1,5 +1,4 @@
 # style
-h5py-stubs==0.1.2
 pandas-stubs==2.3.3.260113
 ruff==0.15.1
 ty==0.0.17


### PR DESCRIPTION
Remaining ignores:

* deprecated: all of TorchGeo's deprecated classes we test
* unresolved-attribute: type hinting bugs in PyTorch/pandas
* unresolved-import: can't find h5py type stubs, ~could try h5py-stubs package~, more wrong than right