### PR TITLE
Docs: remove duplicate type hints in docstrings

### DIFF
--- a/tests/data/enviroatlas/data.py
+++ b/tests/data/enviroatlas/data.py
@@ -215,7 +215,7 @@ def generate_test_data(root: str) -> None:
     """Creates test data archive for the EnviroAtlas dataset.
 
     Args:
-        root (str): Path to store test data
+        root: Path to store test data
     """
     size = (64, 64)
     folder_path = os.path.join(root, 'enviroatlas_lotp')

--- a/tests/data/inria/data.py
+++ b/tests/data/inria/data.py
@@ -34,8 +34,8 @@ def generate_test_data(root: str, n_samples: int = 2) -> None:
     """Creates test data archive for InriaAerialImageLabeling dataset.
 
     Args:
-        root (str): Path to store test data
-        n_samples (int, optional): Number of samples. Defaults to 2.
+        root: Path to store test data
+        n_samples: Number of samples. Defaults to 2.
     """
     dtype = np.dtype('uint8')
     size = (8, 8)

--- a/torchgeo/datasets/vhr10.py
+++ b/torchgeo/datasets/vhr10.py
@@ -34,9 +34,9 @@ def convert_coco_poly_to_mask(
     """Convert coco polygons to mask tensor.
 
     Args:
-        segmentations (List[int]): polygon coordinates
-        height (int): image height
-        width (int): image width
+        segmentations: polygon coordinates
+        height: image height
+        width: image width
 
     Returns:
         Tensor: Mask tensor

--- a/torchgeo/models/swin.py
+++ b/torchgeo/models/swin.py
@@ -263,9 +263,9 @@ class SwinBackbone_Weights(WeightsEnum):
         """Get the state dict for this model from provided url, optionally including backbone layernorm weights.
 
         Args:
-            include_norms (bool): Whether to also return backbone layernorm weights.
-            *args (Any): anything passed to WeightsEnum get_state_dict.
-            **kwargs (Any): anything passed to WeightsEnum get_state_dict.
+            include_norms: Whether to also return backbone layernorm weights.
+            *args: anything passed to WeightsEnum get_state_dict.
+            **kwargs: anything passed to WeightsEnum get_state_dict.
 
         Returns:
             dict with state dict only if include_norms is False,


### PR DESCRIPTION
Sphinx pulls type hints from the function signature, docstring type hints are not necessary.