### PR TITLE
torchgeo.datasets.errors: remove Any type hints

### DIFF
--- a/tests/datasets/test_errors.py
+++ b/tests/datasets/test_errors.py
@@ -1,8 +1,6 @@
 # Copyright (c) TorchGeo Contributors. All rights reserved.
 # Licensed under the MIT License.
 
-from typing import Any
-
 import pytest
 from torch.utils.data import Dataset
 
@@ -15,13 +13,13 @@ from torchgeo.datasets import (
 
 class TestDatasetNotFoundError:
     def test_none(self) -> None:
-        ds: Dataset[Any] = Dataset()
+        ds: Dataset[object] = Dataset()
         match = 'Dataset not found.'
         with pytest.raises(DatasetNotFoundError, match=match):
             raise DatasetNotFoundError(ds)
 
     def test_root(self) -> None:
-        ds: Dataset[Any] = Dataset()
+        ds: Dataset[object] = Dataset()
         ds.root = 'foo'
         match = "Dataset not found in `root='foo'` and cannot be automatically "
         match += 'downloaded, either specify a different `root` or manually '
@@ -30,7 +28,7 @@ class TestDatasetNotFoundError:
             raise DatasetNotFoundError(ds)
 
     def test_paths(self) -> None:
-        ds: Dataset[Any] = Dataset()
+        ds: Dataset[object] = Dataset()
         ds.paths = 'foo'
         match = "Dataset not found in `paths='foo'` and cannot be automatically "
         match += 'downloaded, either specify a different `paths` or manually '
@@ -39,7 +37,7 @@ class TestDatasetNotFoundError:
             raise DatasetNotFoundError(ds)
 
     def test_root_download(self) -> None:
-        ds: Dataset[Any] = Dataset()
+        ds: Dataset[object] = Dataset()
         ds.root = 'foo'
         ds.download = False
         match = "Dataset not found in `root='foo'` and `download=False`, either "
@@ -49,7 +47,7 @@ class TestDatasetNotFoundError:
             raise DatasetNotFoundError(ds)
 
     def test_paths_download(self) -> None:
-        ds: Dataset[Any] = Dataset()
+        ds: Dataset[object] = Dataset()
         ds.paths = 'foo'
         ds.download = False
         match = "Dataset not found in `paths='foo'` and `download=False`, either "


### PR DESCRIPTION
`typing.Any` disables the type checker and should generally be avoided whenever possible. The dataset return type for these tests doesn't matter anyway, so switch to a static type.