### PR TITLE
Fix incorrect mask dimension handling in InriaAerialImageLabelingDataModule

### DIFF
--- a/torchgeo/datamodules/inria.py
+++ b/torchgeo/datamodules/inria.py
@@ -86,22 +86,17 @@ class InriaAerialImageLabelingDataModule(NonGeoDataModule):
             self.predict_dataset = InriaAerialImageLabeling(split='test', **self.kwargs)
 
     def on_after_batch_transfer(self, batch: Sample, dataloader_idx: int) -> Sample:
-        """Apply batch augmentations to the batch after it is transferred to the device.
+        """Apply batch augmentations to the batch after it is transferred to the device."""
 
-        Args:
-            batch: A batch of data that needs to be altered or augmented.
-            dataloader_idx: The index of the dataloader to which the batch belongs.
+        # Handle edge case where batch_size=1 and mask is missing batch dimension
+        if 'mask' in batch:
+            mask = batch['mask']
+            
+            # Case: single sample mask [H, W] → add batch dimension
+            if mask.ndim == 2:
+                batch['mask'] = mask.unsqueeze(0)
+                batch = super().on_after_batch_transfer(batch, dataloader_idx)
+                batch['mask'] = batch['mask'].squeeze(0)
+                return batch
 
-        Returns:
-            A batch of data.
-
-        .. versionadded:: 0.7
-        """
-        # This solves a special case where if batch_size=1 the mask won't be stacked correctly
-        if 'mask' in batch and batch['mask'].ndim == 3:
-            batch['mask'] = batch['mask'].unsqueeze(0)
-            batch = super().on_after_batch_transfer(batch, dataloader_idx)
-            batch['mask'] = batch['mask'].squeeze(dim=1)
-            return batch
-        else:
-            return super().on_after_batch_transfer(batch, dataloader_idx)
+        return super().on_after_batch_transfer(batch, dataloader_idx)

--- a/torchgeo/datamodules/inria.py
+++ b/torchgeo/datamodules/inria.py
@@ -86,17 +86,22 @@ class InriaAerialImageLabelingDataModule(NonGeoDataModule):
             self.predict_dataset = InriaAerialImageLabeling(split='test', **self.kwargs)
 
     def on_after_batch_transfer(self, batch: Sample, dataloader_idx: int) -> Sample:
-        """Apply batch augmentations to the batch after it is transferred to the device."""
+        """Apply batch augmentations to the batch after it is transferred to the device.
 
-        # Handle edge case where batch_size=1 and mask is missing batch dimension
-        if 'mask' in batch:
-            mask = batch['mask']
-            
-            # Case: single sample mask [H, W] → add batch dimension
-            if mask.ndim == 2:
-                batch['mask'] = mask.unsqueeze(0)
-                batch = super().on_after_batch_transfer(batch, dataloader_idx)
-                batch['mask'] = batch['mask'].squeeze(0)
-                return batch
+        Args:
+            batch: A batch of data that needs to be altered or augmented.
+            dataloader_idx: The index of the dataloader to which the batch belongs.
+
+        Returns:
+            A batch of data.
+
+        .. versionadded:: 0.7
+        """
+        # Handle the edge case where a single mask is missing the batch dimension.
+        if 'mask' in batch and batch['mask'].ndim == 2:
+            batch['mask'] = batch['mask'].unsqueeze(0)
+            batch = super().on_after_batch_transfer(batch, dataloader_idx)
+            batch['mask'] = batch['mask'].squeeze(0)
+            return batch
 
         return super().on_after_batch_transfer(batch, dataloader_idx)


### PR DESCRIPTION
## Summary
Fixes incorrect handling of mask dimensions in `InriaAerialImageLabelingDataModule.on_after_batch_transfer`.

## Problem
The current implementation assumes that `mask.ndim == 3` corresponds to a batch_size=1 case. However, this is also true for standard batched masks with shape [B, H, W].

This leads to incorrect reshaping and breaks augmentation consistency.

## Solution
- Restrict special handling to true single-mask case ([H, W])
- Leave batched masks ([B, H, W]) unchanged

## Impact
- Prevents shape mismatch errors during augmentation
- Preserves existing behavior for valid batched inputs

## Notes
This change preserves the original docstring and keeps the modification minimal.