### PR TITLE
[Fix] Inria Datamodule shape inconsistent for different batch_sizes

### DIFF
--- a/torchgeo/datamodules/inria.py
+++ b/torchgeo/datamodules/inria.py
@@ -99,7 +99,7 @@ class InriaAerialImageLabelingDataModule(NonGeoDataModule):
         """
         # This solves a special case where if batch_size=1 the mask won't be stacked correctly
         if 'mask' in batch and batch['mask'].ndim == 3:
-            batch['mask'] = batch['mask'].unsqueeze(0)
+            batch['mask'] = batch['mask'].unsqueeze(1)
             batch = super().on_after_batch_transfer(batch, dataloader_idx)
             batch['mask'] = batch['mask'].squeeze(dim=1)
             return batch


### PR DESCRIPTION
This fixes inconsistent batch shapes of masks returned by the datamodule when using batch_size=1 and batch_size>1.
When using a batch_size=B larger than 1, the masks tensor is of shape (1,B,H,W), which has to be fixed somewhere else.

The mask shape should be (B, H, W) for all values of B.
You may reproduce it with something like:

```
from torchgeo.datamodules import InriaAerialImageLabelingDataModule

if __name__ == "__main__":

    dm = InriaAerialImageLabelingDataModule(batch_size=1, root=<your_root>)
    dm2 = InriaAerialImageLabelingDataModule(batch_size=6,  root=<your_root>)
    dm.setup("fit")
    dm2.setup("fit")

    tl = dm.train_dataloader()
    tl2 = dm2.train_dataloader()

    for batch1, batch2 in zip(tl, tl2):
        batch1 = dm.on_after_batch_transfer(batch1, 0) # to mimic lightning behaviour
        batch2 = dm2.on_after_batch_transfer(batch2, 0)
        print(batch1['mask'].shape, batch2['mask'].shape) # currently returns torch.Size([1, 5000, 5000]) torch.Size([1, 6, 5000, 5000])
        raise NotImplementedError
```