### PR TITLE
pytest: minimize ignored warning messages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,38 +190,8 @@ filterwarnings = [
     'ignore:The global interpreter lock \(GIL\) has been enabled to load module:RuntimeWarning',
     # https://github.com/Lightning-AI/pytorch-lightning/issues/21326
     'ignore:`isinstance\(treespec, LeafSpec\)` is deprecated, use `isinstance\(treespec, TreeSpec\) and treespec.is_leaf\(\)` instead.:FutureWarning',
-#    # https://github.com/Lightning-AI/pytorch-lightning/issues/13256
-#    # https://github.com/Lightning-AI/pytorch-lightning/pull/13261
-#    "ignore:torch.distributed._sharded_tensor will be deprecated:DeprecationWarning:torch.distributed._sharded_tensor",
-#    # https://github.com/Lightning-AI/pytorch-lightning/issues/13989
-#    "ignore:SelectableGroups dict interface is deprecated. Use select.:DeprecationWarning:lightning.pytorch.trainer.connectors.callback_connector",
-#    # https://github.com/Lightning-AI/pytorch-lightning/issues/14594
-#    "ignore:To copy construct from a tensor, it is recommended to use:UserWarning:lightning.pytorch.core.module",
-#    # https://github.com/rasterio/rasterio/issues/1742
-#    # https://github.com/rasterio/rasterio/pull/1753
-#    "ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated:DeprecationWarning:rasterio.crs",
-#    # https://github.com/pytorch/pytorch/issues/60053
-#    # https://github.com/pytorch/pytorch/pull/60059
-#    "ignore:Named tensors and all their associated APIs are an experimental feature and subject to change:UserWarning:torch.nn.functional",
-#    # https://github.com/tensorflow/tensorboard/issues/5798
-#    "ignore:Call to deprecated create function:DeprecationWarning:tensorboard.compat.proto",
-#    # https://github.com/treebeardtech/nbmake/issues/68
-#    'ignore:The \(fspath. py.path.local\) argument to NotebookFile is deprecated:pytest.PytestDeprecationWarning:nbmake.pytest_plugin',
     # https://github.com/pytorch/pytorch/pull/24929
     "ignore:Default grid_sample and affine_grid behavior has changed to align_corners=False since 1.3.0:UserWarning",
-#    # https://github.com/scikit-image/scikit-image/issues/6663
-#    # https://github.com/scikit-image/scikit-image/pull/6637
-#    "ignore:`np.bool8` is a deprecated alias for `np.bool_`.:DeprecationWarning:skimage.util.dtype",
-#    "ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated:DeprecationWarning:jsonargparse",
-#    "ignore:`ModuleAvailableCache` is a special case of `RequirementCache`.:DeprecationWarning:lightning.fabric.plugins.environments.xla",
-#    # https://github.com/pytorch/pytorch/issues/110549
-#    "ignore:allow_ops_in_compiled_graph failed to import torch:ImportWarning:einops",
-#    # https://github.com/kornia/kornia/pull/2967
-#    "ignore:`torch.cuda.amp.custom_fwd\\(args...\\)` is deprecated.:FutureWarning:kornia.feature.lightglue",
-#    # https://github.com/kornia/kornia/pull/2981
-#    "ignore:torch.is_autocast_cpu_enabled\\(\\) is deprecated.:DeprecationWarning:kornia.utils.helpers",
-#    # https://github.com/pytorch/pytorch/pull/129239
-#    "ignore:You are using `torch.load` with `weights_only=False`:FutureWarning",
     # https://github.com/pytorch/pytorch/issues/136264
     "ignore:__array__ implementation doesn't accept a copy keyword:DeprecationWarning",
     "ignore:__array_wrap__ must accept context and return_scalar arguments:DeprecationWarning",
@@ -229,32 +199,18 @@ filterwarnings = [
     # https://github.com/pydantic/pydantic/issues/12618
     "ignore:Core Pydantic V1 functionality isn't compatible with Python 3.14 or greater.:UserWarning",
     "ignore:ForwardRef._evaluate is a private API and is retained for compatibility:DeprecationWarning",
-#    # https://github.com/pydantic/pydantic/pull/11377
-#    "ignore:Failing to pass a value to the 'type_params' parameter of 'typing.*' is deprecated:DeprecationWarning:pydantic",
-#    # https://github.com/Lightning-AI/pytorch-lightning/pull/20802
-#    "ignore::DeprecationWarning:jsonargparse.*",
-#    # https://github.com/geopandas/geopandas/pull/3453
-#    "ignore:The 'shapely.geos' module is deprecated:DeprecationWarning:geopandas._compat",
 
     # Expected warnings
     # Lightning warns us about using num_workers=0, but it's faster on macOS
     "ignore:The .*dataloader.* does not have many workers which may be a bottleneck:UserWarning",
-#    "ignore:The .*dataloader.* does not have many workers which may be a bottleneck:lightning.fabric.utilities.warnings.PossibleUserWarning:lightning",
-#    # Lightning warns us about using the CPU when GPU/MPS is available
+    # Lightning warns us about using the CPU when GPU is available
     "ignore:GPU available but not used.:UserWarning",
-#    "ignore:MPS available but not used.:UserWarning",
     # Lightning warns us if TensorBoard is not installed
     "ignore:Starting from v1.9.0, `tensorboardX` has been removed as a dependency of the `lightning.pytorch` package:UserWarning",
     # https://github.com/Lightning-AI/lightning/issues/18545
     "ignore:LightningCLI's args parameter is intended to run from within Python like if it were from the command line.:UserWarning",
-#    # https://github.com/kornia/kornia/pull/1663
-#    "ignore:`RandomGaussianBlur` has changed its behavior and now randomly sample sigma for both axes.:DeprecationWarning",
-#    # https://github.com/pytorch/pytorch/pull/111576
-#    "ignore:Skipping device Apple Paravirtual device that does not support Metal 2.0:UserWarning",
 
     # Unexpected warnings, worth investigating
-#    # https://github.com/pytest-dev/pytest/issues/11461
-#    "ignore::pytest.PytestUnraisableExceptionWarning",
     # https://github.com/shapely/shapely/issues/2215
     "ignore:divide by zero encountered in oriented_envelope:RuntimeWarning",
     "ignore:invalid value encountered in oriented_envelope:RuntimeWarning",


### PR DESCRIPTION
Many of these warnings were fixed a long time ago in our dependencies. It isn't really harming us to keep them, but I also think we can clean them up a little. I would suggest only ignoring warnings present in the most recent version of our deps.