### PR TITLE
Docs: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+* @adamjstewart @calebrob6 @isaaccorley @nilsleh @ashnair1


### PR DESCRIPTION
The PyTorch folks asked us to add a CODEOWNERS file: https://github.com/pytorch-fdn/ecosystem/issues/60

This file lists people who will automatically be asked to review PRs for the files that match the glob. For now, I've added all maintainers, who I _hope_ are watching the repo anyway. I would love to add more names to this list and give contributors ownership of their personal datasets/models in the future. Unfortunately, only folks with write permissions or higher can use this file.

Let me know if any of you don't want this many notifications or want to explicitly maintain some specific subset of the repo.

### Reference

* https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners