### PR TITLE
test: enable branch coverage in pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,9 @@ Homepage = "https://github.com/torchgeo/torchgeo"
 Slack = "https://torchgeo.slack.com"
 
 # https://coverage.readthedocs.io/en/latest/config.html
+[tool.coverage.run]
+branch = true
+
 [tool.coverage.report]
 # Ignore warnings for overloads
 # https://github.com/nedbat/coveragepy/issues/970#issuecomment-612602180


### PR DESCRIPTION
Enable branch coverage to ensure if-statements are tested for both True and False conditions.

This is the first part of #2501. The configuration change is minimal, but will reveal missing branch coverage that needs to be addressed in follow-up PRs.

Reference: https://coverage.readthedocs.io/en/latest/branch.html

Part of #2501