### PR TITLE
pre-commit: fix ty hook breaking local commits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,6 @@ repos:
         entry: ty check
         language: python
         pass_filenames: false
-        args: [--config-file, pyproject.toml]
         additional_dependencies:
           - einops>=0.6.0
           - kornia>=0.7.4


### PR DESCRIPTION
When committing locally with pre-commit, the ty hook fails because --config-file only accepts ty.toml -> passing the pyproject.toml causes a parse error. 

The CI is unaffected since it runs ty check directly without the flag. Removing the arg fixes local commits and ty auto-discovers pyproject.toml on its own.