### PR TITLE
Document criteria for becoming a maintainer

### DIFF
--- a/.github/MAINTAINERS.md
+++ b/.github/MAINTAINERS.md
@@ -10,6 +10,15 @@ This document lists the Maintainers of the Project. Maintainers may be added onc
 | Nils Lehmann    | @nilsleh      | TUM             |
 | Ashwin Nair     | @ashnair1     | Space42         |
 
+## How to Join
+
+All contributors are welcome and encouraged to review pull requests. However, only the above contributors are trusted with merge privileges. If you would like to become a maintainer, here are some of the qualities we look for:
+
+- Top contributors to the project: https://github.com/torchgeo/torchgeo/graphs/contributors
+- Top reviewers who provide detailed feedback on pull requests
+
+If you satisfy these criteria, we will reach out to you to invite you to be a maintainer.
+
 ---
 
 Part of MVG-0.1-beta.


### PR DESCRIPTION
Action item from our last TSC meeting.

Is this the right file to document this in? Any other criteria we want to add? Some additional rules we could add (or maybe they are too obvious):

* Someone we've personally and/or professionally known long enough to trust them
* Someone who knows the TorchGeo codebase well
* Someone who knows GitHub and open source well

I've purposefully left the number of required commits/reviews ambiguous, but we could make it more explicit (e.g., top N committers, top N% of reviews).

> [!WARNING]
> All amendments to project governance docs require a 2/3 majority approval. Please don't merge until at least 4 maintainers have approved this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated maintainer documentation with a new "How to Join" section. This addition provides guidance on eligibility criteria for becoming a maintainer, including recognition as a top contributor or top reviewer, and notes that qualified individuals will be invited to join the maintainer team.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->