### PR TITLE
LandCoverAI: avoid Any type hints

### DIFF
--- a/torchgeo/datasets/landcoverai.py
+++ b/torchgeo/datasets/landcoverai.py
@@ -137,7 +137,7 @@ class LandCoverAIBase(Dataset[Sample], abc.ABC):
         """Plot a sample from the dataset.
 
         Args:
-            sample: a sample returned by :meth:`__getitem__`
+            sample: a sample returned by `__getitem__`
             show_titles: flag indicating whether to show titles above each panel
             suptitle: optional string to use as a suptitle
 


### PR DESCRIPTION
This ABC doesn't serve that much purpose, the subclasses both override getitem anyway.