### PR TITLE
Related Libraries: STAC support is officially a work in progress

### DIFF
--- a/docs/user/metrics/features.csv
+++ b/docs/user/metrics/features.csv
@@ -1,5 +1,5 @@
 Library,ML Backend,I/O Backend,Spatial Backend,Transform Backend,Datasets,Weights,CLI,GUI,Reprojection,STAC,Time Series
-`TorchGeo`_,PyTorch,"GDAL, h5py, laspy, NetCDF4, OpenCV, pandas, pillow, scipy, xarray","geopandas, R-tree*",Kornia,141,132,✅,❌,✅,❌,🚧
+`TorchGeo`_,PyTorch,"GDAL, h5py, laspy, NetCDF4, OpenCV, pandas, pillow, scipy, xarray","geopandas, R-tree*",Kornia,141,132,✅,❌,✅,🚧,🚧
 `OTB`_,"LibSVM, OpenCV, Shark",GDAL,-,-,0,0,✅,✅,✅,❌,❌
 `TerraTorch`_,PyTorch,"GDAL, h5py, pandas, xarray",-,Albumentations,27,13,✅,❌,✅,❌,🚧
 `DeepForest`_,"PyTorch, TensorFlow*","GDAL, OpenCV, pandas, pillow, scipy",R-tree,"Kornia, Albumentations*",0,4,✅,❌,❌,❌,❌


### PR DESCRIPTION
We had our first STAC working group meeting today and are officially kicking off a concerted effort to add STAC support to TorchGeo. We already have one PR for a specific STAC dataset (#3309), one semi-abandoned PR for a generic STAC API base class (#412), and one active issue documenting progress (#403). I expect a new PR to replace #412 in the near future, but won't comment on an expected timeline since I'm not actually the one doing the work. At this point I think we can claim that STAC support is officially a WIP.

For anyone interested in joining this effort, please join the `#stac` channel on the [TorchGeo Slack](https://torchgeo.slack.com/join/shared_invite/zt-22rse667m-eqtCeNW0yI000Tl4B~2PIw). We need people to write the code but also to test the code.