### PR TITLE
[FIX] Potsdam dataset folder structure 

### DIFF
--- a/torchgeo/datasets/potsdam.py
+++ b/torchgeo/datasets/potsdam.py
@@ -61,6 +61,7 @@ class Potsdam2D(NonGeoDataset):
     filenames = ('4_Ortho_RGBIR.zip', '5_Labels_all.zip')
     md5s = ('c4a8f7d8c7196dd4eba4addd0aae10c1', 'cf7403c1a97c0d279414db')
     image_root = '4_Ortho_RGBIR'
+    mask_root = '5_Labels_all'
     splits: ClassVar[dict[str, list[str]]] = {
         'train': [
             'top_potsdam_2_10',
@@ -153,7 +154,7 @@ class Potsdam2D(NonGeoDataset):
         self.files = []
         for name in self.splits[split]:
             image = os.path.join(root, self.image_root, name) + '_RGBIR.tif'
-            mask = os.path.join(root, name) + '_label.tif'
+            mask = os.path.join(root, self.mask_root, name) + '_label.tif'
             if os.path.exists(image) and os.path.exists(mask):
                 self.files.append(dict(image=image, mask=mask))
 


### PR DESCRIPTION
(sorry for PR bombing, but I guess you prefer more small changes instead of one large commit)
fixes wrong/deprecated folder structure of potsdam dataset. The mask are located in the subfolder '5_Label_all'