### PR TITLE
ChangeStar: Literal inference_mode

### DIFF
--- a/tests/models/test_changestar.py
+++ b/tests/models/test_changestar.py
@@ -1,6 +1,8 @@
 # Copyright (c) TorchGeo Contributors. All rights reserved.
 # Licensed under the MIT License.
 
+from typing import Literal
+
 import pytest
 import torch
 import torch.nn as nn
@@ -93,33 +95,10 @@ class TestChangeStar:
         assert y['change_prob'].shape == (3, 1, 64, 64)
 
     @torch.no_grad()
-    def test_changestar_invalid_inference_mode(self) -> None:
-        dense_feature_extractor = nn.modules.Sequential(
-            nn.modules.Conv2d(3, 32, 3, 1, 1),
-            nn.modules.BatchNorm2d(32),
-            nn.modules.ReLU(),
-            nn.modules.MaxPool2d(3, 2, 1),
-        )
-
-        seg_classifier = nn.modules.Sequential(
-            nn.modules.Conv2d(32, 2, 3, 1, 1),
-            nn.modules.UpsamplingBilinear2d(scale_factor=2.0),
-        )
-
-        match = 'Unknown inference_mode: random'
-        with pytest.raises(ValueError, match=match):
-            ChangeStar(
-                dense_feature_extractor,
-                seg_classifier,
-                ChangeMixin(
-                    in_channels=32 * 2, inner_channels=16, num_convs=4, scale_factor=2.0
-                ),
-                inference_mode='random',
-            )
-
-    @torch.no_grad()
     @pytest.mark.parametrize('inference_mode', ['t1t2', 't2t1', 'mean'])
-    def test_changestar_inference_output_size(self, inference_mode: str) -> None:
+    def test_changestar_inference_output_size(
+        self, inference_mode: Literal['t1t2', 't2t1', 'mean']
+    ) -> None:
         dense_feature_extractor = nn.modules.Sequential(
             nn.modules.Conv2d(3, 32, 3, 1, 1),
             nn.modules.BatchNorm2d(32),

--- a/torchgeo/models/changestar.py
+++ b/torchgeo/models/changestar.py
@@ -3,6 +3,8 @@
 
 """ChangeStar implementations."""
 
+from typing import Literal
+
 import torch
 import torch.nn as nn
 from einops import rearrange
@@ -104,7 +106,7 @@ class ChangeStar(Module):
         dense_feature_extractor: Module,
         seg_classifier: Module,
         changemixin: ChangeMixin,
-        inference_mode: str = 't1t2',
+        inference_mode: Literal['t1t2', 't2t1', 'mean'] = 't1t2',
     ) -> None:
         """Initializes a new ChangeStar model.
 
@@ -123,9 +125,6 @@ class ChangeStar(Module):
         self.dense_feature_extractor = dense_feature_extractor
         self.seg_classifier = seg_classifier
         self.changemixin = changemixin
-
-        if inference_mode not in ['t1t2', 't2t1', 'mean']:
-            raise ValueError(f'Unknown inference_mode: {inference_mode}')
         self.inference_mode = inference_mode
 
     def forward(self, x: Tensor) -> dict[str, Tensor]:
@@ -153,18 +152,19 @@ class ChangeStar(Module):
         results: dict[str, Tensor] = {}
         if not self.training:
             results.update({'bi_seg_logit': bi_seg_logit})
-            if self.inference_mode == 't1t2':
-                results.update({'change_prob': c12.sigmoid()})
-            elif self.inference_mode == 't2t1':
-                results.update({'change_prob': c21.sigmoid()})
-            elif self.inference_mode == 'mean':
-                results.update(
-                    {
-                        'change_prob': torch.stack([c12, c21], dim=0)
-                        .sigmoid_()
-                        .mean(dim=0)
-                    }
-                )
+            match self.inference_mode:
+                case 't1t2':
+                    results.update({'change_prob': c12.sigmoid()})
+                case 't2t1':
+                    results.update({'change_prob': c21.sigmoid()})
+                case 'mean':
+                    results.update(
+                        {
+                            'change_prob': torch.stack([c12, c21], dim=0)
+                            .sigmoid_()
+                            .mean(dim=0)
+                        }
+                    )
         else:
             results.update(
                 {


### PR DESCRIPTION
Not all `str` are valid inputs to `inference_mode`, use `typing.Literal` to check for valid values.